### PR TITLE
fix: build: ignore ~/.wgetrc to avoid interference

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -318,7 +318,7 @@ if (platform == 'windows') {
 
 	// Setup FFMPEG
 	if (!(await fs.exists(config.ffmpegRealname))) {
-		await $`${wgetPath} --tries=10 --retry-connrefused --waitretry=10 --secure-protocol=auto --no-check-certificate --show-progress ${config.windows.ffmpegUrl} -O ${config.windows.ffmpegName}.7z`
+		await $`${wgetPath} --no-config --tries=10 --retry-connrefused --waitretry=10 --secure-protocol=auto --no-check-certificate --show-progress ${config.windows.ffmpegUrl} -O ${config.windows.ffmpegName}.7z`
 		await $`'C:\\Program Files\\7-Zip\\7z.exe' x ${config.windows.ffmpegName}.7z`
 		await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 		await $`rm -rf ${config.windows.ffmpegName}.7z`
@@ -332,7 +332,7 @@ if (platform == 'windows') {
 
 	if (!(await fs.exists('tesseract'))) {
 		console.log('Setting up Tesseract for Windows...')
-		await $`${wgetPath} -nc  --no-check-certificate --show-progress ${tesseractUrl} -O ${tesseractInstaller}`
+		await $`${wgetPath} --no-config -nc --no-check-certificate --show-progress ${tesseractUrl} -O ${tesseractInstaller}`
 		await $`"${process.cwd()}\\${tesseractInstaller}" /S /D=C:\\Program Files\\Tesseract-OCR`
 		await $`rm ${tesseractInstaller}`
 		// Replace the mv command with xcopy
@@ -354,7 +354,7 @@ if (platform == 'windows') {
 	if (!(await fs.exists(onnxRuntimeName))) {
 		console.log('Setting up ONNX Runtime libraries for Windows...')
 		try {
-			await $`${wgetPath} -nc --no-check-certificate --show-progress ${onnxRuntimeUrl} -O ${onnxRuntimeLibs}`
+			await $`${wgetPath} --no-config -nc --no-check-certificate --show-progress ${onnxRuntimeUrl} -O ${onnxRuntimeLibs}`
 			await $`unzip ${onnxRuntimeLibs} || tar -xf ${onnxRuntimeLibs} || echo "Done extracting"`;
 			await $`rm -rf ${onnxRuntimeLibs} || rm ${onnxRuntimeLibs} -Recurse -Force || echo "Done cleaning up zip"`;
 			console.log('ONNX Runtime libraries for Windows set up successfully.')
@@ -369,7 +369,7 @@ if (platform == 'windows') {
 
 	// Setup OpenBlas
 	if (!(await fs.exists(config.openblasRealname)) && hasFeature('openblas')) {
-		await $`${wgetPath} -nc --show-progress ${config.windows.openBlasUrl} -O ${config.windows.openBlasName}.zip`
+		await $`${wgetPath} --no-config -nc --show-progress ${config.windows.openBlasUrl} -O ${config.windows.openBlasName}.zip`
 		await $`"C:\\Program Files\\7-Zip\\7z.exe" x ${config.windows.openBlasName}.zip -o${config.openblasRealname}`
 		await $`rm ${config.windows.openBlasName}.zip`
 		fs.cp(path.join(config.openblasRealname, 'include'), path.join(config.openblasRealname, 'lib'), { recursive: true, force: true })
@@ -379,7 +379,7 @@ if (platform == 'windows') {
 
 	// Setup CLBlast
 	if (!(await fs.exists(config.clblastRealname)) && !hasFeature('cuda')) {
-		await $`${wgetPath} -nc --show-progress ${config.windows.clblastUrl} -O ${config.windows.clblastName}.zip`
+		await $`${wgetPath} --no-config -nc --show-progress ${config.windows.clblastUrl} -O ${config.windows.clblastName}.zip`
 		await $`"C:\\Program Files\\7-Zip\\7z.exe" x ${config.windows.clblastName}.zip` // 7z file inside
 		await $`"C:\\Program Files\\7-Zip\\7z.exe" x ${config.windows.clblastName}.7z` // Inner folder
 		await $`mv ${config.windows.clblastName} ${config.clblastRealname}`
@@ -492,7 +492,7 @@ if (platform == 'macos') {
 
 	// Setup FFMPEG
 	if (!(await fs.exists(config.ffmpegRealname))) {
-		await $`wget -nc ${config.macos.ffmpegUrl} -O ${config.macos.ffmpegName}.tar.xz`
+		await $`wget --no-config -nc ${config.macos.ffmpegUrl} -O ${config.macos.ffmpegName}.tar.xz`
 		await $`tar xf ${config.macos.ffmpegName}.tar.xz`
 		await $`mv ${config.macos.ffmpegName} ${config.ffmpegRealname}`
 		await $`rm ${config.macos.ffmpegName}.tar.xz`
@@ -697,7 +697,7 @@ async function installOllamaSidecar() {
 		if (platform === 'windows') {
 			// await $`powershell -command "Invoke-WebRequest -Uri '${ollamaUrl}' -OutFile '${downloadPath}'"`;
 		} else {
-			await $`wget -q --show-progress ${ollamaUrl} -O ${downloadPath}`;
+			await $`wget --no-config -q --show-progress ${ollamaUrl} -O ${downloadPath}`;
 		}
 
 		console.log('Extracting Ollama...');


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] fix: build: ignore ~/.wgetrc to avoid interference"
labels: ''
assignees: 'louis030195'

---

## description
Users can define personal settings for wget in `~/.wgetrc`. When the `wget` command is run it reads this configuration file by default and add the corresponding options. The `scripts/pre_build.js` script fails when some user options are specified in the configuration file because they conflict with the options that this script uses. The solution is to ignore this user configuration file.

related issue: ø

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test
1. Create a file `~/.wgetrc` and just put `timestamping = on` inside.
2. Run `bun scripts/pre_build.js` from `screenpipe-app-tauri` and confirm that wget errors out because `-nc` and `--timestamp` can't be combined.
3. Move to this branch, and run `bun scripts/pre_build.js` again. This time around wget works properly.

## checklist
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [x] my code follows the project's style guidelines
- [x] i have performed a self-review of my code
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [x] i have added tests that prove my fix is effective or that my feature works
- [x] all tests pass locally with my changes

## additional notes
any other relevant information about the pr.
