### PR TITLE
Switch to windows-latest temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: ./screenpipe-js
 
   test-windows:
-    runs-on: [self-hosted, windows, x64]
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -60,7 +60,7 @@ jobs:
           - platform: "ubuntu-22.04" # Ubuntu x86_64
             args: "--features mkl" # TODO CUDA
             tauri-args: ""
-          - platform: [self-hosted, windows, x64] # Windows x86_64
+          - platform: windows-latest # Windows x86_64
             args: "--target x86_64-pc-windows-msvc" # TODO CUDA --features mkl --features "openblas"
             pre-build-args: "" # --openblas
             tauri-args: "--target x86_64-pc-windows-msvc"


### PR DESCRIPTION
@louis030195 So we can do the release, at least for now - once the server is ready we will switch the release app back to Windows.