### PR TITLE
Add pipe management to Node SDK

### DIFF
--- a/screenpipe-js/browser-sdk/src/index.ts
+++ b/screenpipe-js/browser-sdk/src/index.ts
@@ -285,7 +285,7 @@ class BrowserPipeImpl implements BrowserPipe {
       config: { [key: string]: string },
     ) => Promise<boolean>;
   } = {
-    list: () => {
+    list: async () => {
       try {
         const response = await fetch("http://localhost:3030/pipes/list", {
           method: "GET",
@@ -299,7 +299,7 @@ class BrowserPipeImpl implements BrowserPipe {
         return [];
       }
     },
-    download: (url: string) => {
+    download: async (url: string) => {
       try {
         const response = await fetch("http://localhost:3030/pipes/download", {
           method: "POST",
@@ -315,7 +315,7 @@ class BrowserPipeImpl implements BrowserPipe {
         return false;
       }
     },
-    enable: (pipeId: string) => {
+    enable: async (pipeId: string) => {
       try {
         const response = await fetch("http://localhost:3030/pipes/enable", {
           method: "POST",
@@ -331,7 +331,7 @@ class BrowserPipeImpl implements BrowserPipe {
         return false;
       }
     },
-    disable: (pipeId: string) => {
+    disable: async (pipeId: string) => {
       try {
         const response = await fetch("http://localhost:3030/pipes/disable", {
           method: "POST",
@@ -347,7 +347,7 @@ class BrowserPipeImpl implements BrowserPipe {
         return false;
       }
     },
-    update: (pipeId: string, config: { [key: string]: string }) => {
+    update: async (pipeId: string, config: { [key: string]: string }) => {
       try {
         const response = await fetch("http://localhost:3030/pipes/update", {
           method: "POST",

--- a/screenpipe-js/browser-sdk/src/index.ts
+++ b/screenpipe-js/browser-sdk/src/index.ts
@@ -21,7 +21,7 @@ let wsWithoutImages: WebSocket | null = null;
 
 // Update the wsEvents generator to accept includeImages parameter and manage connections
 async function* wsEvents(
-  includeImages: boolean = false
+  includeImages: boolean = false,
 ): AsyncGenerator<EventStreamResponse, void, unknown> {
   // Reuse existing connection or create new one
   let ws = includeImages ? wsWithImages : wsWithoutImages;
@@ -71,7 +71,7 @@ async function sendInputControl(action: InputAction): Promise<boolean> {
 export interface BrowserPipe {
   sendDesktopNotification(options: NotificationOptions): Promise<boolean>;
   queryScreenpipe(
-    params: ScreenpipeQueryParams
+    params: ScreenpipeQueryParams,
   ): Promise<ScreenpipeResponse | null>;
   input: {
     type: (text: string) => Promise<boolean>;
@@ -79,24 +79,34 @@ export interface BrowserPipe {
     moveMouse: (x: number, y: number) => Promise<boolean>;
     click: (button: "left" | "right" | "middle") => Promise<boolean>;
   };
+  pipes: {
+    list: () => Promise<string[]>;
+    download: (url: string) => Promise<boolean>;
+    enable: (pipeId: string) => Promise<boolean>;
+    disable: (pipeId: string) => Promise<boolean>;
+    update: (
+      pipeId: string,
+      config: { [key: string]: string },
+    ) => Promise<boolean>;
+  };
   streamTranscriptions(): AsyncGenerator<
     TranscriptionStreamResponse,
     void,
     unknown
   >;
   streamVision(
-    includeImages?: boolean
+    includeImages?: boolean,
   ): AsyncGenerator<VisionStreamResponse, void, unknown>;
   captureEvent: (
     event: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
   ) => Promise<void>;
   captureMainFeatureEvent: (
     name: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
   ) => Promise<void>;
   streamEvents(
-    includeImages: boolean
+    includeImages: boolean,
   ): AsyncGenerator<EventStreamResponse, void, unknown>;
 }
 
@@ -109,7 +119,7 @@ class BrowserPipeImpl implements BrowserPipe {
     try {
       // Connect to settings SSE stream
       const settingsStream = new EventSource(
-        "http://localhost:11435/sse/settings"
+        "http://localhost:11435/sse/settings",
       );
 
       // Get initial settings
@@ -155,7 +165,7 @@ class BrowserPipeImpl implements BrowserPipe {
     } catch (error) {
       console.error(
         "failed to fetch settings, defaulting to analytics enabled:",
-        error
+        error,
       );
       return {
         analyticsEnabled: false,
@@ -165,7 +175,7 @@ class BrowserPipeImpl implements BrowserPipe {
   }
 
   async sendDesktopNotification(
-    options: NotificationOptions
+    options: NotificationOptions,
   ): Promise<boolean> {
     const { userId, email } = await this.initAnalyticsIfNeeded();
     const notificationApiUrl = "http://localhost:11435";
@@ -193,7 +203,7 @@ class BrowserPipeImpl implements BrowserPipe {
   }
 
   async queryScreenpipe(
-    params: ScreenpipeQueryParams
+    params: ScreenpipeQueryParams,
   ): Promise<ScreenpipeResponse | null> {
     console.log("queryScreenpipe:", params);
     const { userId, email } = await this.initAnalyticsIfNeeded();
@@ -265,6 +275,97 @@ class BrowserPipeImpl implements BrowserPipe {
       sendInputControl({ type: "MouseClick", data: button }),
   };
 
+  pipes: {
+    list: () => Promise<string[]>;
+    download: (url: string) => Promise<boolean>;
+    enable: (pipeId: string) => Promise<boolean>;
+    disable: (pipeId: string) => Promise<boolean>;
+    update: (
+      pipeId: string,
+      config: { [key: string]: string },
+    ) => Promise<boolean>;
+  } = {
+    list: () => {
+      try {
+        const response = await fetch("http://localhost:3030/pipes/list", {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+        });
+
+        const data = await response.json();
+        return data.data;
+      } catch (error) {
+        console.error("failed to list pipes:", error);
+        return [];
+      }
+    },
+    download: (url: string) => {
+      try {
+        const response = await fetch("http://localhost:3030/pipes/download", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            url,
+          }),
+        });
+
+        return response.ok;
+      } catch (error) {
+        console.error("failed to download pipe:", error);
+        return false;
+      }
+    },
+    enable: (pipeId: string) => {
+      try {
+        const response = await fetch("http://localhost:3030/pipes/enable", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            pipe_id: pipeId,
+          }),
+        });
+
+        return response.ok;
+      } catch (error) {
+        console.error("failed to enable pipe:", error);
+        return false;
+      }
+    },
+    disable: (pipeId: string) => {
+      try {
+        const response = await fetch("http://localhost:3030/pipes/disable", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            pipe_id: pipeId,
+          }),
+        });
+
+        return response.ok;
+      } catch (error) {
+        console.error("failed to disable pipe:", error);
+        return false;
+      }
+    },
+    update: (pipeId: string, config: { [key: string]: string }) => {
+      try {
+        const response = await fetch("http://localhost:3030/pipes/update", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            pipe_id: pipeId,
+            config,
+          }),
+        });
+
+        return response.ok;
+      } catch (error) {
+        console.error("failed to update pipe:", error);
+        return false;
+      }
+    },
+  };
+
   async *streamTranscriptions(): AsyncGenerator<
     TranscriptionStreamResponse,
     void,
@@ -302,7 +403,7 @@ class BrowserPipeImpl implements BrowserPipe {
   }
 
   async *streamVision(
-    includeImages: boolean = false
+    includeImages: boolean = false,
   ): AsyncGenerator<VisionStreamResponse, void, unknown> {
     try {
       for await (const event of wsEvents(includeImages)) {
@@ -321,7 +422,7 @@ class BrowserPipeImpl implements BrowserPipe {
 
   public async captureEvent(
     eventName: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
   ) {
     const { analyticsEnabled } = await this.initAnalyticsIfNeeded();
     if (!analyticsEnabled) return;
@@ -330,7 +431,7 @@ class BrowserPipeImpl implements BrowserPipe {
 
   public async captureMainFeatureEvent(
     featureName: string,
-    properties?: Record<string, any>
+    properties?: Record<string, any>,
   ) {
     const { analyticsEnabled } = await this.initAnalyticsIfNeeded();
     if (!analyticsEnabled) return;
@@ -338,7 +439,7 @@ class BrowserPipeImpl implements BrowserPipe {
   }
 
   public async *streamEvents(
-    includeImages: boolean = false
+    includeImages: boolean = false,
   ): AsyncGenerator<EventStreamResponse, void, unknown> {
     for await (const event of wsEvents(includeImages)) {
       yield event;

--- a/screenpipe-js/node-sdk/src/PipesManager.ts
+++ b/screenpipe-js/node-sdk/src/PipesManager.ts
@@ -1,7 +1,8 @@
 export class PipesManager {
   async list(): Promise<string[]> {
     try {
-      const response = await fetch("http://localhost:3030/pipes/list", {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/list`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
       });
@@ -16,7 +17,8 @@ export class PipesManager {
 
   async download(url: string): Promise<boolean> {
     try {
-      const response = await fetch("http://localhost:3030/pipes/download", {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/download`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -33,7 +35,8 @@ export class PipesManager {
 
   async enable(pipeId: string): Promise<boolean> {
     try {
-      const response = await fetch("http://localhost:3030/pipes/enable", {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/enable`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -50,7 +53,8 @@ export class PipesManager {
 
   async disable(pipeId: string): Promise<boolean> {
     try {
-      const response = await fetch("http://localhost:3030/pipes/disable", {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/disable`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -70,7 +74,8 @@ export class PipesManager {
     config: { [key: string]: string },
   ): Promise<boolean> {
     try {
-      const response = await fetch("http://localhost:3030/pipes/update", {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/update`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/screenpipe-js/node-sdk/src/PipesManager.ts
+++ b/screenpipe-js/node-sdk/src/PipesManager.ts
@@ -1,0 +1,88 @@
+export class PipesManager {
+  async list(): Promise<string[]> {
+    try {
+      const response = await fetch("http://localhost:3030/pipes/list", {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const data = await response.json();
+      return data.data;
+    } catch (error) {
+      console.error("failed to list pipes:", error);
+      return [];
+    }
+  }
+
+  async download(url: string): Promise<void> {
+    try {
+      const response = await fetch("http://localhost:3030/pipes/download", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to download pipe:", error);
+      return false;
+    }
+  }
+
+  async enable(pipeId: string): Promise<void> {
+    try {
+      const response = await fetch("http://localhost:3030/pipes/enable", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to enable pipe:", error);
+      return false;
+    }
+  }
+
+  async disable(pipeId: string): Promise<void> {
+    try {
+      const response = await fetch("http://localhost:3030/pipes/disable", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to disable pipe:", error);
+      return false;
+    }
+  }
+
+  async update(
+    pipeId: string,
+    config: { [key: string]: string },
+  ): Promise<void> {
+    try {
+      const response = await fetch("http://localhost:3030/pipes/update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+          config,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to update pipe:", error);
+      return false;
+    }
+  }
+}

--- a/screenpipe-js/node-sdk/src/PipesManager.ts
+++ b/screenpipe-js/node-sdk/src/PipesManager.ts
@@ -14,7 +14,7 @@ export class PipesManager {
     }
   }
 
-  async download(url: string): Promise<void> {
+  async download(url: string): Promise<boolean> {
     try {
       const response = await fetch("http://localhost:3030/pipes/download", {
         method: "POST",
@@ -31,7 +31,7 @@ export class PipesManager {
     }
   }
 
-  async enable(pipeId: string): Promise<void> {
+  async enable(pipeId: string): Promise<boolean> {
     try {
       const response = await fetch("http://localhost:3030/pipes/enable", {
         method: "POST",
@@ -48,7 +48,7 @@ export class PipesManager {
     }
   }
 
-  async disable(pipeId: string): Promise<void> {
+  async disable(pipeId: string): Promise<boolean> {
     try {
       const response = await fetch("http://localhost:3030/pipes/disable", {
         method: "POST",
@@ -68,7 +68,7 @@ export class PipesManager {
   async update(
     pipeId: string,
     config: { [key: string]: string },
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       const response = await fetch("http://localhost:3030/pipes/update", {
         method: "POST",

--- a/screenpipe-js/node-sdk/src/index.ts
+++ b/screenpipe-js/node-sdk/src/index.ts
@@ -12,6 +12,7 @@ import type {
 import { toSnakeCase, convertToCamelCase } from "../../common/utils";
 import { SettingsManager } from "./SettingsManager";
 import { InboxManager } from "./InboxManager";
+import { PipesManager } from "./PipesManager";
 import { EventSource } from "eventsource";
 import { captureEvent, captureMainFeatureEvent } from "../../common/analytics";
 
@@ -32,6 +33,7 @@ class NodePipe {
 
   public settings = new SettingsManager();
   public inbox = new InboxManager();
+  public pipes = new PipesManager();
 
   public async sendDesktopNotification(
     options: NotificationOptions


### PR DESCRIPTION
---
name: Add pipe management to Node SDK
about: Add pipes functions
title: "Add pipe management to Node SDK"
labels: ''
assignees: ''

---

## description
Adds the following functions to the Node SDK:
- pipe.pipes.list()
- pipe.pipes.download()
- pipe.pipes.enable()
- pipe.pipes.disable()
- pipe.pipes.update()

related issue: #1283

## how to test

add a few steps to test the pr in the most time efficient way.

1. Run screenpipe server at localhost:3030
2. Instantiate NodePipe class
3. Run all functions in `.pipes`

/claim #1283
