### PR TITLE
feat(sidecar): add permissions guard before starting sidecar

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -78,7 +78,7 @@ fn request_av_permission(media_type: nokhwa_bindings_macos::AVMediaType) {
     };
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum OSPermissionStatus {
     // This platform does not require this permission


### PR DESCRIPTION
this pr adds permissions guard before starting sidecar as explained in this isse: #1346 

decided to open the issue just to explain my reasoning behind this and to keep my pr #1279 focused on ui/ux improvements

