### PR TITLE
feat(tauri): add prod configuration file

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -136,15 +136,15 @@ jobs:
           - platform: "macos-latest"
             args: "--target aarch64-apple-darwin --features metal,beta"
             target: aarch64-apple-darwin
-            tauri-args: "--target aarch64-apple-darwin"
+            tauri-args: "--target aarch64-apple-darwin --config src-tauri/tauri.conf.prod.json"
           - platform: "macos-latest"
             args: "--target x86_64-apple-darwin --features metal,beta"
             target: x86_64-apple-darwin
-            tauri-args: "--target x86_64-apple-darwin"
+            tauri-args: "--target x86_64-apple-darwin --config src-tauri/tauri.conf.prod.json"
           - platform: ${{ needs.check_runner.outputs.runner_type }}
             args: "--target x86_64-pc-windows-msvc --features mkl"
             pre-build-args: ""
-            tauri-args: "--target x86_64-pc-windows-msvc"
+            tauri-args: "--target x86_64-pc-windows-msvc --config src-tauri/tauri.conf.prod.json"
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -1,5 +1,8 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/schema.json",
+  "productName": "screenpipe - development",
+  "identifier": "screenpi.pe.dev",
+  "mainBinaryName": "screenpipe - development",
   "build": {
     "beforeDevCommand": "bun run dev",
     "beforeBuildCommand": "bun run build",
@@ -34,8 +37,6 @@
       "assets/*"
     ]
   },
-  "productName": "screenpipe",
-  "identifier": "screenpi.pe",
   "plugins": {
     "updater": {
       "active": true,

--- a/screenpipe-app-tauri/src-tauri/tauri.conf.prod.json
+++ b/screenpipe-app-tauri/src-tauri/tauri.conf.prod.json
@@ -1,0 +1,5 @@
+{
+    "productName": "screenpipe",
+    "mainBinaryName": "screenpipe",
+    "identifier": "screenpi.pe"
+}


### PR DESCRIPTION
part of work in #1279 to resolve issue #1273, opted for a separate pr to keep #1279 focused on ui/ux 

this pr adds
1. a production tauri configuration file 
2. modifies ci to use this new config file when building and releasing the tauri app

doing this keeps (dev and prod) binary name, product name and identifier separate