### PR TITLE
Fix CONTRIBUTING.md dead hyperlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ this section guides you through submitting an enhancement suggestion for screen 
 
 ### rust styleguide
 
-all rust code must adhere to [rust style guide](https://github.com/rust-lang/style-team/blob/master/guide/guide.md).
+all rust code must adhere to [rust style guide](https://github.com/rust-lang/rust/tree/4f2f477fded0a47b21ed3f6aeddeafa5db8bf518/src/doc/style-guide/src).
 
 we follow [this](https://doc.rust-lang.org/cargo/guide/project-layout.html) folder structure.
 


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "Fix rust style guide permalink "
labels: ''
assignees: 'TanGentleman'

---

## description
Old link: https://github.com/rust-lang/style-team/blob/master/guide/guide.md
New link: https://github.com/rust-lang/rust/tree/4f2f477fded0a47b21ed3f6aeddeafa5db8bf518/src/doc/style-guide/src

related issue: #

## type of change
- [ ] bug fix
- [ ] new feature
- [ ] breaking change
- [X] documentation update

## how to test
1. 
2. 
3. 

## checklist
- [X] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have added the custom cursor AI prompt to my settings as mentioned in CONTRIBUTING.md and used to write this PR
- [ ] my code follows the project's style guidelines
- [ ] i have performed a self-review of my code
- [ ] i have updated the documentation if necessary
- [ ] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
- [ ] all tests pass locally with my changes

## additional notes
any other relevant information about the pr.
