### PR TITLE
fix: clerk integration

### DIFF
--- a/screenpipe-app-tauri/app/layout.tsx
+++ b/screenpipe-app-tauri/app/layout.tsx
@@ -12,10 +12,18 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+
+  const getClerkPublishableKey = () => {
+    const isDebug = process.env.TAURI_ENV_DEBUG === "true";
+
+    if(isDebug) return "pk_test_ZGVjZW50LXRyb3V0LTEuY2xlcmsuYWNjb3VudHMuZGV2JA"
+    return "pk_live_Y2xlcmsuc2NyZWVucGkucGUk"
+  }
+
   return (
     <html lang="en" suppressHydrationWarning>
       <ClerkProvider
-        publishableKey="pk_test_ZGVjZW50LXRyb3V0LTEuY2xlcmsuYWNjb3VudHMuZGV2JA"
+        publishableKey={getClerkPublishableKey()}
         allowedRedirectOrigins={["http://localhost:3000", "tauri://localhost"]}
       >
         <Providers>


### PR DESCRIPTION
/claim #822

## description
This PR uses clerk keys based on tauri env. 

Clerk production env. keys will not work on local due to the restrictions on origin. Prod key will only work if the request origin is https://screenpi.pe/

Reference: https://www.reddit.com/r/nextjs/comments/164xfye/using_clerk_auth_in_production_why/

related issue: #822

## type of change
- [x] bug fix
- [ ] new feature
- [ ] breaking change
- [ ] documentation update

## how to test

Clerk prod. key doesnt work on localhost. Working curls of prod. env key when origin is `https://screenpi.pe/` :

`curl --location 'https://clerk.screenpi.pe/v1/environment?__clerk_api_version=2024-10-01&_clerk_js_version=5.36.0' \
--header 'accept: */*' \
--header 'accept-language: en-US,en;q=0.9,hi;q=0.8' \
--header 'cache-control: no-cache' \
--header 'cookie: __cf_bm=JfEaZJAlGRUrTVaLSKpE0EiTzNUNs_6aq3IDDuhwMHc-1733170806-1.0.1.1-HLLB9ms5TDR74wb6UTVPrWKtQpREx.RMh4fEjyE.Pws0f7rDrYzYuxficFBumwx03xiqTFo97uhO_nnOOLMZFA; _cfuvid=sXuEqjCWHbCpSGbT5DdIstDSa4bpxnaFNXvwWOo2pLo-1733170806937-0.0.1.1-604800000; __client_uat=0; __client_uat_ChvtXC15=0; __cf_bm=6fFgjO5ZmDDgbds7UW6KDj2D6WhG2xvmzsj5S2ZOVEE-1733172644-1.0.1.1-XSN4gcHV4TAZ1mEUZyBafNPvpU7DF5DvwLVGcbYijifulCinLaTPUhsCZ5hjxIBpRsCDFRkPsUSD4QeMZN9pZg' \
--header 'origin: https://screenpi.pe' \
--header 'pragma: no-cache' \
--header 'priority: u=1, i' \
--header 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "Windows"' \
--header 'sec-fetch-dest: empty' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-site: cross-site' \
--header 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'`

`curl --location 'https://clerk.screenpi.pe/v1/client?__clerk_api_version=2024-10-01&_clerk_js_version=5.36.0' \
--header 'accept: */*' \
--header 'accept-language: en-US,en;q=0.9,hi;q=0.8' \
--header 'cache-control: no-cache' \
--header 'cookie: _cfuvid=sXuEqjCWHbCpSGbT5DdIstDSa4bpxnaFNXvwWOo2pLo-1733170806937-0.0.1.1-604800000; __cf_bm=iTEFhkjGTZfOLixnM51WeL5huWR4oILoAh5Do33bTyg-1733173957-1.0.1.1-PFxSneO9pSVCbG.pVyQ6k9oM92R54jZwwNC.17N3GPn9XMStenHmAW2OWLHpx8reHV3gY75NF6CyAFqWAGS3Sw; __client_uat=0; __client_uat_ChvtXC15=0; __cf_bm=6fFgjO5ZmDDgbds7UW6KDj2D6WhG2xvmzsj5S2ZOVEE-1733172644-1.0.1.1-XSN4gcHV4TAZ1mEUZyBafNPvpU7DF5DvwLVGcbYijifulCinLaTPUhsCZ5hjxIBpRsCDFRkPsUSD4QeMZN9pZg; __client=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6ImNsaWVudF8ycGc0OTZ1VXJXS2pVb3hIRXlxZGlEeFJmZlgiLCJyb3RhdGluZ190b2tlbiI6IjFvYjA2d29sa3Y0ano0Z2NvZWFsNnVwbm5vZnA5eTYzeGE5cXRsbzYifQ.Aq6fpVeT5GihuPZb8bw9RxJ5dYuHJkyX7ExUXCC78PBBf7bwgiOBieORsJzeN9wwLwzX2lb-ZtoMZ1D_nowZT6NKHH021eD65_dhoHSNj5dcQo-glFgrCFIjIvjRICdcvn6-TdU5UEcGrNT_F3IHfZ8U6mjD7S3AOV_4UrC2M8flAPwqW-Wsy1J-F4p58vQjQtN82FPyhKOQFiPg-R--Yl30nFCzP6nU6g2IC-qKAAMTYUSlBwccIrTy-PFuZpIpLFzPia6GfDjQp2W_JDeC_ob-DNyjp6c1LE6Rw7LHRUNBQL0u7BfRh9DP9KKWm0DLfK0FOdGpkmOqwq_3lArLFQ' \
--header 'origin: https://screenpi.pe' \
--header 'pragma: no-cache' \
--header 'priority: u=1, i' \
--header 'sec-ch-ua: "Google Chrome";v="131", "Chromium";v="131", "Not_A Brand";v="24"' \
--header 'sec-ch-ua-mobile: ?0' \
--header 'sec-ch-ua-platform: "Windows"' \
--header 'sec-fetch-dest: empty' \
--header 'sec-fetch-mode: cors' \
--header 'sec-fetch-site: cross-site' \
--header 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'`

## checklist
- [x] MOST IMPORTANT: this PR will require less than 30 min to review, merge, and release to production and not crash in the hand of thousands of users
- [x] i have read the [CONTRIBUTING.md](https://github.com/mediar-ai/screenpipe/blob/main/CONTRIBUTING.md) file 
- [ ] i have updated the documentation if necessary
- [x] my changes generate no new warnings
- [ ] i have added tests that prove my fix is effective or that my feature works
