### PR TITLE
fix: infinite loop of creating powershell windows

### DIFF
--- a/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -95,6 +95,7 @@ base64 = "0.22.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52.0"
+lazy_static = "1.5.0"
 windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git" }
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
---
fix: #798 
about: this will fix the creating infinite powershell window on invocation of `get_app_icon` and limit the powershell process which was abusing system resources. also used `localforage` for icon caching (including in memory cache). so it won't need to invoke command every time to get base64 of icon. 
the concurrency process limit is 5, assuming every screenpipe user have 16GB of ram!

i should've done in this https://github.com/mediar-ai/screenpipe/pull/706, sorry for the inconvenience!
title: "[pr] "
labels: ''
assignees: ''

---

## description
brief description of the changes in this pr.

related issue: #798

## type of change
- [ ] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time.

## checklist
- [ ] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [ ] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have updated the documentation if necessary
- [ ] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works

## additional notes
any other relevant information about the pr.
