### PR TITLE
Fix infinite powershell

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/icons.rs
+++ b/screenpipe-app-tauri/src-tauri/src/icons.rs
@@ -16,11 +16,11 @@ pub async fn get_app_icon(
     use cocoa::base::{id, nil};
     use cocoa::foundation::{NSAutoreleasePool, NSData, NSString};
     use objc::{class, msg_send, sel, sel_impl};
-    
+
     unsafe {
         // Create autorelease pool
         let pool = NSAutoreleasePool::new(nil);
-        
+
         let result = (|| {
             let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
 
@@ -31,7 +31,7 @@ pub async fn get_app_icon(
                 let path: id = msg_send![workspace, fullPathForApplication: ns_app_name];
                 // Release the NSString we created
                 let _: () = msg_send![ns_app_name, release];
-                
+
                 if path == nil {
                     return Ok(None);
                 }
@@ -68,7 +68,7 @@ pub async fn get_app_icon(
 
         // Drain the autorelease pool
         let _: () = msg_send![pool, drain];
-        
+
         result
     }
 }
@@ -159,7 +159,7 @@ async fn get_exe_from_potential_path(app_name: &str) -> Option<String>{
                 r#"
                     Get-ChildItem -Path "{}" -Filter "*{}*.exe" -Recurse | ForEach-Object {{ $_.FullName }}
                     "#,
-                path, 
+                path,
                 app_name
             )
         } else {
@@ -167,12 +167,15 @@ async fn get_exe_from_potential_path(app_name: &str) -> Option<String>{
                 r#"
                     Get-ChildItem -Path "{}" -Filter "*{}*.exe" | ForEach-Object {{ $_.FullName }}
                     "#,
-                path, 
+                path,
                 app_name
             )
         };
 
         let output = tokio::process::Command::new("powershell")
+            .arg("-NoProfile")
+            .arg("-WindowStyle")
+            .arg("hidden")
             .arg("-Command")
             .arg(command)
             .output()
@@ -196,9 +199,12 @@ async fn get_exe_by_appx(
     use std::str;
 
     let app_name = app_name.strip_suffix(".exe").unwrap_or(&app_name);
-    let app_name_withoutspace = app_name.replace(" ", ""); 
+    let app_name_withoutspace = app_name.replace(" ", "");
 
     let output = tokio::process::Command::new("powershell")
+        .arg("-NoProfile")
+        .arg("-WindowStyle")
+        .arg("hidden")
         .arg("-Command")
         .arg(format!(
             r#"Get-AppxPackage | Where-Object {{ $_.Name -like "*{}*" }}"#,
@@ -220,6 +226,9 @@ async fn get_exe_by_appx(
         .map(str::trim)?;
 
     let exe_output = tokio::process::Command::new("powershell")
+        .arg("-NoProfile")
+        .arg("-WindowStyle")
+        .arg("hidden")
         .arg("-Command")
         .arg(format!(
             r#"
@@ -240,6 +249,9 @@ async fn get_exe_by_appx(
     }
     // second attempt with space if the first attempt couldn't find exe
     let exe_output = tokio::process::Command::new("powershell")
+        .arg("-NoProfile")
+        .arg("-WindowStyle")
+        .arg("hidden")
         .arg("-Command")
         .arg(format!(
             r#"
@@ -295,4 +307,3 @@ pub async fn get_app_icon(
         path: Some(path),
     }))
 }
-

--- a/screenpipe-app-tauri/src-tauri/src/icons.rs
+++ b/screenpipe-app-tauri/src-tauri/src/icons.rs
@@ -172,11 +172,13 @@ async fn get_exe_from_potential_path(app_name: &str) -> Option<String>{
             )
         };
 
+        const CREATE_NO_WINDOW: u32 = 0x8000000;
         let output = tokio::process::Command::new("powershell")
             .arg("-NoProfile")
             .arg("-WindowStyle")
             .arg("hidden")
             .arg("-Command")
+            .creation_flags(CREATE_NO_WINDOW)
             .arg(command)
             .output()
             .await
@@ -201,6 +203,8 @@ async fn get_exe_by_appx(
     let app_name = app_name.strip_suffix(".exe").unwrap_or(&app_name);
     let app_name_withoutspace = app_name.replace(" ", "");
 
+
+    const CREATE_NO_WINDOW: u32 = 0x8000000;
     let output = tokio::process::Command::new("powershell")
         .arg("-NoProfile")
         .arg("-WindowStyle")
@@ -210,6 +214,7 @@ async fn get_exe_by_appx(
             r#"Get-AppxPackage | Where-Object {{ $_.Name -like "*{}*" }}"#,
             app_name_withoutspace
         ))
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .await
         .expect("failed to execute powershell command");
@@ -237,6 +242,7 @@ async fn get_exe_by_appx(
             package_name,
             app_name_withoutspace
         ))
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .await
         .ok()?;
@@ -260,6 +266,7 @@ async fn get_exe_by_appx(
             package_name,
             app_name
         ))
+        .creation_flags(CREATE_NO_WINDOW)
         .output()
         .await
         .ok()?;


### PR DESCRIPTION
/claim #798
/closes #798

@louis030195 In the case that the user had a special PowerShell config in their profile, it might have changed the behavior of the commands, this hides the window as well as a bonus, it might've looked sketchy to the users.