### PR TITLE
fixes windows build

### DIFF
--- a/screenpipe-server/src/bin/screenpipe-server.rs
+++ b/screenpipe-server/src/bin/screenpipe-server.rs
@@ -222,19 +222,19 @@ async fn main() -> anyhow::Result<()> {
                         OutputFormat::Json => println!(
                             "{}",
                             serde_json::to_string_pretty(&json!({
-                                "data": futures::future::join_all(monitors.iter().map(|m| async move {
+                                "data": monitors.iter().map(|m| {
                                     json!({
                                         "id": m.id(),
-                                        "name": m.inner().await.name()
+                                        "name": m.name()
                                     })
-                                })).await,
+                                }).collect::<Vec<_>>(),
                                 "success": true
                             }))?
                         ),
                         OutputFormat::Text => {
                             println!("available monitors:");
                             for monitor in monitors.iter() {
-                                println!("  {}. {:?}", monitor.id(), monitor.inner().await.name());
+                                println!("  {}. {:?}", monitor.id(), monitor.name());
                             }
                         }
                     }
@@ -624,7 +624,7 @@ async fn main() -> anyhow::Result<()> {
 
     let (audio_devices_tx, _) = broadcast::channel(100);
 
-    let realtime_vision_sender_clone = realtime_vision_sender_clone.clone();
+    let _realtime_vision_sender_clone = realtime_vision_sender_clone.clone();
     // TODO: Add SSE stream for realtime audio transcription
     let server = Server::new(
         db_server,

--- a/screenpipe-server/src/lib.rs
+++ b/screenpipe-server/src/lib.rs
@@ -32,3 +32,8 @@ pub use server::HealthCheckResponse;
 pub use server::PaginatedResponse;
 pub use server::Server;
 pub use video::VideoCapture;
+pub use axum::Json as JsonResponse;
+pub use server::{
+    api_list_monitors,
+    MonitorInfo,
+};


### PR DESCRIPTION
---
name: fix windows build 
title: "[pr] "


---

## description
Build failed on windows 
issue screenshot

![Screenshot 2025-02-16 122354](https://github.com/user-attachments/assets/df13d63e-1630-4861-90ee-52190e319a09)


Build successful screenshot
![image](https://github.com/user-attachments/assets/723ea359-ffa4-4d45-8544-f5c4ce0663f6)


reasons for the build faliure 
- windows thread-safety violations in monitor access across async boundaries
- deadlocks from async/mutex patterns when accessing monitor data

how i solved with my understanding
- used MonitorData struct for caching static monitor metadata
- moved monitor operations to spawn_blocking for Windows thread safety

## how to test on windows
 1.cargo build --release --target x86_64-pc-windows-msvc in root folder

turn off windows firewall to avoid potential errors


Checks i made 
- Tested on windows x86_64 with 16 gb ram 
- And run dev mode sucessfully 

Attached test video 


https://github.com/user-attachments/assets/7aa9ac01-d968-4e38-8110-16c1613994af




/claim #1366

PS: happy to take feedback and make any required changes