### PR TITLE
Feat-add-vector-db

### DIFF
--- a/screenpipe-server/Cargo.toml
+++ b/screenpipe-server/Cargo.toml
@@ -117,6 +117,7 @@ sha2 = "0.10.6"
 
 # Fast random number generator
 fastrand = "2.1.1"
+sqlite-vec = "0.1.3"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/screenpipe-server/src/migrations/20241108202826_create_speaker_table.sql
+++ b/screenpipe-server/src/migrations/20241108202826_create_speaker_table.sql
@@ -1,0 +1,1 @@
+-- Add migration script here

--- a/screenpipe-server/src/migrations/20241108202826_create_speaker_table.sql
+++ b/screenpipe-server/src/migrations/20241108202826_create_speaker_table.sql
@@ -1,1 +1,7 @@
--- Add migration script here
+-- Create speakers table
+CREATE TABLE IF NOT EXISTS speakers (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    embedding REAL[512],
+    metadata JSON
+);


### PR DESCRIPTION
---
name: Add Vector DB
about: this uses sqlite-vec to create a speakers table that includes name speaker_embedding and metadata for each speaker.
title: "[pr] "
labels: ''
assignees: ''

---

## description
this uses sqlite-vec to create a speakers table that includes name speaker_embedding and metadata for each speaker.

The `REAL[512]` data type for the embeddings is based on the model [wespeaker-voxceleb-resnet34-LM](https://huggingface.co/pyannote/wespeaker-voxceleb-resnet34-LM)

## type of change
- [ ] bug fix
- [x] new feature
- [ ] breaking change
- [ ] documentation update