### PR TITLE
custom port for mcp server

### DIFF
--- a/screenpipe-integrations/screenpipe-mcp/src/screenpipe_mcp/server.py
+++ b/screenpipe-integrations/screenpipe-mcp/src/screenpipe_mcp/server.py
@@ -6,6 +6,7 @@ from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
 import mcp.types as types
 import mcp.server.stdio
+import argparse
 
 import json
 
@@ -13,11 +14,16 @@ import json
 # Enable nested event loops (needed for some environments)
 nest_asyncio.apply()
 
+# Parse command line arguments
+parser = argparse.ArgumentParser(description='Screenpipe MCP Server')
+parser.add_argument('--port', type=int, default=3030, help='Port number for the screenpipe API (default: 3030)')
+args = parser.parse_args()
+
 # Initialize server
 server = Server("screenpipe")
 
 # Constants
-SCREENPIPE_API = "http://localhost:3030"
+SCREENPIPE_API = f"http://localhost:{args.port}"
 
 @server.list_tools()
 async def handle_list_tools() -> list[types.Tool]:


### PR DESCRIPTION

Now the server will accept a `--port` argument to specify which port the screenpipe API is running on. Here's how it works:

1. If no port is specified, it will default to 3030 (maintaining backward compatibility)
2. If a port is specified using `--port`, it will use that port instead

You can now run the server in different ways:

1. Default port (3030):
```bash
uv run screenpipe-mcp
```

2. Custom port:
```bash
uv run screenpipe-mcp --port 8080
```


