### PR TITLE
Add step in getting started for building OSS desktop app

### DIFF
--- a/content/docs/pages/docs/getting-started.mdx
+++ b/content/docs/pages/docs/getting-started.mdx
@@ -77,7 +77,7 @@ if you require additional configurations such as running in debug mode or switch
 1. start by installing rust and all necessary dependencies:
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   brew install pkg-config ffmpeg jq tesseract
+   brew install pkg-config ffmpeg jq tesseract cmake wget
    ```
 
 2. clone the screenpipe repository:
@@ -95,6 +95,8 @@ if you require additional configurations such as running in debug mode or switch
    ```bash
    ./target/release/screenpipe
    ```
+
+5. for building the desktop app then continue to follow the README for [`screenpipe-app-tauri`](https://github.com/mediar-ai/screenpipe/tree/main/screenpipe-app-tauri/README.md)
 
 [need help? open an issue on github.](https://github.com/mediar-ai/screenpipe/issues/new)
 


### PR DESCRIPTION
## Problem

- I was unable to see the desktop app when installing with `brew`.
- Advanced build steps from source did not mention building of the desktop app either.

## Solution

- Add step in getting started docs for building OSS desktop app
- Add required `cmake` and `wget` dependencies
  - My computer was relatively fresh install of MacOS (I usually develop within Devcontainers) so this will reduce issues for others getting started

### Tested

![image](https://github.com/user-attachments/assets/cd65d302-fba2-42f3-869f-adf74cc0f677)

![image](https://github.com/user-attachments/assets/ddff0cba-2b89-4db1-b7ae-c2e0f1b84c59)
