### PR TITLE
Refactor audio crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ edition = "2021"
 
 [workspace.dependencies]
 # AI
-candle = { package = "candle-core", version = "0.7.2" }
-candle-nn = { package = "candle-nn", version = "0.7.2" }
-candle-transformers = { package = "candle-transformers", version = "0.7.2" }
-tokenizers = "0.20.0"
+candle = { package = "candle-core", version = "0.8.2" }
+candle-nn = { package = "candle-nn", version = "0.8.2" }
+candle-transformers = { package = "candle-transformers", version = "0.8.2" }
+tokenizers = "0.21.0"
 hf-hub = { version = "0.3.2", git = "https://github.com/neo773/hf-hub", features = [
     "native-tls",
 ] }

--- a/screenpipe-audio/Cargo.toml
+++ b/screenpipe-audio/Cargo.toml
@@ -81,6 +81,7 @@ futures = "0.3.31"
 deepgram = { git = "https://github.com/EzraEllette/deepgram-rust-sdk.git" }
 bytes = { version = "1.9.0", features = ["serde"] }
 lru = "0.13.0"
+num-traits = "0.2.19"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 ort = { version = "=2.0.0-rc.6", features = [

--- a/screenpipe-audio/Cargo.toml
+++ b/screenpipe-audio/Cargo.toml
@@ -70,7 +70,7 @@ crossbeam = { workspace = true }
 # Directories
 dirs = "5.0.1"
 
-lazy_static = { version = "1.4.0" }
+lazy_static = "1.4.0"
 realfft = "3.4.0"
 regex = "1.11.0"
 ndarray = "0.16"
@@ -80,6 +80,7 @@ ort-sys = "=2.0.0-rc.8"
 futures = "0.3.31"
 deepgram = { git = "https://github.com/EzraEllette/deepgram-rust-sdk.git" }
 bytes = { version = "1.9.0", features = ["serde"] }
+lru = "0.13.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 ort = { version = "=2.0.0-rc.6", features = [

--- a/screenpipe-audio/src/audio_processing.rs
+++ b/screenpipe-audio/src/audio_processing.rs
@@ -161,3 +161,285 @@ pub fn write_audio_to_file(
     }
     Ok(file_path_clone)
 }
+
+// Audio processing code, adapted from whisper.cpp
+// https://github.com/ggerganov/whisper.cpp
+
+use candle::utils::get_num_threads;
+use std::sync::Arc;
+use std::thread;
+
+pub trait Float:
+    num_traits::Float + num_traits::FloatConst + num_traits::NumAssign + Send + Sync
+{
+}
+
+impl Float for f32 {}
+impl Float for f64 {}
+
+// https://github.com/ggerganov/whisper.cpp/blob/4774d2feb01a772a15de81ffc34b34a1f294f020/whisper.cpp#L2357
+fn fft<T: Float>(inp: &[T]) -> Vec<T> {
+    let n = inp.len();
+    let zero = T::zero();
+    if n == 1 {
+        return vec![inp[0], zero];
+    }
+    if n % 2 == 1 {
+        return dft(inp);
+    }
+    let mut out = vec![zero; n * 2];
+
+    let mut even = Vec::with_capacity(n / 2);
+    let mut odd = Vec::with_capacity(n / 2);
+
+    for (i, &inp) in inp.iter().enumerate() {
+        if i % 2 == 0 {
+            even.push(inp)
+        } else {
+            odd.push(inp);
+        }
+    }
+
+    let even_fft = fft(&even);
+    let odd_fft = fft(&odd);
+
+    let two_pi = T::PI() + T::PI();
+    let n_t = T::from(n).unwrap();
+    for k in 0..n / 2 {
+        let k_t = T::from(k).unwrap();
+        let theta = two_pi * k_t / n_t;
+        let re = theta.cos();
+        let im = -theta.sin();
+
+        let re_odd = odd_fft[2 * k];
+        let im_odd = odd_fft[2 * k + 1];
+
+        out[2 * k] = even_fft[2 * k] + re * re_odd - im * im_odd;
+        out[2 * k + 1] = even_fft[2 * k + 1] + re * im_odd + im * re_odd;
+
+        out[2 * (k + n / 2)] = even_fft[2 * k] - re * re_odd + im * im_odd;
+        out[2 * (k + n / 2) + 1] = even_fft[2 * k + 1] - re * im_odd - im * re_odd;
+    }
+    out
+}
+
+// https://github.com/ggerganov/whisper.cpp/blob/4774d2feb01a772a15de81ffc34b34a1f294f020/whisper.cpp#L2337
+fn dft<T: Float>(inp: &[T]) -> Vec<T> {
+    let zero = T::zero();
+    let n = inp.len();
+    let two_pi = T::PI() + T::PI();
+
+    let mut out = Vec::with_capacity(2 * n);
+    let n_t = T::from(n).unwrap();
+    for k in 0..n {
+        let k_t = T::from(k).unwrap();
+        let mut re = zero;
+        let mut im = zero;
+
+        for (j, &inp) in inp.iter().enumerate() {
+            let j_t = T::from(j).unwrap();
+            let angle = two_pi * k_t * j_t / n_t;
+            re += inp * angle.cos();
+            im -= inp * angle.sin();
+        }
+
+        out.push(re);
+        out.push(im);
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+// https://github.com/ggerganov/whisper.cpp/blob/4774d2feb01a772a15de81ffc34b34a1f294f020/whisper.cpp#L2414
+fn log_mel_spectrogram_w<T: Float>(
+    ith: usize,
+    hann: &[T],
+    samples: &[T],
+    filters: &[T],
+    fft_size: usize,
+    fft_step: usize,
+    speed_up: bool,
+    n_len: usize,
+    n_mel: usize,
+    n_threads: usize,
+) -> Vec<T> {
+    let n_fft = if speed_up {
+        1 + fft_size / 4
+    } else {
+        1 + fft_size / 2
+    };
+
+    let zero = T::zero();
+    let half = T::from(0.5).unwrap();
+    let mut fft_in = vec![zero; fft_size];
+    let mut mel = vec![zero; n_len * n_mel];
+    let n_samples = samples.len();
+    let end = std::cmp::min(n_samples / fft_step + 1, n_len);
+
+    for i in (ith..end).step_by(n_threads) {
+        let offset = i * fft_step;
+
+        // apply Hanning window
+        for j in 0..std::cmp::min(fft_size, n_samples - offset) {
+            fft_in[j] = hann[j] * samples[offset + j];
+        }
+
+        // fill the rest with zeros
+        if n_samples - offset < fft_size {
+            fft_in[n_samples - offset..].fill(zero);
+        }
+
+        // FFT
+        let mut fft_out: Vec<T> = fft(&fft_in);
+
+        // Calculate modulus^2 of complex numbers
+        for j in 0..fft_size {
+            fft_out[j] = fft_out[2 * j] * fft_out[2 * j] + fft_out[2 * j + 1] * fft_out[2 * j + 1];
+        }
+        for j in 1..fft_size / 2 {
+            let v = fft_out[fft_size - j];
+            fft_out[j] += v;
+        }
+
+        if speed_up {
+            // scale down in the frequency domain results in a speed up in the time domain
+            for j in 0..n_fft {
+                fft_out[j] = half * (fft_out[2 * j] + fft_out[2 * j + 1]);
+            }
+        }
+
+        // mel spectrogram
+        for j in 0..n_mel {
+            let mut sum = zero;
+            let mut k = 0;
+            // Unroll loop
+            while k < n_fft.saturating_sub(3) {
+                sum += fft_out[k] * filters[j * n_fft + k]
+                    + fft_out[k + 1] * filters[j * n_fft + k + 1]
+                    + fft_out[k + 2] * filters[j * n_fft + k + 2]
+                    + fft_out[k + 3] * filters[j * n_fft + k + 3];
+                k += 4;
+            }
+            // Handle remainder
+            while k < n_fft {
+                sum += fft_out[k] * filters[j * n_fft + k];
+                k += 1;
+            }
+            mel[j * n_len + i] = T::max(sum, T::from(1e-10).unwrap()).log10();
+        }
+    }
+    mel
+}
+
+pub fn log_mel_spectrogram_<T: Float>(
+    samples: &[T],
+    filters: &[T],
+    fft_size: usize,
+    fft_step: usize,
+    n_mel: usize,
+    speed_up: bool,
+) -> Vec<T> {
+    let zero = T::zero();
+    let two_pi = T::PI() + T::PI();
+    let half = T::from(0.5).unwrap();
+    let one = T::from(1.0).unwrap();
+    let four = T::from(4.0).unwrap();
+    let fft_size_t = T::from(fft_size).unwrap();
+
+    let hann: Vec<T> = (0..fft_size)
+        .map(|i| half * (one - ((two_pi * T::from(i).unwrap()) / fft_size_t).cos()))
+        .collect();
+    let n_len = samples.len() / fft_step;
+
+    // pad audio with at least one extra chunk of zeros
+    let pad = 100 * candle_transformers::models::whisper::CHUNK_LENGTH / 2;
+    let n_len = if n_len % pad != 0 {
+        (n_len / pad + 1) * pad
+    } else {
+        n_len
+    };
+    let n_len = n_len + pad;
+    let samples = {
+        let mut samples_padded = samples.to_vec();
+        let to_add = n_len * fft_step - samples.len();
+        samples_padded.extend(std::iter::repeat(zero).take(to_add));
+        samples_padded
+    };
+
+    // ensure that the number of threads is even and less than 12
+    let n_threads = std::cmp::min(get_num_threads() - get_num_threads() % 2, 12);
+    let n_threads = std::cmp::max(n_threads, 2);
+
+    let hann = Arc::new(hann);
+    let samples = Arc::new(samples);
+    let filters = Arc::new(filters);
+
+    // use scope to allow for non static references to be passed to the threads
+    // and directly collect the results into a single vector
+    let all_outputs = thread::scope(|s| {
+        (0..n_threads)
+            // create threads and return their handles
+            .map(|thread_id| {
+                let hann = Arc::clone(&hann);
+                let samples = Arc::clone(&samples);
+                let filters = Arc::clone(&filters);
+                // spawn new thread and start work
+                s.spawn(move || {
+                    log_mel_spectrogram_w(
+                        thread_id, &hann, &samples, &filters, fft_size, fft_step, speed_up, n_len,
+                        n_mel, n_threads,
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            // wait for each thread to finish and collect their results
+            .map(|handle| handle.join().expect("Thread failed"))
+            .collect::<Vec<_>>()
+    });
+
+    let l = all_outputs[0].len();
+    let mut mel = vec![zero; l];
+
+    // iterate over mel spectrogram segments, dividing work by threads.
+    for segment_start in (0..l).step_by(n_threads) {
+        // go through each thread's output.
+        for thread_output in all_outputs.iter() {
+            // add each thread's piece to our mel spectrogram.
+            for offset in 0..n_threads {
+                let mel_index = segment_start + offset; // find location in mel.
+                if mel_index < mel.len() {
+                    // Make sure we don't go out of bounds.
+                    mel[mel_index] += thread_output[mel_index];
+                }
+            }
+        }
+    }
+
+    let mmax = mel
+        .iter()
+        .max_by(|&u, &v| u.partial_cmp(v).unwrap_or(std::cmp::Ordering::Greater))
+        .copied()
+        .unwrap_or(zero)
+        - T::from(8).unwrap();
+    for m in mel.iter_mut() {
+        let v = T::max(*m, mmax);
+        *m = v / four + one
+    }
+    mel
+}
+
+pub fn pcm_to_mel<T: Float>(
+    cfg: &candle_transformers::models::whisper::Config,
+    samples: &[T],
+    filters: &[T],
+) -> Vec<T> {
+    log_mel_spectrogram_(
+        samples,
+        filters,
+        candle_transformers::models::whisper::N_FFT,
+        candle_transformers::models::whisper::HOP_LENGTH,
+        cfg.num_mel_bins,
+        false,
+    )
+}

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -183,19 +183,23 @@ async fn run_record_and_transcribe(
     );
 
     const OVERLAP_SECONDS: usize = 2;
-    let mut collected_audio = Vec::new();
     let sample_rate = audio_stream.device_config.sample_rate().0 as usize;
     let overlap_samples = OVERLAP_SECONDS * sample_rate;
+    let duration_samples = (duration.as_secs_f64() * sample_rate as f64).ceil() as usize;
+    let max_samples = duration_samples + overlap_samples;
+
+    let mut collected_audio = Vec::with_capacity(max_samples);
 
     while is_running.load(Ordering::Relaxed)
         && !audio_stream.is_disconnected.load(Ordering::Relaxed)
     {
         let start_time = tokio::time::Instant::now();
 
+        // Collect audio for the duration period
         while start_time.elapsed() < duration && is_running.load(Ordering::Relaxed) {
             match tokio::time::timeout(Duration::from_millis(100), receiver.recv()).await {
                 Ok(Ok(chunk)) => {
-                    collected_audio.extend(chunk);
+                    collected_audio.extend_from_slice(&chunk);
                 }
                 Ok(Err(e)) => {
                     error!("error receiving audio data: {}", e);
@@ -203,6 +207,12 @@ async fn run_record_and_transcribe(
                 }
                 Err(_) => {} // Timeout, continue loop
             }
+        }
+
+        // Discard oldest samples if we exceed buffer capacity
+        if collected_audio.len() > max_samples {
+            let excess = collected_audio.len() - max_samples;
+            collected_audio.drain(0..excess);
         }
 
         if !collected_audio.is_empty() {
@@ -215,9 +225,14 @@ async fn run_record_and_transcribe(
             }) {
                 Ok(_) => {
                     debug!("sent audio segment to audio model");
-                    if collected_audio.len() > overlap_samples {
-                        collected_audio =
-                            collected_audio.split_off(collected_audio.len() - overlap_samples);
+                    // Retain only overlap samples for next iteration
+                    let current_len = collected_audio.len();
+                    if current_len > overlap_samples {
+                        let keep_from = current_len - overlap_samples;
+                        collected_audio.drain(0..keep_from);
+                    } else {
+                        // If we don't have enough samples, keep all (unlikely case)
+                        collected_audio.truncate(current_len);
                     }
                 }
                 Err(e) => {

--- a/screenpipe-audio/src/pyannote/embedding.rs
+++ b/screenpipe-audio/src/pyannote/embedding.rs
@@ -2,24 +2,31 @@ use crate::pyannote::session;
 use anyhow::{Context, Result};
 use ndarray::Array2;
 use ort::Session;
-use std::path::Path;
+use std::{path::Path, sync::Mutex};
 
 #[derive(Debug)]
-pub struct EmbeddingExtractor {
-    session: Session,
+pub struct EmbeddingExtractor {}
+
+lazy_static::lazy_static! {
+    static ref EMBEDDING_SESSION: Mutex<Option<Session>> = Mutex::new(None);
 }
 
 impl EmbeddingExtractor {
     pub fn new<P: AsRef<Path>>(model_path: P) -> Result<Self> {
-        let session = session::create_session(model_path.as_ref())?;
-        Ok(Self { session })
+        let mut session = EMBEDDING_SESSION.lock().unwrap();
+        if session.is_none() {
+            *session = Some(session::create_session(model_path.as_ref(), false)?);
+        }
+        Ok(Self {})
     }
     pub fn compute(&mut self, samples: &[f32]) -> Result<impl Iterator<Item = f32>> {
+        let session = EMBEDDING_SESSION.lock().unwrap();
+        let session = session.as_ref().unwrap();
         let features: Array2<f32> = knf_rs::compute_fbank(samples).map_err(anyhow::Error::msg)?;
         let features = features.insert_axis(ndarray::Axis(0)); // Add batch dimension
         let inputs = ort::inputs! ["feats" => features.view()]?;
 
-        let ort_outs = self.session.run(inputs)?;
+        let ort_outs = session.run(inputs).context("Failed to run the session")?;
         let ort_out = ort_outs
             .get("embs")
             .context("Output tensor not found")?

--- a/screenpipe-audio/src/pyannote/identify.rs
+++ b/screenpipe-audio/src/pyannote/identify.rs
@@ -1,11 +1,11 @@
 use anyhow::{bail, Result};
 use ndarray::Array1;
-use std::collections::HashMap;
+use std::num::NonZeroUsize;
 
 #[derive(Debug, Clone)]
 pub struct EmbeddingManager {
     max_speakers: usize,
-    speakers: HashMap<usize, Array1<f32>>,
+    speakers: lru::LruCache<usize, Array1<f32>>,
     next_speaker_id: usize,
 }
 
@@ -13,7 +13,7 @@ impl EmbeddingManager {
     pub fn new(max_speakers: usize) -> Self {
         Self {
             max_speakers,
-            speakers: HashMap::new(),
+            speakers: lru::LruCache::new(NonZeroUsize::new(max_speakers).unwrap()),
             next_speaker_id: 1,
         }
     }
@@ -68,13 +68,26 @@ impl EmbeddingManager {
 
     fn add_speaker(&mut self, embedding: Array1<f32>) -> usize {
         let speaker_id = self.next_speaker_id;
-        self.speakers.insert(speaker_id, embedding);
+        self.speakers.push(speaker_id, embedding);
         self.next_speaker_id += 1;
         speaker_id
     }
 
+    pub fn add_embedding(&mut self, speaker_id: usize, embedding: Array1<f32>) {
+        self.speakers.put(speaker_id, embedding);
+        tracing::info!("Speaker cache size: {}", self.speakers.len());
+    }
+
+    pub fn get_embedding(&mut self, speaker_id: usize) -> Option<&Array1<f32>> {
+        self.speakers.get(&speaker_id)
+    }
+
+    pub fn prune(&mut self) {
+        self.speakers.pop_lru();
+    }
+
     #[allow(unused)]
-    pub fn get_all_speakers(&self) -> &HashMap<usize, Array1<f32>> {
+    pub fn get_all_speakers(&self) -> &lru::LruCache<usize, Array1<f32>> {
         &self.speakers
     }
 }

--- a/screenpipe-audio/src/pyannote/models.rs
+++ b/screenpipe-audio/src/pyannote/models.rs
@@ -118,6 +118,14 @@ async fn download_model(model_type: PyannoteModel) -> Result<()> {
     tokio::io::AsyncWriteExt::write_all(&mut file, &model_data).await?;
     info!("{} model successfully downloaded and saved", filename);
 
+    // debug!("optimizing {} model", filename);
+    // let session = ort::SessionBuilder::new()?
+    //     .with_optimization_level(ort::GraphOptimizationLevel::Level3)?
+    //     .with_intra_threads(1)?
+    //     .with_inter_threads(1)?
+    //     .with_optimized_model_path(path.to_str().unwrap())?;
+    // session.commit_from_file(path.to_str().unwrap())?;
+
     Ok(())
 }
 

--- a/screenpipe-audio/src/pyannote/session.rs
+++ b/screenpipe-audio/src/pyannote/session.rs
@@ -3,11 +3,12 @@ use std::path::Path;
 use anyhow::Result;
 use ort::{GraphOptimizationLevel, Session};
 
-pub fn create_session<P: AsRef<Path>>(path: P) -> Result<Session> {
+pub fn create_session<P: AsRef<Path>>(path: P, enable_memory_pattern: bool) -> Result<Session> {
     let session = Session::builder()?
         .with_optimization_level(GraphOptimizationLevel::Level3)?
         .with_intra_threads(1)?
         .with_inter_threads(1)?
+        .with_memory_pattern(enable_memory_pattern)?
         .commit_from_file(path.as_ref())?;
     Ok(session)
 }

--- a/screenpipe-audio/src/whisper/model.rs
+++ b/screenpipe-audio/src/whisper/model.rs
@@ -11,6 +11,7 @@ pub struct WhisperModel {
     pub tokenizer: Box<Tokenizer>,
     pub device: Device,
     pub mel_filters: Vec<f32>,
+    // pub weights_filename: String,
 }
 
 impl WhisperModel {
@@ -81,6 +82,19 @@ impl WhisperModel {
             device,
             mel_filters,
         })
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        match &mut self.model {
+            Model::Normal(m) => {
+                m.reset_kv_cache();
+            }
+            Model::Quantized(m) => {
+                m.reset_kv_cache();
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/screenpipe-audio/src/whisper/process_chunk.rs
+++ b/screenpipe-audio/src/whisper/process_chunk.rs
@@ -31,7 +31,7 @@ pub async fn process_with_whisper(
     } = &mut *whisper;
 
     debug!("converting pcm to mel spectrogram");
-    let mel = pcm_to_mel(model.config(), audio, mel_filters);
+    let mel = pcm_to_mel(model.config(), audio, mel_filters).await;
     let mel_len = mel.len();
 
     debug!("creating tensor from mel spectrogram");

--- a/screenpipe-audio/src/whisper/process_chunk.rs
+++ b/screenpipe-audio/src/whisper/process_chunk.rs
@@ -55,11 +55,12 @@ pub async fn process_with_whisper(
 
     debug!("initializing decoder");
     let mut dc = Decoder::new(model, tokenizer, 42, device, language_token, true, false)?;
-
+    dc.reset_kv_cache();
     debug!("starting decoding process");
     let segments = dc.run(&mel)?;
     debug!("decoding complete");
 
+    dc.reset_kv_cache();
     process_segments(segments)
 }
 

--- a/screenpipe-audio/src/whisper/process_chunk.rs
+++ b/screenpipe-audio/src/whisper/process_chunk.rs
@@ -1,11 +1,11 @@
 use super::Segment;
 use crate::{
+    audio_processing::pcm_to_mel,
     multilingual,
     whisper::{Decoder, WhisperModel},
 };
 use anyhow::Result;
 use candle::Tensor;
-use candle_transformers::models::whisper::audio;
 use lazy_static::lazy_static;
 use log::debug;
 use regex::Regex;
@@ -31,7 +31,7 @@ pub async fn process_with_whisper(
     } = &mut *whisper;
 
     debug!("converting pcm to mel spectrogram");
-    let mel = audio::pcm_to_mel(model.config(), audio, mel_filters);
+    let mel = pcm_to_mel(model.config(), audio, mel_filters);
     let mel_len = mel.len();
 
     debug!("creating tensor from mel spectrogram");


### PR DESCRIPTION
## description
- Moved `pcm_to_mel` into screenpipe and switched to tokio runtime.
- Reapplied LRU cache for speaker embeddings
- lazy load onnx sessions
- stt is now fully async

related issue: #1318

## how to test
Test using instruments.

### Update your profile (`~/.zshrc`)
```zsh
alias instruments="open /Applications/Xcode.app/Contents/Applications/Instruments.app"
get-task-allow () {
	codesign -s - -v -f --entitlements ~/.get-task-allow.ent $1
}

```
### Create `.get-task-allow.ent` in `~`
```text
.get-task-allow.ent
<?xml version="1.0" encoding="UTF-8"?>

<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
    <dict>
        <key>com.apple.security.get-task-allow</key>
        <true/>
    </dict>
</plist>

```
### Update screenpipe/Cargo.toml `[release]` section (optional)
```toml
[release]
debug=true
```

## Testing (TEST THOROUGHLY)
1. Build screenpipe with `--release (optional)`
2. run `get-task-allow <path_to_screenpipe_build>`
3. Open instruments with `instruments`
4. Select the Leaks & your screenpipe build as the target.
5. Edit the target to add arguments.
6. Press the record button. Fix permissions. It helps to remove screenpipe completely from permissions and add it back when prompted.
7. Use screenpipe normally

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/bfe0e325-f040-4ef5-b384-6ba7b8447843)

### After
![after](https://github.com/user-attachments/assets/cacc6416-ec5b-487c-b7a4-4a24f0abcb6f)


Ran for 13:33 and had under 400MB usage


/claim #1318