### PR TITLE
fix(vision): xcap compile conditional logic change for macos

### DIFF
--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -24,11 +24,12 @@ use std::{
 use tokio::sync::mpsc::Sender;
 use tokio::time::sleep;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use xcap_macoswin::Monitor;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use xcap::Monitor;
+
 
 pub struct CaptureResult {
     pub image: DynamicImage,

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -30,7 +30,6 @@ use xcap_macoswin::Monitor;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 use xcap::Monitor;
 
-
 pub struct CaptureResult {
     pub image: DynamicImage,
     pub frame_number: u64,


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] fix vision compile conditional for xcap v. xcap_macoswin"
labels: 'bug'
assignees: ''

---

## description
brief description of the changes in this pr.

The conditional in `screenpipe-vision/src/core.rs` seems OK, but even though I am on macos, it seems to be taking the linux path (some underlying lib lying?). IDK, didn't check that deep, but did change the conditional to be a bit more specific and seems to work well. 

related issue: #

## how to test

Build a clean clone, should build regardless of OS, resolving correct xcap.Monitor symbol.


if relevant add screenshots or screen captures to prove that this PR works to save us time.
On macos 15.2:

```
   Compiling libsqlite3-sys v0.26.0
   Compiling screenpipe-vision v0.2.16 (/Applications/screenpipe/screenpipe-vision)
   Compiling screenpipe-audio v0.2.16 (/Applications/screenpipe/screenpipe-audio)
   Compiling screenpipe-actions v0.2.16 (/Applications/screenpipe/screenpipe-actions)
   Compiling sqlx-sqlite v0.7.2
error[E0432]: unresolved import `xcap`
  --> screenpipe-vision/src/core.rs:31:5
   |
31 | use xcap::Monitor;
   |     ^^^^ use of undeclared crate or module `xcap`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `screenpipe-vision` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

if you think it can take more than 30 mins for us to review, we will pay between $20 and $200 for someone to review it for us, just ask in the pr.
