### PR TITLE
feat(llm-sidecar): breakup start_ollama_sidecar function

### DIFF
--- a/screenpipe-app-tauri/components/settings/ai-section.tsx
+++ b/screenpipe-app-tauri/components/settings/ai-section.tsx
@@ -174,21 +174,36 @@ const AISection = () => {
   const startOllamaSidecar = async () => {
     posthog.capture("start_ollama_sidecar");
     setOllamaStatus("running");
-    toast({
-      title: "starting ai",
-      description:
-        "downloading and initializing the embedded ai, may take a while (check $HOME/.ollama/models)...",
-    });
-
     try {
       console.log(
         "starting ollama sidecar with settings:",
         settings.embeddedLLM
       );
-      const result = await invoke<string>("start_ollama_sidecar", {
+      
+      await invoke<string>("start_ollama_sidecar", {
         settings: {
           enabled: settings.embeddedLLM.enabled,
           model: settings.embeddedLLM.model,
+          port: settings.embeddedLLM.port,
+        },
+      });
+
+      await invoke<string>("check_ollama_sidecar", {
+        settings: {
+          enabled: settings.embeddedLLM.enabled,
+          model: settings.embeddedLLM.model,
+          port: settings.embeddedLLM.port,
+        },
+      });
+
+      toast({
+        title: "ollama server was initiated successfully",
+      });
+
+      const result = await invoke<string>("run_ollama_model_sidecar", {
+        settings: {
+          enabled: settings.embeddedLLM.enabled,
+          model: 'llama3.2',
           port: settings.embeddedLLM.port,
         },
       });

--- a/screenpipe-app-tauri/src-tauri/src/llm_sidecar.rs
+++ b/screenpipe-app-tauri/src-tauri/src/llm_sidecar.rs
@@ -246,12 +246,10 @@ pub async fn start_ollama_sidecar(
 }
 
 #[tauri::command]
-pub async fn check_ollama_sidecar() -> Result<String, String> {
-    let llm_sidecar = LLMSidecar::new(EmbeddedLLMSettings {
-        enabled: false,
-        model: String::new(),
-        port: 0,
-    });
+pub async fn check_ollama_sidecar(
+    settings: EmbeddedLLMSettings,
+) -> Result<String, String> {
+    let llm_sidecar = LLMSidecar::new(settings);
     llm_sidecar
         .wait_for_server()
         .await

--- a/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -665,6 +665,8 @@ async fn main() {
             set_tray_health_icon,
             llm_sidecar::start_ollama_sidecar,
             llm_sidecar::stop_ollama_sidecar,
+            llm_sidecar::check_ollama_sidecar,
+            llm_sidecar::run_ollama_model_sidecar,
             commands::update_show_screenpipe_shortcut,
             commands::show_meetings,
             commands::show_identify_speakers,


### PR DESCRIPTION
## description
breaking up the function allows the front end to have a better control and state management when interacting with the llm sidecar

related to issue #1206

