### PR TITLE
Use better mirror for ffmpeg downloads

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -20,10 +20,8 @@ console.log('cwd', cwd)
 const config = {
 	ffmpegRealname: 'ffmpeg',
 	windows: {
-		ffmpegName: 'ffmpeg-7.0-windows-desktop-vs2022-default',
-		ffmpegUrl: 'https://unlimited.dl.sourceforge.net/project/avbuild/windows-desktop/ffmpeg-7.0-windows-desktop-vs2022-default.7z?viasf=1',
-
-
+		ffmpegName: 'ffmpeg-release-full',
+		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z',
 		vcpkgPackages: ['opencl', 'onnxruntime-gpu'],
 	},
 	linux: {
@@ -48,8 +46,8 @@ const config = {
 		],
 	},
 	macos: {
-		ffmpegName: 'ffmpeg-7.0-macOS-default',
-		ffmpegUrl: 'https://master.dl.sourceforge.net/project/avbuild/macOS/ffmpeg-7.0-macOS-default.tar.xz?viasf=1',
+		ffmpegName: 'ffmpeg-7.1',
+		ffmpegUrl: 'https://evermeet.cx/ffmpeg/ffmpeg-7.1.7z',
 	},
 }
 
@@ -445,10 +443,10 @@ if (platform == 'macos') {
 
 	// Setup FFMPEG
 	if (!(await fs.exists(config.ffmpegRealname))) {
-		await $`wget --no-config -nc ${config.macos.ffmpegUrl} -O ${config.macos.ffmpegName}.tar.xz`
-		await $`tar xf ${config.macos.ffmpegName}.tar.xz`
+		await $`wget --no-config -nc ${config.macos.ffmpegUrl} -O ${config.macos.ffmpegName}.7z`
+		await $`7z x ${config.macos.ffmpegName}.7z`
 		await $`mv ${config.macos.ffmpegName} ${config.ffmpegRealname}`
-		await $`rm ${config.macos.ffmpegName}.tar.xz`
+		await $`rm ${config.macos.ffmpegName}.7z`
 	} else {
 		console.log('FFMPEG already exists');
 	}

--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -20,8 +20,8 @@ console.log('cwd', cwd)
 const config = {
 	ffmpegRealname: 'ffmpeg',
 	windows: {
-		ffmpegName: 'ffmpeg-release-full',
-		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/ffmpeg-release-full.7z',
+		ffmpegName: 'ffmpeg-7.0.2-full_build-shared',
+		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.0.2-full_build-shared.7z',
 		vcpkgPackages: ['opencl', 'onnxruntime-gpu'],
 	},
 	linux: {
@@ -313,7 +313,6 @@ if (platform == 'windows') {
 		await $`'C:\\Program Files\\7-Zip\\7z.exe' x ${config.windows.ffmpegName}.7z`
 		await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 		await $`rm -rf ${config.windows.ffmpegName}.7z`
-		await $`mv ${config.ffmpegRealname}/lib/x64/* ${config.ffmpegRealname}/lib/`
 	}
 
 	// Setup ONNX Runtime
@@ -444,7 +443,7 @@ if (platform == 'macos') {
 	// Setup FFMPEG
 	if (!(await fs.exists(config.ffmpegRealname))) {
 		await $`wget --no-config -nc ${config.macos.ffmpegUrl} -O ${config.macos.ffmpegName}.7z`
-		await $`7z x ${config.macos.ffmpegName}.7z`
+		await $`7z e ${config.macos.ffmpegName}.7z -o ./${config.macos.ffmpegName}`
 		await $`mv ${config.macos.ffmpegName} ${config.ffmpegRealname}`
 		await $`rm ${config.macos.ffmpegName}.7z`
 	} else {


### PR DESCRIPTION
@louis030195 Fixes the mirrors used to download the ffmpeg binaries - these are listed in the official ffmpeg page so i'd say they're good to use.

Mostly so we don't get blocked by SourceForge.