### PR TITLE
Make sure ONNX is copied into output folder

### DIFF
--- a/screenpipe-audio/build.rs
+++ b/screenpipe-audio/build.rs
@@ -84,9 +84,9 @@ fn install_onnxruntime() {
     if !status.success() {
         panic!("failed to install onnx binary");
     }
-    fs::copy("onnxruntime-win-x64-gpu-1.19.2/lib/onnxruntime.dll", env::var("OUT_DIR").unwrap()).expect("Failed to copy ONNX");
     fs::rename(
         "onnxruntime-win-x64-gpu-1.19.2",
         "../screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-gpu-1.19.2",
     );
+    println!("cargo:rustc-link-search=native=../screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-gpu-1.19.2/lib");
 }

--- a/screenpipe-audio/build.rs
+++ b/screenpipe-audio/build.rs
@@ -84,6 +84,7 @@ fn install_onnxruntime() {
     if !status.success() {
         panic!("failed to install onnx binary");
     }
+    fs::copy("onnxruntime-win-x64-gpu-1.19.2/lib/onnxruntime.dll", env::var("OUT_DIR").unwrap()).expect("Failed to copy ONNX");
     fs::rename(
         "onnxruntime-win-x64-gpu-1.19.2",
         "../screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-gpu-1.19.2",


### PR DESCRIPTION
/claim #794 
/closes #794 

@louis030195 Fixes the issue by copying the newer library so Windows doesn't use the included one in system32.