### PR TITLE
fix(build): Fix hardcoded vcpkg.exe path in pre_build.js(#752)

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -315,7 +315,7 @@ if (platform == 'windows') {
 	}
 
 	// Setup vcpkg packages with environment variables set inline
-	await $`SystemDrive=${process.env.SYSTEMDRIVE} SystemRoot=${process.env.SYSTEMROOT} windir=${process.env.WINDIR} C:\\vcpkg\\vcpkg.exe install ${config.windows.vcpkgPackages}`.quiet()
+	await $`SystemDrive=${process.env.SYSTEMDRIVE} SystemRoot=${process.env.SYSTEMROOT} windir=${process.env.WINDIR} ${process.env.VCPKG_ROOT}\\vcpkg.exe install ${config.windows.vcpkgPackages}`.quiet()
 }
 
 async function getMostRecentBinaryPath(targetArch, paths) {


### PR DESCRIPTION
---
name: pull request
about:  Fix hardcoded vcpkg.exe path in pre_build.js
title: "[pr] fix(build): Fix hardcoded vcpkg.exe path in pre_build.js(#752)"
labels: 'bug'
assignees: ''

---

## description
Use VCPKG_ROOT for vcpkg.exe path.

related issue: #752 

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test

add a few steps to test the pr in the most time efficient way.
https://docs.screenpi.pe/docs/getting-started#windows-installation-experimental
```
SET PKG_CONFIG_PATH=xxxxx
SET VCPKG_ROOT=xxxx\vcpkg
SET LIBCLANG_PATH=xxxxx
cd screenpipe
rustup default stable
cargo build --release 
cd screenpipe-app-tauri
bun install
bun scripts\pre_build.js 
```

if relevant add screenshots or screen captures to prove that this PR works to save us time.
![image](https://github.com/user-attachments/assets/6b0f13a8-89ca-48ce-8e08-8c9d13af89c7)


## checklist
- [ ] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works

