### PR TITLE
Record-all-monitors

### DIFF
--- a/screenpipe-app-tauri/components/recording-settings.tsx
+++ b/screenpipe-app-tauri/components/recording-settings.tsx
@@ -752,6 +752,10 @@ export function RecordingSettings() {
     }
   };
 
+  const handleRecordAllMonitorsChange = (checked: boolean) => {
+    handleSettingsChange({ recordAllMonitors: checked });
+  };
+
   return (
     <div className="w-full space-y-6 py-4">
       <h1 className="text-2xl font-bold mb-4">recording</h1>
@@ -802,15 +806,23 @@ export function RecordingSettings() {
                     <Monitor className="h-4 w-4" />
                     <span>monitors</span>
                   </Label>
-                  <Popover open={openMonitors} onOpenChange={setOpenMonitors}>
+                  <Popover
+                    open={openMonitors && !settings.recordAllMonitors}
+                    onOpenChange={(open) =>
+                      !settings.recordAllMonitors && setOpenMonitors(open)
+                    }
+                  >
                     <PopoverTrigger asChild>
                       <Button
                         variant="outline"
                         role="combobox"
                         aria-expanded={openMonitors}
                         className="w-full justify-between"
+                        disabled={settings.recordAllMonitors}
                       >
-                        {settings.monitorIds.length > 0
+                        {settings.recordAllMonitors
+                          ? "all monitors selected"
+                          : settings.monitorIds.length > 0
                           ? `${settings.monitorIds.length} monitor(s) selected`
                           : "select monitors"}
                         <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -862,6 +874,17 @@ export function RecordingSettings() {
                       </Command>
                     </PopoverContent>
                   </Popover>
+                  <Label
+                    className="flex items-center space-x-2"
+                    htmlFor="recordAllMonitors"
+                  >
+                    <Switch
+                      id="recordAllMonitors"
+                      checked={settings.recordAllMonitors}
+                      onCheckedChange={handleRecordAllMonitorsChange}
+                    />
+                    <span>record all monitors</span>
+                  </Label>
                 </div>
 
                 <div className="flex flex-col space-y-2">

--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -93,6 +93,7 @@ export type Settings = {
   enableRealtimeAudioTranscription: boolean;
   realtimeAudioTranscriptionEngine: string;
   disableVision: boolean;
+  recordAllMonitors: boolean;
 };
 
 const DEFAULT_SETTINGS: Settings = {
@@ -151,6 +152,7 @@ const DEFAULT_SETTINGS: Settings = {
   enableRealtimeAudioTranscription: false,
   realtimeAudioTranscriptionEngine: "whisper-large-v3-turbo",
   disableVision: false,
+  recordAllMonitors: false,
 };
 
 const DEFAULT_IGNORED_WINDOWS_IN_ALL_OS = [

--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "0.25.7"
+version = "0.25.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/screenpipe-server/src/bin/screenpipe-server.rs
+++ b/screenpipe-server/src/bin/screenpipe-server.rs
@@ -467,7 +467,7 @@ async fn main() -> anyhow::Result<()> {
 
     let warning_ocr_engine_clone = cli.ocr_engine.clone();
     let warning_audio_transcription_engine_clone = cli.audio_transcription_engine.clone();
-    let monitor_ids = if cli.monitor_id.is_empty() {
+    let monitor_ids = if cli.monitor_id.is_empty() || cli.record_all_monitors {
         all_monitors.iter().map(|m| m.id()).collect::<Vec<_>>()
     } else {
         cli.monitor_id.clone()

--- a/screenpipe-server/src/cli.rs
+++ b/screenpipe-server/src/cli.rs
@@ -267,6 +267,10 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
+    /// Record all monitors (default: false)
+    #[arg(long, default_value_t = false)]
+    pub record_all_monitors: bool,
+
 }
 
 


### PR DESCRIPTION
- Implemented a new toggle switch in the recording settings to enable/disable recording from all monitors.
- Updated the settings type to include `recordAllMonitors` and set its default value to false.
- Adjusted the UI logic to reflect the state of the new setting, including disabling monitor selection when all monitors are recorded.

# Related Issue: #1148

/claim #1148