### PR TITLE
Dont panic if host has no default input device

### DIFF
--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -355,7 +355,9 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
 
 pub fn default_input_device() -> Result<AudioDevice> {
     let host = cpal::default_host();
-    let device = host.default_input_device().unwrap();
+    let device = host
+        .default_input_device()
+        .ok_or(anyhow!("No default input device detected"))?;
     Ok(AudioDevice::new(device.name()?, DeviceType::Input))
 }
 // this should be optional ?


### PR DESCRIPTION
The `default_input_device()` function on core.rs returns a Result<AudioDevice>, but panics if there is none. By replacing the unwrap with ok_or, we prevent panicking and instead return an Error.