### PR TITLE
feat: add pipe management in sdks

### DIFF
--- a/screenpipe-js/node-sdk/src/PipeManager.ts
+++ b/screenpipe-js/node-sdk/src/PipeManager.ts
@@ -1,5 +1,7 @@
+type Result<T> = { success: true; data: T } | { success: false; error: any };
+
 export class PipesManager {
-  async list(): Promise<string[]> {
+  async list(): Promise<Result<string[]>> {
     try {
       const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
       const response = await fetch(`${apiUrl}/pipes/list`, {
@@ -7,15 +9,19 @@ export class PipesManager {
         headers: { "Content-Type": "application/json" },
       });
 
+      if (!response.ok) {
+        throw new Error(`http error! status: ${response.status}`);
+      }   
+
       const data = await response.json();
-      return data.data;
+      return { success: true, data: data.data };
     } catch (error) {
       console.error("failed to list pipes:", error);
-      return [];
+      return { success: false, error: error };
     }
   }
 
-  async download(url: string): Promise<boolean> {
+  async download(url: string): Promise<Result<Record<string, any>>> {
     try {
       const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
       const response = await fetch(`${apiUrl}/pipes/download`, {
@@ -26,10 +32,15 @@ export class PipesManager {
         }),
       });
 
-      return response.ok;
+      if (!response.ok) {
+        throw new Error(`http error! status: ${response.status}`);
+      }   
+
+      const data: Record<string, any> = await response.json();
+      return { success: true, data: data.data };
     } catch (error) {
       console.error("failed to download pipe:", error);
-      return false;
+      return { success: false, error: error };
     }
   }
 
@@ -51,7 +62,7 @@ export class PipesManager {
     }
   }
 
-  async disable(pipeId: string): Promise<any> {
+  async disable(pipeId: string): Promise<boolean> {
     try {
       const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
       const response = await fetch(`${apiUrl}/pipes/disable`, {
@@ -62,14 +73,10 @@ export class PipesManager {
         }),
       });
 
-      if (!response.ok) {
-        throw new Error("pipe not found");
-      }
-      const data = await response.json();
-      return data;
+      return response.ok;
     } catch (error) {
       console.error("failed to disable pipe:", error);
-      return null;
+      return false;
     }
   }
 
@@ -95,7 +102,7 @@ export class PipesManager {
     }
   }
 
-  async getPipeInfo(pipeId: string): Promise<any> {
+  async info(pipeId: string): Promise<Result<Record<string, any>>> {
     try {
       const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
       const response = await fetch(`${apiUrl}/pipes/info/${pipeId}`, {
@@ -107,11 +114,11 @@ export class PipesManager {
         throw new Error(`http error! status: ${response.status}`);
       }
 
-      const data = await response.json();
-      return data.data;
+      const data: Record<string, any> = await response.json();
+      return { success: true, data: data.data };
     } catch (error) {
       console.error("failed to get pipe info:", error);
-      return null;
+      return { success: false, error: error };
     }
   }
 
@@ -119,7 +126,7 @@ export class PipesManager {
     url: string,
     pipeName: string,
     pipeId: string
-  ): Promise<any> {
+  ): Promise<Result<Record<string, any>>> {
     try {
       const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
       const response = await fetch(`${apiUrl}/pipes/download-private`, {
@@ -136,11 +143,11 @@ export class PipesManager {
         throw new Error(`http error! status: ${response.status}`);
       }
 
-      const data = await response.json();
-      return data.data;
+      const data: Record<string, any> = await response.json();
+      return { success: true, data: data.data };
     } catch (error) {
       console.error("failed to download private pipe:", error);
-      return false;
+      return { success: false, error: error };
     }
   }
 

--- a/screenpipe-js/node-sdk/src/PipeManager.ts
+++ b/screenpipe-js/node-sdk/src/PipeManager.ts
@@ -1,0 +1,164 @@
+export class PipesManager {
+  async list(): Promise<string[]> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/list`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const data = await response.json();
+      return data.data;
+    } catch (error) {
+      console.error("failed to list pipes:", error);
+      return [];
+    }
+  }
+
+  async download(url: string): Promise<boolean> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/download`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to download pipe:", error);
+      return false;
+    }
+  }
+
+  async enable(pipeId: string): Promise<boolean> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/enable`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to enable pipe:", error);
+      return false;
+    }
+  }
+
+  async disable(pipeId: string): Promise<any> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/disable`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("pipe not found");
+      }
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error("failed to disable pipe:", error);
+      return null;
+    }
+  }
+
+  async update(
+    pipeId: string,
+    config: { [key: string]: string },
+  ): Promise<boolean> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/update`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+          config,
+        }),
+      }); 
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to update pipe:", error);
+      return false;
+    }
+  }
+
+  async getPipeInfo(pipeId: string): Promise<any> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/info/${pipeId}`, {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`http error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.data;
+    } catch (error) {
+      console.error("failed to get pipe info:", error);
+      return null;
+    }
+  }
+
+  async downloadPrivate(
+    url: string,
+    pipeName: string,
+    pipeId: string
+  ): Promise<any> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/download-private`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url,
+          pipe_name: pipeName,
+          pipe_id: pipeId,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`http error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.data;
+    } catch (error) {
+      console.error("failed to download private pipe:", error);
+      return false;
+    }
+  }
+
+  async delete(pipeId: string): Promise<boolean> {
+    try {
+      const apiUrl = process.env.SCREENPIPE_SERVER_URL || "http://localhost:3030";
+      const response = await fetch(`${apiUrl}/pipes/delete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          pipe_id: pipeId,
+        }),
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error("failed to delete pipe:", error);
+      return false;
+    }
+  }
+}

--- a/screenpipe-js/node-sdk/src/index.ts
+++ b/screenpipe-js/node-sdk/src/index.ts
@@ -13,6 +13,7 @@ import { toSnakeCase, convertToCamelCase } from "../../common/utils";
 import { SettingsManager } from "./SettingsManager";
 import { InboxManager } from "./InboxManager";
 import { EventSource } from "eventsource";
+import { PipesManager } from "./PipeManager"
 import { captureEvent, captureMainFeatureEvent } from "../../common/analytics";
 
 class NodePipe {
@@ -32,6 +33,7 @@ class NodePipe {
 
   public settings = new SettingsManager();
   public inbox = new InboxManager();
+  public pipes = new PipesManager();
 
   public async sendDesktopNotification(
     options: NotificationOptions


### PR DESCRIPTION
/claim #1283
/closes #1283

these are the methods:

```typescript
    list()
    download()
    enable()
    disable()
    update()
    getPipeInfo()
    downloadPrivate()
    delete()
```
![image](https://github.com/user-attachments/assets/1c369d58-9840-4ff2-8abf-c94eabfefc2e)
