### PR TITLE
Fix-realtime-settings

### DIFF
--- a/screenpipe-actions/ai-proxy/src/index.ts
+++ b/screenpipe-actions/ai-proxy/src/index.ts
@@ -341,17 +341,11 @@ export default Sentry.withSentry(
 				const url = new URL(request.url);
 				const path = url.pathname;
 
-				const upgradeHeader = request.headers.get('upgrade')?.toLowerCase();
-				if (path === '/v1/listen' && upgradeHeader === 'websocket') {
-					console.log('websocket request to /v1/listen detected, bypassing auth');
-					return await handleWebSocketUpgrade(request, env);
-				}
-
 				// Add auth check for protected routes
 				if (path !== '/test') {
 					const authHeader = request.headers.get('Authorization');
 					console.log('authHeader', authHeader);
-					if (!authHeader || !(authHeader.startsWith('Bearer ') || authHeader.startsWith('Token '))) {
+					if (!authHeader || !(authHeader.startsWith('Bearer ') || !authHeader.startsWith('Token '))) {
 						const response = new Response(JSON.stringify({ error: 'unauthorized' }), {
 							status: 401,
 							headers: {
@@ -390,6 +384,12 @@ export default Sentry.withSentry(
 						response.headers.append('Vary', 'Origin');
 						return response;
 					}
+				}
+
+				const upgradeHeader = request.headers.get('upgrade')?.toLowerCase();
+				if (path === '/v1/listen' && upgradeHeader === 'websocket') {
+					console.log('websocket request to /v1/listen detected, bypassing auth');
+					return await handleWebSocketUpgrade(request, env);
 				}
 
 				console.log('path', path);
@@ -606,7 +606,7 @@ terminal 2
 HOST=https://ai-proxy.i-f9f.workers.dev
 HOST=http://localhost:8787
 TOKEN=foobar (check app settings)
-in 
+in
 less "$HOME/Library/Application Support/screenpipe/store.bin"
 
 

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -1,5 +1,5 @@
 use crate::audio_processing::audio_to_mono;
-use crate::deepgram::CUSTOM_DEEPGRAM_API_TOKEN;
+use crate::deepgram::{CUSTOM_DEEPGRAM_API_TOKEN, DEEPGRAM_WEBSOCKET_URL};
 use crate::realtime::realtime_stt;
 use crate::AudioInput;
 use anyhow::{anyhow, Result};
@@ -142,8 +142,12 @@ pub async fn start_realtime_recording(
     deepgram_api_key: Option<String>,
 ) -> Result<()> {
     if deepgram_api_key.is_none() && CUSTOM_DEEPGRAM_API_TOKEN.is_empty() {
-        error!("deepgram api key is not set, skipping realtime recording");
-        return Ok(());
+        if DEEPGRAM_WEBSOCKET_URL.len() > 0 {
+            info!("using custom deepgram api url for realtime transcription");
+        } else {
+            error!("deepgram api key is not set, skipping realtime recording");
+            return Ok(());
+        }
     }
 
     while is_running.load(Ordering::Relaxed) {

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -141,13 +141,16 @@ pub async fn start_realtime_recording(
     is_running: Arc<AtomicBool>,
     deepgram_api_key: Option<String>,
 ) -> Result<()> {
-    if deepgram_api_key.is_none() && CUSTOM_DEEPGRAM_API_TOKEN.is_empty() {
-        error!("deepgram api key is not set, skipping realtime recording");
-        return Ok(());
-    } else if (CUSTOM_DEEPGRAM_API_TOKEN.len() > 0 || deepgram_api_key.is_some())
-        && DEEPGRAM_WEBSOCKET_URL.is_empty()
+    if (CUSTOM_DEEPGRAM_API_TOKEN.len() > 0 || deepgram_api_key.is_some())
+        && !DEEPGRAM_WEBSOCKET_URL.is_empty()
     {
         info!("using custom deepgram api url for realtime transcription");
+    } else if DEEPGRAM_WEBSOCKET_URL.is_empty() {
+        error!("deepgram websocket url is not set, skipping realtime recording");
+        return Ok(());
+    } else {
+        error!("deepgram api key is not set, skipping realtime recording");
+        return Ok(());
     }
 
     while is_running.load(Ordering::Relaxed) {

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -1,4 +1,5 @@
 use crate::audio_processing::audio_to_mono;
+use crate::deepgram::CUSTOM_DEEPGRAM_API_TOKEN;
 use crate::realtime::realtime_stt;
 use crate::AudioInput;
 use anyhow::{anyhow, Result};
@@ -140,6 +141,11 @@ pub async fn start_realtime_recording(
     is_running: Arc<AtomicBool>,
     deepgram_api_key: Option<String>,
 ) -> Result<()> {
+    if deepgram_api_key.is_none() && CUSTOM_DEEPGRAM_API_TOKEN.is_empty() {
+        error!("deepgram api key is not set, skipping realtime recording");
+        return Ok(());
+    }
+
     while is_running.load(Ordering::Relaxed) {
         match realtime_stt(
             audio_stream.clone(),

--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -142,12 +142,12 @@ pub async fn start_realtime_recording(
     deepgram_api_key: Option<String>,
 ) -> Result<()> {
     if deepgram_api_key.is_none() && CUSTOM_DEEPGRAM_API_TOKEN.is_empty() {
-        if DEEPGRAM_WEBSOCKET_URL.len() > 0 {
-            info!("using custom deepgram api url for realtime transcription");
-        } else {
-            error!("deepgram api key is not set, skipping realtime recording");
-            return Ok(());
-        }
+        error!("deepgram api key is not set, skipping realtime recording");
+        return Ok(());
+    } else if (CUSTOM_DEEPGRAM_API_TOKEN.len() > 0 || deepgram_api_key.is_some())
+        && DEEPGRAM_WEBSOCKET_URL.is_empty()
+    {
+        info!("using custom deepgram api url for realtime transcription");
     }
 
     while is_running.load(Ordering::Relaxed) {

--- a/screenpipe-audio/src/deepgram/realtime.rs
+++ b/screenpipe-audio/src/deepgram/realtime.rs
@@ -50,10 +50,6 @@ pub async fn start_deepgram_stream(
 ) -> Result<()> {
     let api_key = deepgram_api_key.unwrap_or(CUSTOM_DEEPGRAM_API_TOKEN.to_string());
 
-    if api_key.is_empty() {
-        return Err(anyhow::anyhow!("Deepgram API key not found"));
-    }
-
     // create shutdown rx from is_running
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 

--- a/screenpipe-server/src/core.rs
+++ b/screenpipe-server/src/core.rs
@@ -556,7 +556,7 @@ async fn record_audio(
                                                 ).await;
                                             }
                                         }));
-                                    }
+                                }
 
                                     join_all(recording_handles).await;
                                 }


### PR DESCRIPTION
## description
- user enable real time audio with deepgram and does not set deepgram api key (CLI throw loads of errors)
  - will only throw the error once by checking for the variables
- user enable real time audio with screenpipe cloud and they don't have access to screenpipe cloud or something like this (did not subscribe)
  - Will return authorization error and keep throwing it in a loop
- user try to use real time audio in CLI mode with deepgram without api key
  - will only throw the error once by checking for the variables
- user try to use real time audio in CLI mode with screenpipe cloud and does not properly configure the env var required (check related issues / PR / codebase to figure out)
  - Will continue to throw errors.

related issue: #1335 

## how to test

1. run screenpipe with realtime enabled and no keys
2. run screenpipe with a deployed ai-proxy and test auth

Validating the custom url and key seems out of scope. I don't have screenpipe cloud so I can't test the authorization

/claim #1335 