### PR TITLE
docs: fix grammar in "Where is the data stored?" section

### DIFF
--- a/content/docs/pages/docs/faq.mdx
+++ b/content/docs/pages/docs/faq.mdx
@@ -9,7 +9,7 @@
 <details>
   <summary>Where is the data stored?</summary>
   
-  - 100% of the data stay local in a SQLite database and mp4/mp3 files. You own your data
+  - 100% of the data stays local in a SQLite database and mp4/mp3 files. You own your data
 </details>
 
 <details>


### PR DESCRIPTION
## description

A grammar issue in the "Where is the data stored?" section. The phrase "100% of the data stay local" should be corrected to "100% of the data stays local" because "data" is considered an uncountable noun and requires a singular verb. 

This change ensures proper grammar.