### PR TITLE
(feat) macOS/Linux one-liner installation script 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,21 @@ get_os_arch() {
     esac
 }
 
+install_xcode_tools() {
+    # Only run if the tools are not installed yet
+    # To check that try to print the SDK path
+    xcode-select -p &> /dev/null
+    if [ $? -ne 0 ]; then
+        echo "Command Line Tools for Xcode not found. Installing from softwareupdate…"
+        # This temporary file prompts the 'softwareupdate' utility to list the Command Line Tools
+        touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress;
+        PROD=$(softwareupdate -l | grep "\*.*Command Line" | tail -n 1 | sed 's/^[^C]* //')
+        softwareupdate -i "$PROD" --verbose;
+    else
+        echo "Command Line Tools for Xcode have been installed."
+    fi
+}
+
 echo "Fetching latest version from GitHub..."
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/mediar-ai/screenpipe/releases/latest)
 VERSION=$(echo "$LATEST_RELEASE" | grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
@@ -106,6 +121,10 @@ if [ "$os" = "unknown-linux-gnu" ]; then
             sudo zypper --quiet --non-interactive install $PKGS >/dev/null 2>&1
         fi
     fi
+fi
+
+if [ "$(uname)" = "Darwin" ]; then
+    install_xcode_tools
 fi
 
 echo "Downloading screenpipe v${VERSION} for ${arch}-${os}..."

--- a/install.sh
+++ b/install.sh
@@ -231,6 +231,29 @@ if ! ln -sf "$INSTALL_DIR/screenpipe" "$HOME/.local/bin/screenpipe"; then
     exit 1
 fi
 
+echo "Adding ~/.local/bin to PATH..."
+
+# Detect shell and update appropriate config file
+SHELL_CONFIG=""
+case "$SHELL" in
+    */zsh)
+        SHELL_CONFIG="$HOME/.zshrc"
+        ;;
+    */bash)
+        SHELL_CONFIG="$HOME/.bashrc"
+        ;;
+esac
+
+echo "SHELL_CONFIG: $SHELL_CONFIG"
+
+if [ -n "$SHELL_CONFIG" ]; then
+    echo "" >>"$SHELL_CONFIG"
+    echo 'export PATH="$HOME/.local/bin:$PATH"' >>"$SHELL_CONFIG"
+    echo "Please restart your terminal or run: source $SHELL_CONFIG"
+else
+    echo "Please add ~/.local/bin to your PATH manually"
+fi
+
 # Cleanup
 cd || exit 1
 rm -rf "$TMP_DIR"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# Check if running on macOS and needs sudo
+if [[ "$(uname)" == "Darwin" && "$EUID" -ne 0 ]]; then
+    echo "On macOS, please run with sudo to handle security measures"
+    exit 1
+fi
+
+# Function to detect OS and architecture
+get_os_arch() {
+    local os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    local arch=$(uname -m)
+
+    case "$arch" in
+    x86_64) arch="x86_64" ;;
+    aarch64 | arm64) arch="aarch64" ;;
+    *)
+        echo "Unsupported architecture: $arch"
+        exit 1
+        ;;
+    esac
+
+    case "$os" in
+    darwin)
+        echo "apple-darwin" "$arch"
+        ;;
+    linux)
+        echo "unknown-linux-gnu" "$arch"
+        ;;
+    *)
+        echo "Unsupported OS: $os"
+        exit 1
+        ;;
+    esac
+}
+
+echo "Fetching latest version from GitHub..."
+LATEST_RELEASE=$(curl -s https://api.github.com/repos/mediar-ai/screenpipe/releases/latest)
+VERSION=$(echo "$LATEST_RELEASE" | grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
+
+if [ -z "$VERSION" ]; then
+    echo "Failed to fetch latest version"
+    exit 1
+fi
+
+echo "Latest version: $VERSION"
+
+read os arch <<<$(get_os_arch)
+
+FILENAME="screenpipe-${VERSION}-${arch}-${os}.tar.gz"
+URL="https://github.com/mediar-ai/screenpipe/releases/download/v${VERSION}/${FILENAME}"
+
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR"
+
+echo "Downloading screenpipe v${VERSION} for ${arch}-${os}..."
+curl -L "$URL" -o "$FILENAME"
+
+echo "Extracting..."
+tar xzf "$FILENAME"
+
+echo "Installing..."
+INSTALL_DIR="/usr/local/screenpipe"
+
+# Remove existing installation
+rm -rf "$INSTALL_DIR"
+
+# Create the exact directory structure needed
+mkdir -p "$INSTALL_DIR/screenpipe-vision/lib"
+
+# Copy files maintaining the expected structure
+cp lib/libscreenpipe_arm64.dylib "$INSTALL_DIR/screenpipe-vision/lib/"
+cp bin/screenpipe "$INSTALL_DIR/"
+
+# Fix binary linking on macOS
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Fixing binary linking..."
+    cd "$INSTALL_DIR"
+
+    echo "Current library paths:"
+    otool -L "./screenpipe"
+
+    # Remove any existing rpaths
+    install_name_tool -delete_rpath "@executable_path/screenpipe-vision/lib" "./screenpipe" 2>/dev/null || true
+
+    # Add new rpath
+    install_name_tool -add_rpath "@executable_path/screenpipe-vision/lib" "./screenpipe"
+
+    # Change the library path in the binary
+    install_name_tool -change "screenpipe-vision/lib/libscreenpipe_arm64.dylib" "@rpath/libscreenpipe_arm64.dylib" "./screenpipe"
+
+    # Also try changing the library id
+    install_name_tool -id "@rpath/libscreenpipe_arm64.dylib" "$INSTALL_DIR/screenpipe-vision/lib/libscreenpipe_arm64.dylib"
+
+    echo "Updated library paths:"
+    otool -L "./screenpipe"
+    otool -L "$INSTALL_DIR/screenpipe-vision/lib/libscreenpipe_arm64.dylib"
+fi
+
+# Remove quarantine attributes on macOS
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Removing quarantine attributes..."
+    xattr -r -d com.apple.quarantine "$INSTALL_DIR" 2>/dev/null || true
+fi
+
+# Set proper permissions
+chown -R root:wheel "$INSTALL_DIR"
+chmod -R 755 "$INSTALL_DIR"
+
+# Create symlink in /usr/local/bin
+ln -sf "$INSTALL_DIR/screenpipe" "/usr/local/bin/screenpipe"
+
+# Cleanup
+cd
+rm -rf "$TMP_DIR"
+
+echo "Installation complete!"

--- a/install.sh
+++ b/install.sh
@@ -198,9 +198,6 @@ if [ "$(uname)" = "Darwin" ]; then
     echo "Fixing binary linking..."
     cd "$INSTALL_DIR" || exit 1
 
-    echo "Current library paths:"
-    otool -L "./screenpipe"
-
     # Remove any existing rpaths
     install_name_tool -delete_rpath "@executable_path/screenpipe-vision/lib" "./screenpipe" 2>/dev/null || true
 
@@ -212,10 +209,6 @@ if [ "$(uname)" = "Darwin" ]; then
 
     # Also try changing the library id
     install_name_tool -id "@rpath/libscreenpipe_arm64.dylib" "$INSTALL_DIR/screenpipe-vision/lib/libscreenpipe_arm64.dylib"
-
-    echo "Updated library paths:"
-    otool -L "./screenpipe"
-    otool -L "$INSTALL_DIR/screenpipe-vision/lib/libscreenpipe_arm64.dylib"
 fi
 
 # Remove quarantine attributes on macOS


### PR DESCRIPTION
Adds install.sh script to handle dynamic library linking and security attributes on macOS (using rpaths and quarantine removal)


https://github.com/user-attachments/assets/841ba5f3-28db-4f5b-b90f-995932ed54c4


## how to test

```bash
sudo ./install.sh
```

/closes https://github.com/mediar-ai/screenpipe/issues/915
/claim https://github.com/mediar-ai/screenpipe/issues/915