### PR TITLE
Improve version extraction logic in fetch_latest_version script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,9 +42,8 @@ get_os_arch() {
 
 echo "fetching latest version from github..."
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/mediar-ai/screenpipe/releases/latest)
-# Extract version using multiple steps to ensure proper parsing
-VERSION=$(echo "$LATEST_RELEASE" | tr -d '\n' | grep -o '"tag_name":"v[^"]*"' | cut -d':' -f2 | tr -d '"' | sed 's/^v//')
-
+# Extract version using grep and sed for cross-platform compatibility
+VERSION=$(echo "$LATEST_RELEASE" | grep -o '"tag_name": *"v[^"]*"' | sed 's/.*"v\([^"]*\)".*/\1/')
 if [ -z "$VERSION" ]; then
     echo "failed to fetch latest version"
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,8 @@ get_os_arch() {
 
 echo "fetching latest version from github..."
 LATEST_RELEASE=$(curl -s https://api.github.com/repos/mediar-ai/screenpipe/releases/latest)
-VERSION=$(echo "$LATEST_RELEASE" | grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | sed 's/^v//')
+# Extract version using multiple steps to ensure proper parsing
+VERSION=$(echo "$LATEST_RELEASE" | tr -d '\n' | grep -o '"tag_name":"v[^"]*"' | cut -d':' -f2 | tr -d '"' | sed 's/^v//')
 
 if [ -z "$VERSION" ]; then
     echo "failed to fetch latest version"


### PR DESCRIPTION
[pr] fix: improve version parsing reliability in install script

## description
This PR improves the version parsing logic in the installation script to make it more reliable when fetching the latest version from GitHub. The changes handle potential formatting issues in the JSON response by:
- Removing newlines that could interfere with grep
- Using a more precise grep pattern for tag_name
- Simplifying the string processing pipeline

related issue: # (no related issue)

## how to test

1. Delete any existing screenpipe installation
2. Run the installation script:
   ```bash
   curl -fsSL raw.githubusercontent.com/fortran01/screenpipe/fix/install-script-version-parsing/install.sh | sh
   ```
 3. Verify that the script successfully:
- Fetches the latest version
- Downloads and installs the correct version
- Does not show "failed to fetch latest version" error