### PR TITLE
Fix process killing

### DIFF
--- a/screenpipe-app-tauri/app/page.tsx
+++ b/screenpipe-app-tauri/app/page.tsx
@@ -73,7 +73,7 @@ export default function Home() {
       }),
 
       listen("shortcut-stop-recording", async () => {
-        await invoke("kill_all_sreenpipes");
+        await invoke("kill_all_screenpipes");
 
         toast({
           title: "recording stopped",
@@ -90,7 +90,7 @@ export default function Home() {
           description: `switched to ${profile} profile, restarting screenpipe now`,
         });
 
-        await invoke("kill_all_sreenpipes");
+        await invoke("kill_all_screenpipes");
 
         await new Promise((resolve) => setTimeout(resolve, 1000));
 

--- a/screenpipe-app-tauri/components/dev-mode-settings.tsx
+++ b/screenpipe-app-tauri/components/dev-mode-settings.tsx
@@ -152,7 +152,7 @@ export const DevModeSettings = ({ localDataDir }: { localDataDir: string }) => {
       duration: Infinity,
     });
     try {
-      await invoke("kill_all_sreenpipes");
+      await invoke("kill_all_screenpipes");
       await new Promise((resolve) => setTimeout(resolve, 2000));
       toastId.update({
         id: toastId.id,

--- a/screenpipe-app-tauri/components/onboarding/pipe-store.tsx
+++ b/screenpipe-app-tauri/components/onboarding/pipe-store.tsx
@@ -36,7 +36,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
         await fetch("http://localhost:3030/health");
       } catch (error) {
         // Screenpipe not running, try to spawn it
-        await invoke("kill_all_sreenpipes");
+        await invoke("kill_all_screenpipes");
         await new Promise((resolve) => setTimeout(resolve, 1_000));
         await invoke("spawn_screenpipe");
         await new Promise((resolve) => setTimeout(resolve, 5_000));

--- a/screenpipe-app-tauri/components/onboarding/status.tsx
+++ b/screenpipe-app-tauri/components/onboarding/status.tsx
@@ -219,7 +219,7 @@ const OnboardingStatus: React.FC<OnboardingStatusProps> = ({
       duration: Infinity,
     });
     try {
-      await invoke("kill_all_sreenpipes");
+      await invoke("kill_all_screenpipes");
       await new Promise((resolve) => setTimeout(resolve, 1_000));
 
       await invoke("spawn_screenpipe");

--- a/screenpipe-app-tauri/components/recording-settings.tsx
+++ b/screenpipe-app-tauri/components/recording-settings.tsx
@@ -314,7 +314,7 @@ export function RecordingSettings() {
         }
       }
 
-      await invoke("kill_all_sreenpipes");
+      await invoke("kill_all_screenpipes");
 
       await new Promise((resolve) => setTimeout(resolve, 1000));
       // Start a new instance with updated settings

--- a/screenpipe-app-tauri/components/settings.tsx
+++ b/screenpipe-app-tauri/components/settings.tsx
@@ -64,7 +64,7 @@ export function Settings() {
       title: "Restarting Screenpipe",
       description: "Please wait while we restart Screenpipe",
     });
-    await invoke("kill_all_sreenpipes");
+    await invoke("kill_all_screenpipes");
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 

--- a/screenpipe-app-tauri/components/updater.tsx
+++ b/screenpipe-app-tauri/components/updater.tsx
@@ -25,7 +25,7 @@ Release notes: ${update.body}
       // on windows only - TODO shouldnt be necessary
       const os = platform();
       if (os === "windows") {
-        await invoke("kill_all_sreenpipes");
+        await invoke("kill_all_screenpipes");
       }
 
       const toastId = toast({

--- a/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -51,7 +51,7 @@ pub use commands::reset_all_pipes;
 pub use commands::set_tray_health_icon;
 pub use commands::set_tray_unhealth_icon;
 pub use server::spawn_server;
-pub use sidecar::kill_all_sreenpipes;
+pub use sidecar::kill_all_screenpipes;
 pub use sidecar::spawn_screenpipe;
 pub use store::get_profiles_store;
 pub use store::get_store;
@@ -660,7 +660,7 @@ async fn main() {
         .manage(sidecar_state)
         .invoke_handler(tauri::generate_handler![
             spawn_screenpipe,
-            kill_all_sreenpipes,
+            kill_all_screenpipes,
             permissions::open_permission_settings,
             permissions::request_permission,
             permissions::do_permissions_check,
@@ -811,7 +811,7 @@ async fn main() {
                             // Stop any running recordings
                             let state = app_handle_clone.state::<SidecarState>();
                             if let Err(e) =
-                                kill_all_sreenpipes(state, app_handle_clone.clone()).await
+                                kill_all_screenpipes(state, app_handle_clone.clone()).await
                             {
                                 error!("Error stopping recordings during quit: {}", e);
                             }
@@ -839,7 +839,7 @@ async fn main() {
                         let app_handle = app_handle.clone();
                         tauri::async_runtime::spawn(async move {
                             let state = app_handle.state::<SidecarState>();
-                            if let Err(err) = kill_all_sreenpipes(state, app_handle.clone()).await {
+                            if let Err(err) = kill_all_screenpipes(state, app_handle.clone()).await {
                                 error!("Failed to stop recording: {}", err);
                                 let _ = app_handle
                                     .notification()
@@ -872,7 +872,7 @@ async fn main() {
 
                         tokio::task::block_in_place(move || {
                             Handle::current().block_on(async move {
-                                if let Err(err) = sidecar::kill_all_sreenpipes(
+                                if let Err(err) = sidecar::kill_all_screenpipes(
                                     app_handle.state::<SidecarState>(),
                                     app_handle.clone(),
                                 )

--- a/screenpipe-app-tauri/src-tauri/src/sidecar.rs
+++ b/screenpipe-app-tauri/src-tauri/src/sidecar.rs
@@ -80,7 +80,7 @@ impl User {
 }
 
 #[tauri::command]
-pub async fn kill_all_sreenpipes(
+pub async fn kill_all_screenpipes(
     state: State<'_, SidecarState>,
     _app: tauri::AppHandle,
 ) -> Result<(), String> {

--- a/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -1,4 +1,4 @@
-use crate::kill_all_sreenpipes;
+use crate::kill_all_screenpipes;
 use crate::SidecarState;
 use anyhow::Error;
 use log::{error, info};
@@ -107,7 +107,7 @@ impl UpdatesManager {
                             .set_text("downloading latest version of screenpipe")?;
 
                         if let Err(err) =
-                            kill_all_sreenpipes(self.app.state::<SidecarState>(), self.app.clone())
+                            kill_all_screenpipes(self.app.state::<SidecarState>(), self.app.clone())
                                 .await
                         {
                             error!("Failed to kill sidecar: {}", err);
@@ -131,7 +131,7 @@ impl UpdatesManager {
                     #[cfg(not(target_os = "windows"))]
                     {
                         if let Err(err) =
-                            kill_all_sreenpipes(self.app.state::<SidecarState>(), self.app.clone())
+                            kill_all_screenpipes(self.app.state::<SidecarState>(), self.app.clone())
                                 .await
                         {
                             error!("Failed to kill sidecar: {}", err);

--- a/screenpipe-server/src/pipe_manager.rs
+++ b/screenpipe-server/src/pipe_manager.rs
@@ -15,6 +15,9 @@ use tokio::sync::mpsc::{self, Sender};
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+#[cfg(windows)]
+use windows::Win32::Foundation::HANDLE;
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PipeInfo {
     pub id: String,
@@ -298,8 +301,6 @@ impl PipeManager {
         }
     }
 
-    #[cfg(windows)]
-    use windows::Win32::Foundation::HANDLE;
     #[cfg(windows)]
     fn terminate_process(process: &mut HANDLE, exit_code: u32) {
         use windows::Win32::System::Threading::{

--- a/screenpipe-server/src/pipe_manager.rs
+++ b/screenpipe-server/src/pipe_manager.rs
@@ -298,14 +298,6 @@ impl PipeManager {
         }
     }
 
-    #[cfg(windows)]
-    fn terminate_process(process: &mut HANDLE, exit_code: u32) {
-        
-        unsafe {
-            
-        }
-    }
-
     pub async fn stop_pipe(&self, id: &str) -> Result<()> {
         let mut pipes = self.running_pipes.write().await;
         if let Some(handle) = pipes.remove(id) {


### PR DESCRIPTION
/claim #1226 
/closes #1226 

@louis030195 Turns out in some places it was calling an non-existent function "kill_all_screenpipes", because the actual function was "kill_all_sreenpipes", renamed it and the calls, also uses a better method for terminating Windows processes properly.