### PR TITLE
refactor: AI provider settings

### DIFF
--- a/pipes/search/src/app/settings/page.tsx
+++ b/pipes/search/src/app/settings/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import AiProvider from "@/components/ai-provider";
+
+const SettingsPage: React.FC = () => {
+  return (
+    <div className="container mx-auto p-4">
+      <AiProvider />
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/pipes/search/src/components/ai-provider.tsx
+++ b/pipes/search/src/components/ai-provider.tsx
@@ -1,0 +1,198 @@
+"use client";
+import React, { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useSettings } from "@/lib/hooks/use-settings";
+
+const AiProvider: React.FC = () => {
+  const { settings } = useSettings();
+  const [aiSettings, setAiSettings] = useState({
+    openaiApiKey: settings.coustomSettings.search.openaiApiKey,
+    aiModel: settings.coustomSettings.search.aiModel,
+    aiUrl: settings.coustomSettings.search.aiUrl,
+    customPrompt: settings.coustomSettings.search.customPrompt,
+    aiProviderType: settings.coustomSettings.search.aiProviderType,
+    embeddedLLM: {
+      port: settings.coustomSettings.search.embeddedLLM.port,
+      enabled: settings.coustomSettings.search.embeddedLLM.enabled,
+      model: settings.coustomSettings.search.embeddedLLM.model,
+    },
+    aiMaxContextChars: settings.coustomSettings.search.aiMaxContextChars,
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setAiSettings((prevSettings) => ({
+      ...prevSettings,
+      [name]: value,
+    }));
+    console.log("changed", aiSettings);
+  };
+  const handleSave = async () => {
+    try {
+      const response = await fetch("/api/settings", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          key: "customSettings.search",
+          value: aiSettings,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to save settings");
+      }
+
+      const result = await response.json();
+      console.log("Settings saved", result);
+    } catch (error) {
+      console.error("Error saving settings:", error);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>AI Provider Settings</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div>
+            <label
+              htmlFor="openaiApiKey"
+              className="block text-sm font-medium text-gray-700"
+            >
+              OpenAI API Key
+            </label>
+            <Input
+              id="openaiApiKey"
+              name="openaiApiKey"
+              value={aiSettings.openaiApiKey}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="aiModel"
+              className="block text-sm font-medium text-gray-700"
+            >
+              AI Model
+            </label>
+            <Input
+              id="aiModel"
+              name="aiModel"
+              value={aiSettings.aiModel}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="aiUrl"
+              className="block text-sm font-medium text-gray-700"
+            >
+              AI URL
+            </label>
+            <Input
+              id="aiUrl"
+              name="aiUrl"
+              value={aiSettings.aiUrl}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="customPrompt"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Custom Prompt
+            </label>
+            <Input
+              id="customPrompt"
+              name="customPrompt"
+              value={aiSettings.customPrompt}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="aiProviderType"
+              className="block text-sm font-medium text-gray-700"
+            >
+              AI Provider Type
+            </label>
+            <Input
+              id="aiProviderType"
+              name="aiProviderType"
+              value={aiSettings.aiProviderType}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="embeddedLLM.port"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Embedded LLM Port
+            </label>
+            <Input
+              id="embeddedLLM.port"
+              name="embeddedLLM.port"
+              value={aiSettings.embeddedLLM.port}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="embeddedLLM.enabled"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Embedded LLM Enabled
+            </label>
+            <Input
+              id="embeddedLLM.enabled"
+              name="embeddedLLM.enabled"
+              value={aiSettings.embeddedLLM.enabled.toString()}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="embeddedLLM.model"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Embedded LLM Model
+            </label>
+            <Input
+              id="embeddedLLM.model"
+              name="embeddedLLM.model"
+              value={aiSettings.embeddedLLM.model}
+              onChange={handleChange}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="aiMaxContextChars"
+              className="block text-sm font-medium text-gray-700"
+            >
+              AI Max Context Chars
+            </label>
+            <Input
+              id="aiMaxContextChars"
+              name="aiMaxContextChars"
+              value={aiSettings.aiMaxContextChars.toString()}
+              onChange={handleChange}
+            />
+          </div>
+        </div>
+        <Button className="my-2" onClick={handleSave}>
+          Save Settings
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AiProvider;


### PR DESCRIPTION
/fix #1394
/claim #1394 

![image](https://github.com/user-attachments/assets/5c8f0b41-f0a5-453b-85a2-2eee86a8c5cb)

`store.bin` 
```
  "customSettings.search.openaiApiKey": "",
  "customSettings.search.aiModel": "gpt-4o",
  "customSettings.search.aiUrl": "https://api.openai.com/v1",
  "customSettings.search.customPrompt": "Rules:\n    - You can analyze/view/show/access videos to the user by putting .mp4 files in a code block (we'll render it) like this: `/users/video.mp4`, use the exact, absolute, file path from file_path property\n    - Do not try to embed video in links (e.g. [](.mp4) or https://.mp4) instead put the file_path in a code block using backticks\n    - Do not put video in multiline code block it will not render the video (e.g. ```bash\n.mp4``` IS WRONG) instead using inline code block with single backtick\n    - Always answer my question/intent, do not make up things\n    \n    ",
  "customSettings.search.aiProviderType": "openai",
  "customSettings.search.embeddedLLM.port": 11434,
  "customSettings.search.embeddedLLM.enabled": false,
  "customSettings.search.embeddedLLM.model": "llama3.2:1b-instruct-q4_K_M",
  "customSettings.search.aiMaxContextChars": 512000

```

i'm planning:
- store custom ai settings for each plugin( but i can use app ai settings also if not needed like this) 
- i'll make it configurable and add it cli to reuse in all other plugins .

@louis030195  what's your thoughts? need some feedback to proceed further