### PR TITLE
feat: add window visibility percentage to frames and search API

### DIFF
--- a/screenpipe-db/benches/db_benchmarks.rs
+++ b/screenpipe-db/benches/db_benchmarks.rs
@@ -16,7 +16,7 @@ async fn setup_large_db(size: usize) -> DatabaseManager {
             .await
             .unwrap();
         let frame_id = db
-            .insert_frame("test_device", None, None, None, None, false)
+            .insert_frame("test_device", None, None, None, None, false, Some(0.0))
             .await
             .unwrap();
         let ocr_text = format!("OCR text {}", rng.gen::<u32>());
@@ -86,6 +86,8 @@ fn bench_search(c: &mut Criterion) {
                                 None,
                                 None,
                                 None,
+                                None,
+                                None
                             )
                             .await
                             .unwrap()

--- a/screenpipe-db/src/migrations/20250318033635_add_visible_percentage_to_frames.sql
+++ b/screenpipe-db/src/migrations/20250318033635_add_visible_percentage_to_frames.sql
@@ -1,0 +1,6 @@
+-- Add migration script here
+-- Add visible_percentage column with a default value of 0.0 (fully hidden)
+ALTER TABLE frames ADD COLUMN visible_percentage REAL DEFAULT 0.0;
+
+-- Create an index for the new column to optimize queries
+CREATE INDEX IF NOT EXISTS idx_frames_visible_percentage ON frames(visible_percentage);

--- a/screenpipe-db/src/types.rs
+++ b/screenpipe-db/src/types.rs
@@ -30,6 +30,7 @@ pub struct Frame {
     pub browser_url: String,
     pub app_name: String,
     pub window_name: String,
+    pub visible_percentage: f32,
 }
 #[derive(FromRow, Debug)]
 pub struct OCRResultRaw {
@@ -46,6 +47,7 @@ pub struct OCRResultRaw {
     pub tags: Option<String>,
     pub browser_url: Option<String>,
     pub focused: Option<bool>,
+    pub visible_percentage: f32,
 }
 
 #[derive(OaSchema, Debug, Serialize, Deserialize)]
@@ -63,6 +65,7 @@ pub struct OCRResult {
     pub tags: Vec<String>,
     pub browser_url: Option<String>,
     pub focused: Option<bool>,
+    pub visible_percentage: f32,
 }
 
 #[derive(OaSchema, Debug, Deserialize, PartialEq, Default, Clone)]

--- a/screenpipe-db/tests/db.rs
+++ b/screenpipe-db/tests/db.rs
@@ -37,7 +37,7 @@ mod tests {
             .await
             .unwrap();
         let frame_id = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -65,6 +65,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -113,6 +115,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -134,6 +138,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -189,6 +195,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -210,6 +218,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -232,7 +242,7 @@ mod tests {
             .await
             .unwrap();
         let frame_id = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
 
@@ -297,6 +307,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -318,6 +330,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -348,7 +362,7 @@ mod tests {
             .await
             .unwrap();
         let frame_id1 = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -388,7 +402,7 @@ mod tests {
 
         // Insert remaining data
         let frame_id2 = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -489,6 +503,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -513,6 +529,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -536,6 +554,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -563,6 +583,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -585,6 +607,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -603,7 +627,7 @@ mod tests {
             .await
             .unwrap();
         let frame_id1 = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -641,7 +665,7 @@ mod tests {
 
         // Insert remaining data
         let frame_id2 = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -690,6 +714,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -716,6 +742,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1074,7 +1102,7 @@ mod tests {
 
         // Insert first frame with OCR
         let frame_id1 = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -1088,7 +1116,7 @@ mod tests {
 
         // Insert second frame with OCR
         let frame_id2 = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -1117,6 +1145,8 @@ mod tests {
                 Some("test_video"),
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1144,6 +1174,8 @@ mod tests {
                 Some("non_existent"),
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1171,6 +1203,8 @@ mod tests {
                 Some("test_video"),
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1196,6 +1230,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1245,6 +1281,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1274,6 +1312,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1296,6 +1336,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1318,6 +1360,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1334,7 +1378,7 @@ mod tests {
             .await
             .unwrap();
         let frame_id = db
-            .insert_frame("test_device", None, None, Some("test"), Some(""), false)
+            .insert_frame("test_device", None, None, Some("test"), Some(""), false, Some(1.0))
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -1400,6 +1444,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1420,6 +1466,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -1440,6 +1488,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();

--- a/screenpipe-server/src/core.rs
+++ b/screenpipe-server/src/core.rs
@@ -245,6 +245,7 @@ async fn record_video(
                         Some(window_result.app_name.as_str()),
                         Some(window_result.window_name.as_str()),
                         window_result.focused,
+                        Some(window_result.visible_percentage)
                     )
                     .await;
 
@@ -286,6 +287,7 @@ async fn record_video(
                                     confidence: window_result.confidence,
                                     timestamp: frame.timestamp,
                                     browser_url: window_result.browser_url.clone(),
+                                    visible_percentage: window_result.visible_percentage,
                                 },
                             ) {
                                 Ok(_) => {

--- a/screenpipe-server/tests/endpoint_test.rs
+++ b/screenpipe-server/tests/endpoint_test.rs
@@ -179,11 +179,11 @@ mod tests {
             .await
             .unwrap();
         let frame_id1 = db
-            .insert_frame("test_device", None, None, None, None, true)
+            .insert_frame("test_device", None, None, None, None, true, None)
             .await
             .unwrap();
         let frame_id2 = db
-            .insert_frame("test_device", None, None, None, None, true)
+            .insert_frame("test_device", None, None, None, None, true, None)
             .await
             .unwrap();
         db.insert_ocr_text(
@@ -253,6 +253,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -273,6 +275,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -293,6 +297,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -313,6 +319,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -333,6 +341,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -353,6 +363,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -373,6 +385,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -389,7 +403,7 @@ mod tests {
             .await
             .unwrap();
         let frame_id1 = db
-            .insert_frame("test_device", None, None, None, None, true)
+            .insert_frame("test_device", None, None, None, None, true, None)
             .await
             .unwrap();
         let audio_chunk_id1 = db.insert_audio_chunk("test_audio1.wav").await.unwrap();
@@ -457,6 +471,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -478,6 +494,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -500,6 +518,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -526,6 +546,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -551,6 +573,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -570,6 +594,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -591,7 +617,7 @@ mod tests {
             .await
             .unwrap();
         let old_frame_id = db
-            .insert_frame("test_device", None, None, None, None, true)
+            .insert_frame("test_device", None, None, None, None, true, None)
             .await
             .unwrap();
 
@@ -601,7 +627,7 @@ mod tests {
             .await
             .unwrap();
         let recent_frame_id = db
-            .insert_frame("test_device", None, None, None, None, true)
+            .insert_frame("test_device", None, None, None, None, true, None)
             .await
             .unwrap();
 
@@ -655,6 +681,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -685,6 +713,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -731,6 +761,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();
@@ -754,6 +786,8 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
+                None
             )
             .await
             .unwrap();

--- a/screenpipe-server/tests/tags_test.rs
+++ b/screenpipe-server/tests/tags_test.rs
@@ -371,6 +371,7 @@ async fn insert_test_data(db: &Arc<DatabaseManager>) {
             Some("test_app"),
             Some("test_window"),
             true,
+            None
         )
         .await
         .unwrap();

--- a/screenpipe-server/tests/video_utils_test.rs
+++ b/screenpipe-server/tests/video_utils_test.rs
@@ -131,6 +131,7 @@ async fn test_extract_frames_and_ocr() -> Result<()> {
         app_name: "test_app".to_string(),
         is_focused: true,
         process_id: 1234,
+        visible_percentage: 1.0
     };
 
     // perform ocr using apple native (macos only)

--- a/screenpipe-vision/src/core.rs
+++ b/screenpipe-vision/src/core.rs
@@ -116,6 +116,7 @@ pub struct WindowOcrResult {
     pub focused: bool,
     pub confidence: f64,
     pub browser_url: Option<String>,
+    pub visible_percentage: f32,
 }
 
 pub struct OcrTaskData {
@@ -144,7 +145,7 @@ impl std::fmt::Display for ContinuousCaptureError {
     }
 }
 
-pub async fn continuous_capture(
+pub async fn continuous_capture( 
     result_tx: Sender<CaptureResult>,
     interval: Duration,
     ocr_engine: OcrEngine,
@@ -402,6 +403,7 @@ async fn process_window_ocr(
         focused: captured_window.is_focused,
         confidence: confidence.unwrap_or(0.0),
         browser_url,
+        visible_percentage: captured_window.visible_percentage,
     })
 }
 
@@ -539,6 +541,7 @@ pub struct WindowOcr {
     )]
     pub timestamp: Instant,
     pub browser_url: Option<String>,
+    pub visible_percentage: f32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION

## description

This PR introduces a new `visible_percentage` field to the frames table, enabling us to track and query how much of a window is visible on the screen. It includes updates across the migrations, Rust data structures, APIs, to support this feature. Visibility calculations consider the positions and overlap of multiple windows.

This enhancement is particularly useful when using the `--capture-unfocused-windows` flag. It allows users to precisely filter and distinguish search results based on the actual visibility of unfocused windows, greatly enhancing precision and relevance in scenarios with overlapping windows.

## how to test

1. Run screenpipe and run it with the --capture-unfocused-windows flag
`./target/release/screenpipe --disable-audio --enable-frame-cache --capture-unfocused-windows`
2. Capture frames while windows overlap and verify that the `visible_percentage` field reflects the correct visibility percentage.
3. Perform searches with visibility filters using the new parameters `min_visible_percentage` and `max_visible_percentage` and verify correct filtering

![CleanShot 2025-03-18 at 20 48 05@2x](https://github.com/user-attachments/assets/aa1e9468-4aa8-444c-bcd3-7ead53970cde)
