### PR TITLE
optimize API calls

### DIFF
--- a/screenpipe-app-tauri/app/page.tsx
+++ b/screenpipe-app-tauri/app/page.tsx
@@ -36,11 +36,10 @@ export default function Home() {
   // staggered polling with exponential backoff while maintaining responsiveness
   // while reducing backend load
   useEffect(() => {
-    const interval = setInterval(() => {
-      loadUser(settings.user?.token!);
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [settings]);
+      if (settings.user?.token) {
+        loadUser(settings.user.token);
+      }
+  }, [settings.user.token]);
 
   useEffect(() => {
     const getAudioDevices = async () => {

--- a/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/screenpipe-app-tauri/components/pipe-store.tsx
@@ -30,6 +30,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import localforage from "localforage";
 
 const corePipes: string[] = ["data-table", "search"];
 
@@ -106,20 +107,6 @@ export const PipeStore: React.FC = () => {
           const installedPipe = installedPipes.find(
             (p) => p.config?.id === plugin.id,
           );
-          const currentVersion = installedPipe?.config?.version;
-
-          let has_update = false;
-          if (currentVersion) {
-            try {
-              const updateCheck = await pipeApi.checkUpdate(
-                plugin.id,
-                currentVersion,
-              );
-              has_update = updateCheck.has_update;
-            } catch (error) {
-              console.error(`Failed to check updates for ${plugin.id}:`, error);
-            }
-          }
 
           return {
             ...plugin,
@@ -130,7 +117,7 @@ export const PipeStore: React.FC = () => {
             ),
             is_core_pipe: corePipes.includes(plugin.name),
             is_enabled: installedPipe?.config?.enabled ?? false,
-            has_update,
+            has_update: false,
           };
         }),
       );
@@ -904,7 +891,7 @@ export const PipeStore: React.FC = () => {
 
   useEffect(() => {
     fetchPurchaseHistory();
-  }, [settings.user]);
+  }, [settings.user.token]);
 
   useEffect(() => {
     fetchInstalledPipes();
@@ -914,6 +901,33 @@ export const PipeStore: React.FC = () => {
     const interval = setInterval(() => {
       fetchInstalledPipes();
     }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const checkForUpdates = async () => {
+      // Get last check time from local storage
+      const lastCheckTime = await localforage.getItem<number>('lastUpdateCheck');
+      const now = Date.now();
+      
+      // Check if 5 minutes have passed since last check
+      if (lastCheckTime && now - lastCheckTime < 5 * 60 * 1000) {
+        return;
+      }
+
+      // Store current time as last check
+      await localforage.setItem('lastUpdateCheck', now);
+
+      // Check for updates silently (no toast)
+      await handleUpdateAllPipes(true);
+    };
+
+    // Run check immediately
+    checkForUpdates();
+
+    // Set up interval to check every 5 minutes
+    const interval = setInterval(checkForUpdates, 5 * 60 * 1000);
+    
     return () => clearInterval(interval);
   }, []);
 

--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "0.34.7"
+version = "0.35.7"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
Optimizes calls to the following endpoints

Only gets called if user token changes and the token is set, we were pinging this even if the user was not logged in
```
/api/user 
```

Only gets called if user token changes 
```
/api/plugins/user-purchase-history
```
Previous implementation checked updates even for pipes that were not installed by the user, this also checks it periodically by storing `lastCheck` in local storage
```
/api/plugins/check-update
```