### PR TITLE
fix: screenpipe support in china

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ reqwest = { version = "0.11", features = ["blocking", "multipart", "json"] }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 vcpkg = "0.2"
 
+[patch.crates-io]
+hf-hub = { git = "https://github.com/king-jingxiang/hf-hub" }
+
 [workspace.metadata.vcpkg]
 git = "https://github.com/microsoft/vcpkg"
 rev = "2023.04.15"


### PR DESCRIPTION
This PR fixes hugging face being blocked in China.
User can specify env variable `HF_ENDPOINT=https://hf-mirror.com` for CLI to use China mirror



## type of change
- [x] bug fix (non-breaking change which fixes an issue)

/claim #341
/closes #341