### PR TITLE
make released cli work on ubuntu 22

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -183,7 +183,7 @@ jobs:
           path: screenpipe-*.zip
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [x86_64-unknown-linux-gnu]


### PR DESCRIPTION
using older version to support both ubuntu 22 to 24 and many older distributions