### PR TITLE
fix: can focus combobox items (#679)

### DIFF
--- a/screenpipe-app-tauri/package.json
+++ b/screenpipe-app-tauri/package.json
@@ -27,7 +27,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
-    "@radix-ui/react-popover": "^1.1.1",
+    "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-scroll-area": "^1.1.0",
     "@radix-ui/react-select": "^2.1.1",


### PR DESCRIPTION
## description
- Update @radix-ui/react-popover to ^1.1.2 that eventually fix the focusing issue of the combobox items.

related issue: #679 #654 

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test

1. Make sure to have `"@radix-ui/react-popover": "^1.1.2"` under `dependencies` in /screenpipe-app-tauri/package.json
2. Run `bun install` from /screenpipe-app-tauri in your terminal to update @radix-ui/react-popover
3. Run `bun tauri dev`
4. Once the application has started, go to Settings menu and check the following combobox elements are properly working
    - monitors
    - audio devices
    - languages

if relevant add screenshots or screen captures to prove that this PR works to save us time.

https://github.com/user-attachments/assets/3da3f06f-2993-4029-8b76-1a62527ebed3



## checklist
- [x] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [x] i have added tests that prove my fix is effective or that my feature works

## additional notes
I tried inspecting related components from shadcn library but they all looked good and don't seem to cause the issue. Just out of the intuition, I suspected that it's caused by the Popover component of radix-ui so I updated it to the latest version and it eventually worked.