### PR TITLE
Fix zero search results in MCP server

### DIFF
--- a/screenpipe-integrations/screenpipe-mcp/src/screenpipe_mcp/server.py
+++ b/screenpipe-integrations/screenpipe-mcp/src/screenpipe_mcp/server.py
@@ -121,7 +121,9 @@ async def handle_call_tool(
                     continue
                 
                 content = result["content"]
-                if content.get("type") == "OCR":
+                content_type = result.get("type", "Unknown")
+                
+                if content_type == "OCR":
                     text = (
                         f"OCR Text: {content.get('text', 'N/A')}\n"
                         f"App: {content.get('app_name', 'N/A')}\n"
@@ -129,14 +131,14 @@ async def handle_call_tool(
                         f"Time: {content.get('timestamp', 'N/A')}\n"
                         "---\n"
                     )
-                elif content.get("type") == "Audio":
+                elif content_type == "Audio":
                     text = (
                         f"Audio Transcription: {content.get('transcription', 'N/A')}\n"
                         f"Device: {content.get('device_name', 'N/A')}\n"
                         f"Time: {content.get('timestamp', 'N/A')}\n"
                         "---\n"
                     )
-                elif content.get("type") == "UI":
+                elif content_type == "UI":
                     text = (
                         f"UI Text: {content.get('text', 'N/A')}\n"
                         f"App: {content.get('app_name', 'N/A')}\n"
@@ -145,9 +147,15 @@ async def handle_call_tool(
                         "---\n"
                     )
                 else:
-                    continue
+                    text = str(content)
                 
                 formatted_results.append(text)
+
+            if not formatted_results:
+                return [types.TextContent(
+                    type="text", 
+                    text=f"No {arguments.get('content_type', 'content')} found in your screen recordings."
+                )]
 
             return [types.TextContent(
                 type="text",


### PR DESCRIPTION
Enhances content processing for different types of screen recordings

Adds handling for unknown content types by converting to string Provides fallback message when no results are found Improves robustness of content type checking and result formatting

Ensures more comprehensive and user-friendly output for screen recording searches

---
name: pull request
about: submit changes to the project
title: "[pr] Improve content handling and result formatting for screen recordings"
labels: 'enhancement'
assignees: ''

---

## description
This PR enhances the content processing capabilities for screen recordings and improves result formatting. Key changes include:

- Added handling for unknown content types with string conversion fallback
- Implemented better content type checking
- Enhanced result formatting for more user-friendly output
- Added fallback messaging when no results are found

related issue: # (please add if there's a related issue)

## how to test

1. Run a screen recording search with various content types (text)
2. Verify that unknown content types are properly converted to string [no idea how to do this yet]
3. Check that appropriate fallback messages appear when no results are found

No screenshots needed as these are primarily backend changes affecting content processing.

This PR should take less than 30 minutes to review as it focuses on content handling improvements with clear test cases.