### PR TITLE
Fix powershell script in getting-started.mdx

### DIFF
--- a/content/docs/pages/docs/getting-started.mdx
+++ b/content/docs/pages/docs/getting-started.mdx
@@ -44,7 +44,7 @@ then stream the OCR data (requires `jq`):
   </Tab>
   <Tab>
     ```powershell copy
-    curl -N "http://localhost:3030/sse/vision" | while read -r line; do echo $line | sed 's/^data: //' | jq; done
+    Remove-item alias:curl; curl -N "http://localhost:3030/sse/vision" | ForEach-Object { $_ -replace '^data: ', '' | jq }
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
The PowerShell script wasn't working on Windows, it was just a copy of the script for Unix.

As it turns out, Windows has a cmdlet (a PowerShell command) called curl that takes precedence over the actual curl binary, so we have to temporarily remove that alias in order to run this command (and of course, the user also has to have curl, jq, and sed installed as with the other scripts).
As you can see in the image, `Remove-item alias:curl;` will fail if the user has already removed it, but the command will continue so it's fine.

Before:

![image](https://github.com/user-attachments/assets/d67cb417-3f41-45a1-8486-87ffd6674617)



After:

![image](https://github.com/user-attachments/assets/2b566f75-2098-499d-bc51-88ac84d5d7d3)

