### PR TITLE
Make pipes update in background

### DIFF
--- a/screenpipe-app-tauri/components/login-dialog.tsx
+++ b/screenpipe-app-tauri/components/login-dialog.tsx
@@ -44,9 +44,9 @@ export const LoginDialog: React.FC<LoginDialogProps> = ({ open, onOpenChange }) 
 export const useLoginCheck = () => {
   const [showLoginDialog, setShowLoginDialog] = useState(false);
 
-  const checkLogin = (user: any | null) => {
+  const checkLogin = (user: any | null, showDialog: boolean = true) => {
     if (!user?.token) {
-      setShowLoginDialog(true);
+      if (showDialog) setShowLoginDialog(true);
       return false;
     }
     return true;

--- a/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -5,7 +5,7 @@ use log::{error, info};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::menu::{MenuItem, MenuItemBuilder};
-use tauri::{Manager, Wry};
+use tauri::{Emitter, Manager, Wry};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_dialog::MessageDialogButtons;
 use tauri_plugin_updater::UpdaterExt;
@@ -44,6 +44,11 @@ impl UpdatesManager {
                 return Result::Ok(false);
             }
         }
+
+        if let Err(err) = self.app.emit("update-all-pipes", ()) {
+            error!("Failed to update all pipes: {}", err);
+        }
+
         if let Some(update) = self.app.updater()?.check().await? {
             *self.update_available.lock().await = true;
 


### PR DESCRIPTION
The app will now emit an "update-all-pipes" event to the front-end when running `check_for_updates` (which happens Rust-side every 5 minutes).

When the front-end catches this event, the pipe-store component will run `handleUpdateAllPipes`, but it won't show the login dialog or the toast unless updates are found.

I'm not able to test if it runs properly when there is an update because that requires access to `https://screenpi.pe/api/plugins`, but I can confirm it works when `pipesToUpdate` is set manually.

/claim #1292
/closes #1292