### PR TITLE
fix: correct indentation for macOS activation policy in main.rs

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -891,10 +891,9 @@ async fn main() {
                         error!("Failed to start health check service: {}", e);
                     }
                 });
-            }
 
-            #[cfg(target_os = "macos")]
-            app.set_activation_policy(tauri::ActivationPolicy::Regular);
+                app.set_activation_policy(tauri::ActivationPolicy::Regular);
+            }
 
             // LLM Sidecar setup
             let embedded_llm: EmbeddedLLMSettings = store


### PR DESCRIPTION
---
name: [pull request](fix: correct indentation for macOS activation policy in main.rs)
about: removed the second cfg macos, one is enough to use it correctly
title: "[pr] "
labels: ''
assignees: ''

---

## description
just removed the second cfg macos issue, now window is building on github actions just fine and test results on windows are good as well. unless you meant the ollama build, which still builds and has a long time to run to be honest.

/claim #1100

related issue: #1100

## how to test

add a few steps to test the pr in the most time efficient way.

1. tested it via github actions on my own repo/branch

if relevant add screenshots or screen captures to prove that this PR works to save us time.
![image](https://github.com/user-attachments/assets/7a071c84-0d9b-489f-857c-dc87099d875b)

would only take 5 minutes at most to be honest.
