### PR TITLE
fix: converge interleaved audio samples

### DIFF
--- a/screenpipe-audio/src/audio_processing.rs
+++ b/screenpipe-audio/src/audio_processing.rs
@@ -79,18 +79,20 @@ pub fn average_noise_spectrum(audio: &[f32]) -> f32 {
     total_sum / audio.len() as f32
 }
 
-pub fn stereo_to_mono(audio: &[f32], channels: u16) -> Vec<f32> {
-    let mut mono = audio.to_vec();
+pub fn audio_to_mono(audio: &[f32], channels: u16) -> Vec<f32> {
+    let mut mono_samples = Vec::with_capacity(audio.len() / channels as usize);
 
-    if channels > 1 {
-        mono = audio
-            .chunks(2)
-            .map(|x| {
-                let (left, right) = (x[0], x[1]);
-                (left + right) / 2.0
-            })
-            .collect::<Vec<f32>>();
+    // Iterate over the audio slice in chunks, each containing `channels` samples
+    for chunk in audio.chunks(channels as usize) {
+        // Sum the samples from all channels in the current chunk
+        let sum: f32 = chunk.iter().sum();
+
+        // Calculate the averagechannelsono sample
+        let mono_sample = sum / channels as f32;
+
+        // Store the computed mono sample
+        mono_samples.push(mono_sample);
     }
 
-    mono
+    mono_samples
 }

--- a/screenpipe-audio/src/audio_processing.rs
+++ b/screenpipe-audio/src/audio_processing.rs
@@ -79,7 +79,7 @@ pub fn average_noise_spectrum(audio: &[f32]) -> f32 {
     total_sum / audio.len() as f32
 }
 
-pub fn converge_to_mono(audio: &[f32], channels: u16) -> Vec<f32> {
+pub fn stereo_to_mono(audio: &[f32], channels: u16) -> Vec<f32> {
     let mut mono = audio.to_vec();
 
     if channels > 1 {

--- a/screenpipe-audio/src/audio_processing.rs
+++ b/screenpipe-audio/src/audio_processing.rs
@@ -78,3 +78,19 @@ pub fn average_noise_spectrum(audio: &[f32]) -> f32 {
 
     total_sum / audio.len() as f32
 }
+
+pub fn converge_to_mono(audio: &[f32], channels: u16) -> Vec<f32> {
+    let mut mono = audio.to_vec();
+
+    if channels > 1 {
+        mono = audio
+            .chunks(2)
+            .map(|x| {
+                let (left, right) = (x[0], x[1]);
+                (left + right) / 2.0
+            })
+            .collect::<Vec<f32>>();
+    }
+
+    mono
+}

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -1,4 +1,4 @@
-use crate::audio_processing::stereo_to_mono;
+use crate::audio_processing::audio_to_mono;
 use crate::AudioInput;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -203,7 +203,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = stereo_to_mono(bytemuck::cast_slice(data), channels);
+                        let mono = audio_to_mono(bytemuck::cast_slice(data), channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }
@@ -218,7 +218,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = stereo_to_mono(bytemuck::cast_slice(data), channels);
+                        let mono = audio_to_mono(bytemuck::cast_slice(data), channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }
@@ -233,7 +233,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = stereo_to_mono(bytemuck::cast_slice(data), channels);
+                        let mono = audio_to_mono(bytemuck::cast_slice(data), channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }
@@ -248,7 +248,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = stereo_to_mono(data, channels);
+                        let mono = audio_to_mono(data, channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -1,3 +1,4 @@
+use crate::audio_processing::converge_to_mono;
 use crate::AudioInput;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -126,7 +127,7 @@ async fn get_device_and_config(
 
         #[cfg(target_os = "macos")]
         {
-            if audio_device.device_type == DeviceType::Output {
+            if is_output_device {
                 if let Ok(screen_capture_host) = cpal::host_from_id(cpal::HostId::ScreenCaptureKit)
                 {
                     devices = screen_capture_host.input_devices()?;
@@ -165,7 +166,8 @@ pub async fn record_and_transcribe(
 ) -> Result<()> {
     let (cpal_audio_device, config) = get_device_and_config(&audio_device).await?;
     let sample_rate = config.sample_rate().0;
-    let channels = config.channels() as u16;
+    let channels = config.channels();
+
     debug!(
         "Audio device config: sample_rate={}, channels={}",
         sample_rate, channels
@@ -201,7 +203,9 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let _ = audio_queue_clone.push(bytemuck::cast_slice(data).to_vec());
+                        let mono = converge_to_mono(bytemuck::cast_slice(data), channels);
+
+                        let _ = audio_queue_clone.push(mono);
                     }
                 },
                 error_callback,
@@ -214,7 +218,9 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let _ = audio_queue_clone.push(bytemuck::cast_slice(data).to_vec());
+                        let mono = converge_to_mono(bytemuck::cast_slice(data), channels);
+
+                        let _ = audio_queue_clone.push(mono);
                     }
                 },
                 error_callback,
@@ -227,7 +233,9 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let _ = audio_queue_clone.push(bytemuck::cast_slice(data).to_vec());
+                        let mono = converge_to_mono(bytemuck::cast_slice(data), channels);
+
+                        let _ = audio_queue_clone.push(mono);
                     }
                 },
                 error_callback,
@@ -240,7 +248,9 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let _ = audio_queue_clone.push(data.to_vec());
+                        let mono = converge_to_mono(data, channels);
+
+                        let _ = audio_queue_clone.push(mono);
                     }
                 },
                 error_callback,

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -1,4 +1,4 @@
-use crate::audio_processing::converge_to_mono;
+use crate::audio_processing::stereo_to_mono;
 use crate::AudioInput;
 use anyhow::{anyhow, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -203,7 +203,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = converge_to_mono(bytemuck::cast_slice(data), channels);
+                        let mono = stereo_to_mono(bytemuck::cast_slice(data), channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }
@@ -218,7 +218,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = converge_to_mono(bytemuck::cast_slice(data), channels);
+                        let mono = stereo_to_mono(bytemuck::cast_slice(data), channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }
@@ -233,7 +233,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = converge_to_mono(bytemuck::cast_slice(data), channels);
+                        let mono = stereo_to_mono(bytemuck::cast_slice(data), channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }
@@ -248,7 +248,7 @@ pub async fn record_and_transcribe(
                         .upgrade()
                         .map_or(false, |arc| arc.load(Ordering::Relaxed))
                     {
-                        let mono = converge_to_mono(data, channels);
+                        let mono = stereo_to_mono(data, channels);
 
                         let _ = audio_queue_clone.push(mono);
                     }

--- a/screenpipe-audio/src/stt.rs
+++ b/screenpipe-audio/src/stt.rs
@@ -422,7 +422,7 @@ pub async fn stt(
         encode_single_audio(
             bytemuck::cast_slice(&audio_input.data),
             audio_input.sample_rate,
-            audio_input.channels,
+            1,
             &file_path.into(),
         )?;
     }

--- a/screenpipe-audio/src/stt.rs
+++ b/screenpipe-audio/src/stt.rs
@@ -315,12 +315,7 @@ pub async fn stt(
         audio_input.data.as_ref().to_vec()
     };
 
-    let audio_data = if audio_input.device.device_type == DeviceType::Input {
-        normalize_v2(&audio_data)
-    } else {
-        // ! for some reason buggy on output devices
-        audio_data
-    };
+    let audio_data = normalize_v2(&audio_data);
 
     let frame_size = 1600; // 100ms frame size for 16kHz audio
     let mut speech_frames = Vec::new();


### PR DESCRIPTION
## description
I identified an issue with the collection of audio data. devices with 2 channels use an interleaved format of [left,right,left,right] and this wasn't accounted for. By converging the left and right audio samples, the transcripts are working again.

related issue: #521
related issue: #525

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test
1. on mac use display audio as an input
2. test transcription