### PR TITLE
fix: screenpipe cli not working on windows 10 11

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -168,6 +168,7 @@ jobs:
           $packageDir = "screenpipe-${{ env.VERSION }}-x86_64-pc-windows-msvc"
           New-Item -Path "$packageDir/bin" -ItemType Directory -Force
           Copy-Item "target/x86_64-pc-windows-msvc/release/screenpipe.exe" "$packageDir/bin/"
+          Copy-Item "target/x86_64-pc-windows-msvc/release/onnxruntime.dll" "$packageDir/bin/"
           7z a "$packageDir.zip" "./$packageDir/*"
 
       - name: Calculate SHA256


### PR DESCRIPTION
Some windows dont have onnxruntime.dll
there we will need to bundle it with our cli
