### PR TITLE
Add speech ratio check to audio processing pipeline

### DIFF
--- a/screenpipe-audio/src/segments.rs
+++ b/screenpipe-audio/src/segments.rs
@@ -21,7 +21,7 @@ pub async fn prepare_segments(
     embedding_manager: EmbeddingManager,
     embedding_extractor: Arc<StdMutex<EmbeddingExtractor>>,
     device: &str,
-) -> Result<tokio::sync::mpsc::Receiver<SpeechSegment>> {
+) -> Result<(tokio::sync::mpsc::Receiver<SpeechSegment>, bool)> {
     let audio_data = normalize_v2(audio_data);
 
     let frame_size = 1600;
@@ -64,7 +64,8 @@ pub async fn prepare_segments(
         speech_frame_count
     );
     let (tx, rx) = tokio::sync::mpsc::channel(100);
-    if !audio_frames.is_empty() && speech_ratio >= min_speech_ratio {
+    let speech_ratio_ok = speech_ratio >= min_speech_ratio;
+    if !audio_frames.is_empty() && speech_ratio_ok {
         let segments = get_segments(
             &audio_data,
             16000,
@@ -81,5 +82,5 @@ pub async fn prepare_segments(
         }
     }
 
-    Ok(rx)
+    Ok((rx, speech_ratio_ok))
 }

--- a/screenpipe-audio/src/stt.rs
+++ b/screenpipe-audio/src/stt.rs
@@ -240,13 +240,17 @@ pub async fn create_whisper_channel(
                             audio.data = Arc::new(audio_data.clone());
                             audio.sample_rate = m::SAMPLE_RATE as u32;
 
-                            let mut segments = match prepare_segments(&audio_data, vad_engine.clone(), &segmentation_model_path, embedding_manager.clone(), embedding_extractor.clone(), &audio.device.to_string()).await {
-                                Ok(segments) => segments,
+                            let (mut segments, speech_ratio_ok) = match prepare_segments(&audio_data, vad_engine.clone(), &segmentation_model_path, embedding_manager.clone(), embedding_extractor.clone(), &audio.device.to_string()).await {
+                                Ok((segments, speech_ratio_ok)) => (segments, speech_ratio_ok),
                                 Err(e) => {
                                     error!("Error preparing segments: {:?}", e);
                                     continue;
                                 }
                             };
+
+                            if !speech_ratio_ok {
+                                continue;
+                            }
 
                             let path = match write_audio_to_file(
                                 &audio.data.to_vec(),


### PR DESCRIPTION
## description
Checks speech ratio before writing audio files.

related issue: #1350

## how to test

start screenpipe audio with only display device selected and don't play any audio. no files should save. Alternatively, use screenpipe audio with audio permissions disabled and ensure no audio files are written

@oliverqx 