### PR TITLE
feat: add timeline icon in linux

### DIFF
--- a/screenpipe-app-tauri/components/timeline/timeline-dock-section.tsx
+++ b/screenpipe-app-tauri/components/timeline/timeline-dock-section.tsx
@@ -34,6 +34,7 @@ export function TimelineIconsSection({
 }: {
   blocks: StreamTimeSeriesResponse[];
 }) {
+  const os = platform();
   const [iconCache, setIconCache] = useState<{ [key: string]: string }>({});
   const [selectedApp, setSelectedApp] = useState<ProcessedBlock | null>(null);
   const { setSelectionRange } = useTimelineSelection();
@@ -242,7 +243,11 @@ export function TimelineIconsSection({
                   }}
                 >
                   <img
-                    src={`data:image/png;base64,${block.iconSrc}`}
+                    src={
+                      os === "linux" 
+                      ? `data:image/svg+xml;base64,${block.iconSrc}`
+                      : `data:image/png;base64,${block.iconSrc}`
+                    }
                     className="w-full h-full opacity-70"
                     alt={block.appName}
                     loading="lazy"
@@ -302,7 +307,11 @@ export function TimelineIconsSection({
               <div className="flex items-center gap-2">
                 {selectedApp?.iconSrc && (
                   <img
-                    src={`data:image/png;base64,${selectedApp.iconSrc}`}
+                    src={
+                      os === "linux"
+                      ? `data:image/svg+xml;base64,${selectedApp.iconSrc}`
+                      : `data:image/png;base64,${selectedApp.iconSrc}`
+                    }
                     className="w-6 h-6"
                     alt={selectedApp.appName}
                   />

--- a/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -97,6 +97,10 @@ base64 = "0.22.1"
 winreg = "0.52.0"
 windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git" }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+gtk = "0.18.1"
+base64 = "0.22.1"
+
 [features]
 cudart = []
 metal = []


### PR DESCRIPTION
---
name: timeline apps icon for linux
about: this will add app icons in timeline ui on linux, i used a [`gtk`](https://crates.io/crates/gtk) crate for getting the icon path and info, but the icon was in svg format, so i need to do some changes in `timeline-dock-section.tsx`  bcz converting svg icon to png will require some extra crate. also in linux timeline isn't streaming frames so its hard to attach screenshots, but i've tested [this](https://github.com/tribhuwan-kumar/screenpipe/blob/3a2bf72f658055dfacc7762479853c5a5a1e7c17/screenpipe-app-tauri/src-tauri/src/icons.rs#L266) function outside the app & i'm sure it will work! 
title: "[pr] "
labels: ''
assignees: ''
fix: #712
/claim #712

---

## description
brief description of the changes in this pr.

related issue: #712 

## type of change
- [ ] bug fix
- [x] new feature
- [ ] breaking change
- [ ] documentation update

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time.

## checklist
- [ ] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [ ] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have updated the documentation if necessary
- [ ] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works

## additional notes
any other relevant information about the pr.
