### PR TITLE
added video input to list-monitors

### DIFF
--- a/screenpipe-server/src/bin/screenpipe-server.rs
+++ b/screenpipe-server/src/bin/screenpipe-server.rs
@@ -17,6 +17,7 @@ use screenpipe_server::{
     start_continuous_recording, watch_pid, DatabaseManager, PipeManager, ResourceMonitor, Server,
 };
 use screenpipe_vision::monitor::list_monitors;
+use screenpipe_vision::video_input_device::list_video_devices;
 #[cfg(target_os = "macos")]
 use screenpipe_vision::run_ui;
 use serde_json::{json, Value};
@@ -365,9 +366,14 @@ async fn main() -> anyhow::Result<()> {
     }
     let all_monitors = list_monitors().await;
     if cli.list_monitors {
+        let video_devices = list_video_devices().await;
         println!("available monitors:");
         for monitor in all_monitors.iter() {
             println!("  {}. {:?}", monitor.id(), monitor);
+        }
+        println!("available video input devices:");
+        for device in video_devices.iter() {
+            println!("  {}. {}", device.id, device.name);
         }
         return Ok(());
     }

--- a/screenpipe-vision/src/lib.rs
+++ b/screenpipe-vision/src/lib.rs
@@ -5,6 +5,7 @@ pub mod custom_ocr;
 #[cfg(target_os = "windows")]
 pub mod microsoft;
 pub mod monitor;
+pub mod video_input_device;
 #[cfg(target_os = "macos")]
 pub mod run_ui_monitoring_macos;
 pub mod tesseract;

--- a/screenpipe-vision/src/video_input_device.rs
+++ b/screenpipe-vision/src/video_input_device.rs
@@ -1,0 +1,61 @@
+#[cfg(target_os = "macos")]
+const MULTI_MEDIA_FRAMEWORK: &str = "avfoundation";
+
+#[cfg(target_os = "windows")]
+const MULTI_MEDIA_FRAMEWORK: &str = "directshow";
+
+#[cfg(target_os = "linux")]
+const MULTI_MEDIA_FRAMEWORK: &str = "v4l2";
+
+use tokio::process::Command;
+
+pub struct VideoDevice {
+  pub id: String,
+  pub name: String,
+}
+
+pub async fn list_video_devices() -> Vec<VideoDevice>{
+    list_input_devices(MULTI_MEDIA_FRAMEWORK).await
+}
+
+async fn list_input_devices(framework: &str) -> Vec<VideoDevice>{
+  let output = Command::new("ffmpeg")
+      .arg("-f")
+      .arg(framework)
+      .arg("-list_devices")
+      .arg("true")
+      .arg("-i")
+      .arg("")
+      .output()
+      .await;
+
+  let mut devices = Vec::new();
+
+  let output = output.unwrap();
+  let stderr_output = String::from_utf8_lossy(&output.stderr);
+
+  let mut parsing_video = false;
+  for line in stderr_output.lines() {
+      if line.contains("video devices"){
+        parsing_video = true;
+        continue;
+      }
+      if line.contains("audio devices") {
+          break;
+      }
+      if parsing_video {
+        if let Some(device) = parse_device(line) {
+            devices.push(device);
+        }
+      }
+    }
+  devices
+}
+
+fn parse_device(line: &str) -> Option<VideoDevice> {
+  let parts: Vec<&str> = line.splitn(3, "] ").collect();
+  Some(VideoDevice {
+    id: parts[1].trim_matches('[').to_string(),
+    name: parts[2].trim().to_string(),
+  })
+}


### PR DESCRIPTION
---
name: list webcam, iphone, etc. in list-monitors

---

## description
added the video inputs to the `--list-monitors` command.
if this approach is not what was expected feel free to close, if the output format is not what was expected or more information was expected I am happy to make changes.

related issue: #
/claim #1160 
## how to test

add a few steps to test the pr in the most time efficient way.

1. run `ffmpeg -f avfoundation -list_devices true -i ""` command with platform specific framework
2.  run screenpipe --list-monitors
3.  compare outputs

if relevant add screenshots or screen captures to prove that this PR works to save us time.
```
henry@Henrys-MacBook-Pro screenpipe % ./target/release/screenpipe --list-monitors                  
2025-01-29T19:54:39.900866Z  INFO screenpipe: screenpipe already in PATH at: /Users/henry/.local/bin/screenpipe
2025-01-29T19:54:39.900907Z  INFO screenpipe: screenpipe is available and properly set in the PATH
available monitors:
  1. Monitor { impl_monitor: ImplMonitor { cg_display: CGDisplay { id: 1 }, id: 1, name: "Monitor #41033", x: 0, y: 0, width: 1440, height: 900, rotation: 0.0, scale_factor: 2.0, frequency: 60.0, is_primary: true } }
available video input devices:
  0. FaceTime HD Camera
  1. OBS Virtual Camera
  2. Capture screen 0
```

if you think it can take more than 30 mins for us to review, we will pay between $20 and $200 for someone to review it for us, just ask in the pr.
