### PR TITLE
fix: add fallback kill commands for windows

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/sidecar.rs
+++ b/screenpipe-app-tauri/src-tauri/src/sidecar.rs
@@ -126,7 +126,7 @@ pub async fn stop_screenpipe(
                 .arg("hidden")
                 .arg("-Command")
                 .arg(format!(
-                    r#"Get-WmiObject Win32_Process | Where-Object {{ $_.CommandLine -like "*screenpipe" }} | ForEach-Object {{ taskkill.exe /T /F /PID $_.ProcessId }}"#,
+                    r#"Get-WmiObject Win32_Process | Where-Object {{ $_.CommandLine -like "*screenpipe*" }} | ForEach-Object {{ taskkill.exe /T /F /PID $_.ProcessId }}"#,
                 ))
                 .creation_flags(CREATE_NO_WINDOW)
                 .output()

--- a/screenpipe-app-tauri/src-tauri/src/sidecar.rs
+++ b/screenpipe-app-tauri/src-tauri/src/sidecar.rs
@@ -107,13 +107,26 @@ pub async fn stop_screenpipe(
         {
             const CREATE_NO_WINDOW: u32 = 0x08000000;
             tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-            tokio::process::Command::new("powershell")
+            let _ = tokio::process::Command::new("powershell")
                 .arg("-NoProfile")
                 .arg("-WindowStyle")
                 .arg("hidden")
                 .arg("-Command")
                 .arg(format!(
                     r#"taskkill.exe /F /T /IM screenpipe.exe"#,
+                ))
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .await;
+
+            // fallback wild kill
+            tokio::process::Command::new("powershell")
+                .arg("-NoProfile")
+                .arg("-WindowStyle")
+                .arg("hidden")
+                .arg("-Command")
+                .arg(format!(
+                    r#"Get-WmiObject Win32_Process | Where-Object {{ $_.CommandLine -like "*screenpipe" }} | ForEach-Object {{ taskkill.exe /T /F /PID $_.ProcessId }}"#,
                 ))
                 .creation_flags(CREATE_NO_WINDOW)
                 .output()

--- a/screenpipe-server/src/pipe_manager.rs
+++ b/screenpipe-server/src/pipe_manager.rs
@@ -358,6 +358,24 @@ impl PipeManager {
                     .await;
             }
 
+            #[cfg(windows)]
+            {
+                // killing by name is faster
+                const CREATE_NO_WINDOW: u32 = 0x08000000;
+                let _ = tokio::process::Command::new("powershell")
+                    .arg("-NoProfile")
+                    .arg("-WindowStyle")
+                    .arg("hidden")
+                    .arg("-Command")
+                    .arg(format!(
+                        r#"Get-WmiObject Win32_Process | Where-Object {{ $_.CommandLine -like "*.screenpipe\pipes\{}*" }} | ForEach-Object {{ taskkill.exe /T /F /PID $_.ProcessId }}"#,
+                        &id.to_string()
+                    ))
+                    .creation_flags(CREATE_NO_WINDOW)
+                    .output()
+                    .await;
+            }
+
             match handle.state {
                 PipeState::Port(port) => {
                     tokio::task::spawn(async move {


### PR DESCRIPTION
---
fix: #1425

fast kill for avoiding multiple instance of same pipe on different port

---

## description
brief description of the changes in this pr.

related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
