### PR TITLE
fix: use build for pipe instead of dev mode

### DIFF
--- a/screenpipe-core/src/pipes.rs
+++ b/screenpipe-core/src/pipes.rs
@@ -295,6 +295,7 @@ mod pipes {
                     "Download",
                     "Task dev ",
                     "$ next dev",
+                    "$ next start",
                     "$ next lint",
                     "$ next build",
                     "ready started server",


### PR DESCRIPTION
---
about: it'll build the next js pipes after installing dependency

/claim #970
/closed #970

---

## description


![Screenshot 2025-01-03 172159](https://github.com/user-attachments/assets/bbd2a1e1-6f39-46be-976b-19a789939be5)
![Screenshot 2025-01-03 172212](https://github.com/user-attachments/assets/09d83962-d62f-4eaa-86e4-1a9407a8fabd)

related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time.

if you think it can take more than 30 mins for us to review, we will pay between $20 and $200 for someone to review it for us, just ask in the pr.
