### PR TITLE
run next.js pipes in production mode

### DIFF
--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "axum",


### PR DESCRIPTION
This PR runs the Next.js pipes in production mode.

Cases
- [x] Check if .next directory exists
- [x] Verify build-manifest.json exists (indicates valid build)
- [x] Clean up invalid/incomplete builds
- [x] Use production mode (start) if build successful
- [x] Fall back to development mode (dev) if build fails

Requisite PR that needs to be merged first https://github.com/mediar-ai/screenpipe/pull/1079 it involves all the heavy work involved to make this one work.


/claim #970
/closes #970