### PR TITLE
Copy zipfile as bytes

### DIFF
--- a/screenpipe-audio/build.rs
+++ b/screenpipe-audio/build.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "windows")]
-use std::{env, fs, io, process::Command};
+use std::{env, fs, process::Command};
 
 fn main() {
     #[cfg(target_os = "windows")]
@@ -12,10 +12,8 @@ fn main() {
 
         let url = "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-win-x64-gpu-1.19.2.zip";
         let resp = reqwest::blocking::get(url).expect("request failed");
-        let body = resp.text().expect("body invalid");
-        let mut out =
-            fs::File::create("onnxruntime-win-x64-gpu-1.19.2.zip").expect("failed to create file");
-        io::copy(&mut body.as_bytes(), &mut out).expect("failed to copy content");
+        let body = resp.bytes().expect("body invalid");
+        fs::write("./onnxruntime-win-x64-gpu-1.19.2.zip", &body);
         let status = Command::new("unzip")
             .args(["onnxruntime-win-x64-gpu-1.19.2.zip"])
             .status()


### PR DESCRIPTION
@louis030195 Might be needed since GitHub Actions uses UTF-8 encoding for downloads.