### PR TITLE
fix: possibly fix infinte powershell

### DIFF
--- a/screenpipe-core/src/pipes.rs
+++ b/screenpipe-core/src/pipes.rs
@@ -106,6 +106,7 @@ function Get-ChildProcesses($ProcessId) {{
 while ($true) {{
     try {{
         $parent = Get-Process -Id $parentPid -ErrorAction Stop
+        $child = Get-Process -Id $childPid -ErrorAction Stop
         Start-Sleep -Seconds 1
     }} catch {{
         Write-Host "Parent process ($parentPid) not found, terminating child processes"
@@ -119,7 +120,7 @@ while ($true) {{
         foreach ($processId in $allProcesses) {{
             try {{
                 Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
-                Write-Host "Stopped process: $pid"
+                Write-Host "Stopped process: $processId"
             }} catch {{
                 Write-Host "Process $processId already terminated"
             }}


### PR DESCRIPTION
---
watch dog shouldn't running when there is not child process

fix: #1494

---

## description

brief description of the changes in this pr.

related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
