### PR TITLE
v0 fix self healing

### DIFF
--- a/screenpipe-server/src/lib.rs
+++ b/screenpipe-server/src/lib.rs
@@ -6,7 +6,7 @@ mod resource_monitor;
 mod server;
 mod video;
 
-pub use core::{start_continuous_recording, RecorderControl};
+pub use core::{start_continuous_recording, RecordingState};
 pub use db::{ContentType, DatabaseManager, SearchResult};
 pub use logs::MultiWriter;
 pub use resource_monitor::{ResourceMonitor, RestartSignal};

--- a/screenpipe-server/src/server.rs
+++ b/screenpipe-server/src/server.rs
@@ -328,7 +328,7 @@ pub async fn health_check(State(state): State<Arc<AppState>>) -> JsonResponse<He
     debug!("Last audio timestamp: {:?}", last_audio);
 
     let now = Utc::now();
-    let threshold = Duration::from_secs(60);
+    let threshold: Duration = Duration::from_secs(60);
     let loading_threshold = Duration::from_secs(120);
 
     let app_start_time = state.app_start_time;

--- a/screenpipe-server/src/video.rs
+++ b/screenpipe-server/src/video.rs
@@ -17,10 +17,12 @@ use std::time::Duration;
 
 const MAX_FPS: f64 = 30.0; // Adjust based on your needs
 
+#[derive(Debug, Clone)]
 pub struct VideoCapture {
     frame_queue: Arc<Mutex<VecDeque<CaptureResult>>>,
     video_frame_queue: Arc<Mutex<VecDeque<CaptureResult>>>,
     pub ocr_frame_queue: Arc<Mutex<VecDeque<CaptureResult>>>,
+    stop_signal: Arc<Mutex<bool>>,
 }
 
 impl VideoCapture {
@@ -37,6 +39,8 @@ impl VideoCapture {
         let ocr_frame_queue = Arc::new(Mutex::new(VecDeque::new()));
         let new_chunk_callback = Arc::new(new_chunk_callback);
         let new_chunk_callback_clone = Arc::clone(&new_chunk_callback);
+        let stop_signal = Arc::new(Mutex::new(false));
+        let stop_signal_capture = Arc::new(Mutex::new(false));
 
         let capture_frame_queue = frame_queue.clone();
         let capture_video_frame_queue = video_frame_queue.clone();
@@ -49,6 +53,7 @@ impl VideoCapture {
                 save_text_files,
                 ocr_engine,
                 get_monitor().await,
+                stop_signal_capture,
             )
             .await;
         });
@@ -58,6 +63,11 @@ impl VideoCapture {
         // Spawn another thread to handle receiving and queueing the results
         let _queue_thread = tokio::spawn(async move {
             while let Some(result) = result_receiver.recv().await {
+                // throw error for testing smthing
+                // if result.frame_number == 1 {
+                //     error!("Error for testing");
+                //     return;
+                // }
                 let frame_number = result.frame_number;
                 debug!("Received frame {} for queueing", frame_number);
                 let mut queue = capture_frame_queue.lock().await;
@@ -77,21 +87,26 @@ impl VideoCapture {
 
         let video_frame_queue_clone = video_frame_queue.clone();
         let output_path = output_path.to_string();
-        let _video_thread = tokio::spawn(async move {
-            save_frames_as_video(
-                &video_frame_queue_clone,
-                &output_path,
-                fps,
-                new_chunk_callback_clone,
-            )
-            .await;
-        });
-
-        VideoCapture {
+        let video_capture = VideoCapture {
             frame_queue,
             video_frame_queue,
             ocr_frame_queue,
-        }
+            stop_signal,
+        };
+        let video_capture_clone = video_capture.clone();
+
+        let _video_thread = tokio::spawn(async move {
+            video_capture_clone
+                .save_frames_as_video(
+                    &video_frame_queue_clone,
+                    &output_path,
+                    fps,
+                    new_chunk_callback_clone,
+                )
+                .await;
+        });
+
+        video_capture
     }
 
     pub async fn get_latest_frame(&self) -> Option<CaptureResult> {
@@ -104,161 +119,177 @@ impl VideoCapture {
     pub fn get_video_frame_queue(&self) -> Arc<Mutex<VecDeque<CaptureResult>>> {
         Arc::clone(&self.video_frame_queue)
     }
-}
-async fn save_frames_as_video(
-    frame_queue: &Arc<Mutex<VecDeque<CaptureResult>>>,
-    output_path: &str,
-    fps: f64,
-    new_chunk_callback: Arc<dyn Fn(&str) + Send + Sync>,
-) {
-    debug!("Starting save_frames_as_video function");
-    let frames_per_video = 30; // Adjust this value as needed
-    let mut frame_count = 0;
-    let (sender, mut receiver): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = channel(512);
-    let sender = Arc::new(sender);
-    let mut current_ffmpeg: Option<Child> = None;
-    let mut current_stdin: Option<ChildStdin> = None;
 
-    loop {
-        if frame_count % frames_per_video == 0 || current_ffmpeg.is_none() {
-            debug!("Starting new FFmpeg process");
-            // Close previous FFmpeg process if exists
-            if let Some(child) = current_ffmpeg.take() {
-                drop(current_stdin.take()); // Ensure stdin is closed
-                let output = child
-                    .wait_with_output()
-                    .await
-                    .expect("ffmpeg process failed");
-                debug!("FFmpeg process exited with status: {}", output.status);
-                if !output.status.success() {
-                    error!("FFmpeg stderr: {}", String::from_utf8_lossy(&output.stderr));
-                }
+    pub async fn stop(&mut self) {
+        debug!("Stopping VideoCapture");
+        let mut stop_signal = self.stop_signal.lock().await;
+        *stop_signal = true;
+
+        // Wait for a short time to allow other threads to finish
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        debug!("VideoCapture stopped");
+    }
+
+    async fn save_frames_as_video(
+        &self,
+        frame_queue: &Arc<Mutex<VecDeque<CaptureResult>>>,
+        output_path: &str,
+        fps: f64,
+        new_chunk_callback: Arc<dyn Fn(&str) + Send + Sync>,
+    ) {
+        debug!("Starting save_frames_as_video function");
+        let frames_per_video = 30; // Adjust this value as needed
+        let mut frame_count = 0;
+        let (sender, mut receiver): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = channel(512);
+        let sender = Arc::new(sender);
+        let mut current_ffmpeg: Option<Child> = None;
+        let mut current_stdin: Option<ChildStdin> = None;
+
+        loop {
+            if *self.stop_signal.lock().await {
+                debug!("Stopping save_frames_as_video loop");
+                break;
             }
-
-            // Wait for at least one frame before starting a new FFmpeg process
-            let first_frame = loop {
-                if let Some(result) = frame_queue.lock().await.pop_front() {
-                    debug!("Got first frame for new chunk");
-                    break result;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            };
-
-            // Encode the first frame
-            let mut buffer = Vec::new();
-            first_frame
-                .image
-                .write_to(&mut std::io::Cursor::new(&mut buffer), ImageFormat::Png)
-                .expect("Failed to encode first frame");
-
-            let time = Utc::now();
-            let formatted_time = time.format("%Y-%m-%d_%H-%M-%S").to_string();
-            // Start new FFmpeg process with a new output file
-            let output_file = PathBuf::from(output_path)
-                .join(format!("{}.mp4", formatted_time))
-                .to_str()
-                .expect("Failed to create valid path")
-                .to_string();
-
-            // Call the callback with the new video chunk file path
-            new_chunk_callback(&output_file);
-
-            match start_ffmpeg_process(&output_file, fps).await {
-                Ok(mut child) => {
-                    let mut stdin = child.stdin.take().expect("Failed to open stdin");
-                    let stderr = child.stderr.take().expect("Failed to open stderr");
-                    let stdout = child.stdout.take().expect("Failed to open stdout");
-
-                    // Write the first frame to FFmpeg
-                    stdin
-                        .write_all(&buffer)
+            if frame_count % frames_per_video == 0 || current_ffmpeg.is_none() {
+                debug!("Starting new FFmpeg process");
+                // Close previous FFmpeg process if exists
+                if let Some(child) = current_ffmpeg.take() {
+                    drop(current_stdin.take()); // Ensure stdin is closed
+                    let output = child
+                        .wait_with_output()
                         .await
-                        .expect("Failed to write first frame to ffmpeg");
-                    frame_count += 1;
-
-                    // Spawn a task to log FFmpeg's stderr
-                    tokio::spawn(async move {
-                        let reader = BufReader::new(stderr);
-                        let mut lines = reader.lines();
-                        while let Ok(Some(line)) = lines.next_line().await {
-                            debug!("FFmpeg: {}", line);
-                        }
-                    });
-
-                    // Log FFmpeg's stdout
-                    tokio::spawn(async move {
-                        let reader = BufReader::new(stdout);
-                        let mut lines = reader.lines();
-                        while let Ok(Some(line)) = lines.next_line().await {
-                            debug!("FFmpeg: {}", line);
-                        }
-                    });
-
-                    current_ffmpeg = Some(child);
-                    current_stdin = Some(stdin);
-                    debug!("New FFmpeg process started for file: {}", output_file);
+                        .expect("ffmpeg process failed");
+                    debug!("FFmpeg process exited with status: {}", output.status);
+                    if !output.status.success() {
+                        error!("FFmpeg stderr: {}", String::from_utf8_lossy(&output.stderr));
+                    }
                 }
-                Err(e) => {
-                    error!("Failed to start FFmpeg process: {}", e);
-                    // Handle the error appropriately, maybe try to restart or exit
-                }
-            }
-        }
 
-        if let Some(result) = frame_queue.lock().await.pop_front() {
-            debug!("Processing frame in video.rs"); // {}", frame_count + 1
-            let sender = Arc::clone(&sender);
+                // Wait for at least one frame before starting a new FFmpeg process
+                let first_frame = loop {
+                    if let Some(result) = frame_queue.lock().await.pop_front() {
+                        debug!("Got first frame for new chunk");
+                        break result;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                };
 
-            tokio::spawn(async move {
+                // Encode the first frame
                 let mut buffer = Vec::new();
-                match result
+                first_frame
                     .image
                     .write_to(&mut std::io::Cursor::new(&mut buffer), ImageFormat::Png)
-                {
-                    Ok(_) => {
-                        sender
-                            .send(buffer)
-                            .await
-                            .expect("Failed to send encoded frame");
-                    }
-                    Err(e) => error!("Failed to encode image as PNG: {}", e),
-                }
-            });
-        } else {
-            // debug!("No frames in queue, waiting...");
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
+                    .expect("Failed to encode first frame");
 
-        // Write encoded frames to FFmpeg
-        while let Ok(buffer) = receiver.try_recv() {
-            if let Some(stdin) = current_stdin.as_mut() {
-                match stdin.write_all(buffer.as_slice()).await {
-                    Ok(_) => {
+                let time = Utc::now();
+                let formatted_time = time.format("%Y-%m-%d_%H-%M-%S").to_string();
+                // Start new FFmpeg process with a new output file
+                let output_file = PathBuf::from(output_path)
+                    .join(format!("{}.mp4", formatted_time))
+                    .to_str()
+                    .expect("Failed to create valid path")
+                    .to_string();
+
+                // Call the callback with the new video chunk file path
+                new_chunk_callback(&output_file);
+
+                match start_ffmpeg_process(&output_file, fps).await {
+                    Ok(mut child) => {
+                        let mut stdin = child.stdin.take().expect("Failed to open stdin");
+                        let stderr = child.stderr.take().expect("Failed to open stderr");
+                        let stdout = child.stdout.take().expect("Failed to open stdout");
+
+                        // Write the first frame to FFmpeg
+                        stdin
+                            .write_all(&buffer)
+                            .await
+                            .expect("Failed to write first frame to ffmpeg");
                         frame_count += 1;
-                        debug!("Wrote frame {} to FFmpeg", frame_count);
+
+                        // Spawn a task to log FFmpeg's stderr
+                        tokio::spawn(async move {
+                            let reader = BufReader::new(stderr);
+                            let mut lines = reader.lines();
+                            while let Ok(Some(line)) = lines.next_line().await {
+                                debug!("FFmpeg: {}", line);
+                            }
+                        });
+
+                        // Log FFmpeg's stdout
+                        tokio::spawn(async move {
+                            let reader = BufReader::new(stdout);
+                            let mut lines = reader.lines();
+                            while let Ok(Some(line)) = lines.next_line().await {
+                                debug!("FFmpeg: {}", line);
+                            }
+                        });
+
+                        current_ffmpeg = Some(child);
+                        current_stdin = Some(stdin);
+                        debug!("New FFmpeg process started for file: {}", output_file);
                     }
                     Err(e) => {
-                        error!("Failed to write frame to ffmpeg: {}", e);
-                        if e.kind() == std::io::ErrorKind::BrokenPipe {
-                            warn!("FFmpeg process may have terminated unexpectedly. Restarting...");
-                            break;
-                        }
-                    }
-                }
-
-                // Flush every second
-                if frame_count % fps as usize == 0 {
-                    debug!("Flushing FFmpeg input");
-                    if let Err(e) = stdin.flush().await {
-                        error!("Failed to flush FFmpeg input: {}", e);
+                        error!("Failed to start FFmpeg process: {}", e);
+                        // Handle the error appropriately, maybe try to restart or exit
                     }
                 }
             }
-        }
 
-        // Yield to other tasks periodically
-        if frame_count % 100 == 0 {
-            tokio::task::yield_now().await;
+            if let Some(result) = frame_queue.lock().await.pop_front() {
+                debug!("Processing frame in video.rs"); // {}", frame_count + 1
+                let sender = Arc::clone(&sender);
+
+                tokio::spawn(async move {
+                    let mut buffer = Vec::new();
+                    match result
+                        .image
+                        .write_to(&mut std::io::Cursor::new(&mut buffer), ImageFormat::Png)
+                    {
+                        Ok(_) => {
+                            sender
+                                .send(buffer)
+                                .await
+                                .expect("Failed to send encoded frame");
+                        }
+                        Err(e) => error!("Failed to encode image as PNG: {}", e),
+                    }
+                });
+            } else {
+                // debug!("No frames in queue, waiting...");
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+
+            // Write encoded frames to FFmpeg
+            while let Ok(buffer) = receiver.try_recv() {
+                if let Some(stdin) = current_stdin.as_mut() {
+                    match stdin.write_all(buffer.as_slice()).await {
+                        Ok(_) => {
+                            frame_count += 1;
+                            debug!("Wrote frame {} to FFmpeg", frame_count);
+                        }
+                        Err(e) => {
+                            error!("Failed to write frame to ffmpeg: {}", e);
+                            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                                warn!("FFmpeg process may have terminated unexpectedly. Restarting...");
+                                return;
+                            }
+                        }
+                    }
+
+                    // Flush every second
+                    if frame_count % fps as usize == 0 {
+                        debug!("Flushing FFmpeg input");
+                        if let Err(e) = stdin.flush().await {
+                            error!("Failed to flush FFmpeg input: {}", e);
+                        }
+                    }
+                }
+            }
+
+            // Yield to other tasks periodically
+            if frame_count % 100 == 0 {
+                tokio::task::yield_now().await;
+            }
         }
     }
 }

--- a/screenpipe-vision/src/bin/screenpipe-vision.rs
+++ b/screenpipe-vision/src/bin/screenpipe-vision.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use screenpipe_vision::{continuous_capture, get_monitor, OcrEngine};
 use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc::channel;
+use tokio::sync::{mpsc::channel, Mutex};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -22,6 +22,7 @@ async fn main() {
     let (result_tx, mut result_rx) = channel(512);
 
     let save_text_files = cli.save_text_files;
+    let stop_signal = Arc::new(Mutex::new(false));
 
     let capture_thread = tokio::spawn(async move {
         continuous_capture(
@@ -30,6 +31,7 @@ async fn main() {
             save_text_files,
             Arc::new(OcrEngine::Tesseract),
             get_monitor().await,
+            stop_signal.clone(),
         )
         .await
     });


### PR DESCRIPTION
fix and implement a self-healing mode

why?

sometimes the frame or audio recording become stale after long time or on windows when computer sleep long enough or IDK

i'd rather make the code antifragile/redundant at high level first than spending decades digging into low parts



- it checks if the /health endpoint returns unhealthy, which is a state when last frame and last audio chunk has not been added to the db for a while
- it avoids infinite loop restart through cooldown
- it properly stop inner loops running in threads etc 


different ways to test this PR:

```bash
cargo build --release # add --features metal on mac
./target/release/screenpipe --self-healing
```

1. passive: run  for decades (24h+) and search in the log "restart" or things like this, or see if everything still runs smoothly, 
2. active:
  - try to make your computer sleep etc.
  - try to kill stuff, like turning off permissions, (killing ffmpeg unlikely will be detected as crash as our KPI here is data inserted in db), try to delete your db maybe? or turning the audio device currently used, or blocking the API idk


on my side it was working, but need to test deeper


PS: went kinda bulldozer removing lot of dead code, so would be nice to merge fast otherwise feel like this PR will die
