### PR TITLE
Implement email exa search

### DIFF
--- a/examples/typescript/pipe-email-exa-search/README.md
+++ b/examples/typescript/pipe-email-exa-search/README.md
@@ -1,0 +1,88 @@
+## pipe-email-exa-search
+
+### Overview
+1. Pulls random sections of screenpipe text results from the previous day
+2. Tries to pull user interests from each section
+3. Combines user interests across the sections to create an exa search query
+4. Uses Exa.ai to search for relevant content to the user's screen
+5. Emails the top 25 results to the user at the predetermined time each day
+
+Warning: There is potential for data leak to Exa AI
+
+#### quick setup
+
+1. run ollama:
+   ```
+   ollama run llama3.2:3b-instruct-q4_K_M
+   ```
+2. [create app specific password](https://support.google.com/accounts/answer/185833?hl=en) in your google account that will be used to send yourself emails
+3. [Get Exa.ai API key](https://exa.ai/)
+4. configure pipe in the app ui, save, enable, restart screenpipe recording
+
+
+```json
+{
+  "fields": [
+    {
+      "name": "emailTime",
+      "type": "time",
+      "default": "22:00",
+      "description": "Time to send daily summary email"
+    },
+    {
+      "name": "emailAddress",
+      "type": "string",
+      "default": "",
+      "description": "Email address to send the daily summary to"
+    },
+    {
+      "name": "emailPassword",
+      "type": "string",
+      "default": "",
+      "description": "App specific password for your gmail account, https://support.google.com/accounts/answer/185833?hl=en"
+    },
+    {
+      "name": "exaApiKey",
+      "type": "string",
+      "default": "",
+      "description": "Exa Api key, you can get one for free at https://exa.ai/"
+    },
+    {
+      "name": "ollamaApiUrl",
+      "type": "string",
+      "default": "http://localhost:11434/api/chat",
+      "description": "AI API URL, can be ollama, openai, any openai compatible API, risky to use cloud providers due to high usage"
+    },
+    {
+      "name": "ollamaModel",
+      "type": "string",
+      "default": "llama3.2:3b-instruct-q4_K_M",
+      "description": "AI Model"
+    },
+    {
+      "name": "pageSize",
+      "type": "number",
+      "default": 100,
+      "description": "Number of records to retrieve from screenpipe per page for structured extraction, keep in mind LLMs have a context window limit. Increase this value if using audio."
+    },
+    {
+      "name": "topicQueryCount",
+      "type" : "number",
+      "default" : 10,
+      "description" : "Number of random pages to pull from screenpipe for sub-summarization. The total records used will be pageSize times topicQueryCount"
+    },
+    {
+      "name": "windowName",
+      "type": "window",
+      "default": "",
+      "description": "Specific window name to filter the screen data, for example 'gmail', 'john', 'slack', 'myCodeFile.tsx', etc. this will filter out audio"
+    },
+    {
+      "name": "contentType",
+      "type": "contentType",
+      "default": "ocr",
+      "description": "Type of content to analyze: 'ocr', 'audio', or 'all'. OCR usually contains more content, so it's recommended to choose either OCR or audio rather than 'all' for better performance."
+    }
+  ]
+}
+```

--- a/examples/typescript/pipe-email-exa-search/README.md
+++ b/examples/typescript/pipe-email-exa-search/README.md
@@ -50,7 +50,7 @@ Warning: There is potential for data leak to Exa AI
     {
       "name": "ollamaApiUrl",
       "type": "string",
-      "default": "http://localhost:11434/api/chat",
+      "default": "http://localhost:11434/api",
       "description": "AI API URL, can be ollama, openai, any openai compatible API, risky to use cloud providers due to high usage"
     },
     {

--- a/examples/typescript/pipe-email-exa-search/deno.json
+++ b/examples/typescript/pipe-email-exa-search/deno.json
@@ -1,5 +1,8 @@
 {
     "imports": {
+        "zod": "npm:zod",
+        "ai": "npm:ai",
+        "ollama-ai-provider": "npm:ollama-ai-provider",
         "fs": "node:fs",
         "nodemailer": "npm:nodemailer",
         "screenpipe": "https://raw.githubusercontent.com/mediar-ai/screenpipe/main/screenpipe-js/main.ts",

--- a/examples/typescript/pipe-email-exa-search/deno.json
+++ b/examples/typescript/pipe-email-exa-search/deno.json
@@ -1,0 +1,8 @@
+{
+    "imports": {
+        "fs": "node:fs",
+        "nodemailer": "npm:nodemailer",
+        "screenpipe": "https://raw.githubusercontent.com/mediar-ai/screenpipe/main/screenpipe-js/main.ts",
+        "exa-js" : "npm:exa-js"
+    }
+}

--- a/examples/typescript/pipe-email-exa-search/pipe.json
+++ b/examples/typescript/pipe-email-exa-search/pipe.json
@@ -27,7 +27,7 @@
     {
       "name": "ollamaApiUrl",
       "type": "string",
-      "default": "http://localhost:11434/api/chat",
+      "default": "http://localhost:11434/api",
       "description": "AI API URL, can be ollama, openai, any openai compatible API, risky to use cloud providers due to high usage"
     },
     {

--- a/examples/typescript/pipe-email-exa-search/pipe.json
+++ b/examples/typescript/pipe-email-exa-search/pipe.json
@@ -1,0 +1,64 @@
+{
+  "fields": [
+    {
+      "name": "emailTime",
+      "type": "time",
+      "default": "22:00",
+      "description": "Time to send daily summary email"
+    },
+    {
+      "name": "emailAddress",
+      "type": "string",
+      "default": "",
+      "description": "Email address to send the daily summary to"
+    },
+    {
+      "name": "emailPassword",
+      "type": "string",
+      "default": "",
+      "description": "App specific password for your gmail account, https://support.google.com/accounts/answer/185833?hl=en"
+    },
+    {
+      "name": "exaApiKey",
+      "type": "string",
+      "default": "",
+      "description": "Exa Api key, you can get one for free at https://exa.ai/"
+    },
+    {
+      "name": "ollamaApiUrl",
+      "type": "string",
+      "default": "http://localhost:11434/api/chat",
+      "description": "AI API URL, can be ollama, openai, any openai compatible API, risky to use cloud providers due to high usage"
+    },
+    {
+      "name": "ollamaModel",
+      "type": "string",
+      "default": "llama3.2:3b-instruct-q4_K_M",
+      "description": "AI Model"
+    },
+    {
+      "name": "pageSize",
+      "type": "number",
+      "default": 100,
+      "description": "Number of records to retrieve from screenpipe per page for structured extraction, keep in mind LLMs have a context window limit. Increase this value if using audio."
+    },
+    {
+      "name": "topicQueryCount",
+      "type" : "number",
+      "default" : 10,
+      "description" : "Number of random pages to pull from screenpipe for sub-summarization. The total records used will be pageSize times topicQueryCount"
+    },
+    {
+      "name": "windowName",
+      "type": "window",
+      "default": "",
+      "description": "Specific window name to filter the screen data, for example 'gmail', 'john', 'slack', 'myCodeFile.tsx', etc. this will filter out audio"
+    },
+    {
+      "name": "contentType",
+      "type": "contentType",
+      "default": "ocr",
+      "description": "Type of content to analyze: 'ocr', 'audio', or 'all'. OCR usually contains more content, so it's recommended to choose either OCR or audio rather than 'all' for better performance."
+    }
+  ]
+}

--- a/examples/typescript/pipe-email-exa-search/pipe.ts
+++ b/examples/typescript/pipe-email-exa-search/pipe.ts
@@ -1,0 +1,339 @@
+import * as fs from "fs";
+import nodemailer from "nodemailer";
+import { ContentItem, pipe } from "screenpipe";
+import process from "node:process";
+import Exa from "exa-js"
+
+interface ScreenTopicQuery {
+  query: string;
+  highlights: string[]; 
+  quality: number; 
+}
+
+interface FinalSummaryQuery {
+  summary_query: string;
+  quality: number; 
+}
+
+function getRandomOffsets(total: number, count: number): number[] {
+  const offsets = new Set<number>();
+  while (offsets.size < count) {
+    offsets.add(Math.floor(Math.random() * total));
+  }
+  return Array.from(offsets);
+}
+
+async function sendEmail(
+  to: string,
+  password: string,
+  subject: string,
+  body: string
+): Promise<void> {
+  // Create a transporter using SMTP
+  const transporter = nodemailer.createTransport({
+    host: "smtp.gmail.com", // Replace with your SMTP server
+    port: 587,
+    secure: false, // Use TLS
+    auth: {
+      user: to, // assuming the sender is the same as the recipient
+      pass: password,
+    },
+  });
+
+  // Send mail with defined transport object
+  const info = await transporter.sendMail({
+    from: to, // sender address
+    to: to, // list of receivers
+    subject: subject, // Subject line
+    html: body, // plain text body
+  });
+
+  if (!info) {
+    throw new Error("failed to send email");
+  }
+  console.log(`email sent to ${to} with subject: ${subject}`);
+}
+
+async function generateScreenTopicQuery(
+  screenData: ContentItem[],
+  ollamaModel: string,
+  ollamaApiUrl: string
+): Promise<ScreenTopicQuery> {
+  const prompt = `
+    You are an assistant who generates search queries for an embedding search database to help a user find content of interest.
+
+    Below is content that has been on the user's screen recently:
+
+    ${JSON.stringify(screenData)}
+
+    Task:
+      - Analyze the content above.
+      - Identify the main themes and topics.
+      - Generate a single, concise sentence that summarizes the user's interests.
+      - Include as many relevant keywords and concepts from the content as possible.
+      - The sentence should be suitable as a search query for finding similar content. 
+
+    Return a JSON object with the following structure:
+    {
+        "query": "sentence for querying the embedding search database",
+        "highlights": "Quick list of highlights used to generate the query",
+        "quality": "float between 0 and 1 estimating the quality of the generated query for finding content of interest"
+    }
+
+    Rules:
+    - Do not add backticks to the JSON eg \`\`\`json\`\`\` is WRONG
+    - DO NOT RETURN ANYTHING BUT JSON. NO COMMENTS BELOW THE JSON.
+    `;
+
+  const response = await fetch(ollamaApiUrl, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    body: JSON.stringify({
+      model: ollamaModel,
+      messages: [{ role: "user", content: prompt }],
+      stream: false,
+    }),
+  });
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error("Error checking goal focus log:", errorBody);
+    throw new Error(
+      `HTTP error! status: ${response.status}, body: ${errorBody}`
+    );
+  }
+
+  const result = await response.json();
+
+  console.log("AI answer:", result);
+
+  const cleanedResult = result.message.content
+    .trim()
+    .replace(/^```(?:json)?\s*|\s*```$/g, "") // remove start and end code block markers
+    .replace(/\n/g, "") // remove newlines
+    .replace(/\\n/g, "") // remove escaped newlines
+    .trim(); // trim any remaining whitespace
+
+  let parsedContent;
+  try {
+    parsedContent = JSON.parse(cleanedResult);
+  } catch (error) {
+    console.warn("failed to parse ai response:", error);
+    console.warn("cleaned result:", cleanedResult);
+    throw new Error("invalid ai response format");
+  }
+  return parsedContent
+}
+
+async function generateScreenTopicSummaryQuery(
+  topicQueries: string[],
+  ollamaModel: string,
+  ollamaApiUrl: string
+): Promise<FinalSummaryQuery> {
+  const prompt = `
+    You are an assistant who helps summarize multiple topic queries.
+
+    Below are topic queries generated from recent screen content:
+
+    ${JSON.stringify(topicQueries)}
+
+    Task:
+      - Summarize these queries into a single comprehensive query that reflects the overall themes and topics.
+      - Include as many relevant keywords and concepts as possible.
+      - The sentence should be suitable as a search query for finding similar content. 
+
+    Return a JSON object with the following structure:
+    {
+        "summary_query": "summarized query for searching the database",
+        "quality": "float between 0 and 1 estimating the quality of the summarized query"
+    }
+
+    Rules:
+    - Do not add backticks to the JSON eg \`\`\`json\`\`\` is WRONG
+    - DO NOT RETURN ANYTHING BUT JSON. NO COMMENTS BELOW THE JSON.
+    `;
+
+  const summarizationResponse = await fetch(ollamaApiUrl, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    body: JSON.stringify({
+      model: ollamaModel,
+      messages: [{ role: "user", content: prompt }],
+      stream: false,
+    }),
+  });
+  if (!summarizationResponse.ok) {
+    const errorBody = await summarizationResponse.text();
+    console.error("Error checking goal focus log:", errorBody);
+    throw new Error(
+      `HTTP error! status: ${summarizationResponse.status}, body: ${errorBody}`
+    );
+  }
+
+  const result = await summarizationResponse.json();
+
+  console.log("Summarize AI answer:", result);
+
+  const cleanedResult = result.message.content
+    .trim()
+    .replace(/^```(?:json)?\s*|\s*```$/g, "") // remove start and end code block markers
+    .replace(/\n/g, "") // remove newlines
+    .replace(/\\n/g, "") // remove escaped newlines
+    .trim(); // trim any remaining whitespace
+
+  let parsedContent;
+  try {
+    parsedContent = JSON.parse(cleanedResult);
+  } catch (error) {
+    console.warn("failed to parse ai response:", error);
+    console.warn("cleaned result:", cleanedResult);
+    throw new Error("invalid ai response format");
+  }
+  return parsedContent
+}
+
+function formatExaResultsForEmail(results: any[]): string {
+  return results.map((result, index) => `
+    <h2>${result.title}</h2>
+    <p><strong>Author(s):</strong> ${result.author}</p>
+    <p><strong>Published Date:</strong> ${new Date(result.publishedDate).toDateString()}</p>
+    <p><strong>Link:</strong> <a href="${result.url}">${result.url}</a></p>
+    <p><strong>Summary:</strong></p>
+    <blockquote>${result.summary.substring(0, 500)}</blockquote>
+    <p><strong>Relevance Score:</strong> ${result.score.toFixed(2)}</p>
+    <hr/>
+  `).join('');
+}
+
+async function exaSearchPipeline(): Promise<void> {
+  console.log("starting exa search pipeline");
+
+  const config = await pipe.loadPipeConfig();
+  console.log("loaded config:", JSON.stringify(config, null, 2));
+
+  const emailTime = config.emailTime;
+  const emailAddress = config.emailAddress;
+  const emailPassword = config.emailPassword;
+  const ollamaModel = config.ollamaModel;
+  const ollamaApiUrl = config.ollamaApiUrl;
+  const windowName = config.windowName || "";
+  const pageSize = config.pageSize;
+  const contentType = config.contentType || "ocr"; // Default to 'ocr' if not specified
+  const topicQueryCount = config.topicQueryCount || 10;
+  const exaApiKey = config.exaApiKey
+
+  const logsDir = `${process.env.PIPE_DIR}/logs`;
+  try {
+    fs.mkdirSync(logsDir);
+  } catch (_error) {
+    console.warn("failed to create logs dir, probably already exists");
+  }
+
+  let lastEmailSent = new Date(0); // Initialize to a past date
+
+  // send a welcome email to announce what will happen, when it will happen, and what it will do
+  const welcomeEmail = `
+    Welcome to the exa search pipeline!
+
+    This pipe will send you recommended exa content based on your screen data.
+
+    It will run at ${emailTime} every day.
+
+    Search query:
+  `;
+  await sendEmail(
+    emailAddress,
+    emailPassword,
+    "Exa Search Pipeline",
+    welcomeEmail
+  );
+
+  const [emailHour, emailMinute] = emailTime.split(":").map(Number);
+
+  while (true) {
+    try {
+      const now = new Date();
+      let shouldRunSearch= false;
+      
+      const emailTimeToday = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+        emailHour,
+        emailMinute,
+      );
+      shouldRunSearch =
+        now >= emailTimeToday &&
+        now.getTime() - lastEmailSent.getTime() > 24 * 60 * 60 * 1000;
+
+      if (shouldRunSearch){
+        const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+        const screenData = await pipe.queryScreenpipe({
+          start_time: oneDayAgo.toISOString(),
+          end_time: now.toISOString(),
+          window_name: windowName,
+          limit: pageSize,
+          content_type: contentType,
+        });
+
+        if (screenData && screenData.data && screenData.data.length > 0) {
+          const randomOffsets = getRandomOffsets(screenData.data.length, topicQueryCount);
+
+          const topicQueries = [];
+          for (const offset of randomOffsets) {
+            const pageData = screenData.data.slice(offset, offset + pageSize); // Extract section of data
+            const screenTopicQuery = await generateScreenTopicQuery(pageData, ollamaModel, ollamaApiUrl);
+            topicQueries.push(screenTopicQuery.query);
+          }
+          const finalSummary = await generateScreenTopicSummaryQuery(topicQueries, ollamaModel, ollamaApiUrl)
+
+          // Perform exa searchs
+          const exa = new Exa(exaApiKey)
+
+          const exaResult = await exa.searchAndContents(
+            finalSummary.summary_query,
+            {
+              type: "neural",
+              useAutoprompt: true,
+              numResults: 25,
+              text: true,
+              summary: true
+            }
+          )
+          
+          console.log("First exa results", exaResult.results[0])
+          const cleanedExaResults = formatExaResultsForEmail(exaResult.results)
+
+          const sumEmail = `
+            <h1>Exa Search Pipeline Results</h1>
+            <h2>Exa Query</h2>
+            <p><strong>Query:</strong> ${finalSummary.summary_query}</p>
+            
+            <h2>Exa Results</h2>
+            <div>${cleanedExaResults}</div>
+          `;
+          await sendEmail(
+            emailAddress,
+            emailPassword,
+            "Exa Search Pipeline Results",
+            sumEmail
+          );
+          await pipe.inbox.send({
+            title: "Exa Search Results",
+            body: finalSummary.summary_query,
+          });
+          lastEmailSent = now;
+        }
+      }
+    } catch (error) {
+      console.warn("error in exa search pipeline:", error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 600000));
+  }
+}
+
+console.log(`Starting Exa Search Pipeline`);
+exaSearchPipeline();


### PR DESCRIPTION
---
name: email exa search

about: 
Implements the email exa search pipe which emails a user content relevant to what they have looked on their screen the previous day using Exa.ai.

Related issue: https://github.com/mediar-ai/screenpipe/issues/365
Fixes: https://github.com/mediar-ai/screenpipe/issues/365
/claim https://github.com/mediar-ai/screenpipe/issues/365

---


## type of change
- [x] new feature

## how to test
1. Run the email exa search pipe

## checklist
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [x] my code follows the project's style guidelines
- [x] i have performed a self-review of my code
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [x] i have added tests that prove my fix is effective or that my feature works
- [x] all tests pass locally with my changes
