### PR TITLE
Sign Windows binaries with test key

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -344,6 +344,7 @@ jobs:
 
       - name: Get version from Cargo.toml
         shell: bash
+        if: matrix.tauri-args == '--target x86_64-pc-windows-msvc'
         run: |
           VERSION=$(grep '^version = ' screenpipe-app-tauri/src-tauri/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
           echo "VERSION=$VERSION" >> $GITHUB_ENV

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -344,14 +344,14 @@ jobs:
 
       - name: Upload screenpipe binary for signing
         id: upload-unsigned-artifact
-        if: matrix.args == '--target x86_64-pc-windows-msvc'
+        if: matrix.tauri-args == '--target x86_64-pc-windows-msvc'
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-screenpipe
-          path: ./screenpipe-app-tauri/src-tauri/target/release/screenpipe.exe
+          path: ./screenpipe-app-tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/screenpipe_${{ env.VERSION }}_x64-setup.exe
 
       - name: Sign artifact
-        if: matrix.args == '--target x86_64-pc-windows-msvc'
+        if: matrix.tauri-args == '--target x86_64-pc-windows-msvc'
         uses: signpath/github-action-submit-signing-request@v1
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
@@ -360,7 +360,7 @@ jobs:
           signing-policy-slug: 'test-signing'
           github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
           wait-for-completion: true
-          output-artifact-directory: './screenpipe-app-tauri/src-tauri/target/release/screenpipe.exe'
+          output-artifact-directory: './screenpipe-app-tauri/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/screenpipe_${{ env.VERSION }}_x64-setup.exe'
 
       - name: Upload Assets to CrabNebula Cloud
         uses: crabnebula-dev/cloud-release@v0.2.6

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -218,7 +218,7 @@ jobs:
         shell: bash
         working-directory: ./screenpipe-app-tauri
         run: |
-          ls . 
+          ls .
           bun install
 
       # - name: Setup tmate session # HACK
@@ -341,6 +341,26 @@ jobs:
           args: ${{ matrix.tauri-args }}
           projectPath: "./screenpipe-app-tauri"
           tauriScript: bunx tauri -v
+
+      - name: Upload screenpipe binary for signing
+        id: upload-unsigned-artifact
+        if: matrix.args == '--target x86_64-pc-windows-msvc'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-screenpipe
+          path: ./screenpipe-app-tauri/src-tauri/target/release/screenpipe.exe
+
+      - name: Sign artifact
+        if: matrix.args == '--target x86_64-pc-windows-msvc'
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '9cd36272-53da-46a4-9d5c-a0870243ba97'
+          project-slug: 'screenpipe'
+          signing-policy-slug: 'test-signing'
+          github-artifact-id: '${{ steps.upload-unsigned-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: './screenpipe-app-tauri/src-tauri/target/release/screenpipe.exe'
 
       - name: Upload Assets to CrabNebula Cloud
         uses: crabnebula-dev/cloud-release@v0.2.6

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -342,6 +342,12 @@ jobs:
           projectPath: "./screenpipe-app-tauri"
           tauriScript: bunx tauri -v
 
+      - name: Get version from Cargo.toml
+        shell: bash
+        run: |
+          VERSION=$(grep '^version = ' screenpipe-app-tauri/src-tauri/Cargo.toml | sed 's/version = "\(.*\)"/\1/')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Upload screenpipe binary for signing
         id: upload-unsigned-artifact
         if: matrix.tauri-args == '--target x86_64-pc-windows-msvc'


### PR DESCRIPTION
/claim #321 
/closes #321

@louis030195 You need to define the GitHub Actions secret "SIGNPATH_API_TOKEN" with a token you can get with the guide at https://about.signpath.io/documentation/users#interactive-api-token

Simply enter your profile, and click in generate token.

Also, let me know when you get a release certificate from Signpath, to change it to release-signing.