### PR TITLE
add audio device selection to meetings

### DIFF
--- a/screenpipe-app-tauri/components/meeting-history.tsx
+++ b/screenpipe-app-tauri/components/meeting-history.tsx
@@ -86,10 +86,10 @@ async function getItem(key: string): Promise<any> {
 }
 
 interface MeetingSegment {
-  start: string;
-  end: string;
+  timestamp: string;
   transcription: string;
   deviceName: string;
+  deviceType: string;
 }
 
 interface Meeting {
@@ -478,10 +478,10 @@ export default function MeetingHistory() {
           selectedDevices: new Set([trans.content.deviceName]),
           segments: [
             {
-              start: trans.content.timestamp,
-              end: trans.content.timestamp,
+              timestamp: trans.content.timestamp,
               transcription: trans.content.transcription,
               deviceName: trans.content.deviceName,
+              deviceType: trans.content.deviceType,
             },
           ],
           deviceNames: new Set([trans.content.deviceName]),
@@ -497,10 +497,10 @@ export default function MeetingHistory() {
         }] ${trans.content.transcription}\n`;
         currentMeeting.selectedDevices.add(trans.content.deviceName);
         currentMeeting.segments.push({
-          start: trans.content.timestamp,
-          end: trans.content.timestamp,
+          timestamp: trans.content.timestamp,
           transcription: trans.content.transcription,
           deviceName: trans.content.deviceName,
+          deviceType: trans.content.deviceType,
         });
         currentMeeting.deviceNames.add(trans.content.deviceName);
       }
@@ -892,7 +892,13 @@ export default function MeetingHistory() {
                                   .filter((s) =>
                                     meeting.selectedDevices.has(s.deviceName)
                                   )
-                                  .map((s) => s.transcription)
+                                  .map((s) => {
+                                    return `${s.timestamp} [${
+                                      s.deviceType?.toLowerCase() === "input"
+                                        ? "you"
+                                        : "others"
+                                    }]`;
+                                  })
                                   .join("\n"),
                                 "transcription"
                               )
@@ -908,8 +914,19 @@ export default function MeetingHistory() {
                               .filter((s) =>
                                 meeting.selectedDevices.has(s.deviceName)
                               )
-                              .map((s) => s.transcription)
-                              .join("\n")}
+                              .map((s, i) => (
+                                <React.Fragment key={i}>
+                                  <span className="font-bold">
+                                    {`${s.timestamp} [${
+                                      s.deviceType?.toLowerCase() === "input"
+                                        ? "you"
+                                        : "others"
+                                    }]`}
+                                  </span>{" "}
+                                  {s.transcription}
+                                  {"\n"}
+                                </React.Fragment>
+                              ))}
                           </pre>
                         </div>
                         <div className="relative">

--- a/screenpipe-app-tauri/components/meeting-history.tsx
+++ b/screenpipe-app-tauri/components/meeting-history.tsx
@@ -45,6 +45,8 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { ValueOf } from "next/dist/shared/lib/constants";
+import { Checkbox } from "./ui/checkbox";
 
 function formatDate(date: string): string {
   const dateObj = new Date(date);
@@ -83,6 +85,13 @@ async function getItem(key: string): Promise<any> {
   return null;
 }
 
+interface MeetingSegment {
+  start: string;
+  end: string;
+  transcription: string;
+  deviceName: string;
+}
+
 interface Meeting {
   meetingGroup: number;
   meetingStart: string;
@@ -92,6 +101,9 @@ interface Meeting {
   participants: string | null;
   summary: string | null;
   mergedWith?: number[]; // Array of meeting groups merged with this one
+  selectedDevices: Set<string>;
+  deviceNames: Set<string>;
+  segments: MeetingSegment[];
 }
 
 interface AudioContent {
@@ -267,7 +279,9 @@ export default function MeetingHistory() {
         },
         {
           role: "user" as const,
-          content: `${enhancedPrompt}:\n\n${meeting.fullTranscription}`,
+          content: `${enhancedPrompt}:\n\n${meeting.segments
+            .map((s) => s.transcription)
+            .join("\n")}`,
         },
       ];
 
@@ -461,6 +475,16 @@ export default function MeetingHistory() {
           name: null,
           participants: null,
           summary: null,
+          selectedDevices: new Set([trans.content.deviceName]),
+          segments: [
+            {
+              start: trans.content.timestamp,
+              end: trans.content.timestamp,
+              transcription: trans.content.transcription,
+              deviceName: trans.content.deviceName,
+            },
+          ],
+          deviceNames: new Set([trans.content.deviceName]),
         };
       } else if (currentMeeting) {
         currentMeeting.meetingEnd = trans.content.timestamp;
@@ -471,6 +495,14 @@ export default function MeetingHistory() {
             ? "others"
             : "unknown"
         }] ${trans.content.transcription}\n`;
+        currentMeeting.selectedDevices.add(trans.content.deviceName);
+        currentMeeting.segments.push({
+          start: trans.content.timestamp,
+          end: trans.content.timestamp,
+          transcription: trans.content.transcription,
+          deviceName: trans.content.deviceName,
+        });
+        currentMeeting.deviceNames.add(trans.content.deviceName);
       }
     });
 
@@ -584,6 +616,11 @@ export default function MeetingHistory() {
         nextMeeting.meetingGroup,
         ...(nextMeeting.mergedWith || []),
       ],
+      segments: [...currentMeeting.segments, ...nextMeeting.segments],
+      selectedDevices: new Set([
+        ...Array.from(currentMeeting.selectedDevices),
+        ...Array.from(nextMeeting.selectedDevices),
+      ]),
     };
 
     updatedMeetings[index] = mergedMeeting;
@@ -591,6 +628,29 @@ export default function MeetingHistory() {
     setMeetings(updatedMeetings);
     setItem("meetings", updatedMeetings);
   };
+
+  const handleDeviceToggle = useCallback(
+    (meetingGroup: number, deviceName: string, isChecked: boolean) => {
+      setMeetings((prevMeetings) => {
+        return prevMeetings.map((meeting) => {
+          if (meeting.meetingGroup === meetingGroup) {
+            const updatedSelectedDevices = new Set(meeting.selectedDevices);
+            if (isChecked) {
+              updatedSelectedDevices.add(deviceName);
+            } else {
+              updatedSelectedDevices.delete(deviceName);
+            }
+            return {
+              ...meeting,
+              selectedDevices: updatedSelectedDevices,
+            };
+          }
+          return meeting;
+        });
+      });
+    },
+    []
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -717,24 +777,60 @@ export default function MeetingHistory() {
                   <React.Fragment key={index}>
                     <Card className="relative">
                       <CardHeader>
-                        <CardTitle className="text-lg font-semibold flex flex-wrap items-center gap-2">
-                          meeting {meeting.meetingGroup}
-                          {meeting.mergedWith &&
-                            meeting.mergedWith.length > 0 && (
-                              <>
-                                <Badge variant="secondary">merged</Badge>
-                                {meeting.mergedWith.map((mergedGroupId) => (
-                                  <Badge key={mergedGroupId} variant="outline">
-                                    meeting {mergedGroupId}
-                                  </Badge>
-                                ))}
-                              </>
-                            )}
-                        </CardTitle>
-                        <CardDescription>
-                          {formatDate(meeting.meetingStart)} -{" "}
-                          {formatDate(meeting.meetingEnd)}
-                        </CardDescription>
+                        <div className="grid grid-cols-2">
+                          <div>
+                            <CardTitle className="text-lg font-semibold flex flex-wrap items-center gap-2">
+                              meeting {meeting.meetingGroup}
+                              {meeting.mergedWith &&
+                                meeting.mergedWith.length > 0 && (
+                                  <>
+                                    <Badge variant="secondary">merged</Badge>
+                                    {meeting.mergedWith.map((mergedGroupId) => (
+                                      <Badge
+                                        key={mergedGroupId}
+                                        variant="outline"
+                                      >
+                                        meeting {mergedGroupId}
+                                      </Badge>
+                                    ))}
+                                  </>
+                                )}
+                            </CardTitle>
+                            <CardDescription>
+                              {formatDate(meeting.meetingStart)} -{" "}
+                              {formatDate(meeting.meetingEnd)}
+                            </CardDescription>
+                          </div>
+                          <div className="mb-4 text-end">
+                            <h4 className="font-semibold mb-2">Devices:</h4>
+                            <div className="flex flex-wrap gap-4 justify-end">
+                              {Array.from(meeting.deviceNames).map(
+                                (deviceName) => (
+                                  <label
+                                    key={deviceName}
+                                    className="flex items-center space-x-2"
+                                  >
+                                    <Checkbox
+                                      checked={meeting.selectedDevices.has(
+                                        deviceName
+                                      )}
+                                      onCheckedChange={(checked) =>
+                                        handleDeviceToggle(
+                                          meeting.meetingGroup,
+                                          deviceName,
+                                          checked as boolean
+                                        )
+                                      }
+                                    />
+                                    <span className="text-sm">
+                                      {deviceName}
+                                    </span>
+                                  </label>
+                                )
+                              )}
+                            </div>
+                          </div>
+                        </div>
                       </CardHeader>
                       <CardContent>
                         <div className="mb-4">
@@ -788,14 +884,17 @@ export default function MeetingHistory() {
                           </div>
                         </div>
                         <div className="mb-4 relative">
-                          <h4 className="font-semibold mb-2">
-                            full transcription:
-                          </h4>
+                          <h4 className="font-semibold mb-2">transcription:</h4>
                           <Button
                             onClick={() =>
                               copyWithToast(
-                                meeting.fullTranscription,
-                                "full transcription"
+                                meeting.segments
+                                  .filter((s) =>
+                                    meeting.selectedDevices.has(s.deviceName)
+                                  )
+                                  .map((s) => s.transcription)
+                                  .join("\n"),
+                                "transcription"
                               )
                             }
                             className="absolute top-0 right-0 p-1 h-6 w-6"
@@ -805,7 +904,12 @@ export default function MeetingHistory() {
                             <Copy className="h-4 w-4" />
                           </Button>
                           <pre className="whitespace-pre-wrap bg-gray-100 p-3 rounded text-sm max-h-40 overflow-y-auto">
-                            {meeting.fullTranscription}
+                            {meeting.segments
+                              .filter((s) =>
+                                meeting.selectedDevices.has(s.deviceName)
+                              )
+                              .map((s) => s.transcription)
+                              .join("\n")}
                           </pre>
                         </div>
                         <div className="relative">

--- a/screenpipe-app-tauri/components/meeting-history.tsx
+++ b/screenpipe-app-tauri/components/meeting-history.tsx
@@ -432,6 +432,19 @@ export default function MeetingHistory() {
     }
   }
 
+  function formatTimestamp(timestamp: string): string {
+    const date = new Date(timestamp);
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      timeZoneName: "short",
+    }).format(date);
+  }
+
   function processMeetings(transcriptions: AudioTranscription[]): Meeting[] {
     console.log("processing transcriptions:", transcriptions);
     let meetings: Meeting[] = [];
@@ -465,7 +478,7 @@ export default function MeetingHistory() {
           meetingGroup: meetingGroup,
           meetingStart: trans.content.timestamp,
           meetingEnd: trans.content.timestamp,
-          fullTranscription: `${trans.content.timestamp} [${
+          fullTranscription: `${formatTimestamp(trans.content.timestamp)} [${
             trans.content.deviceType?.toLowerCase() === "input"
               ? "you"
               : trans.content.deviceType?.toLowerCase() === "output"
@@ -893,7 +906,7 @@ export default function MeetingHistory() {
                                     meeting.selectedDevices.has(s.deviceName)
                                   )
                                   .map((s) => {
-                                    return `${s.timestamp} [${
+                                    return `${formatTimestamp(s.timestamp)} [${
                                       s.deviceType?.toLowerCase() === "input"
                                         ? "you"
                                         : "others"
@@ -917,7 +930,7 @@ export default function MeetingHistory() {
                               .map((s, i) => (
                                 <React.Fragment key={i}>
                                   <span className="font-bold">
-                                    {`${s.timestamp} [${
+                                    {`${formatTimestamp(s.timestamp)} [${
                                       s.deviceType?.toLowerCase() === "input"
                                         ? "you"
                                         : "others"


### PR DESCRIPTION
## description
Allows users to select the audio devices for a meeting.
Does not affect summary or person identification.
related issue: #553

## type of change
- [ ] bug fix
- [x] new feature
- [ ] breaking change
- [ ] documentation update

## how to test
1. check / uncheck devices
2. verify transcript change
3. 

## checklist
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [x] my code follows the project's style guidelines
- [x] i have performed a self-review of my code
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
- [x] all tests pass locally with my changes
/claim 553
