### PR TITLE
feat: added response format

### DIFF
--- a/screenpipe-actions/ai-proxy/src/providers/gemini.ts
+++ b/screenpipe-actions/ai-proxy/src/providers/gemini.ts
@@ -13,8 +13,23 @@ export class GeminiProvider implements AIProvider {
 		this.client = new GoogleGenerativeAI(apiKey);
 	}
 
+	private createGenerationConfig(body: RequestBody) {
+		const config: any = {
+		  temperature: body.temperature,
+		};
+	
+		if (body.response_format?.type === 'json_schema' && body.response_format.schema) {
+		  config.responseMimeType = 'application/json';
+		  config.responseSchema = body.response_format.schema;
+		} else if (body.response_format?.type === 'json_object') {
+		  config.responseMimeType = 'application/json';
+		}
+	
+		return config;
+	  }
+
 	async createCompletion(body: RequestBody): Promise<Response> {
-		this.model = this.client.getGenerativeModel({ model: body.model });
+		this.model = this.client.getGenerativeModel({ model: body.model, generationConfig: this.createGenerationConfig(body) });
 
 		const chat = this.model.startChat({
 			history: this.formatMessages(body.messages),

--- a/screenpipe-actions/ai-proxy/src/providers/openai.ts
+++ b/screenpipe-actions/ai-proxy/src/providers/openai.ts
@@ -3,7 +3,6 @@ import { Message, RequestBody, ResponseFormat } from '../types';
 import OpenAI from 'openai';
 import type { ChatCompletionMessage, ChatCompletionCreateParams } from 'openai/resources/chat';
 import type { ResponseFormatJSONSchema } from 'openai/resources';
-import { JSONSchema } from 'openai/lib/jsonschema';
 
 export class OpenAIProvider implements AIProvider {
 	supportsTools = true;
@@ -15,7 +14,7 @@ export class OpenAIProvider implements AIProvider {
 		this.client = new OpenAI({ apiKey });
 	}
 
-	private createJSONSchemaFormat(schema: JSONSchema, name: string, description?: string): ResponseFormatJSONSchema {
+	private createJSONSchemaFormat(schema: Record<string, unknown>, name: string, description?: string): ResponseFormatJSONSchema {
 		return {
 			type: 'json_schema',
 			json_schema: {
@@ -37,7 +36,6 @@ export class OpenAIProvider implements AIProvider {
 				if (!format.schema || !format.name) {
 					throw new Error('Schema and name are required for json_schema response format');
 				}
-				// The schema is now properly typed with JSONSchema
 				return this.createJSONSchemaFormat(format.schema, format.name, format.description);
 			default:
 				return undefined;

--- a/screenpipe-actions/ai-proxy/src/providers/openai.ts
+++ b/screenpipe-actions/ai-proxy/src/providers/openai.ts
@@ -1,7 +1,9 @@
 import { AIProvider } from './base';
-import { Message, RequestBody } from '../types';
+import { Message, RequestBody, ResponseFormat } from '../types';
 import OpenAI from 'openai';
 import type { ChatCompletionMessage, ChatCompletionCreateParams } from 'openai/resources/chat';
+import type { ResponseFormatJSONSchema } from 'openai/resources';
+import { JSONSchema } from 'openai/lib/jsonschema';
 
 export class OpenAIProvider implements AIProvider {
 	supportsTools = true;
@@ -13,27 +15,45 @@ export class OpenAIProvider implements AIProvider {
 		this.client = new OpenAI({ apiKey });
 	}
 
+	private createJSONSchemaFormat(schema: JSONSchema, name: string, description?: string): ResponseFormatJSONSchema {
+		return {
+			type: 'json_schema',
+			json_schema: {
+				name,
+				description,
+				schema,
+				strict: true,
+			},
+		};
+	}
+
+	private formatResponseFormat(format?: ResponseFormat): ChatCompletionCreateParams['response_format'] {
+		if (!format) return undefined;
+
+		switch (format.type) {
+			case 'json_object':
+				return { type: 'json_object' };
+			case 'json_schema':
+				if (!format.schema || !format.name) {
+					throw new Error('Schema and name are required for json_schema response format');
+				}
+				// The schema is now properly typed with JSONSchema
+				return this.createJSONSchemaFormat(format.schema, format.name, format.description);
+			default:
+				return undefined;
+		}
+	}
+
 	async createCompletion(body: RequestBody): Promise<Response> {
 		const messages = this.formatMessages(body.messages);
+		const responseFormat = this.formatResponseFormat(body.response_format);
 
 		const params: ChatCompletionCreateParams = {
 			model: body.model,
 			messages,
 			temperature: body.temperature,
 			stream: false,
-			response_format:
-				body.response_format?.type === 'json_object'
-					? { type: 'json_object' }
-					: body.response_format?.type === 'json_schema'
-					? {
-							type: 'json_schema',
-							json_schema: {
-								schema: body.response_format.schema!,
-								name: body.response_format.name || 'default',
-								strict: true,
-							},
-					  }
-					: undefined,
+			response_format: responseFormat,
 			tools: body.tools as ChatCompletionCreateParams['tools'],
 			tool_choice: body.tool_choice as ChatCompletionCreateParams['tool_choice'],
 		};

--- a/screenpipe-actions/ai-proxy/src/types.ts
+++ b/screenpipe-actions/ai-proxy/src/types.ts
@@ -81,13 +81,6 @@ export interface ResponseFormat {
 	description?: string;
 }
 
-// export interface JSONSchemaFormat {
-// 	schema: Record<string, unknown>;
-// 	name: string;
-// 	description?: string;
-// 	strict?: boolean;
-//   }
-
 export interface ImageContent {
 	type: 'image';
 	image_url: {

--- a/screenpipe-actions/ai-proxy/src/types.ts
+++ b/screenpipe-actions/ai-proxy/src/types.ts
@@ -56,11 +56,7 @@ export interface Tool {
 	function: {
 		name: string;
 		description: string;
-		parameters: {
-			type: 'object';
-			properties: Record<string, any>;
-			required?: string[];
-		};
+		parameters: InputSchema
 	};
 }
 
@@ -74,9 +70,11 @@ export interface RequestBody {
 	response_format?: ResponseFormat;
 }
 
+type InputSchema = Anthropic.Tool.InputSchema;
+
 export interface ResponseFormat {
 	type: 'text' | 'json_object' | 'json_schema';
-	schema?: Record<string, unknown>;
+	schema?: InputSchema;
 	name?: string;
 	description?: string;
 }

--- a/screenpipe-actions/ai-proxy/src/types.ts
+++ b/screenpipe-actions/ai-proxy/src/types.ts
@@ -76,9 +76,17 @@ export interface RequestBody {
 
 export interface ResponseFormat {
 	type: 'text' | 'json_object' | 'json_schema';
-	schema?: Record<string, any>;
+	schema?: Record<string, unknown>;
 	name?: string;
+	description?: string;
 }
+
+// export interface JSONSchemaFormat {
+// 	schema: Record<string, unknown>;
+// 	name: string;
+// 	description?: string;
+// 	strict?: boolean;
+//   }
 
 export interface ImageContent {
 	type: 'image';


### PR DESCRIPTION
## description
Added json schema response format for openai, claude and gemini

related issue: #1299 
/claim #1299

openai
![Screenshot from 2025-02-08 00-55-16](https://github.com/user-attachments/assets/a44eaa53-ef47-4b3b-ac53-8d1dd7137874)


claude
![Screenshot from 2025-02-08 01-31-36](https://github.com/user-attachments/assets/1a7dde4f-c9ef-4a27-9d41-3164230ac7ed)

gemini
![Screenshot from 2025-02-08 01-44-36](https://github.com/user-attachments/assets/a3ec37bd-5807-41db-9c2d-cc89aa8817f2)

