### PR TITLE
fix: build for macos

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,4 +27,10 @@ rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
 #     "-C", "link-arg=-Wl,-rpath,${CARGO_MANIFEST_DIR}/screenpipe-vision/lib"
 # ]
 
+[target.aarch64-apple-darwin]
+rustflags = ["-L", "screenpipe-vision/lib"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-L", "screenpipe-vision/lib"]
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ image = "0.25"
 reqwest = { version = "0.11", features = ["blocking", "multipart", "json"] }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 vcpkg = "0.2"
+cc = "1.0"
 
 [patch.crates-io]
 # enables chinese mirror (hf is banned in china)

--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -3777,7 +3777,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenpipe-app"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/screenpipe-vision/build.rs
+++ b/screenpipe-vision/build.rs
@@ -1,9 +1,50 @@
 #[cfg(target_os = "macos")]
 use std::{env, process::Command, path::PathBuf};
 
+#[cfg(target_os = "macos")]
+fn compile_swift_library() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let lib_path = PathBuf::from(&manifest_dir).join("lib");
+    
+    // Create lib directory if it doesn't exist
+    std::fs::create_dir_all(&lib_path).expect("failed to create lib directory");
+
+    // Compile for both architectures
+    let status = Command::new("swiftc")
+        .args(&[
+            "-emit-library",
+            "-target", if cfg!(target_arch = "aarch64") { 
+                "arm64-apple-macosx11.0" 
+            } else { 
+                "x86_64-apple-macosx11.0" 
+            },
+            "-o", lib_path.join(if cfg!(target_arch = "aarch64") {
+                "libscreenpipe_arm64.dylib"
+            } else {
+                "libscreenpipe_x86_64.dylib"
+            }).to_str().unwrap(),
+            "src/ocr.swift",
+            "-framework", "Metal",
+            "-framework", "MetalPerformanceShaders",
+            "-framework", "Vision",
+            "-framework", "CoreImage",
+        ])
+        .status()
+        .expect("failed to compile Swift library");
+
+    if !status.success() {
+        panic!("failed to compile Swift library");
+    }
+
+    // Tell cargo to link the library
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
+    println!("cargo:rustc-link-lib=dylib=screenpipe");
+}
+
 fn main() {
     #[cfg(target_os = "macos")]
     {
+        compile_swift_library();
         let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
         let bin_path = PathBuf::from(&manifest_dir).join("bin");
 


### PR DESCRIPTION
fresh git clone and build 
```cargo build --release --features metal```
resulted in:

screenpipe/target/release/deps/screenpipe_vision-f8108412ff8ef1ec" "-Wl,-dead_strip" "-nodefaultlibs"
  = note: ld: library 'screenpipe' not found
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
          

error: could not compile `screenpipe-vision` (bin "screenpipe-vision") due to 1 previous error