### PR TITLE
fix(ci): create CrabNebula Cloud release on a separate job

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -13,7 +13,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: create draft release
+        uses: crabnebula-dev/cloud-release@v0.2.0
+        with:
+          command: release draft ${{ secrets.CN_APP_SLUG }} --framework tauri
+          api-key: ${{ secrets.CN_API_KEY }}
+
   publish-tauri:
+    needs: draft
     permissions:
       contents: write
     strategy:
@@ -164,12 +177,6 @@ jobs:
           projectPath: "./examples/apps/screenpipe-app-tauri"
           tauriScript: bunx tauri -v
 
-      - name: Create CrabNebula Cloud Release Draft
-        uses: crabnebula-dev/cloud-release@v0.2.0
-        with:
-          command: release draft ${{ secrets.CN_APP_SLUG }} --framework tauri
-          api-key: ${{ secrets.CN_API_KEY }}
-
       - name: Upload Assets to CrabNebula Cloud
         uses: crabnebula-dev/cloud-release@v0.2.0
         with:
@@ -177,9 +184,18 @@ jobs:
           api-key: ${{ secrets.CN_API_KEY }}
           path: ./examples/apps/screenpipe-app-tauri/src-tauri
 
-      # - name: Publish CrabNebula Cloud Release
-      #   uses: crabnebula-dev/cloud-release@v0.2.0
-      #   with:
-      #     command: release publish ${{ secrets.CN_APP_SLUG }} --framework tauri
-      #     api-key: ${{ secrets.CN_API_KEY }}
-      # basically wait for macos manual add sset
+  # basically wait for macos manual add sset
+  #publish:
+  #  needs: publish-tauri
+
+  #  runs-on: ubuntu-latest
+
+  #  steps:
+  #    - uses: actions/checkout@v4
+
+  #    - name: publish release
+  #      uses: crabnebula-dev/cloud-release@v0.2.0
+  #      with:
+  #        command: release publish ${{ secrets.CN_APP_SLUG }} --framework tauri
+  #        api-key: ${{ secrets.CN_API_KEY }}
+  


### PR DESCRIPTION
Following https://docs.crabnebula.dev/cloud/continuous-integration/#tauri-workflow