### PR TITLE
Give deno pipes a blocking current thread

### DIFF
--- a/screenpipe-core/src/deno/runtime.js
+++ b/screenpipe-core/src/deno/runtime.js
@@ -35,15 +35,15 @@ const sendLog = async (level, ...args) => {
 const console = {
     log: (...args) => {
         core.print(`[pipe][${globalThis.metadata.id}][info]: ${argsToMessage(...args)}\n`, false);
-        // sendLog("info", ...args);
+        sendLog("info", ...args);
     },
     error: (...args) => {
         core.print(`[pipe][${globalThis.metadata.id}][error]: ${argsToMessage(...args)}\n`, true);
-        // sendLog("error", ...args);
+        sendLog("error", ...args);
     },
     warn: (...args) => {
         core.print(`[pipe][${globalThis.metadata.id}][warn]: ${argsToMessage(...args)}\n`, true);
-        // sendLog("warn", ...args);
+        sendLog("warn", ...args);
     }
 };
 


### PR DESCRIPTION
## description
spawn a blocking thread in which a current thread runtime is created to run deno pipes.

related issue: #445
/claim #445

## type of change
- [x] bug fix (non-breaking change which fixes an issue)
- [ ] new feature (non-breaking change which adds functionality)
- [ ] breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] this change requires a documentation update

## how to test
describe how to test your changes. include steps like:

1. checkout this branch
2. build screenpipe
3. add 1 or multiple js/ts pipes
4. run screenpipe

## screenshots (if applicable)
NA

## checklist
- [x] i read rust & programming best practices 
- [x] my code follows the style guidelines of this project
- [x] i have performed a self-review of my own code
- [ ] i have made corresponding changes to the documentation
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
- [ ] new and existing unit tests pass locally with my changes
- [ ] any dependent changes have been merged and published in downstream modules
- [ ] other operating systems are not broken

## additional notes
Is this the best place to separate the current-thread from the multi-threaded?