### PR TITLE
fix: use published release

### DIFF
--- a/.github/scripts/generate_changelog_md.sh
+++ b/.github/scripts/generate_changelog_md.sh
@@ -17,7 +17,7 @@ else
   CN_CMD=cn
 fi
 
-LAST_RELEASE=$($CN_CMD release list screenpipe --api-key $CN_API_KEY --format json | jq '.[0]')
+LAST_RELEASE=$($CN_CMD release list screenpipe --api-key $CN_API_KEY --format json | jq '.[0] | select(.status == "Published")')
 COMMIT_DATE_LAST_RELEASE=$(echo $LAST_RELEASE | jq '.createdAt')
 
 # Format date for git (remove quotes if present)


### PR DESCRIPTION
I see the issue with changelog is still happening.

I figured the (hopefully last) issue is that we're creating a draft at the same time we execute the changelog generation.
The issue occurs because when this script runs on the pipeline, it creates a draft at the same time. So is trying to compare two equal commits, and that's why it quits unexpectedly saying there's no more commits to include.

This PR filters only the first item with status `Published`. The recently created release will have status `Draft` instead.
