### PR TITLE
fixing discord link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -454,6 +454,6 @@ now you can either dev screenpipe on linux or run screenpipe in the cloud that r
 
 ## join the community
 
-say 👋 in our [public discord channel](https://discord.gg/du9ebuw7uq). we discuss how to bring this lib to production, help each other with contributions, personal projects or just hang out ☕.
+say 👋 in our [public discord channel](https://discord.gg/dU9EBuw7Uq). we discuss how to bring this lib to production, help each other with contributions, personal projects or just hang out ☕.
 
 thank you for contributing to screen pipe! 🎉


### PR DESCRIPTION
fix old link to https://discord.gg/dU9EBuw7Uq (minor fix)

---
name: fixing discord link in CONTRIBUTING.md ,discord invite link is case sensitive
title: fixing discord link in CONTRIBUTING.md


---

## description
old link
![image](https://github.com/user-attachments/assets/e2955407-78eb-4005-b7a0-9cd4a5514404)

new link

![image](https://github.com/user-attachments/assets/949c7285-233b-4622-8f85-b383d362bb71)




