### PR TITLE
fix Silero Silence Speech detection

### DIFF
--- a/screenpipe-audio/src/audio_processing.rs
+++ b/screenpipe-audio/src/audio_processing.rs
@@ -8,8 +8,13 @@ pub fn normalize_v2(audio: &[f32]) -> Vec<f32> {
         .iter()
         .fold(0.0f32, |max, &sample| max.max(sample.abs()));
 
-    let target_rms = 0.2; // Adjust as needed
-    let target_peak = 0.95; // Adjust as needed
+    // Return the original audio if it's completely silent
+    if rms == 0.0 || peak == 0.0 {
+        return audio.to_vec();
+    }
+
+    let target_rms = 0.2;
+    let target_peak = 0.95;
 
     let rms_scaling = target_rms / rms;
     let peak_scaling = target_peak / peak;


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description
Silero treats NaN as speech. Display output silence becomes NaN because of division by zero in the normalize function.

related issue: #

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test
1. turn on screenpipe with output and no audio playing.