### PR TITLE
Remove all the warnings from the code

### DIFF
--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -338,6 +338,8 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            // Avoid "unused variable" warning in non-macOS systems
+            let _ = name;
             true
         }
     }

--- a/screenpipe-core/src/ffmpeg.rs
+++ b/screenpipe-core/src/ffmpeg.rs
@@ -2,17 +2,11 @@ use log::{debug, error};
 use std::path::PathBuf;
 use which::which;
 
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
-
 #[cfg(not(windows))]
 const EXECUTABLE_NAME: &str = "ffmpeg";
 
 #[cfg(windows)]
 const EXECUTABLE_NAME: &str = "ffmpeg.exe";
-
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 pub fn find_ffmpeg_path() -> Option<PathBuf> {
     debug!("Starting search for ffmpeg executable");

--- a/screenpipe-server/src/resource_monitor.rs
+++ b/screenpipe-server/src/resource_monitor.rs
@@ -8,11 +8,13 @@ use std::io::Read;
 use std::io::Seek;
 use std::io::SeekFrom;
 use std::io::Write;
-use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use sysinfo::{PidExt, ProcessExt, System, SystemExt};
 use tracing::{error, info};
+
+#[cfg(target_os = "macos")]
+use std::process::Command;
 
 pub struct ResourceMonitor {
     start_time: Instant,

--- a/screenpipe-vision/build.rs
+++ b/screenpipe-vision/build.rs
@@ -1,4 +1,7 @@
+#[cfg(target_os = "macos")]
 use std::env;
+
+#[cfg(target_os = "macos")]
 use std::path::PathBuf;
 
 fn main() {


### PR DESCRIPTION
This is a pretty small pull request but I think it has its merit, this removes all the warnings that Cargo brings up when building the project.