### PR TITLE
fix windows build

### DIFF
--- a/screenpipe-server/Cargo.toml
+++ b/screenpipe-server/Cargo.toml
@@ -97,6 +97,9 @@ name = "new_db_benchmark"
 harness = false
 
 [features]
+default = []
+
+[target.'cfg(any(target_os = "macos", target_os = "linux"))'.features]
 default = ["pipes"]
 
 metal = ["candle/metal", "candle-nn/metal", "candle-transformers/metal"]


### PR DESCRIPTION
Fix windows build:

```
Compiling sqlx-macros v0.7.4
Compiling console-api v0.7.0
Compiling ffmpeg-next v7.0.4
Compiling screenpipe-vision v0.1.68 (D:\Projects\screen-pipe\screenpipe-vision)
error: failed to run custom build command for `v8 v0.92.0`
```