### PR TITLE
fix: correct logo text and GitHub icon colors in light mode

### DIFF
--- a/content/docs/styles/globals.css
+++ b/content/docs/styles/globals.css
@@ -11,7 +11,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #0a0a0a;
     --invert-logo: 0;
   }
 }


### PR DESCRIPTION
---
name: correct logo text and GitHub icon colors in light mode
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

This fixes the issue where the logo text and GitHub icon appeared white in light mode.

<img width="1470" alt="Screenshot 2024-11-02 at 3 48 27 PM" src="https://github.com/user-attachments/assets/99eeeb21-cfd9-4045-9af2-27fde4edb0a9">

<img width="1470" alt="Screenshot 2024-11-02 at 3 48 50 PM" src="https://github.com/user-attachments/assets/1d0f6bd7-41bf-40f2-ab9d-ca9954c5a6bc">

related issue: #

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [x] documentation update

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time.

## checklist
- [x] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have updated the documentation if necessary
- [ ] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works

## additional notes
any other relevant information about the pr.
