### PR TITLE
fix: iterate over newSettings to avoid setting unchanged settings

### DIFF
--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -214,7 +214,7 @@ export function useSettings() {
       const updatedSettings = { ...settings, ...newSettings };
 
       // Save each setting individually to the store
-      for (const [key, value] of Object.entries(updatedSettings)) {
+      for (const [key, value] of Object.entries(newSettings)) {
         await store!.set(key, value);
       }
 


### PR DESCRIPTION
## description

By going with this:

```
// Create complete updated settings object
      const updatedSettings = { ...settings, ...newSettings };

// Save each setting individually to the store
      for (const [key, value] of Object.entries(updatedSettings)) {
        await store!.set(key, value);
      }
```
store.set is called even for settings that remain unchanged.

~~Also noticed issue with my code was that I did this:~~

```
// Save each setting individually to the store
      for (const key of newSettings) {
        await store!.set(key, value);
      }
```
~~instead of:~~
```
// Save each setting individually to the store
      for (const [key, value] of Object.entries(newSettings)) {
        await store!.set(key, value);
      }
```
~~Apologies for that.~~

Rest of code that was removed in commit #648c89abeb770ab5a2630fa90d9fcd80e1bbc813, I did consider removing but didnt want to cause any side effects as I didnt really understand how the settings feature was implemented. So I tried to make my solution as non invasive as possible

EDIT:
Not quite sure if issue came from my code, as `key of newSettings` is working properly in my local instance
