### PR TITLE
Add: Client screenshot to server

### DIFF
--- a/Win32/.gitignore
+++ b/Win32/.gitignore
@@ -1,0 +1,52 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf

--- a/Win32/README.md
+++ b/Win32/README.md
@@ -1,0 +1,15 @@
+## Dependencies
+- Windows API
+- Clang/LLVM
+- Makefile
+
+## build
+```
+make buildworld
+```
+
+## Usage
+```
+Program.exe "192.168.1.8" "RDP_User" "123456" "screenshot_2.bmp" "targetfolder"
+```
+NOTES: If location is in root directory, use dot `.` to define it.

--- a/Win32/include/Media-Capture.hh
+++ b/Win32/include/Media-Capture.hh
@@ -1,0 +1,13 @@
+#ifndef MEDIA_CAPTURE_HH
+#define MEDIA_CAPTURE_HH
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#include <windows.h>
+#include <wingdi.h>
+
+// Capture client the desktop screen
+VOID CaptureAndSaveDesktop(LPCWSTR filename);
+
+#endif /* defined(_WIN32) || defined(_WIN64) */
+#endif /* MEDIA_CAPTURE_HH */

--- a/Win32/include/Network.hh
+++ b/Win32/include/Network.hh
@@ -1,0 +1,18 @@
+#ifndef NETWORK_HH
+#define NETWORK_HH
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#include <windows.h>
+#include <winnt.h>
+#include <wininet.h>
+
+HINTERNET OpenFTPConnection(LPCWSTR host, LPCWSTR username, LPCWSTR password);
+BOOL SendFileViaFTP(HANDLE hConnection, LPCWSTR localFile, LPCWSTR remoteFile);
+BOOL CloseFTPConnection(HINTERNET hConnection);
+
+VOID UploadFile(LPCWSTR server, LPCWSTR username, LPCWSTR password, LPCWSTR screenshot_name, LPCWSTR target_folder);
+BOOL FTP_FolderExist(HINTERNET hFTPSession, LPCWSTR foldername);
+
+#endif /* defined(_WIN32) || defined(_WIN64) */
+#endif /* NETWORK_HH */

--- a/Win32/lib/Capture-Media.cxx
+++ b/Win32/lib/Capture-Media.cxx
@@ -1,0 +1,123 @@
+#ifndef UNICODE
+#define UNICODE
+#endif /* UNICODE */
+
+#include "../include/Media-Capture.hh"
+#include <winuser.h>
+#include <stdio.h>
+
+#pragma comment(lib, "gdi32.lib")
+
+VOID SaveBitmapToFile(HBITMAP hBitmap, LPCWSTR filename)
+{
+    BITMAP bmp;
+    BITMAPINFOHEADER bi;
+    BITMAPFILEHEADER bfh;
+    HANDLE hFile;
+    DWORD dwWritten;
+    HDC hdcMem;
+    HGDIOBJ hOldBitmap;
+    
+    // Get information about the bitmap
+    if (GetObject(hBitmap, sizeof(BITMAP), &bmp) == 0) {
+        printf("Failed to get bitmap object\n");
+        return;
+    }
+
+    // Fill BITMAPINFOHEADER structure
+    bi.biSize = sizeof(BITMAPINFOHEADER);
+    bi.biWidth = bmp.bmWidth;
+    bi.biHeight = bmp.bmHeight;
+    bi.biPlanes = 1;
+    bi.biBitCount = 24;  // 24-bit RGB
+    bi.biCompression = BI_RGB;  // No compression
+    bi.biSizeImage = ((bmp.bmWidth * 24 + 31) / 32) * 4 * bmp.bmHeight;
+    bi.biXPelsPerMeter = 0;
+    bi.biYPelsPerMeter = 0;
+    bi.biClrUsed = 0;
+    bi.biClrImportant = 0;
+    
+    // Create a device context and compatible bitmap to get pixel data
+    hdcMem = CreateCompatibleDC(NULL);
+    hOldBitmap = SelectObject(hdcMem, hBitmap);
+    
+    // Allocate memory to store the image
+    BYTE* lpBits = (BYTE*)malloc(bi.biSizeImage);
+    if (lpBits == NULL)
+    {
+        printf("Error allocating memory for image data\n");
+        return;
+    }
+    
+    // Get pixel data from bitmap
+    if (GetDIBits(hdcMem, hBitmap, 0, bmp.bmHeight, lpBits, (BITMAPINFO*)&bi, DIB_RGB_COLORS) == 0)
+    {
+        printf("Error getting DIB bits\n");
+        free(lpBits);
+        return;
+    }
+    
+    // Create or open the file
+    hFile = CreateFileW(filename, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (hFile == INVALID_HANDLE_VALUE)
+    {
+        printf("Error creating file\n");
+        free(lpBits);
+        return;
+    }
+    
+    // Fill BITMAPFILEHEADER structure
+    bfh.bfType = 0x4D42;  // 'BM' in hexadecimal
+    bfh.bfSize = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + bi.biSizeImage;
+    bfh.bfReserved1 = 0;
+    bfh.bfReserved2 = 0;
+    bfh.bfOffBits = sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER);
+    
+    // Write the file header
+    WriteFile(hFile, &bfh, sizeof(BITMAPFILEHEADER), &dwWritten, NULL);
+    
+    // Write the bitmap info header
+    WriteFile(hFile, &bi, sizeof(BITMAPINFOHEADER), &dwWritten, NULL);
+    
+    // Write the pixel data
+    WriteFile(hFile, lpBits, bi.biSizeImage, &dwWritten, NULL);
+    
+    // Clean up
+    CloseHandle(hFile);
+    free(lpBits);
+    SelectObject(hdcMem, hOldBitmap);
+    DeleteDC(hdcMem);
+}
+
+VOID CaptureAndSaveDesktop(LPCWSTR filename)
+{
+    // Get the handle of the desktop window
+    HWND hDesktopWnd = GetDesktopWindow();
+    
+    // Get the device context (DC) of the desktop window
+    HDC hdcDesktop = GetDC(hDesktopWnd);
+    
+    // Get the size of the screen
+    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+    
+    // Create a compatible DC to capture the screen image
+    HDC hdcMem = CreateCompatibleDC(hdcDesktop);
+    
+    // Create a compatible bitmap
+    HBITMAP hBitmap = CreateCompatibleBitmap(hdcDesktop, screenWidth, screenHeight);
+    
+    // Select the bitmap into the memory DC
+    HGDIOBJ hOld = SelectObject(hdcMem, hBitmap);
+    
+    // Copy the desktop content to the bitmap using BitBlt
+    BitBlt(hdcMem, 0, 0, screenWidth, screenHeight, hdcDesktop, 0, 0, SRCCOPY);
+    
+    // Save the bitmap to a file
+    SaveBitmapToFile(hBitmap, filename);
+    
+    // Cleanup
+    SelectObject(hdcMem, hOld);
+    DeleteDC(hdcMem);
+    ReleaseDC(hDesktopWnd, hdcDesktop);
+}

--- a/Win32/lib/FTP-Inet.cxx
+++ b/Win32/lib/FTP-Inet.cxx
@@ -1,0 +1,148 @@
+#ifndef UNICODE
+#define UNICODE
+#endif /* UNICODE */
+
+#pragma comment(lib, "wininet.lib")
+
+#include "../include/Network.hh"
+
+#include <Windows.h>
+#include <stdio.h>
+
+#if defined(_WIN32) || defined(_WIN64)
+
+VOID PrintInternetError()
+{
+    DWORD dwError = 0;
+    WCHAR szBuffer[256];
+    DWORD dwSize = sizeof(szBuffer) / sizeof(szBuffer[0]);
+
+    if (InternetGetLastResponseInfo(&dwError, szBuffer, &dwSize)) {
+        wprintf_s(L"[ERROR] :%d\n", szBuffer);
+    } else {
+        wprintf_s(L"[ERROR] Unknown error: %lu\n", GetLastError());
+    }
+}
+
+HINTERNET OpenFTPConnection(LPCWSTR host, LPCWSTR username, LPCWSTR password)
+{
+	// Initialize the WinINet for FTP connection
+	// The user agent is set to "Screenpipe-Exchange/1.0"
+	HINTERNET hInternet = InternetOpenW(
+		L"Screenpipe-Agent/1.0",
+		INTERNET_OPEN_TYPE_DIRECT, 
+		NULL, NULL, 0
+	);
+
+	// Check if the connection was successful
+	if (hInternet == NULL) {
+		PrintInternetError();
+		InternetCloseHandle(hInternet);
+		return NULL;
+	}
+
+    // Connect to the FTP server
+	HINTERNET hFTPSession = InternetConnectW(
+		hInternet,
+		host,
+		INTERNET_DEFAULT_FTP_PORT,
+		username,
+		password,
+		INTERNET_SERVICE_FTP,
+		INTERNET_FLAG_PASSIVE,
+		0
+	);
+
+	// Check if the connection was successful
+	if (hFTPSession == NULL) {
+        DWORD error = GetLastError();
+        wprintf_s(L"InternetConnectW failed. Error: %lu\n", error);
+
+        switch (error) {
+        case ERROR_INTERNET_NAME_NOT_RESOLVED:
+            wprintf_s(L"FTP host not found.\n");
+            break;
+        case ERROR_INTERNET_LOGIN_FAILURE:
+            wprintf_s(L"Invalid username or password.\n");
+            break;
+        case ERROR_INTERNET_TIMEOUT:
+            wprintf_s(L"Connection timed out. Check the network.\n");
+            break;
+        default:
+            PrintInternetError();
+        }
+	}
+
+	// Print a message to indicate that the connection was successful
+	wprintf_s(L"FTP Connection opened\n");
+	return hFTPSession;
+}
+
+VOID UploadFile(LPCWSTR server, LPCWSTR username, LPCWSTR password, LPCWSTR screenshot_name, LPCWSTR target_folder)
+{
+    HINTERNET hFtpSession;
+    hFtpSession = OpenFTPConnection(server, username, password);
+
+	// Make folder if it does not exist
+	if (!FTP_FolderExist(hFtpSession, target_folder)) {
+		if (FtpCreateDirectoryW(hFtpSession, target_folder)) {
+			wprintf_s(L"Folder created: %s\n", target_folder);
+		} else {
+			wprintf_s(L"Failed to create folder: %s. Error: %lu\n", target_folder, GetLastError());
+		}
+	}
+
+    // Create the remote file path with the target folder
+    WCHAR remoteFile[MAX_PATH];
+    wcsncpy_s(remoteFile, target_folder, MAX_PATH - 1);  // Copy target folder to remoteFile
+    wcsncat_s(remoteFile, L"\\", MAX_PATH - wcslen(remoteFile) - 1);  // Add folder separator
+    wcsncat_s(remoteFile, screenshot_name, MAX_PATH - wcslen(remoteFile) - 1);  // Add file name to path
+
+    // Upload file to FTP server
+    if (FtpPutFile(hFtpSession, screenshot_name, remoteFile, FTP_TRANSFER_TYPE_BINARY, 0)) {
+        wprintf_s(L"Successfully uploaded file: %s\n", screenshot_name);
+    } else {
+        wprintf_s(L"Failed to upload ERROR: %lu\n", GetLastError());
+    }
+
+    // Clean up
+    CloseFTPConnection(hFtpSession);
+}
+
+// Check if the specified folder exists on the FTP server
+BOOL FTP_FolderExist(HINTERNET hFTPSession, LPCWSTR foldername)
+{
+    WIN32_FIND_DATAW findData;
+    HINTERNET hFind = FtpFindFirstFileW(
+        hFTPSession,
+        foldername,
+        &findData,
+        INTERNET_FLAG_NO_CACHE_WRITE,
+        0
+    );
+
+    if (hFind != NULL) {
+        wprintf_s(L"Folder found: %s\n", foldername);
+        InternetCloseHandle(hFind);
+        return TRUE;
+    }
+
+    DWORD error = GetLastError();
+    if (error == ERROR_NO_MORE_FILES) {
+        wprintf_s(L"Folder not found: %s\n", foldername);
+        return FALSE;
+    }
+
+    return FALSE;
+}
+
+// Close connection to the FTP server
+BOOL CloseFTPConnection(HINTERNET hConnection)
+{
+	if (hConnection != NULL) {
+		return InternetCloseHandle(hConnection);
+	}
+	return FALSE;
+}
+
+#endif /* defined(_WIN32) || defined(_WIN64) */

--- a/Win32/makefile
+++ b/Win32/makefile
@@ -1,0 +1,14 @@
+# Purpose: Build the project
+include tools/config.mk
+
+OUT = Program.exe
+
+SRCS = $(wildcard src/*.cc)
+LIBS = $(wildcard lib/*.cxx)
+
+.PHONY: buildworld
+
+buildworld:
+	@echo "Comnpiling..."
+	$(CXX) $(SRCS) $(LIBS) \
+	$(OPT_Uni) -o $(OUT) $(LIB_LNK)

--- a/Win32/src/Application.cc
+++ b/Win32/src/Application.cc
@@ -1,0 +1,33 @@
+#ifndef UNICODE
+#define UNICODE
+#endif /* UNICODE */
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#include "Argument.hh"
+#include <wininet.h>
+
+#pragma comment(lib, "wininet.lib")
+
+#include "../include/Network.hh"
+#include "../include/Media-Capture.hh"
+
+int wmain(int argc, LPCWSTR argv[]){
+
+	ArgumentUsage(argv[1]);
+
+	LPCWSTR server = argv[1];
+	LPCWSTR username = argv[2];
+	LPCWSTR password = argv[3];
+	LPCWSTR screenshot_name = argv[4];
+	LPCWSTR target_folder = argv[5];
+
+	// Upload the screenshot
+    CaptureAndSaveDesktop(screenshot_name);
+
+	UploadFile(server, username, password, screenshot_name, target_folder);
+
+	return 0;
+}
+
+#endif /* defined(_WIN32) || defined(_WIN64) */

--- a/Win32/src/Argument.hh
+++ b/Win32/src/Argument.hh
@@ -1,0 +1,25 @@
+#ifndef UNICODE
+#define UNICODE
+#endif /* UNICODE */
+
+#if defined(_WIN32) || defined(_WIN64)
+
+#include <windows.h>
+#include <winbase.h>
+#include <wingdi.h>
+
+#include <stdio.h>
+
+// Argument usage for the program to display help
+inline VOID ArgumentUsage(LPCWSTR lpValue) {
+	LPCWSTR lpUsage = L"help";
+	if (lstrcmpiW(lpValue, lpUsage) == 0) {
+		printf_s("Usage: <server> <username> <password> <screenshot_name> <target_folder>\n");
+		printf_s("Example: \"ftp.example.com\" \"admin\" \"admin\" \"Screenshot_1\" \"ScreenpipeFolder\" \n\n");
+
+		printf_s("Screenshot file are only use BMP format\n");
+		printf_s("FTP port only setup to 21\n");
+	}
+}
+
+#endif /* defined(_WIN32) || defined(_WIN64) */

--- a/Win32/tools/config.mk
+++ b/Win32/tools/config.mk
@@ -1,0 +1,8 @@
+# This file is used to configure the build system.
+CXX		=	clang++
+
+# Compiler universal flags
+OPT_Uni	=	-O2 -v
+
+# Linking Windows libraries
+LIB_LNK	=	-luser32 -lkernel32 -lgdi32


### PR DESCRIPTION
/claims #850 

# Summary
- Take client screenshot using GDI
- Using FTP for image transfer

# Issues
- Not possible to use WTSVirtualChannel without open RDP session
- Connect using WTSOpenServer & WTSConnectSession while MS-RDP active with the same credentials can cause session conflict
- Also not possible to use MS-RDP session for transfer data through because it has session isolation

# Prerequisites Dependencies & Toolchains
- Windows API (10.0.26100.0)
- Clang/LLVM (17.0.5)
- GNU Makefile

# How to build
```
make buildworld
```

# How to test
```
Program.exe "ftp.example.com" "username" "password" "Screenhot_name.bmp" "Screenshot_Folder"
```

# Screenshot
From Client
![image](https://github.com/user-attachments/assets/3531f695-a6e9-4ed9-ab05-e8b6c6b0cbe1)
From Server
![image](https://github.com/user-attachments/assets/e491b4e0-e0c5-451f-8805-23863f78c018)

