### PR TITLE
chore: use xcap version 0.3.3 (non-released yet)

### DIFF
--- a/screenpipe-vision/Cargo.toml
+++ b/screenpipe-vision/Cargo.toml
@@ -43,6 +43,9 @@ tracing = { workspace = true }
 which = "6.0"
 serde = "1.0.200"
 
+# TO-DO: change it to "0.3.3" when released
+xcap = { package = "xcap", git = "https://github.com/ologbonowiwi/xcap", rev = "ae0dab1" }
+
 once_cell = { workspace = true }
 base64 = "0.22.1"
 
@@ -88,9 +91,6 @@ harness = false
 name = "screenpipe-vision-websocket"
 path = "examples/websocket.rs"
 
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-xcap = "0.3.2"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [
   "Graphics_Imaging",
@@ -100,7 +100,6 @@ windows = { version = "0.58", features = [
 ] }
 # version 0.3.2 on Windows is broken
 # see https://github.com/nashaofu/xcap/issues/194
-xcap = "0.2.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "=0.2.164"


### PR DESCRIPTION
the version selected on `Cargo.toml` is the same as nashaofu/xcap#195, but merged on my fork, so we don't have to wait xcap to be released.

I disabled the logs briefly to see if the error would keep appearing. it's not 🙌🏽 
![image](https://github.com/user-attachments/assets/e98ef907-2f27-448f-a18b-e459c4176699)
