### PR TITLE
SP-774: fix close sp be and embedded ai

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/llm_sidecar.rs
+++ b/screenpipe-app-tauri/src-tauri/src/llm_sidecar.rs
@@ -1,14 +1,17 @@
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::process::Stdio;
 use std::time::Duration;
 use tauri::async_runtime::Receiver;
 use tauri::Emitter;
 use tauri::Manager;
 use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
+use tokio::process::Command;
 use tokio::time::sleep;
 use tracing::{error, info};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddedLLMSettings {
     pub enabled: bool,
@@ -26,6 +29,8 @@ pub enum OllamaStatus {
 pub struct LLMSidecar {
     settings: EmbeddedLLMSettings,
     status: OllamaStatus,
+    serve_process_id: Option<u32>,
+    model_process_id: Option<u32>,
 }
 
 impl LLMSidecar {
@@ -33,12 +38,14 @@ impl LLMSidecar {
         Self {
             settings,
             status: OllamaStatus::Idle,
+            serve_process_id: None,
+            model_process_id: None,
         }
     }
 
     pub async fn start(&mut self, app: tauri::AppHandle) -> Result<String> {
         self.status = OllamaStatus::Running;
-        app.emit("ollama_status", &self.status)?;
+        app.emit_all("ollama_status", &self.status)?;
 
         // Get the resource directory path
         let resource_path = app.path().resource_dir().unwrap();
@@ -48,7 +55,7 @@ impl LLMSidecar {
         let new_cuda_path = format!("{}:{}", cuda_path, resource_path.display());
 
         info!("Starting Ollama serve command...");
-        let mut serve_command = app.shell().sidecar("ollama").unwrap();
+        let mut serve_command = app.shell().sidecar("ollama")?;
         serve_command = serve_command
             .args(&["serve"])
             .env(
@@ -62,17 +69,18 @@ impl LLMSidecar {
             serve_command = serve_command.env("OLLAMA_ORIGINS", "*");
         }
 
-        let (mut receiver, _) = serve_command.spawn()?;
+        let (mut serve_receiver, serve_child) = serve_command.spawn()?;
+        self.serve_process_id = Some(serve_child.pid());
 
         // Stream logs for serve command
-        self.stream_logs("ollama-serve", &mut receiver).await?;
+        self.stream_logs("ollama-serve", &mut serve_receiver).await?;
 
         info!("Waiting for Ollama server to start...");
         self.wait_for_server().await?;
 
         // Now run the model
         info!("Starting Ollama model...");
-        let mut model_command = app.shell().sidecar("ollama").unwrap();
+        let mut model_command = app.shell().sidecar("ollama")?;
         model_command = model_command
             .args(&["run", &self.settings.model])
             .env("CUDA_PATH", &new_cuda_path);
@@ -82,10 +90,11 @@ impl LLMSidecar {
             model_command = model_command.env("OLLAMA_ORIGINS", "*");
         }
 
-        let (mut receiver, _) = model_command.spawn()?;
+        let (mut model_receiver, model_child) = model_command.spawn()?;
+        self.model_process_id = Some(model_child.pid());
 
         // Stream logs for model command
-        self.stream_logs("ollama-model", &mut receiver).await?;
+        self.stream_logs("ollama-model", &mut model_receiver).await?;
 
         info!("Testing Ollama model...");
         let test_result = self.test_model().await?;
@@ -149,18 +158,18 @@ impl LLMSidecar {
         for attempt in 1..=MAX_RETRIES {
             match self.attempt_model_test().await {
                 Ok(result) => {
-                    info!("model test successful on attempt {}: {}", attempt, result);
+                    info!("Model test successful on attempt {}: {}", attempt, result);
                     return Ok(result);
                 }
                 Err(e) => {
                     if attempt == MAX_RETRIES {
                         return Err(anyhow!(
-                            "failed to test model after {} attempts: {}",
+                            "Failed to test model after {} attempts: {}",
                             MAX_RETRIES,
                             e
                         ));
                     }
-                    error!("model test failed on attempt {}: {}", attempt, e);
+                    error!("Model test failed on attempt {}: {}", attempt, e);
                     sleep(RETRY_DELAY).await;
                 }
             }
@@ -191,13 +200,13 @@ impl LLMSidecar {
             .await?;
 
         if !response.status().is_success() {
-            return Err(anyhow!("failed to get response from model"));
+            return Err(anyhow!("Failed to get response from model"));
         }
 
         let data: serde_json::Value = response.json().await?;
         let result = data["choices"][0]["message"]["content"]
             .as_str()
-            .ok_or_else(|| anyhow!("unexpected response format"))?
+            .ok_or_else(|| anyhow!("Unexpected response format"))?
             .trim()
             .to_string();
 
@@ -206,30 +215,79 @@ impl LLMSidecar {
 
     pub async fn stop(&mut self, app: tauri::AppHandle) -> Result<()> {
         self.status = OllamaStatus::Idle;
-        app.emit("ollama_status", &self.status)?;
+        app.emit_all("ollama_status", &self.status)?;
 
-        #[cfg(target_os = "windows")]
-        {
-            app.shell()
-                .command("taskkill")
-                .args(&["/F", "/IM", "ollama.exe"])
-                .spawn()
-                .unwrap();
+        // Attempt to gracefully terminate the serve process
+        if let Some(pid) = self.serve_process_id {
+            info!("Terminating ollama-serve process with PID {}", pid);
+            #[cfg(target_os = "windows")]
+            {
+                Command::new("taskkill")
+                    .args(&["/PID", &pid.to_string(), "/T", "/F"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("Failed to execute taskkill");
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                Command::new("kill")
+                    .arg(pid.to_string())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("Failed to execute kill command");
+            }
         }
 
-        #[cfg(not(target_os = "windows"))]
-        {
-            let output = app
-                .shell()
-                .command("pkill")
-                .arg("ollama")
-                .output()
-                .await
-                .unwrap();
-            info!("Ollama stopped: {:?}", output);
+        // Attempt to gracefully terminate the model process
+        if let Some(pid) = self.model_process_id {
+            info!("Terminating ollama-model process with PID {}", pid);
+            #[cfg(target_os = "windows")]
+            {
+                Command::new("taskkill")
+                    .args(&["/PID", &pid.to_string(), "/T", "/F"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("Failed to execute taskkill");
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                Command::new("kill")
+                    .arg(pid.to_string())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("Failed to execute kill command");
+            }
         }
+
+        // Verify that no 'ollama' processes are running
+        self.verify_ollama_termination().await?;
 
         Ok(())
+    }
+
+    async fn verify_ollama_termination(&self) -> Result<()> {
+        use sysinfo::{ProcessExt, SystemExt};
+
+        let mut system = sysinfo::System::new_all();
+        system.refresh_processes();
+
+        let processes = system
+            .processes_by_name("ollama")
+            .collect::<Vec<_>>();
+
+        if processes.is_empty() {
+            info!("All ollama processes have been terminated.");
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "Some ollama processes are still running: {:?}",
+                processes.iter().map(|p| p.pid()).collect::<Vec<_>>()
+            ))
+        }
     }
 }
 

--- a/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -1,9 +1,7 @@
 use crate::kill_all_sreenpipes;
-use crate::llm_sidecar::stop_ollama_sidecar;
 use crate::SidecarState;
 use anyhow::Error;
 use log::{error, info};
-use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::menu::{MenuItem, MenuItemBuilder};
@@ -30,7 +28,7 @@ impl UpdatesManager {
             update_available: Arc::new(Mutex::new(false)),
             update_installed: Arc::new(Mutex::new(false)),
             app: app.clone(),
-            update_menu_item: MenuItemBuilder::with_id("update_now", "Screenpipe is up to date")
+            update_menu_item: MenuItemBuilder::with_id("update_now", "screenpipe is up to date")
                 .enabled(false)
                 .build(app)?,
         })
@@ -43,8 +41,18 @@ impl UpdatesManager {
         if let Some(update) = self.app.updater()?.check().await? {
             *self.update_available.lock().await = true;
 
-            self.update_menu_item.set_enabled(true)?;
-            self.update_menu_item.set_text("Update now")?;
+            #[cfg(target_os = "windows")]
+            {
+                self.update_menu_item.set_enabled(true)?;
+                self.update_menu_item.set_text("update now")?;
+            }
+
+            #[cfg(not(target_os = "windows"))]
+            {
+                self.update_menu_item.set_enabled(false)?;
+                self.update_menu_item
+                    .set_text("downloading latest version of screenpipe")?;
+            }
 
             if let Some(tray) = self.app.tray_by_id("screenpipe_main") {
                 let path = self.app.path().resolve(
@@ -52,10 +60,18 @@ impl UpdatesManager {
                     tauri::path::BaseDirectory::Resource,
                 )?;
 
-                if let Ok(image) = tauri::Image::from_path(path) {
+                if let Ok(image) = tauri::image::Image::from_path(path) {
                     tray.set_icon(Some(image))?;
                     tray.set_icon_as_template(true)?;
                 }
+            }
+
+            #[cfg(not(target_os = "windows"))]
+            {
+                update.download_and_install(|_, _| {}, || {}).await?;
+                *self.update_installed.lock().await = true;
+                self.update_menu_item.set_enabled(true)?;
+                self.update_menu_item.set_text("update now")?;
             }
 
             if show_dialog {
@@ -104,59 +120,17 @@ impl UpdatesManager {
                 }
             }
 
-            return Ok(true);
+            return Result::Ok(true);
         }
 
-        Ok(false)
-    }
-
-    async fn perform_update(&self) -> Result<(), Box<dyn std::error::Error>> {
-        self.update_menu_item.set_enabled(false)?;
-        self.update_menu_item
-            .set_text("Downloading the latest version of Screenpipe")?;
-
-        let is_dev_mode = cfg!(debug_assertions);
-
-        if !is_dev_mode || cfg!(target_os = "windows") {
-            // Stop the embedded AI
-            if let Err(err) = stop_ollama_sidecar(self.app.clone()).await {
-                error!("Failed to stop llm_sidecar: {}", err);
-            } else {
-                info!("Successfully stopped llm_sidecar.");
-            }
-
-            // Stop the Screenpipe backend
-            if let Err(err) =
-                kill_all_sreenpipes(self.app.state::<SidecarState>(), self.app.clone()).await
-            {
-                error!("Failed to terminate Screenpipe backend: {}", err);
-            } else {
-                info!("Successfully terminated Screenpipe backend.");
-            }
-        }
-
-        // Proceed with the update
-        if let Some(update) = self.app.updater()?.check().await? {
-            update.download_and_install(|_, _| {}, || {}).await?;
-            *self.update_installed.lock().await = true;
-            self.update_menu_item.set_enabled(true)?;
-            self.update_menu_item.set_text("Update now")?;
-            info!("Update downloaded and ready to install.");
-        } else {
-            error!("Update was not found during perform_update.");
-        }
-
-        // Restart the app to apply the update
-        self.update_screenpipe();
-
-        Ok(())
+        Result::Ok(false)
     }
 
     pub fn update_now_menu_item_ref(&self) -> &MenuItem<Wry> {
         &self.update_menu_item
     }
 
-    pub fn update_screenpipe(&self) {
+    pub fn update_screenpipe(&self) -> Option<Error> {
         self.app.restart();
     }
 
@@ -166,7 +140,7 @@ impl UpdatesManager {
         loop {
             interval.tick().await;
             if !*self.update_available.lock().await {
-                if let Err(e) = self.check_for_updates(false).await {
+                if let Err(e) = self.check_for_updates(true).await {
                     error!("Failed to check for updates: {}", e);
                 }
             }
@@ -180,19 +154,18 @@ pub fn start_update_check(
 ) -> Result<Arc<UpdatesManager>, Box<dyn std::error::Error>> {
     let updates_manager = Arc::new(UpdatesManager::new(app, interval_minutes)?);
 
-    // Check for updates at startup
+    // Check for updates at boot
     tokio::spawn({
         let updates_manager = updates_manager.clone();
         async move {
             if let Err(e) = updates_manager.check_for_updates(false).await {
                 error!("Failed to check for updates: {}", e);
-            } else {
-                info!("Initial update check completed.");
             }
+            info!("Update check started");
         }
     });
 
-    // Start periodic update checks
+    // Start periodic events
     tokio::spawn({
         let updates_manager = updates_manager.clone();
         async move {


### PR DESCRIPTION
Feature: Screenpipe Update Process

  Scenario: Properly close Screenpipe backend during updates
    Given the Screenpipe application is running
    And the backend process is active
    When an update is triggered
    Then the backend process is gracefully terminated
    And no orphaned backend processes remain running

  Scenario: Properly close the embedded AI during updates
    Given the Screenpipe application is running
    And the embedded AI process (`llm_sidecar.rs`) is active
    When an update is triggered
    Then the embedded AI process is gracefully terminated
    And no orphaned AI processes remain running

  Scenario: Notify the user of updates without disruption
    Given the Screenpipe application is running
    And a new update is available
    When the application checks for updates
    Then the user receives a non-intrusive notification
    And the user can choose to install the update or defer it

  Scenario: Allow the user to defer updates
    Given the Screenpipe application is running
    And a new update is available
    When the user chooses to update later
    Then the application continues to run without interruption
    And the update is not applied immediately

  Scenario: Restart the application after updating
    Given the Screenpipe application is running
    And a new update is downloaded and installed
    When the update process completes
    Then the application restarts automatically
    And the new version is applied

  Scenario: Handle updates differently in development mode
    Given the application is running in development mode
    And the backend or embedded AI processes are active
    When an update is triggered
    Then the processes are not terminated
    And the update proceeds without killing active processes

  Scenario: Ensure robust process termination
    Given the Screenpipe backend and embedded AI processes are active
    When an update is triggered
    And the termination of a process fails
    Then an error is logged
    And the update process continues
    And a retry mechanism is in place to ensure termination

  Scenario: Validate no orphaned processes remain
    Given the Screenpipe backend and embedded AI processes are active
    When the application checks for running processes after termination
    Then no orphaned processes are detected
    And a success message is logged