### PR TITLE
Fix the `edit this page` button in docs

### DIFF
--- a/content/docs/theme.config.tsx
+++ b/content/docs/theme.config.tsx
@@ -14,7 +14,7 @@ const themeConfig = {
   project: {
     link: "https://github.com/mediar-ai/screenpipe", // Project link
   },
-  docsRepositoryBase: "https://github.com/mediar-ai/screenpipe/", // Documentation repo link
+  docsRepositoryBase: "https://github.com/mediar-ai/screenpipe/tree/main/content/docs", // Documentation repo link
   footer: {
     text: "screenpipe docs",
   },


### PR DESCRIPTION

## description
![image](https://github.com/user-attachments/assets/7e437945-9304-4521-9cdd-b379fa3e5dcc)
The `edit this page` button in the docs points to a non-existing page 

## type of change
- [ ] bug fix
- [ ] new feature
- [ ] breaking change
- [x] documentation update

## how to test
1. Go to the [docs page](https://docs.screenpi.pe/docs/getting-started)
2. click on `Edit this page`

## checklist
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [x] my code follows the project's style guidelines
- [x] i have performed a self-review of my code
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [x] i have added tests that prove my fix is effective or that my feature works
- [x] all tests pass locally with my changes
