### PR TITLE
fix: mac sonoma 14.7 segfault

### DIFF
--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -396,7 +396,7 @@ pub fn default_output_device() -> Result<AudioDevice> {
     {
         // ! see https://github.com/RustAudio/cpal/pull/894
         if let Ok(host) = cpal::host_from_id(cpal::HostId::ScreenCaptureKit) {
-            if let Some(device) = host.default_input_device() {
+            if let Some(device) = host.default_output_device() {
                 if let Ok(name) = device.name() {
                     return Ok(AudioDevice::new(name, DeviceType::Output));
                 }

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -349,15 +349,17 @@ pub async fn list_audio_devices() -> Result<Vec<AudioDevice>> {
     {
         // !HACK macos is supposed to use special macos feature "display capture"
         // ! see https://github.com/RustAudio/cpal/pull/894
-        if let Ok(host) = cpal::host_from_id(cpal::HostId::ScreenCaptureKit) {
-            for device in host.input_devices()? {
-                if let Ok(name) = device.name() {
-                    if should_include_output_device(&name) {
-                        devices.push(AudioDevice::new(name, DeviceType::Output));
-                    }
-                }
-            }
-        }
+        // if let Ok(host) = cpal::host_from_id(cpal::HostId::ScreenCaptureKit) {
+        //     // host.input_devices() segfaults on MacOS M1 Sonoma 14.7
+
+        //     for device in host.input_devices()? {
+        //         if let Ok(name) = device.name() {
+        //             if should_include_output_device(&name) {
+        //                 devices.push(AudioDevice::new(name, DeviceType::Output));
+        //             }
+        //         }
+        //     }
+        // }
     }
 
     // add default output device - on macos think of custom virtual devices


### PR DESCRIPTION
- **fix: comment out input by host segfaulting**
- **fix: use output device instead of input device**


before my changes:
<img width="1153" alt="Screenshot 2024-10-12 at 15 41 19" src="https://github.com/user-attachments/assets/2e9cb46c-3338-4e57-9435-6d682f28788e">
after:
<img width="1140" alt="Screenshot 2024-10-12 at 15 41 48" src="https://github.com/user-attachments/assets/e2218bab-5775-450b-b9f0-63a0601b27d5">


---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description
apparently there's unsafe code under the input retrieving on cpal (assuming this because the error it was not possible to catch/handle the error, it just shuts the app down without any logs). I've commented out this code, and also changed a place where the method name is `default_output_device`, but was internally using `default_input_device` instead

related issue: #

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## checklist
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [x] my code follows the project's style guidelines
- [x] i have performed a self-review of my code
- [ ] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
- [x] all tests pass locally with my changes

## additional notes
not sure if anything broke as side effect. I highly recommend test on another machine to confirm everything works fine before merging it.

![image](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWdrMnBsbTlqNzFlMnppNW5vN2U4Y2EzbGRyZmFudWUxZnR6eGoxZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/P7JmDW7IkB7TW/giphy.webp)