### PR TITLE
feat: include `hvc1` codec to load h.265 videos

### DIFF
--- a/screenpipe-app-tauri/components/video.tsx
+++ b/screenpipe-app-tauri/components/video.tsx
@@ -120,7 +120,7 @@ export const VideoComponent = memo(function VideoComponent({
         </div>
       ) : (
         <video controls className="w-full rounded-md">
-          <source src={mediaSrc} type="video/mp4" />
+          <source src={mediaSrc} type="video/mp4; codecs=hvc1" />
           Your browser does not support the video tag.
         </video>
       )}


### PR DESCRIPTION
/claim #666

https://github.com/user-attachments/assets/f0c2d821-cf3c-4c32-9ac8-5c6be0b7de28

