### PR TITLE
fix(server): add appropriate tesseract import

### DIFF
--- a/screenpipe-server/src/index.rs
+++ b/screenpipe-server/src/index.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use image::DynamicImage;
 use regex::Regex;
+use screenpipe_vision::perform_ocr_tesseract;
 use screenpipe_vision::utils::{compare_with_previous_image, OcrEngine};
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] fix missing import in server for perform_ocr_tesseract"
labels: ''
assignees: ''

---

## description
Adds a missing import in the server imports that resulted in the following build error:

```
   Compiling sqlx v0.7.2
error[E0425]: cannot find function `perform_ocr_tesseract` in this scope
   --> screenpipe-server/src/index.rs:166:26
    |
166 |                     _ => perform_ocr_tesseract(&frame, vec![]),
    |                          ^^^^^^^^^^^^^^^^^^^^^ not found in this scope
    |
help: consider importing this function
    |
1   + use screenpipe_vision::perform_ocr_tesseract;
    |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `screenpipe-server` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

related issue: #1156 

## how to test

add a few steps to test the pr in the most time efficient way.

1. pull main, attempt to build
2. should build without issue 
