### PR TITLE
feat: disable update check in bun tauri dev

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -2,6 +2,7 @@ use crate::kill_all_sreenpipes;
 use crate::SidecarState;
 use anyhow::Error;
 use log::{error, info};
+use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::menu::{MenuItem, MenuItemBuilder};
@@ -38,6 +39,12 @@ impl UpdatesManager {
         &self,
         show_dialog: bool,
     ) -> Result<bool, Box<dyn std::error::Error>> {
+        if let Ok(val) = std::env::var("TAURI_ENV_DEBUG") {
+            if val == "true" {
+                info!("dev mode is enabled, skipping update check");
+                return Result::Ok(false);
+            }
+        }
         if let Some(update) = self.app.updater()?.check().await? {
             *self.update_available.lock().await = true;
 


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description
when we run `bun tauri dev` or `bun tauri build --debug` then the value of Environment variable
TAURI_ENV_DEBUG = true 
in all other commands it is false

Reference: https://v2.tauri.app/reference/environment-variables/#tauri-cli-hook-commands
 
closes #539 

## how to test

add a few steps to test the pr in the most time efficient way.

1. do `bun tauri dev`
2. see that it doesn't check for updates