### PR TITLE
fix: url parsing issue and .next dir not found

### DIFF
--- a/screenpipe-core/src/pipes.rs
+++ b/screenpipe-core/src/pipes.rs
@@ -1441,7 +1441,7 @@ async fn run_cron_schedule(
         };
 
         info!(
-            "next cron execution for pipe {} at path {} in {} seconds",
+            "[{}] next cron execution for pipe at path {} in {} seconds",
             pipe,
             path,
             duration.as_secs()
@@ -1502,25 +1502,34 @@ pub async fn cleanup_pipe_crons(pipe: &str) -> Result<()> {
 
 async fn try_build_nextjs(pipe_dir: &Path, bun_path: &Path) -> Result<BuildStatus> {
     info!(
-        "checking if i need to build the next.js project in: {:?}",
-        pipe_dir
+        "[{}] checking if i need to build the next.js project",
+        pipe_dir.file_name().unwrap_or_default().to_string_lossy()
     );
 
-    // Check if build already exists and is valid
+    // remove invalid build 
+    // read the build value from pipe.json
     let build_dir = pipe_dir.join(".next");
-    if build_dir.exists() {
-        let build_manifest = build_dir.join("build-manifest.json");
-        if build_manifest.exists() {
-            info!("found existing next.js build, skipping rebuild");
+    let pipe_json_path = pipe_dir.join("pipe.json");
+    if pipe_json_path.exists() {
+        let pipe_json = tokio::fs::read_to_string(&pipe_json_path).await?;
+        let pipe_config: Value = serde_json::from_str(&pipe_json)?;
+        let is_build = pipe_config.get("build").and_then(Value::as_bool).unwrap_or(false);
+        if is_build {
+            info!("[{}] pipe is already build, skipping rebuild", 
+            pipe_dir.file_name().unwrap_or_default().to_string_lossy()
+            );
             return Ok(BuildStatus::Success);
+        } else {
+            if !is_build && build_dir.exists() {
+                debug!("[{}] removing invalid next.js build directory",
+                    pipe_dir.file_name().unwrap_or_default().to_string_lossy()
+                );
+                tokio::fs::remove_dir_all(&build_dir).await?;
+            }
         }
-        // Invalid/incomplete build directory - remove it
-        debug!("removing invalid next.js build directory");
-        tokio::fs::remove_dir_all(&build_dir).await?;
     }
 
     // Update build status to InProgress in pipe.json
-    let pipe_json_path = pipe_dir.join("pipe.json");
     if pipe_json_path.exists() {
         let pipe_json = tokio::fs::read_to_string(&pipe_json_path).await?;
         let mut pipe_config: Value = serde_json::from_str(&pipe_json)?;
@@ -1529,7 +1538,9 @@ async fn try_build_nextjs(pipe_dir: &Path, bun_path: &Path) -> Result<BuildStatu
         tokio::fs::write(&pipe_json_path, updated_pipe_json).await?;
     }
 
-    info!("running next.js build");
+    info!("[{}] running next.js build",
+        pipe_dir.file_name().unwrap_or_default().to_string_lossy()
+    );
     let build_output = Command::new(bun_path)
         .arg("run")
         .arg("--bun")
@@ -1539,11 +1550,28 @@ async fn try_build_nextjs(pipe_dir: &Path, bun_path: &Path) -> Result<BuildStatu
         .await?;
 
     if build_output.status.success() {
-        info!("next.js build completed successfully");
+        let pipe_json = tokio::fs::read_to_string(&pipe_json_path).await?;
+        let mut pipe_config: Value = serde_json::from_str(&pipe_json)?;
+        pipe_config["build"] = json!("true");
+        let updated_pipe_json = serde_json::to_string_pretty(&pipe_config)?;
+        let mut file = File::create(&pipe_json_path).await?;
+        file.write_all(updated_pipe_json.as_bytes()).await?;
+        info!("[{}] next.js pipe build successfully", 
+            pipe_dir.file_name().unwrap_or_default().to_string_lossy()
+        );
         Ok(BuildStatus::Success)
     } else {
+        let pipe_json = tokio::fs::read_to_string(&pipe_json_path).await?;
+        let mut pipe_config: Value = serde_json::from_str(&pipe_json)?;
+        pipe_config["build"] = json!("false");
+        let updated_pipe_json = serde_json::to_string_pretty(&pipe_config)?;
+        let mut file = File::create(&pipe_json_path).await?;
+        file.write_all(updated_pipe_json.as_bytes()).await?;
         let error_message = String::from_utf8_lossy(&build_output.stderr).to_string();
-        error!("next.js build failed: {}", error_message);
+        error!("[{}] next.js build failed: {}",
+            pipe_dir.file_name().unwrap_or_default().to_string_lossy(),
+            error_message
+        );
         Ok(BuildStatus::Failed(error_message))
     }
 }

--- a/screenpipe-server/src/pipe_manager.rs
+++ b/screenpipe-server/src/pipe_manager.rs
@@ -568,7 +568,7 @@ impl PipeManager {
                     }
                 }
                 Err(e) => {
-                    println!("failed to start pipe {}: {}", id, e);
+                    info!("[{}] failed to start pipe {}:", id, e);
                     Err(e)
                 }
             }


### PR DESCRIPTION
---

fix: #1533

it can handle all these url 
`https://github.com/KentTDang/AI-Interview-Coach/`
`https://github.com/KentTDang/AI-Interview-Coach/tree/main`
`https://github.com/mediar-ai/screenpipe/tree/main/pipes/search`

and fixed the pipe exits with `.next` directory not found error
---

## description

brief description of the changes in this pr.

related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
