### PR TITLE
Update release-app.yml

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -329,7 +329,7 @@ jobs:
             libsamplerate-dev \
             libwebrtc-audio-processing-dev \
             libgtk-3-dev \
-            libwebkit2gtk-4.0-dev \
+            libwebkit2gtk-4.1-dev \
             librsvg2-dev \
             patchelf
           curl -fsSL https://bun.sh/install | bash

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -325,6 +325,7 @@ jobs:
             libbz2-dev \
             zlib1g-dev \
             libonig-dev \
+            libappindicator3-dev \
             libayatana-appindicator3-dev \
             libsamplerate-dev \
             libwebrtc-audio-processing-dev \


### PR DESCRIPTION
        # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
        # You can remove the one that doesn't apply to your app to speed up the workflow a bit.

https://v1.tauri.app/v1/guides/building/cross-platform/#experimental-build-windows-apps-on-linux-and-macos

