### PR TITLE
feat(x256): add x256 support 

### DIFF
--- a/screenpipe-core/src/lib.rs
+++ b/screenpipe-core/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod ffmpeg;
-pub use ffmpeg::find_ffmpeg_path;
+pub use ffmpeg::{find_ffmpeg_path, check_x265_support};
 #[cfg(feature = "llm")]
 pub mod llm;
 #[cfg(feature = "llm")]


### PR DESCRIPTION
/claim #666
/closes #666

This PR uses the changes from #580 and adds Key Improvements:

- Added automatic x265 codec detection on macOS systems
- Implemented intelligent fallback to x264 when x265 is unavailable
- Optimized encoding parameters for both x265 and x264 codecs
- Enhanced error handling and logging for better diagnostics


related issue: #666

## type of change

- [ ] bug fix
- [x] new feature
- [ ] breaking change
- [ ] documentation update


## checklist
- [x] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works

