### PR TITLE
 Fix[ReleaseApp-CI]:  SSL Connection Error During FFMPEG Download and Add Retry Mechanism

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -174,7 +174,7 @@ if (platform == 'windows') {
 
 	// Setup FFMPEG
 	if (!(await fs.exists(config.ffmpegRealname))) {
-		await $`${wgetPath} -nc  --no-check-certificate --show-progress ${config.windows.ffmpegUrl} -O ${config.windows.ffmpegName}.7z`
+		await $`${wgetPath} --tries=5 --retry-connrefused --waitretry=10 --secure-protocol=auto --no-check-certificate --show-progress ${config.windows.ffmpegUrl} -O ${config.windows.ffmpegName}.7z`
 		await $`'C:\\Program Files\\7-Zip\\7z.exe' x ${config.windows.ffmpegName}.7z`
 		await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 		await $`rm -rf ${config.windows.ffmpegName}.7z`


### PR DESCRIPTION
## description

This PR addresses an issue where `wget` fails to establish an SSL connection while downloading the FFMPEG binary for Windows during the build process. The error typically results in the termination of the build due to a non-properly terminated TLS connection. To fix this I have added a  retry mechanism with the --tries and --retry-connrefused options was added to ensure more robust handling of intermittent network issues in release app CI.

Closes #432
/claim #432 

## type of change
- [x] bug fix (non-breaking change which fixes an issue)
- [ ] new feature (non-breaking change which adds functionality)
- [ ] breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] this change requires a documentation update

## how to test

I have ran  release APP CI multiple times now consistently passing CI without any failures. Before this patch the CI fails for every subsequent build and passes once in a moon 
