### PR TITLE
documentation: include CMake installation in Linux dependencies

### DIFF
--- a/content/docs/pages/docs/getting-started.mdx
+++ b/content/docs/pages/docs/getting-started.mdx
@@ -186,7 +186,7 @@ bun tauri build
 
 1. install dependencies with the following commands:
    ```bash
-   sudo apt-get install -y ffmpeg tesseract-ocr libavformat-dev libavfilter-dev libavdevice-dev libtesseract-dev
+   sudo apt-get install -y ffmpeg tesseract-ocr cmake libavformat-dev libavfilter-dev libavdevice-dev libtesseract-dev
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
 

--- a/content/docs/pages/docs/getting-started.mdx
+++ b/content/docs/pages/docs/getting-started.mdx
@@ -186,7 +186,7 @@ bun tauri build
 
 1. install dependencies with the following commands:
    ```bash
-   sudo apt-get install -y libavformat-dev libavfilter-dev libavdevice-dev ffmpeg tesseract-ocr libtesseract-dev
+   sudo apt-get install -y ffmpeg tesseract-ocr libavformat-dev libavfilter-dev libavdevice-dev libtesseract-dev
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
    ```
 


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description
brief description of the changes in this pr.
> Neglecting to install cmake leads to error: `failed to run custom build command for 'alsa-sys v0.3.1'` when running cargo build --release on linux (sidenote: I'm using WSL2 running Ubuntu 22.04).
1. [reorder apt-get install command for enhanced readability](https://github.com/mediar-ai/screenpipe/commit/f9cc1af61ec6a7b0a0f18468b3a87bd5888d1e55)
2. [docs: add missing 'cmake' installation step to apt-get instructions for linux](https://github.com/mediar-ai/screenpipe/commit/823665aa4683ce3bf4b5fd148127a95f3dac7e9a)

related issue: none

## type of change
- [ ] bug fix
- [ ] new feature
- [ ] breaking change
- [x] documentation update

## how to test
docs update, no tests to run

## checklist
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [x] my code follows the project's style guidelines
- [ ] i have performed a self-review of my code
- [x] i have updated the documentation if necessary
- [ ] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
- [ ] all tests pass locally with my changes

## additional notes
none