### PR TITLE
fix: windows audio vision continuous recording

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.1.78"
+version = "0.1.79"
 authors = ["louis030195 <hi@louis030195.com>"]
 description = ""
 repository = "https://github.com/mediar-ai/screenpipe"

--- a/examples/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/examples/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "screenpipe-app"
-version = "0.1.87"
+version = "0.1.88"
 description = ""
 authors = ["you"]
 license = ""

--- a/screenpipe-audio/benches/record_and_transcribe_benchmark.rs
+++ b/screenpipe-audio/benches/record_and_transcribe_benchmark.rs
@@ -33,7 +33,11 @@ async fn setup_test() -> (
 }
 
 fn bench_record_and_transcribe(c: &mut Criterion) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+    .worker_threads(4)  // Adjust based on your system
+    .enable_all()
+    .build()
+    .unwrap();
 
     let mut group = c.benchmark_group("Record and Transcribe");
     group.sample_size(10);

--- a/screenpipe-server/src/core.rs
+++ b/screenpipe-server/src/core.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::task::JoinHandle;
 
@@ -33,6 +34,8 @@ pub async fn start_continuous_recording(
     monitor_id: u32,
     use_pii_removal: bool,
     vision_disabled: bool,
+    vision_handle: &Handle,
+    audio_handle: &Handle,
 ) -> Result<()> {
     let (whisper_sender, whisper_receiver, whisper_shutdown_flag) = if audio_disabled {
         // Create a dummy channel if no audio devices are available, e.g. audio disabled
@@ -69,8 +72,8 @@ pub async fn start_continuous_recording(
         ));
     }
 
-    let video_handle = if !vision_disabled {
-        tokio::spawn(async move {
+    let video_task = if !vision_disabled {
+        vision_handle.spawn(async move {
             record_video(
                 db_manager_video,
                 output_path_video,
@@ -85,14 +88,14 @@ pub async fn start_continuous_recording(
             .await
         })
     } else {
-        tokio::spawn(async move {
+        vision_handle.spawn(async move {
             tokio::time::sleep(Duration::from_secs(60)).await;
             Ok(())
         })
     };
 
-    let audio_handle = if !audio_disabled {
-        tokio::spawn(async move {
+    let audio_task = if !audio_disabled {
+        audio_handle.spawn(async move {
             record_audio(
                 db_manager_audio,
                 output_path_audio,
@@ -106,14 +109,14 @@ pub async fn start_continuous_recording(
             .await
         })
     } else {
-        tokio::spawn(async move {
+        audio_handle.spawn(async move {
             tokio::time::sleep(Duration::from_secs(60)).await;
             Ok(())
         })
     };
 
     // Wait for both tasks to complete
-    let (video_result, audio_result) = tokio::join!(video_handle, audio_handle);
+    let (video_result, audio_result) = tokio::join!(video_task, audio_task);
 
     // Handle any errors from the tasks
     if let Err(e) = video_result {

--- a/screenpipe-server/src/video.rs
+++ b/screenpipe-server/src/video.rs
@@ -32,7 +32,14 @@ impl VideoCapture {
         ocr_engine: Arc<OcrEngine>,
         monitor_id: u32,
     ) -> Self {
-        info!("Starting new video capture");
+            info!("Starting new video capture");
+        let fps = if fps.is_finite() && fps > 0.0 {
+            fps
+        } else {
+            warn!("Invalid FPS value: {}. Using default of 1.0", fps);
+            1.0
+        };
+        let interval = Duration::from_secs_f64(1.0 / fps);
         let video_frame_queue = Arc::new(ArrayQueue::new(MAX_QUEUE_SIZE));
         let ocr_frame_queue = Arc::new(ArrayQueue::new(MAX_QUEUE_SIZE));
         let new_chunk_callback = Arc::new(new_chunk_callback);
@@ -44,7 +51,7 @@ impl VideoCapture {
         let _capture_thread = tokio::spawn(async move {
             continuous_capture(
                 result_sender,
-                Duration::from_secs_f64(1.0 / fps),
+                interval,
                 save_text_files,
                 *ocr_engine,
                 monitor_id,

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -71,6 +71,7 @@ pub async fn continuous_capture(
     loop {
         let capture_result = match capture_screenshot(&monitor).await {
             Ok((image, window_images, image_hash, _capture_duration)) => {
+                debug!("Captured screenshot on monitor {} with hash: {}", monitor_id, image_hash);
                 Some((image, window_images, image_hash))
             }
             Err(e) => {

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -60,7 +60,13 @@ pub async fn continuous_capture(
     let mut max_average: Option<MaxAverageFrame> = None;
     let mut max_avg_value = 0.0;
 
-    let monitor = get_monitor_by_id(monitor_id).await.unwrap();
+    let monitor = match get_monitor_by_id(monitor_id).await {
+        Some(m) => m,
+        None => {
+            error!("Failed to get monitor with id: {}. Exiting continuous_capture.", monitor_id);
+            return;
+        }
+    };
 
     loop {
         let capture_result = match capture_screenshot(&monitor).await {

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -195,7 +195,9 @@ pub async fn process_ocr_task(
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
             OcrEngine::Tesseract => perform_ocr_tesseract(&window_image),
             #[cfg(target_os = "windows")]
-            OcrEngine::WindowsNative => perform_ocr_windows(&window_image).await,
+            OcrEngine::WindowsNative => perform_ocr_windows(&window_image)
+                .await
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?,
             #[cfg(target_os = "macos")]
             OcrEngine::AppleNative => parse_apple_ocr_result(&perform_ocr_apple(&window_image)),
             _ => {

--- a/screenpipe-vision/src/microsoft.rs
+++ b/screenpipe-vision/src/microsoft.rs
@@ -1,6 +1,8 @@
-use image::DynamicImage;
+use image::{DynamicImage, GenericImageView};
+use anyhow::{Result, bail};
+
 #[cfg(target_os = "windows")]
-pub async fn perform_ocr_windows(image: &DynamicImage) -> (String, String, Option<f64>) {
+pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String, Option<f64>)> {
     use std::io::Cursor;
     use windows::{
         Graphics::Imaging::BitmapDecoder,
@@ -8,29 +10,33 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> (String, String, Optio
         Storage::Streams::{DataWriter, InMemoryRandomAccessStream},
     };
 
+    // Check image dimensions
+    let (width, height) = image.dimensions();
+    if width == 0 || height == 0 {
+        bail!("Invalid image dimensions: {}x{}", width, height);
+    }
+
     let mut buffer = Vec::new();
     image
         .write_to(&mut Cursor::new(&mut buffer), image::ImageFormat::Png)
-        .unwrap();
+        .map_err(|e| anyhow::anyhow!("Failed to write image to buffer: {}", e))?;
 
-    let stream = InMemoryRandomAccessStream::new().unwrap();
-    let writer = DataWriter::CreateDataWriter(&stream).unwrap();
-    writer.WriteBytes(&buffer).unwrap();
-    writer.StoreAsync().unwrap().get().unwrap();
-    writer.FlushAsync().unwrap().get().unwrap();
-    stream.Seek(0).unwrap();
+    let stream = InMemoryRandomAccessStream::new()?;
+    let writer = DataWriter::CreateDataWriter(&stream)?;
+    writer.WriteBytes(&buffer)?;
+    writer.StoreAsync()?.get()?;
+    writer.FlushAsync()?.get()?;
+    stream.Seek(0)?;
 
-    let decoder = BitmapDecoder::CreateWithIdAsync(BitmapDecoder::PngDecoderId().unwrap(), &stream)
-        .unwrap()
-        .get()
-        .unwrap();
+    let decoder = BitmapDecoder::CreateWithIdAsync(BitmapDecoder::PngDecoderId()?, &stream)?
+        .get()?;
 
-    let bitmap = decoder.GetSoftwareBitmapAsync().unwrap().get().unwrap();
+    let bitmap = decoder.GetSoftwareBitmapAsync()?.get()?;
 
-    let engine = WindowsOcrEngine::TryCreateFromUserProfileLanguages().unwrap();
-    let result = engine.RecognizeAsync(&bitmap).unwrap().get().unwrap();
+    let engine = WindowsOcrEngine::TryCreateFromUserProfileLanguages()?;
+    let result = engine.RecognizeAsync(&bitmap)?.get()?;
 
-    let text = result.Text().unwrap().to_string();
+    let text = result.Text()?.to_string();
 
     let json_output = serde_json::json!([{
         "text": text,
@@ -38,5 +44,5 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> (String, String, Optio
     }])
     .to_string();
 
-    (text, json_output, Some(1.0))
+    Ok((text, json_output, Some(1.0)))
 }

--- a/screenpipe-vision/src/microsoft.rs
+++ b/screenpipe-vision/src/microsoft.rs
@@ -1,5 +1,5 @@
 use image::{DynamicImage, GenericImageView};
-use anyhow::{Result, bail};
+use anyhow::Result;
 
 #[cfg(target_os = "windows")]
 pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String, Option<f64>)> {
@@ -13,7 +13,8 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String
     // Check image dimensions
     let (width, height) = image.dimensions();
     if width == 0 || height == 0 {
-        bail!("Invalid image dimensions: {}x{}", width, height);
+        // Return an empty result instead of panicking
+        return Ok(("".to_string(), "[]".to_string(), None));
     }
 
     let mut buffer = Vec::new();


### PR DESCRIPTION
- separate audio and vision jobs into their own runners
- specify 4 threads for tokio runner
- prevent windows ocr panicking from killing the runner
- bump minor versions

![image](https://github.com/user-attachments/assets/94f88ce6-5f33-41ac-8eab-3306d9a3246e)

/claim #226