### PR TITLE
Hotfix/issue_183/memory leakage

### DIFF
--- a/screenpipe-server/src/video.rs
+++ b/screenpipe-server/src/video.rs
@@ -15,7 +15,7 @@ use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 const MAX_FPS: f64 = 30.0; // Adjust based on your needs
-const MAX_QUEUE_SIZE: usize = 100;
+const MAX_QUEUE_SIZE: usize = 10;
 
 pub struct VideoCapture {
     #[allow(unused)]

--- a/screenpipe-server/src/video.rs
+++ b/screenpipe-server/src/video.rs
@@ -88,11 +88,11 @@ impl VideoCapture {
 
                 let result = Arc::new(result);
 
-                let frame_pushed = push_to_queue(&capture_frame_queue, &result, "Frame");
+                // let frame_pushed = push_to_queue(&capture_frame_queue, &result, "Frame");
                 let video_pushed = push_to_queue(&capture_video_frame_queue, &result, "Video");
                 let ocr_pushed = push_to_queue(&capture_ocr_frame_queue, &result, "OCR");
 
-                if !frame_pushed || !video_pushed || !ocr_pushed {
+                if !video_pushed || !ocr_pushed {
                     error!(
                         "Failed to push frame {} to one or more queues",
                         frame_number


### PR DESCRIPTION
frame_queue is not being consumed anywhere right now. It grew to a very large size which was increasing the memory extremely high. The maximum memory must be dependent on the monitor resolution as the frame size would differ. 

This led to a tremendous increase in memory utilization. 

We have capped the max queue size and also stopped pushing to the queue. If we want to consume it later, we can again start pushing.

After the changed, tried running `.\target\release\screenpipe.exe --ocr-engine windows-native --disable-audio` for constantly 1 hour, the memory spike never occurred. I think this could potentially solve #183

Tested it exhaustively on Windows. Need to test it on mac + linux.

### How did you test?
- The mp4 files are being generated, checked it in the \.screenpipe\data
- No Error logs in debug mode