### PR TITLE
Disable text selection for non-interactive UI elements to improve UX

### DIFF
--- a/screenpipe-app-tauri/app/globals.css
+++ b/screenpipe-app-tauri/app/globals.css
@@ -114,6 +114,12 @@
   }
 }
 
+@layer utilities {
+  .no-select {
+    user-select: none;
+  }
+}
+
 .pf-v6-c-text-input-group__text-input {
   overflow: hidden;
     text-overflow: ellipsis;
@@ -128,6 +134,7 @@
   padding-left: 38px!important;
   padding-right: 16px!important;
   padding-top: 8px!important;
+  user-select: none;
 }
 .pf-v6-c-text-input-group__text-input::placeholder {
   padding-left: 20px!important;
@@ -139,4 +146,11 @@
   position: absolute!important;
 }
 
+div, p, span {
+  user-select: none;
+}
+
+.selectable {
+  user-select: text;
+}
 


### PR DESCRIPTION

## description
Disable text selection for non-interactive UI elements

- Added `.no-select` utility class
- Disabled selection for `.pf-v6-c-text-input-group__text-input`
- Added global rules for `div`, `p`, and `span`
- Added `.selectable` class for necessary elements

Improves UX by preventing accidental text selection in non-interactive areas.

related issue: #1451
/claim #1451
/closes #1451 


