### PR TITLE
chore: release screenpipe to official Homebrew/core

### DIFF
--- a/content/docs/pages/docs/getting-started.mdx
+++ b/content/docs/pages/docs/getting-started.mdx
@@ -132,7 +132,7 @@ bun tauri build
 
 1. to install screenpipe using homebrew, simply execute the following commands:
    ```bash copy
-   brew tap mediar-ai/screenpipe https://github.com/mediar-ai/screenpipe.git
+   brew update
    brew install screenpipe
    ```
 


### PR DESCRIPTION
---
name: chore: release screenpipe to official Homebrew/core
about: updates the docs to use official homebrew instead of repository tap
title: "chore: release screenpipe to official Homebrew/core"
labels: ''
assignees: ''

---

## description
release screenpipe to official Homebrew/core

Closes #614 
/claim #614 
related PR on homebrew https://github.com/Homebrew/homebrew-core/pull/196345

## type of change
- [x] documentation update


## checklist
- [x] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works

