### PR TITLE
Restore ollama Windows and Linux support

### DIFF
--- a/screenpipe-app-tauri/components/settings.tsx
+++ b/screenpipe-app-tauri/components/settings.tsx
@@ -588,8 +588,6 @@ export function Settings({ className }: { className?: string }) {
                 local machine or elsewhere and the exact model name.
               </p>
 
-              {currentPlatform === "macos" && (
-                <>
                   <Separator className="my-4" />
 
                   <div className="w-full">
@@ -726,8 +724,6 @@ export function Settings({ className }: { className?: string }) {
                       </div>
                     </>
                   )}
-                </>
-              )}
             </CardContent>
           </Card>
 

--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -55,6 +55,7 @@ const config = {
 			'libasound2-dev', // cpal
 			'libomp-dev', // OpenMP in ggml.ai
 			'libstdc++-12-dev', //ROCm
+			'libxdo-dev',
 		],
 	},
 	macos: {
@@ -686,27 +687,23 @@ async function installOllamaSidecar() {
 	}
 
 	try {
-
-		// ! windows and linux not supported for now 
-
-		
 		await fs.mkdir(ollamaDir, { recursive: true });
 		const downloadPath = path.join(ollamaDir, path.basename(ollamaUrl));
 
 		console.log('Downloading Ollama...');
 		if (platform === 'windows') {
-			// await $`powershell -command "Invoke-WebRequest -Uri '${ollamaUrl}' -OutFile '${downloadPath}'"`;
+			await $`powershell -command "Invoke-WebRequest -Uri '${ollamaUrl}' -OutFile '${downloadPath}'"`;
 		} else {
 			await $`wget -q --show-progress ${ollamaUrl} -O ${downloadPath}`;
 		}
 
 		console.log('Extracting Ollama...');
 		if (platform === 'windows') {
-			// await $`powershell -command "Expand-Archive -Path '${downloadPath}' -DestinationPath '${ollamaDir}'"`;
-			// await fs.rename(path.join(ollamaDir, 'ollama.exe'), path.join(ollamaDir, ollamaExe));
+			await $`powershell -command "Expand-Archive -Path '${downloadPath}' -DestinationPath '${ollamaDir}'"`;
+			await fs.rename(path.join(ollamaDir, 'ollama.exe'), path.join(ollamaDir, ollamaExe));
 		} else if (platform === 'linux') {
-			// await $`tar -xzf "${downloadPath}" -C "${ollamaDir}"`;
-			// await fs.rename(path.join(ollamaDir, 'ollama'), path.join(ollamaDir, ollamaExe));
+			await $`tar -xzf "${downloadPath}" -C "${ollamaDir}"`;
+			await fs.rename(path.join(ollamaDir, 'bin/ollama'), path.join(ollamaDir, ollamaExe));
 		} else if (platform === 'macos') {
 			// just copy to both archs
 			await fs.copyFile(downloadPath, path.join(ollamaDir, "ollama-aarch64-apple-darwin"));
@@ -715,7 +712,7 @@ async function installOllamaSidecar() {
 
 		console.log('Setting permissions...');
 		if (platform === 'linux') {
-			// await fs.chmod(path.join(ollamaDir, ollamaExe), '755');
+			await fs.chmod(path.join(ollamaDir, ollamaExe), '755');
 		} else if (platform === 'macos') {
 			await fs.chmod(path.join(ollamaDir, "ollama-aarch64-apple-darwin"), '755');
 			await fs.chmod(path.join(ollamaDir, "ollama-x86_64-apple-darwin"), '755');

--- a/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -2,7 +2,11 @@
     "bundle": {
         "externalBin": [
             "screenpipe",
-            "deno"
+            "deno",
+            "ollama"
+        ],
+        "resources": [
+            "lib/ollama/*"
         ],
         "linux": {
             "deb": {

--- a/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
@@ -2,13 +2,15 @@
     "bundle": {
         "externalBin": [
             "screenpipe",
-            "deno"
+            "deno",
+            "ollama"
         ],
         "resources": {
             "ffmpeg\\bin\\x64\\*": "./",
             "ffmpeg\\lib\\*": "./",
             "tesseract\\*": "./",
-            "onnxruntime*\\lib\\*.dll": "./"
+            "onnxruntime*\\lib\\*.dll": "./",
+            "lib\\*": "./"
         }
     }
 }


### PR DESCRIPTION
/claim #507

This correctly copies the ollama bin in Linux and adds the libs as resources.