### PR TITLE
Fix assorted typos and spelling

### DIFF
--- a/content/docs/NOTES.md
+++ b/content/docs/NOTES.md
@@ -9,7 +9,7 @@ Any other issue? [Will solve your problem in less than 15 min](https://cal.com/l
   <summary>Frames not recorded</summary>
 
   Try a different monitor. `screenpipe --list-monitors` and `screenpipe --monitor-id <monitor id>`
-    
+
   </details>
 
   <details>
@@ -23,20 +23,20 @@ Abort trap: 6
 >
 
   i'll investigate this issue now, in the meantime you can do this:
-  
+
   ```
   brew tap mediar-ai/screenpipe https://github.com/mediar-ai/screenpipe.git
   brew install screenpipe
   ```
-  
-  
-  and then 
-  
+
+
+  and then
+
   ```
   cd
   screenpipe --ocr-engine apple-native
   ```
-  
+
   </details>
 
   <details>
@@ -46,26 +46,26 @@ Abort trap: 6
   Sometimes this happen when computer goes to sleep for long. Just restart. We're going to make it fix itself automatically soon.
 
   </details>
-  
+
   <details>
 
   <summary>Permission error in Windows</summary>
 
   If you run into this error in your CMD terminal using CLI you should run the terminal as administrator (right click on the icon)
-  
+
   </details>
-  
+
   <details>
 
   <summary>`TESSDATA_PREFIX` error</summary>
 
-  This can happen on Windows. 
-  
+  This can happen on Windows.
+
   - Type "environment" in the search bar of Windows, and click environment variables.
   - Click "new" (the first one).
   - The key will be `TESSDATA_PREFIX` and the value will be the path you installed screenpipe (default is `C:\Users\<your username>\AppData\Local\screenpipe`)
 
-  You can also try our experimental Windows OCR engine by adding `--ocr-engine windows-native` which sould solve the above problem too
+  You can also try our experimental Windows OCR engine by adding `--ocr-engine windows-native` which should solve the above problem too
 
   </details>
 
@@ -93,7 +93,7 @@ Abort trap: 6
   <summary>I can't install screenpipe</summary>
 
   Make sure to press control + right click on the `.dmg` file and press open
-  
+
   <img width="372" alt="Screenshot 2024-07-24 at 16 07 22" src="https://github.com/user-attachments/assets/1b077f0f-0b90-4d40-b61d-ba11c8a8285c">
 
   Then drag the app to your application folder
@@ -115,18 +115,18 @@ Abort trap: 6
 
 <details>
   <summary>All files are 10 KB</summary>
-  
+
   Some audio files might be small, like when there is no sound at all.
 </details>
 
 <details>
   <summary>MacOS Audio does not work</summary>
-  
-  Make sure to enable permissions in settings. 
+
+  Make sure to enable permissions in settings.
   <img width="827" alt="Screenshot 2024-07-24 at 16 08 51" src="https://github.com/user-attachments/assets/799c0834-8d35-476b-80f8-67f94342b891">
 
   Still does not work? Remove and re-enable the permission: click on screenpipe and click the minus "-" icon:
-  
+
 ![Screenshot 2024-07-30 at 14 41 33](https://github.com/user-attachments/assets/3b67bd52-c9a1-4fb0-a4be-3e7713c54ebd)
 
   Then restart screenpipe and the dialog of permission should pop again and enable it, restarting screenpipe
@@ -135,12 +135,12 @@ Abort trap: 6
 
 <details>
   <summary>MacOS Screen capture does not work</summary>
-  
-   Make sure to enable permissions in settings. 
+
+   Make sure to enable permissions in settings.
   <img width="827" alt="Screenshot 2024-07-24 at 16 08 51" src="https://github.com/user-attachments/assets/799c0834-8d35-476b-80f8-67f94342b891">
 
   Still does not work? Remove and re-enable the permission: click on screenpipe and click the minus "-" icon:
-  
+
 ![Screenshot 2024-07-30 at 14 41 33](https://github.com/user-attachments/assets/3b67bd52-c9a1-4fb0-a4be-3e7713c54ebd)
 
   Then restart screenpipe and the dialog of permission should pop again and enable it, restarting screenpipe
@@ -156,11 +156,11 @@ Abort trap: 6
     Windows: Using the app, you can find the data in C:\Users\AppData\Local\screenpipe
     MacOS: Using the app, you can find the data in ~/Library/Application Support/screenpipe
     Linux: Using the app, you can find the data in ~/.config/screenpipe
-  
+
 </details>
 
 <details>
   <summary>How can I interpret my data more intuitively?</summary>
 
-  We recommend using [TablePlus](https://tableplus.com/) to open the SQLite database located alongside the data. 
+  We recommend using [TablePlus](https://tableplus.com/) to open the SQLite database located alongside the data.
 </details>

--- a/examples/typescript/apple-shortcut/main.js
+++ b/examples/typescript/apple-shortcut/main.js
@@ -59,7 +59,7 @@ async function runScreenpipe(input) {
         messages: [
             {
                 role: "user",
-                content: `Based on this user selection: "${input}", generate parameters as JSON for 3 different queries to screenpipe. Each query should have "q", "offset", "limit", and start_time, end_time fields. Rules: - q should be a single keyword that would properly find in the text found on the user screen some information that would help answering the user question. Return a list of objects with the key "queries" - q contains a single query, again, for example instead of "life plan" just use "life" - Respond with only the updated JSON object - User's Date & time now is ${currentDate} - Make sure to respect user's date - Be concise, asnwer as a bullet list - Your answer will be read out loud so make sure it's adapted`
+                content: `Based on this user selection: "${input}", generate parameters as JSON for 3 different queries to screenpipe. Each query should have "q", "offset", "limit", and start_time, end_time fields. Rules: - q should be a single keyword that would properly find in the text found on the user screen some information that would help answering the user question. Return a list of objects with the key "queries" - q contains a single query, again, for example instead of "life plan" just use "life" - Respond with only the updated JSON object - User's Date & time now is ${currentDate} - Make sure to respect user's date - Be concise, answer as a bullet list - Your answer will be read out loud so make sure it's adapted`
             }
         ],
         model: OPENAI_MODEL,

--- a/examples/typescript/pipe-meeting-summary-by-email/pipe.ts
+++ b/examples/typescript/pipe-meeting-summary-by-email/pipe.ts
@@ -4,7 +4,7 @@ async function summarizeAudio(
   aiModel: string,
   customSummaryPrompt: string
 ): Promise<string> {
-  const prompt = `Very important intructions to follow: "${customSummaryPrompt}"
+  const prompt = `Very important instructions to follow: "${customSummaryPrompt}"
 
     summarize the following meeting transcript:
 
@@ -63,7 +63,7 @@ async function checkTimeAdjustment(
 
     ${JSON.stringify(audioData)}
 
-    Determine if this appears to be a complete meeting or if it might be truncated. 
+    Determine if this appears to be a complete meeting or if it might be truncated.
     Return a JSON object with the following structure:
     {
       "shouldAdjust": boolean,

--- a/examples/typescript/vercel-ai-chatbot/components/empty-screen.tsx
+++ b/examples/typescript/vercel-ai-chatbot/components/empty-screen.tsx
@@ -12,7 +12,7 @@ export function EmptyScreen() {
           Welcome to ScreenPipe AI Chatbot!
         </h1>
         <p className="leading-normal text-muted-foreground">
-          This is an example AI Assistant implmenetation using{' '}
+          This is an example AI Assistant implementation using{' '}
           <ExternalLink href="https://nextjs.org">Next.js</ExternalLink>, the{' '}
           <ExternalLink href="https://sdk.vercel.ai">
             Vercel AI SDK

--- a/screenpipe-app-tauri/components/chat-list-web-llm.tsx
+++ b/screenpipe-app-tauri/components/chat-list-web-llm.tsx
@@ -252,7 +252,7 @@ export function ChatList() {
                 <div>
                   <div className="font-medium">GPT-4</div>
                   <div className="text-muted-foreground/80">
-                    With DALL-E, browing and analysis. Limit 40 messages / 3
+                    With DALL-E, browsing and analysis. Limit 40 messages / 3
                     hours
                   </div>
                 </div>

--- a/screenpipe-app-tauri/components/notification-handler.tsx
+++ b/screenpipe-app-tauri/components/notification-handler.tsx
@@ -17,7 +17,7 @@ const NotificationHandler: React.FC = () => {
   useEffect(() => {
     const checkAndRequestPermission = async () => {
       let permission = await isPermissionGranted();
-      console.log("notifcation permission", permission);
+      console.log("notification permission", permission);
 
       if (!permission) {
         const result = await requestPermission();

--- a/screenpipe-app-tauri/src-tauri/gen/schemas/desktop-schema.json
+++ b/screenpipe-app-tauri/src-tauri/gen/schemas/desktop-schema.json
@@ -37,7 +37,7 @@
   ],
   "definitions": {
     "Capability": {
-      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows fine grained access to the Tauri core, application, or plugin commands. If a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, \"platforms\": [\"macOS\",\"windows\"] } ```",
+      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows fine grained access to the Tauri core, application, or plugin commands. If a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, \"platforms\": [\"macOS\",\"windows\"] } ```",
       "type": "object",
       "required": [
         "identifier",
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programatic access to files selected by the user.",
+          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.",
           "default": "",
           "type": "string"
         },

--- a/screenpipe-app-tauri/src-tauri/gen/schemas/macOS-schema.json
+++ b/screenpipe-app-tauri/src-tauri/gen/schemas/macOS-schema.json
@@ -37,7 +37,7 @@
   ],
   "definitions": {
     "Capability": {
-      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows fine grained access to the Tauri core, application, or plugin commands. If a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, \"platforms\": [\"macOS\",\"windows\"] } ```",
+      "description": "A grouping and boundary mechanism developers can use to isolate access to the IPC layer.\n\nIt controls application windows fine grained access to the Tauri core, application, or plugin commands. If a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create groups of windows, based on their required system access, which can reduce impact of frontend vulnerabilities in less privileged windows. Windows can be added to a capability by exact name (e.g. `main-window`) or glob patterns like `*` or `admin-*`. A Window can have none, one, or multiple associated capabilities.\n\n## Example\n\n```json { \"identifier\": \"main-user-files-write\", \"description\": \"This capability allows the `main` window on macOS and Windows access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.\", \"windows\": [ \"main\" ], \"permissions\": [ \"core:default\", \"dialog:open\", { \"identifier\": \"fs:allow-write-text-file\", \"allow\": [{ \"path\": \"$HOME/test.txt\" }] }, \"platforms\": [\"macOS\",\"windows\"] } ```",
       "type": "object",
       "required": [
         "identifier",
@@ -49,7 +49,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programatic access to files selected by the user.",
+          "description": "Description of what the capability is intended to allow on associated windows.\n\nIt should contain a description of what the grouped permissions should allow.\n\n## Example\n\nThis capability allows the `main` window access to `filesystem` write related commands and `dialog` commands to enable programmatic access to files selected by the user.",
           "default": "",
           "type": "string"
         },

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -343,7 +343,7 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     // macos hack using screen capture kit for output devices - does not work well
     #[cfg(target_os = "macos")]
     {
-        // !HACK macos is suppoed to use special macos feature "display capture"
+        // !HACK macos is supposed to use special macos feature "display capture"
         // ! see https://github.com/RustAudio/cpal/pull/894
         if let Ok(host) = cpal::host_from_id(cpal::HostId::ScreenCaptureKit) {
             for device in host.input_devices()? {

--- a/screenpipe-server/src/cli.rs
+++ b/screenpipe-server/src/cli.rs
@@ -100,7 +100,7 @@ pub struct Cli {
     /// Your screen rarely change more than 1 times within a second, right?
     #[cfg_attr(not(target_os = "macos"), arg(short, long, default_value_t = 1.0))]
     #[cfg_attr(target_os = "macos", arg(short, long, default_value_t = 0.2))] 
-    pub fps: f64, // ! not crazy about this (unconsistent behaviour across platforms) see https://github.com/mediar-ai/screenpipe/issues/173
+    pub fps: f64, // ! not crazy about this (inconsistent behaviour across platforms) see https://github.com/mediar-ai/screenpipe/issues/173
     
     /// Audio chunk duration in seconds
     #[arg(short = 'd', long, default_value_t = 30)]

--- a/screenpipe-vision/src/monitor.rs
+++ b/screenpipe-vision/src/monitor.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use xcap::{Monitor, Window};
 
 // ! logic here: we pick the biggest window and assume it's the one showing the most text that will be grabbed by OCR
-// TODO: longer term we should define a data strcture for OCR on specific monitor, window, etc.
+// TODO: longer term we should define a data structure for OCR on specific monitor, window, etc.
 pub async fn get_focused_window(monitor: Arc<Monitor>) -> Option<Window> {
     let windows = Window::all().unwrap_or_default();
 


### PR DESCRIPTION
This pull request includes several typo corrections across multiple files to improve code readability and accuracy. The changes span various components, including documentation, TypeScript code, JSON schemas, and Rust source files.

### Typo Corrections:

* [`content/docs/NOTES.md`](diffhunk://#diff-1f9d4d4da656cd5d792e933ffd5dfcb8f593ab72797aeef6cb48f92916e0f515L68-R68): Corrected "sould" to "should".
* [`examples/typescript/apple-shortcut/main.js`](diffhunk://#diff-950bf2bbceb90df11ac31c60081fd1f9022080ec8e5da34b867c2d709156851cL62-R62): Corrected "asnwer" to "answer".
* [`examples/typescript/pipe-meeting-summary-by-email/pipe.ts`](diffhunk://#diff-385d15302a08bae9816efd13913ecfac2cd8f16307a1c16bf016e66d544b025bL7-R7): Corrected "intructions" to "instructions".
* [`examples/typescript/vercel-ai-chatbot/components/empty-screen.tsx`](diffhunk://#diff-09b62e79af076538b5db240bff7f66fb24d5c30acea1ba8600b68720b386fd2dL15-R15): Corrected "implmenetation" to "implementation".
* [`screenpipe-app-tauri/components/chat-list-web-llm.tsx`](diffhunk://#diff-663f8c694e54a576fed67f922a0e68d72a5b067b77b25996a6b2c7a1f95fd1a3L255-R255): Corrected "browing" to "browsing".
* [`screenpipe-app-tauri/components/notification-handler.tsx`](diffhunk://#diff-4a8af77acd263c3113f91570e929b269307b842a4ebe7ec6075092054b58a0baL20-R20): Corrected "notifcation" to "notification".
* [`screenpipe-app-tauri/src-tauri/gen/schemas/desktop-schema.json`](diffhunk://#diff-b499035af0e5338a8675d5bc757f86147a1d37b117360027a702e3fbf2f053f8L40-R40): Corrected "programatic" to "programmatic". [[1]](diffhunk://#diff-b499035af0e5338a8675d5bc757f86147a1d37b117360027a702e3fbf2f053f8L40-R40) [[2]](diffhunk://#diff-b499035af0e5338a8675d5bc757f86147a1d37b117360027a702e3fbf2f053f8L52-R52)
* [`screenpipe-app-tauri/src-tauri/gen/schemas/macOS-schema.json`](diffhunk://#diff-b499035af0e5338a8675d5bc757f86147a1d37b117360027a702e3fbf2f053f8L40-R40): Corrected "programatic" to "programmatic". [[1]](diffhunk://#diff-b499035af0e5338a8675d5bc757f86147a1d37b117360027a702e3fbf2f053f8L40-R40) [[2]](diffhunk://#diff-b499035af0e5338a8675d5bc757f86147a1d37b117360027a702e3fbf2f053f8L52-R52)
* [`screenpipe-audio/src/core.rs`](diffhunk://#diff-43858b5b9d45785def40a91685eced0da516c6e6db0038862945361fab28cddeL346-R346): Corrected "suppoed" to "supposed".
* [`screenpipe-server/src/cli.rs`](diffhunk://#diff-2276e839c872295927af0eba86653a860869c072a1f178e78855fb9ef7b0d8efL103-R103): Corrected "unconsistent" to "inconsistent".
* [`screenpipe-vision/src/monitor.rs`](diffhunk://#diff-932aeada106d3ba6f9a54279e1c8b800cc0c4fcaac294baa548d307b8a373199L6-R6): Corrected "strcture" to "structure".