### PR TITLE
Use specific target triple

### DIFF
--- a/screenpipe-app-tauri/src-tauri/build.rs
+++ b/screenpipe-app-tauri/src-tauri/build.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "macos")]
-use std::{fs, process::Command};
+use std::{fs, process::Command, env};
 
 fn main() {
     // Copies executables and hardcodes the dylibs
@@ -9,7 +9,7 @@ fn main() {
         {
             let primary_path = "../../target/x86_64-apple-darwin/release/screenpipe";
             let fallback_path = "../../target/release/screenpipe";
-            
+
             let source_path = if fs::metadata(primary_path).is_ok() {
                 primary_path
             } else {
@@ -18,7 +18,7 @@ fn main() {
 
             fs::copy(source_path, "screenpipe-x86_64-apple-darwin")
                 .expect("failed to copy screenpipe binary");
-            
+
             Command::new("install_name_tool")
                 .args(["-change", "../../screenpipe-vision/lib/libscreenpipe_x86_64.dylib",
                        "@executable_path/../Frameworks/libscreenpipe_x86_64.dylib", "./screenpipe-x86_64-apple-darwin"])
@@ -31,10 +31,10 @@ fn main() {
                 .expect("failed to execute process");
         }
         #[cfg(target_arch = "aarch64")]
-        {
+        if env::var("TARGET").unwrap() == "aarch64-apple-darwin" {
             let primary_path = "../../target/aarch64-apple-darwin/release/screenpipe";
             let fallback_path = "../../target/release/screenpipe";
-            
+
             let source_path = if fs::metadata(primary_path).is_ok() {
                 primary_path
             } else {
@@ -43,7 +43,7 @@ fn main() {
 
             fs::copy(source_path, "screenpipe-aarch64-apple-darwin")
                 .expect("failed to copy screenpipe binary");
-            
+
             Command::new("install_name_tool")
                 .args(["-change", "../../screenpipe-vision/lib/libscreenpipe_arm64.dylib",
                        "@executable_path/../Frameworks/libscreenpipe_arm64.dylib", "./screenpipe-aarch64-apple-darwin"])


### PR DESCRIPTION
@louis030195 We try using specifically the ARM target so that x86 doesn't grab it - but if it still does, might likely be a Cargo bug.