### PR TITLE
[looking for testers urgently] start and stop vision device on demand through /vision/start

### DIFF
--- a/screenpipe-audio/src/bin/screenpipe-audio-forever.rs
+++ b/screenpipe-audio/src/bin/screenpipe-audio-forever.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use dashmap::DashMap;
 use log::info;
 use screenpipe_audio::create_whisper_channel;
 use screenpipe_audio::default_input_device;
@@ -8,10 +9,10 @@ use screenpipe_audio::list_audio_devices;
 use screenpipe_audio::parse_audio_device;
 use screenpipe_audio::record_and_transcribe;
 use screenpipe_audio::vad_engine::VadSensitivity;
-use screenpipe_audio::AudioDevice;
 use screenpipe_audio::AudioStream;
 use screenpipe_audio::AudioTranscriptionEngine;
 use screenpipe_audio::VadEngineEnum;
+use screenpipe_core::AudioDevice;
 use screenpipe_core::Language;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -88,14 +89,14 @@ async fn main() -> Result<()> {
     }
 
     let chunk_duration = Duration::from_secs_f32(args.audio_chunk_duration);
-    let (whisper_sender, whisper_receiver, _) = create_whisper_channel(
+    let (whisper_sender, whisper_receiver) = create_whisper_channel(
         Arc::new(AudioTranscriptionEngine::WhisperDistilLargeV3),
         VadEngineEnum::Silero, // Or VadEngineEnum::WebRtc, hardcoded for now
         args.deepgram_api_key,
         &PathBuf::from("output.mp4"),
         VadSensitivity::Medium,
         languages,
-        None,
+        DashMap::new(),
     )
     .await?;
 

--- a/screenpipe-audio/src/bin/screenpipe-audio.rs
+++ b/screenpipe-audio/src/bin/screenpipe-audio.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use dashmap::DashMap;
 use log::info;
 use screenpipe_audio::create_whisper_channel;
 use screenpipe_audio::default_input_device;
@@ -8,10 +9,10 @@ use screenpipe_audio::list_audio_devices;
 use screenpipe_audio::parse_audio_device;
 use screenpipe_audio::record_and_transcribe;
 use screenpipe_audio::vad_engine::VadSensitivity;
-use screenpipe_audio::AudioDevice;
 use screenpipe_audio::AudioStream;
 use screenpipe_audio::AudioTranscriptionEngine;
 use screenpipe_audio::VadEngineEnum;
+use screenpipe_core::AudioDevice;
 use screenpipe_core::Language;
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
@@ -92,14 +93,14 @@ async fn main() -> Result<()> {
 
     let chunk_duration = Duration::from_secs(10);
     let output_path = PathBuf::from("output.mp4");
-    let (whisper_sender, whisper_receiver, _) = create_whisper_channel(
+    let (whisper_sender, whisper_receiver) = create_whisper_channel(
         Arc::new(AudioTranscriptionEngine::WhisperDistilLargeV3),
         VadEngineEnum::WebRtc, // Or VadEngineEnum::WebRtc, hardcoded for now
         deepgram_api_key,
         &output_path,
         VadSensitivity::Medium,
         languages,
-        None
+        DashMap::new(),
     )
     .await?;
     // Spawn threads for each device

--- a/screenpipe-audio/src/deepgram/realtime.rs
+++ b/screenpipe-audio/src/deepgram/realtime.rs
@@ -1,7 +1,6 @@
 use crate::{
     deepgram::CUSTOM_DEEPGRAM_API_TOKEN, realtime::RealtimeTranscriptionEvent, AudioStream,
 };
-use crate::{AudioDevice, DeviceType};
 use anyhow::Result;
 use bytes::BufMut;
 use bytes::Bytes;
@@ -11,6 +10,8 @@ use deepgram::common::options::Encoding;
 use deepgram::common::stream_response::StreamResponse;
 use futures::channel::mpsc::{self, Receiver as FuturesReceiver};
 use futures::{SinkExt, TryStreamExt};
+use screenpipe_core::AudioDevice;
+use screenpipe_core::AudioDeviceType;
 use screenpipe_core::Language;
 use std::sync::{atomic::AtomicBool, Arc};
 use std::time::Duration;
@@ -126,7 +127,7 @@ async fn handle_transcription(
     {
         let res = channel.alternatives.first().unwrap();
         let text = res.transcript.clone();
-        let is_input = device.device_type == DeviceType::Input;
+        let is_input = device.device_type == AudioDeviceType::Input;
 
         if !text.is_empty() {
             match realtime_transcription_sender.send(RealtimeTranscriptionEvent {

--- a/screenpipe-audio/src/lib.rs
+++ b/screenpipe-audio/src/lib.rs
@@ -14,8 +14,7 @@ pub use audio_processing::resample;
 pub use core::{
     default_input_device, default_output_device, get_device_and_config, list_audio_devices,
     parse_audio_device, record_and_transcribe, start_realtime_recording, trigger_audio_permission,
-    AudioDevice, AudioStream, AudioTranscriptionEngine, DeviceControl, DeviceType,
-    LAST_AUDIO_CAPTURE,
+    AudioStream, AudioTranscriptionEngine, LAST_AUDIO_CAPTURE,
 };
 pub mod realtime;
 pub use encode::encode_single_audio;

--- a/screenpipe-audio/src/stt.rs
+++ b/screenpipe-audio/src/stt.rs
@@ -12,11 +12,11 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use candle_transformers::models::whisper as m;
+use dashmap::DashMap;
 use log::{debug, error};
 #[cfg(target_os = "macos")]
 use objc::rc::autoreleasepool;
-use screenpipe_core::{AudioDevice, DeviceControl, DeviceType, Language};
-use std::collections::HashMap;
+use screenpipe_core::{AudioDevice, DeviceControl, Language};
 use std::{
     path::Path,
     sync::Arc,
@@ -155,7 +155,7 @@ pub async fn create_whisper_channel(
     output_path: &Path,
     vad_sensitivity: VadSensitivity,
     languages: Vec<Language>,
-    device_control_rx: tokio::sync::watch::Receiver<DeviceControl>,
+    devices: DashMap<String, DeviceControl>,
 ) -> Result<(
     crossbeam::channel::Sender<AudioInput>,
     crossbeam::channel::Receiver<TranscriptionResult>,
@@ -189,26 +189,18 @@ pub async fn create_whisper_channel(
     let embedding_manager = EmbeddingManager::new(usize::MAX);
 
     tokio::spawn(async move {
-        // HACK: mm ideally this should use device manager's state ...
-        let mut device_states: HashMap<String, bool> = HashMap::new();
-
         loop {
             crossbeam::select! {
                 recv(input_receiver) -> input_result => {
                     match input_result {
                         Ok(mut audio) => {
-                            // Get latest device state before processing
-                            if let Ok(_) = device_control_rx.has_changed() {
-                                let control = device_control_rx.borrow().clone();
-                                if let DeviceType::Audio(device) = control.device {
-                                    device_states.insert(device.to_string(), control.is_running);
-                                }
-                            }
-
                             // Check device state
-                            if !device_states.get(&audio.device.to_string()).copied().unwrap_or(false) {
-                                debug!("Skipping audio processing for stopped device: {}", audio.device);
-                                continue;
+                            if let Some(device) = devices.get(&audio.device.to_string()) {
+                                if !device.is_running {
+                                    debug!("Skipping audio processing for stopped device: {}", audio.device);
+                                    debug!("Device states: {:?}", devices);
+                                    continue;
+                                }
                             }
 
                             debug!("Received input from input_receiver");

--- a/screenpipe-audio/src/whisper/model.rs
+++ b/screenpipe-audio/src/whisper/model.rs
@@ -3,7 +3,7 @@ use candle::{Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::whisper::{self as m, Config};
 use hf_hub::{api::sync::Api, Repo, RepoType};
-use log::{debug, info};
+use log::debug;
 use tokenizers::Tokenizer;
 
 #[derive(Clone)]
@@ -17,7 +17,7 @@ impl WhisperModel {
     pub fn new(engine: &crate::AudioTranscriptionEngine) -> Result<Self> {
         debug!("Initializing WhisperModel");
         let device = Device::new_metal(0).unwrap_or(Device::new_cuda(0).unwrap_or(Device::Cpu));
-        info!("device = {:?}", device);
+        debug!("device = {:?}", device);
 
         debug!("Fetching model files");
         let (config_filename, tokenizer_filename, weights_filename) = {

--- a/screenpipe-core/src/devices.rs
+++ b/screenpipe-core/src/devices.rs
@@ -1,0 +1,94 @@
+use std::fmt;
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug)]
+pub enum DeviceType {
+    Audio(AudioDevice),
+    Vision(u32), // monitor_id
+}
+
+impl fmt::Display for DeviceType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DeviceType::Audio(audio_device) => write!(f, "{}", audio_device),
+            DeviceType::Vision(monitor_id) => write!(f, "{}", monitor_id),
+        }
+    }
+}
+#[derive(Clone, Debug)]
+pub struct DeviceControl {
+    pub device: DeviceType,
+    pub is_running: bool,
+    pub is_paused: bool,
+}
+
+impl Default for DeviceControl {
+    fn default() -> Self {
+        Self {
+            device: DeviceType::Audio(AudioDevice::new(
+                "default".to_string(),
+                AudioDeviceType::Input,
+            )),
+            is_running: false,
+            is_paused: false,
+        }
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Debug, Deserialize)]
+pub enum AudioDeviceType {
+    Input,
+    Output,
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Serialize, Debug)]
+pub struct AudioDevice {
+    pub name: String,
+    pub device_type: AudioDeviceType,
+}
+
+impl AudioDevice {
+    pub fn new(name: String, device_type: AudioDeviceType) -> Self {
+        AudioDevice { name, device_type }
+    }
+
+    pub fn from_name(name: &str) -> anyhow::Result<Self> {
+        if name.trim().is_empty() {
+            return Err(anyhow!("Device name cannot be empty"));
+        }
+
+        let (name, device_type) = if name.to_lowercase().ends_with("(input)") {
+            (
+                name.trim_end_matches("(input)").trim().to_string(),
+                AudioDeviceType::Input,
+            )
+        } else if name.to_lowercase().ends_with("(output)") {
+            (
+                name.trim_end_matches("(output)").trim().to_string(),
+                AudioDeviceType::Output,
+            )
+        } else {
+            return Err(anyhow!(
+                "Device type (input/output) not specified in the name"
+            ));
+        };
+
+        Ok(AudioDevice::new(name, device_type))
+    }
+}
+
+impl fmt::Display for AudioDevice {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} ({})",
+            self.name,
+            match self.device_type {
+                AudioDeviceType::Input => "input",
+                AudioDeviceType::Output => "output",
+            }
+        )
+    }
+}

--- a/screenpipe-core/src/lib.rs
+++ b/screenpipe-core/src/lib.rs
@@ -39,3 +39,6 @@ pub mod network;
 pub use network::*;
 
 pub use language::{Language, TESSERACT_LANGUAGES};
+
+pub mod devices;
+pub use devices::*;

--- a/screenpipe-server/src/db.rs
+++ b/screenpipe-server/src/db.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use image::DynamicImage;
 use libsqlite3_sys::sqlite3_auto_extension;
 use log::{debug, error, warn};
-use screenpipe_audio::{AudioDevice, DeviceType};
+use screenpipe_core::{AudioDevice, AudioDeviceType};
 use screenpipe_vision::OcrEngine;
 use sqlite_vec::sqlite3_vec_init;
 use sqlx::migrate::MigrateDatabase;
@@ -146,7 +146,7 @@ impl DatabaseManager {
         .bind(Utc::now())
         .bind(transcription_engine)
         .bind(&device.name)
-        .bind(device.device_type == DeviceType::Input)
+        .bind(device.device_type == AudioDeviceType::Input)
         .bind(speaker_id)
         .bind(start_time)
         .bind(end_time)
@@ -902,9 +902,9 @@ impl DatabaseManager {
                     .unwrap_or_default(),
                 device_name: raw.device_name,
                 device_type: if raw.is_input_device {
-                    DeviceType::Input
+                    AudioDeviceType::Input
                 } else {
-                    DeviceType::Output
+                    AudioDeviceType::Output
                 },
                 speaker,
                 start_time: raw.start_time,

--- a/screenpipe-server/src/db_types.rs
+++ b/screenpipe-server/src/db_types.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use screenpipe_audio::DeviceType;
+use screenpipe_core::AudioDeviceType;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use std::error::Error as StdError;
@@ -105,7 +105,7 @@ pub struct AudioResult {
     pub transcription_engine: String,
     pub tags: Vec<String>,
     pub device_name: String,
-    pub device_type: DeviceType,
+    pub device_type: AudioDeviceType,
     pub speaker: Option<Speaker>,
     pub start_time: Option<f64>,
     pub end_time: Option<f64>,

--- a/screenpipe-server/src/server.rs
+++ b/screenpipe-server/src/server.rs
@@ -12,6 +12,7 @@ use futures::{
 use image::ImageFormat::{self};
 
 use crate::{
+    core::VisionDeviceControl,
     db_types::{ContentType, SearchResult, Speaker, TagContentType},
     pipe_manager::PipeManager,
     video::{finish_ffmpeg_process, start_ffmpeg_process, write_frame_to_ffmpeg, MAX_FPS},
@@ -38,10 +39,7 @@ use std::{
     convert::Infallible,
     net::SocketAddr,
     path::PathBuf,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
     time::Duration,
 };
 
@@ -61,8 +59,8 @@ use crate::text_embeds::generate_embedding;
 
 pub struct AppState {
     pub db: Arc<DatabaseManager>,
-    pub vision_control: Arc<AtomicBool>,
     pub audio_devices_tx: Arc<broadcast::Sender<(AudioDevice, DeviceControl)>>,
+    pub vision_devices_tx: Arc<broadcast::Sender<(u32, VisionDeviceControl)>>,
     pub devices_status: HashMap<AudioDevice, DeviceControl>,
     pub app_start_time: DateTime<Utc>,
     pub screenpipe_dir: PathBuf,
@@ -696,7 +694,11 @@ async fn download_pipe_private_handler(
     State(state): State<Arc<AppState>>,
     JsonResponse(payload): JsonResponse<DownloadPipePrivateRequest>,
 ) -> Result<JsonResponse<serde_json::Value>, (StatusCode, JsonResponse<Value>)> {
-    match state.pipe_manager.download_pipe_private(&payload.url, &payload.pipe_name, &payload.pipe_id).await {
+    match state
+        .pipe_manager
+        .download_pipe_private(&payload.url, &payload.pipe_name, &payload.pipe_id)
+        .await
+    {
         Ok(pipe_dir) => Ok(JsonResponse(json!({
             "data": {
                 "pipe_id": pipe_dir,
@@ -841,8 +843,8 @@ async fn list_pipes_handler(State(state): State<Arc<AppState>>) -> JsonResponse<
 pub struct Server {
     db: Arc<DatabaseManager>,
     addr: SocketAddr,
-    vision_control: Arc<AtomicBool>,
     audio_devices_tx: Arc<tokio::sync::broadcast::Sender<(AudioDevice, DeviceControl)>>,
+    vision_devices_tx: Arc<tokio::sync::broadcast::Sender<(u32, VisionDeviceControl)>>,
     screenpipe_dir: PathBuf,
     pipe_manager: Arc<PipeManager>,
     vision_disabled: bool,
@@ -858,8 +860,8 @@ impl Server {
     pub fn new(
         db: Arc<DatabaseManager>,
         addr: SocketAddr,
-        vision_control: Arc<AtomicBool>,
         audio_devices_tx: Arc<tokio::sync::broadcast::Sender<(AudioDevice, DeviceControl)>>,
+        vision_devices_tx: Arc<tokio::sync::broadcast::Sender<(u32, VisionDeviceControl)>>,
         screenpipe_dir: PathBuf,
         pipe_manager: Arc<PipeManager>,
         vision_disabled: bool,
@@ -872,8 +874,8 @@ impl Server {
         Server {
             db,
             addr,
-            vision_control,
             audio_devices_tx,
+            vision_devices_tx,
             screenpipe_dir,
             pipe_manager,
             vision_disabled,
@@ -896,8 +898,8 @@ impl Server {
     {
         let app_state = Arc::new(AppState {
             db: self.db.clone(),
-            vision_control: self.vision_control,
             audio_devices_tx: self.audio_devices_tx,
+            vision_devices_tx: self.vision_devices_tx,
             devices_status: device_status,
             app_start_time: Utc::now(),
             screenpipe_dir: self.screenpipe_dir.clone(),
@@ -1853,6 +1855,77 @@ async fn semantic_search_handler(
     }
 }
 
+#[derive(Deserialize)]
+pub struct VisionDeviceControlRequest {
+    device_id: u32,
+}
+
+#[derive(Serialize)]
+pub struct VisionDeviceControlResponse {
+    success: bool,
+    message: String,
+}
+
+async fn start_vision_device(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<VisionDeviceControlRequest>,
+) -> Result<JsonResponse<VisionDeviceControlResponse>, (StatusCode, JsonResponse<Value>)> {
+    // Validate device exists
+    let monitors = list_monitors().await;
+    if !monitors.iter().any(|m| m.id() == payload.device_id) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            JsonResponse(json!({
+                "error": format!("monitor not found: {}", payload.device_id),
+                "success": false
+            })),
+        ));
+    }
+
+    let _ = state.vision_devices_tx.send((
+        payload.device_id,
+        VisionDeviceControl {
+            is_running: true,
+            is_paused: false,
+        },
+    ));
+
+    Ok(JsonResponse(VisionDeviceControlResponse {
+        success: true,
+        message: format!("started vision device: {}", payload.device_id),
+    }))
+}
+
+async fn stop_vision_device(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<VisionDeviceControlRequest>,
+) -> Result<JsonResponse<VisionDeviceControlResponse>, (StatusCode, JsonResponse<Value>)> {
+    // Validate device exists
+    let monitors = list_monitors().await;
+    if !monitors.iter().any(|m| m.id() == payload.device_id) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            JsonResponse(json!({
+                "error": format!("monitor not found: {}", payload.device_id),
+                "success": false
+            })),
+        ));
+    }
+
+    let _ = state.vision_devices_tx.send((
+        payload.device_id,
+        VisionDeviceControl {
+            is_running: false,
+            is_paused: false,
+        },
+    ));
+
+    Ok(JsonResponse(VisionDeviceControlResponse {
+        success: true,
+        message: format!("stopped vision device: {}", payload.device_id),
+    }))
+}
+
 pub fn create_router() -> Router<Arc<AppState>> {
     let cors = CorsLayer::new()
         .allow_origin(Any)
@@ -1874,7 +1947,10 @@ pub fn create_router() -> Router<Arc<AppState>> {
         .route("/pipes/info/:pipe_id", get(get_pipe_info_handler))
         .route("/pipes/list", get(list_pipes_handler))
         .route("/pipes/download", post(download_pipe_handler))
-        .route("/pipes/download-private", post(download_pipe_private_handler))
+        .route(
+            "/pipes/download-private",
+            post(download_pipe_private_handler),
+        )
         .route("/pipes/enable", post(run_pipe_handler))
         .route("/pipes/disable", post(stop_pipe_handler))
         .route("/pipes/update", post(update_pipe_config_handler))
@@ -1900,6 +1976,8 @@ pub fn create_router() -> Router<Arc<AppState>> {
         .route("/audio/stop", post(stop_audio_device))
         .route("/sse/vision", get(sse_vision_handler))
         .route("/semantic-search", get(semantic_search_handler))
+        .route("/vision/start", post(start_vision_device))
+        .route("/vision/stop", post(stop_vision_device))
         .layer(cors);
 
     #[cfg(feature = "experimental")]
@@ -2033,221 +2111,3 @@ struct MergeSpeakersRequest {
     speaker_to_keep_id: i64,
     speaker_to_merge_id: i64,
 }
-/*
-
-Curl commands for reference:
-# 1. Basic search query
-curl "http://localhost:3030/search?q=test&limit=5&offset=0" | jq
-
-# 2. Search with content type filter (OCR)
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=ocr" | jq
-
-# 3. Search with content type filter (Audio)
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=audio" | jq
-
-# 4. Search with pagination
-curl "http://localhost:3030/search?q=test&limit=10&offset=20" | jq
-
-# 6. Search with no query (should return all results)
-curl "http://localhost:3030/search?limit=5&offset=0"
-
-// list devices
-// # curl "http://localhost:3030/audio/list" | jq
-
-
-echo "Listing audio devices:"
-curl "http://localhost:3030/audio/list" | jq
-
-
-echo "Searching for content:"
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=all" | jq
-curl "http://localhost:3030/search?limit=5&offset=0&content_type=ocr" | jq
-
-curl "http://localhost:3030/search?q=libmp3&limit=5&offset=0&content_type=all" | jq
-
-# last 5 w frames
-curl "http://localhost:3030/search?limit=5&offset=0&content_type=all&include_frames=true&start_time=$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-# 30 min to 25 min ago
-curl "http://localhost:3030/search?limit=5&offset=0&content_type=all&include_frames=true&start_time=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-25M +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-curl "http://localhost:3030/search?limit=1&offset=0&content_type=all&include_frames=true&start_time=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-25M +%Y-%m-%dT%H:%M:%SZ)" | jq -r '.data[0].content.frame' | base64 --decode > /tmp/frame.png && open /tmp/frame.png
-
-# Search for content from the last 30 minutes
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=all&start_time=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-25M +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-# Search for content up to 1 hour ago
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=all&end_time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-# Search for content between 2 hours ago and 1 hour ago
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=all&start_time=$(date -u -v-2H +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-# Search for OCR content from yesterday
-curl "http://localhost:3030/search?q=test&limit=5&offset=0&content_type=ocr&start_time=$(date -u -v-1d -v0H -v0M -v0S +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-1d -v23H -v59M -v59S +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-# Search for audio content with a keyword from the beginning of the current month
-curl "http://localhost:3030/search?q=libmp3&limit=5&offset=0&content_type=audio&start_time=$(date -u -v1d -v0H -v0M -v0S +%Y-%m-01T%H:%M:%SZ)" | jq
-
-curl "http://localhost:3030/search?app_name=cursor"
-curl "http://localhost:3030/search?content_type=audio&min_length=20"
-
-curl "http://localhost:3030/search?q=Matt&offset=0&limit=50&start_time=$(date -u -v-2H +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" | jq .
-
-
-curl "http://localhost:3030/search?limit=50&offset=0&content_type=all&start_time=$(date -u -v-2H +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-date -u -v-2H +%Y-%m-%dT%H:%M:%SZ
-2024-08-12T06:51:54Z
-date -u -v-1H +%Y-%m-%dT%H:%M:%SZ
-2024-08-12T07:52:17Z
-
-curl 'http://localhost:3030/search?limit=50&offset=0&content_type=all&start_time=2024-08-12T06:48:18Z&end_time=2024-08-12T07:48:34Z' | jq .
-
-
-curl "http://localhost:3030/search?q=Matt&offset=0&limit=10&start_time=2024-08-12T04:00:00Z&end_time=2024-08-12T05:00:00Z&content_type=all" | jq .
-
-curl "http://localhost:3030/search?q=Matt&offset=0&limit=10&start_time=2024-08-12T06:43:53Z&end_time=2024-08-12T08:43:53Z&content_type=all" | jq .
-
-curl 'http://localhost:3030/search?offset=0&limit=10&start_time=2024-08-12T04%3A00%3A00Z&end_time=2024-08-12T05%3A00%3A00Z&content_type=all' | jq .
-
-
-
-
-
-
-
-
-
-
-
-# First, search for Rust-related content
-curl "http://localhost:3030/search?q=debug&limit=5&offset=0&content_type=ocr"
-
-# Then, assuming you found a relevant item with id 123, tag it
-curl -X POST "http://localhost:3030/tags/vision/626" \
-     -H "Content-Type: application/json" \
-     -d '{"tags": ["debug"]}'
-
-
-
-
-# List all pipes
-curl "http://localhost:3030/pipes/list" | jq
-
-# Download a new pipe
-curl -X POST "http://localhost:3030/pipes/download" \
-     -H "Content-Type: application/json" \
-     -d '{"url": "./pipes/pipe-stream-ocr-text"}' | jq
-
-curl -X POST "http://localhost:3030/pipes/download" \
-     -H "Content-Type: application/json" \
-     -d '{"url": "./pipes/pipe-security-check"}' | jq
-
-
-curl -X POST "http://localhost:3030/pipes/download" \
-     -H "Content-Type: application/json" \
-     -d '{"url": "https://github.com/mediar-ai/screenpipe/tree/main/pipes/pipe-stream-ocr-text"}' | jq
-
-
-# Get info for a specific pipe
-curl "http://localhost:3030/pipes/info/pipe-stream-ocr-text" | jq
-
-# Run a pipe
-curl -X POST "http://localhost:3030/pipes/enable" \
-     -H "Content-Type: application/json" \
-     -d '{"pipe_id": "pipe-stream-ocr-text"}' | jq
-
-
-
-     curl -X POST "http://localhost:3030/pipes/enable" \
-     -H "Content-Type: application/json" \
-     -d '{"pipe_id": "pipe-security-check"}' | jq
-
-# Stop a pipe
-curl -X POST "http://localhost:3030/pipes/disable" \
-     -H "Content-Type: application/json" \
-     -d '{"pipe_id": "pipe-stream-ocr-text"}' | jq
-
-# Update pipe configuration
-curl -X POST "http://localhost:3030/pipes/update" \
-     -H "Content-Type: application/json" \
-     -d '{
-       "pipe_id": "pipe-stream-ocr-text",
-       "config": {
-         "key": "value",
-         "another_key": "another_value"
-       }
-     }' | jq
-
-
-
-
-
-# Basic search with min_length and max_length
-curl "http://localhost:3030/search?q=test&limit=10&offset=0&min_length=5&max_length=50" | jq
-
-# Search for OCR content with length constraints
-curl "http://localhost:3030/search?q=code&content_type=ocr&limit=5&offset=0&min_length=20&max_length=100" | jq
-
-# Search for audio content with length constraints
-curl "http://localhost:3030/search?q=meeting&content_type=audio&limit=5&offset=0&min_length=50&max_length=200" | jq
-
-# Search with time range and length constraints
-curl "http://localhost:3030/search?q=project&limit=10&offset=0&min_length=10&max_length=100&start_time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" | jq
-
-# Search with app_name and length constraints
-curl "http://localhost:3030/search?app_name=cursor&limit=5&offset=0&min_length=15&max_length=150" | jq
-
-# Search with window_name and length constraints
-curl "http://localhost:3030/search?window_name=alacritty&min_length=5&max_length=50" | jq
-
-# Search for very short content
-curl "http://localhost:3030/search?q=&limit=10&offset=0&max_length=10" | jq
-
-# Search for very long content
-curl "http://localhost:3030/search?q=&limit=10&offset=0&min_length=500" | jq
-
-
-curl "http://localhost:3030/search?limit=10&offset=0&min_length=500&content_type=audio" | jq
-
-
-# read random data and generate a clip using the merge endpoint
-
-
-# Perform the search and store the response
-
-# First, let's search for some recent video content
-SEARCH_RESPONSE1=$(curl -s "http://localhost:3030/search?q=&limit=5&offset=0&content_type=ocr&start_time=$(date -u -v-30M +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-25M +%Y-%m-%dT%H:%M:%SZ)")
-SEARCH_RESPONSE2=$(curl -s "http://localhost:3030/search?q=&limit=5&offset=0&content_type=ocr&start_time=$(date -u -v-40M +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-35M +%Y-%m-%dT%H:%M:%SZ)")
-SEARCH_RESPONSE3=$(curl -s "http://localhost:3030/search?q=&limit=5&offset=0&content_type=ocr&start_time=$(date -u -v-50M +%Y-%m-%dT%H:%M:%SZ)&end_time=$(date -u -v-45M +%Y-%m-%dT%H:%M:%SZ)")
-
-# Extract the file paths from the search results without creating JSON arrays
-VIDEO_PATHS1=$(echo "$SEARCH_RESPONSE1" | jq -r '.data[].content.file_path' | sort -u)
-VIDEO_PATHS2=$(echo "$SEARCH_RESPONSE2" | jq -r '.data[].content.file_path' | sort -u)
-VIDEO_PATHS3=$(echo "$SEARCH_RESPONSE3" | jq -r '.data[].content.file_path' | sort -u)
-
-# Merge the video paths and create a single JSON array
-MERGED_VIDEO_PATHS=$(echo "$VIDEO_PATHS1"$'\n'"$VIDEO_PATHS2"$'\n'"$VIDEO_PATHS3" | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
-
-# Create the JSON payload for merging videos
-MERGE_PAYLOAD=$(jq -n \
-  --argjson video_paths "$MERGED_VIDEO_PATHS" \
-  '{
-    video_paths: $video_paths
-  }')
-
-echo "Merge Payload: $MERGE_PAYLOAD"
-
-# Send the merge request and store the response
-MERGE_RESPONSE=$(curl -s -X POST "http://localhost:3030/experimental/frames/merge" \
-  -H "Content-Type: application/json" \
-  -d "$MERGE_PAYLOAD")
-
-echo "Merge Response: $MERGE_RESPONSE"
-
-# Extract the merged video path from the response
-MERGED_VIDEO_PATH=$(echo "$MERGE_RESPONSE" | jq -r '.video_path')
-
-echo "Merged Video Path: $MERGED_VIDEO_PATH"
-
-*/

--- a/screenpipe-server/src/server.rs
+++ b/screenpipe-server/src/server.rs
@@ -1940,7 +1940,7 @@ pub fn create_router() -> Router<Arc<AppState>> {
     let router = Router::new()
         .route("/search", get(search))
         .route("/audio/list", get(api_list_audio_devices))
-        .route("/vision/list", post(api_list_monitors))
+        .route("/vision/list", get(api_list_monitors))
         .route(
             "/tags/:content_type/:id",
             post(add_tags).delete(remove_tags),

--- a/screenpipe-vision/src/bin/screenpipe-vision.rs
+++ b/screenpipe-vision/src/bin/screenpipe-vision.rs
@@ -5,7 +5,7 @@ use screenpipe_vision::{
     OcrEngine,
 };
 use std::{sync::Arc, time::Duration};
-use tokio::sync::mpsc::channel;
+use tokio::sync::{mpsc::channel, watch};
 use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
 
 #[derive(Parser)]
@@ -39,6 +39,8 @@ async fn main() {
     let id = monitor.id();
     let window_filters = WindowFilters::new(&[], &[]);
 
+    let (_, shutdown_rx) = watch::channel(false);
+
     tokio::spawn(async move {
         continuous_capture(
             result_tx,
@@ -48,6 +50,7 @@ async fn main() {
             Arc::new(window_filters),
             languages.clone(),
             false,
+            shutdown_rx,
         )
         .await
     });

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -29,6 +29,8 @@ use std::{
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
+use tracing::info;
 
 #[cfg(target_os = "macos")]
 use xcap_macos::Monitor;
@@ -137,6 +139,7 @@ pub async fn continuous_capture(
     window_filters: Arc<WindowFilters>,
     languages: Vec<Language>,
     capture_unfocused_windows: bool,
+    mut shutdown_rx: watch::Receiver<bool>,
 ) {
     let mut frame_counter: u64 = 0;
     let mut previous_image: Option<DynamicImage> = None;
@@ -151,95 +154,116 @@ pub async fn continuous_capture(
     let monitor = get_monitor_by_id(monitor_id).await.unwrap();
 
     loop {
-        let capture_result =
-            match capture_screenshot(&monitor, &window_filters, capture_unfocused_windows).await {
-                Ok((image, window_images, image_hash, _capture_duration)) => {
-                    debug!(
-                        "Captured screenshot on monitor {} with hash: {}",
-                        monitor.id(),
-                        image_hash
-                    );
-                    Some((image, window_images, image_hash))
-                }
-                Err(e) => {
-                    error!("Failed to capture screenshot: {}", e);
-                    None
-                }
-            };
-
-        if let Some((image, window_images, image_hash)) = capture_result {
-            let current_average = match compare_with_previous_image(
-                previous_image.as_ref(),
-                &image,
-                &mut max_average,
-                frame_counter,
-                &mut max_avg_value,
-            )
-            .await
-            {
-                Ok(avg) => avg,
-                Err(e) => {
-                    error!("Error comparing images: {}", e);
-                    0.0
-                }
-            };
-
-            let current_average = if previous_image.is_none() {
-                1.0
-            } else {
-                current_average
-            };
-
-            if current_average < 0.006 {
-                debug!(
-                    "Skipping frame {} due to low average difference: {:.3}",
-                    frame_counter, current_average
-                );
-                frame_counter += 1;
-                tokio::time::sleep(interval).await;
-                continue;
-            }
-
-            if current_average > max_avg_value {
-                max_average = Some(MaxAverageFrame {
-                    image: image.clone(),
-                    window_images: window_images.clone(),
-                    image_hash,
-                    frame_number: frame_counter,
-                    timestamp: Instant::now(),
-                    result_tx: result_tx.clone(),
-                    average: current_average,
-                });
-                max_avg_value = current_average;
-            }
-
-            previous_image = Some(image);
-
-            if let Some(max_avg_frame) = max_average.take() {
-                let ocr_task_data = OcrTaskData {
-                    image: max_avg_frame.image,
-                    window_images: max_avg_frame.window_images,
-                    frame_number: max_avg_frame.frame_number,
-                    timestamp: max_avg_frame.timestamp,
-                    result_tx: max_avg_frame.result_tx,
-                };
-
-                if let Err(e) =
-                    process_ocr_task(ocr_task_data, &ocr_engine, languages.clone()).await
-                {
-                    error!("Error processing OCR task: {}", e);
-                }
-
-                frame_counter = 0;
-                max_avg_value = 0.0;
-            }
-        } else {
-            debug!("Skipping frame {} due to capture failure", frame_counter);
+        // Check shutdown signal
+        if *shutdown_rx.borrow() {
+            info!(
+                "continuous_capture: received shutdown signal for monitor {}",
+                monitor_id
+            );
+            break;
         }
 
-        frame_counter += 1;
-        tokio::time::sleep(interval).await;
+        // Use tokio::select! to handle both capture and shutdown
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    info!("continuous_capture: shutdown signal received for monitor {}", monitor_id);
+                    break;
+                }
+            }
+            _ = async {
+                let capture_result = match capture_screenshot(&monitor, &window_filters, capture_unfocused_windows).await {
+                    Ok((image, window_images, image_hash, _capture_duration)) => {
+                        debug!(
+                            "captured screenshot on monitor {} with hash: {}",
+                            monitor.id(),
+                            image_hash
+                        );
+                        Some((image, window_images, image_hash))
+                    }
+                    Err(e) => {
+                        error!("Failed to capture screenshot: {}", e);
+                        None
+                    }
+                };
+
+                if let Some((image, window_images, image_hash)) = capture_result {
+                    let current_average = match compare_with_previous_image(
+                        previous_image.as_ref(),
+                        &image,
+                        &mut max_average,
+                        frame_counter,
+                        &mut max_avg_value,
+                    )
+                    .await
+                    {
+                        Ok(avg) => avg,
+                        Err(e) => {
+                            error!("Error comparing images: {}", e);
+                            0.0
+                        }
+                    };
+
+                    let current_average = if previous_image.is_none() {
+                        1.0
+                    } else {
+                        current_average
+                    };
+
+                    if current_average < 0.006 {
+                        debug!(
+                            "Skipping frame {} due to low average difference: {:.3}",
+                            frame_counter, current_average
+                        );
+                        frame_counter += 1;
+                        tokio::time::sleep(interval).await;
+                        return;
+                    }
+
+                    if current_average > max_avg_value {
+                        max_average = Some(MaxAverageFrame {
+                            image: image.clone(),
+                            window_images: window_images.clone(),
+                            image_hash,
+                            frame_number: frame_counter,
+                            timestamp: Instant::now(),
+                            result_tx: result_tx.clone(),
+                            average: current_average,
+                        });
+                        max_avg_value = current_average;
+                    }
+
+                    previous_image = Some(image);
+
+                    if let Some(max_avg_frame) = max_average.take() {
+                        let ocr_task_data = OcrTaskData {
+                            image: max_avg_frame.image,
+                            window_images: max_avg_frame.window_images,
+                            frame_number: max_avg_frame.frame_number,
+                            timestamp: max_avg_frame.timestamp,
+                            result_tx: max_avg_frame.result_tx,
+                        };
+
+                        if let Err(e) =
+                            process_ocr_task(ocr_task_data, &ocr_engine, languages.clone()).await
+                        {
+                            error!("Error processing OCR task: {}", e);
+                        }
+
+                        frame_counter = 0;
+                        max_avg_value = 0.0;
+                    }
+                } else {
+                    debug!("Skipping frame {} due to capture failure", frame_counter);
+                }
+
+                frame_counter += 1;
+                tokio::time::sleep(interval).await;
+            } => {}
+        }
     }
+
+    debug!("Continuous capture stopped for monitor {}", monitor_id);
 }
 
 pub struct MaxAverageFrame {

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -29,7 +29,6 @@ use std::{
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc::Sender;
-use tokio::time::sleep;
 
 #[cfg(target_os = "macos")]
 use xcap_macos::Monitor;
@@ -149,20 +148,16 @@ pub async fn continuous_capture(
         monitor_id
     );
 
+    let monitor = get_monitor_by_id(monitor_id).await.unwrap();
+
     loop {
-        let monitor = match get_monitor_by_id(monitor_id).await {
-            Some(m) => m,
-            None => {
-                sleep(Duration::from_secs(1)).await;
-                continue;
-            }
-        };
         let capture_result =
             match capture_screenshot(&monitor, &window_filters, capture_unfocused_windows).await {
                 Ok((image, window_images, image_hash, _capture_duration)) => {
                     debug!(
                         "Captured screenshot on monitor {} with hash: {}",
-                        monitor_id, image_hash
+                        monitor.id(),
+                        image_hash
                     );
                     Some((image, window_images, image_hash))
                 }

--- a/screenpipe-vision/src/monitor.rs
+++ b/screenpipe-vision/src/monitor.rs
@@ -4,6 +4,7 @@ use xcap_macos::Monitor;
 #[cfg(not(target_os = "macos"))]
 use xcap::Monitor;
 
+
 pub async fn list_monitors() -> Vec<Monitor> {
     Monitor::all().unwrap().to_vec()
 }


### PR DESCRIPTION
### Testing Audio & Vision Device Control

This PR adds endpoints to control vision devices individually. Here's how to test:

```bash
cargo build --release [ --features metal ]
```

#### 1. Audio Device Control

open https://www.youtube.com/watch?v=4HRWgnHDu-w in another tab

```bash
./target/release/screenpipe --data-dir /tmp/sp --port 3035 --disable-vision --debug
```

First, list available audio devices and store the first one:
```bash
# List audio devices
curl http://localhost:3035/audio/list | jq
# Store first device name
AUDIO_DEVICE=$(curl http://localhost:3035/audio/list | jq -r '.[0].name')

# Stop the audio device
curl -X POST http://localhost:3035/audio/stop \
  -H "Content-Type: application/json" \
  -d "{\"device_name\": \"$AUDIO_DEVICE\"}"

# Start the audio device
curl -X POST http://localhost:3035/audio/start \
  -H "Content-Type: application/json" \
  -d "{\"device_name\": \"$AUDIO_DEVICE\"}"
```

#### 2. Vision Device Control

```bash
./target/release/screenpipe --fps 1 --data-dir /tmp/sp --port 3035 --disable-audio --debug
```

Similarly for vision devices:
```bash
# List vision devices
curl http://localhost:3035/vision/list | jq
# Store first device id
VISION_DEVICE=$(curl http://localhost:3035/vision/list | jq -r '.[0].id')

# Stop the vision device
curl -X POST http://localhost:3035/vision/stop \
  -H "Content-Type: application/json" \
  -d "{\"device_id\": $VISION_DEVICE}"

# Start the vision device 
curl -X POST http://localhost:3035/vision/start \
  -H "Content-Type: application/json" \
  -d "{\"device_id\": $VISION_DEVICE}"
```

#### 3. Verification

1. check logs, is OCR properly starting and stopping?
2. check logs is audio transcription properly starting and stopping?
3. is your CPU/RAM normal? is your computer on fire? database data added? (OCR, transcriptions)

