### PR TITLE
add missing dependencies in Linux build instructions

### DIFF
--- a/content/docs/pages/docs/getting-started.mdx
+++ b/content/docs/pages/docs/getting-started.mdx
@@ -202,7 +202,7 @@ bun tauri build
 
 1. install dependencies with the following commands:
 ```bash copy
-sudo apt-get install -y ffmpeg tesseract-ocr cmake libavformat-dev libavfilter-dev libavdevice-dev libtesseract-dev libxdo-dev libsdl2-dev libclang-dev libxtst-dev
+sudo apt-get install -y g++ ffmpeg tesseract-ocr cmake libavformat-dev libavfilter-dev libavdevice-dev libssl-dev libtesseract-dev libxdo-dev libsdl2-dev libclang-dev libxtst-dev
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 


### PR DESCRIPTION
## description
This PR adds two system packages required to build screenpipe on a Ubuntu system, specifically on a container created from the `ubuntu-toolbox:24.04` image.

Missing `libssl-dev` resulted in `error: failed to run custom build command for 'openssl-sys v0.9.104'`.

Missing C++ compiler resulted in error when compiling `esaxx-rs`.

## type of change
- [ ] bug fix
- [ ] new feature
- [ ] breaking change
- [x] documentation update

## how to test
Run a `ubuntu-toolbox:24.04` container, and build screenpipe successfully using provided instructions.

## checklist
- [x] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [x] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works