### PR TITLE
fix: Linux Intergration Test

### DIFF
--- a/.github/scripts/check_logs.sh
+++ b/.github/scripts/check_logs.sh
@@ -4,7 +4,7 @@ if grep -q "panic" screenpipe_output.log; then
   echo "CLI crashed"
   exit 1
 fi
-if ! grep -q "Server listening on 127.0.0.1:3030" screenpipe_output.log; then
+if ! grep -q "Server listening on [::]:3030" screenpipe_output.log; then
   echo "Server did not start correctly"
   exit 1
 fi

--- a/.github/workflows/linux-integration-test.yml
+++ b/.github/workflows/linux-integration-test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Check final storage usage
       run: du -ha ~/.screenpipe/data
 
-    - name: Upload logs and data
+    - name: Upload logs
       uses: actions/upload-artifact@v4
       if: always()
       with:

--- a/.github/workflows/linux-integration-test.yml
+++ b/.github/workflows/linux-integration-test.yml
@@ -1,10 +1,6 @@
 name: Linux Integration Test
 
-on:
-  push:
-    branches: [ main  ]
-  pull_request:
-    branches: [ main  ]
+on: [push]
 
 jobs:
   test-linux:
@@ -53,14 +49,16 @@ jobs:
     - name: Check final storage usage
       run: du -ha ~/.screenpipe/data
 
-    - name: Upload logs
+    - name: Upload logs and data
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: screenpipe-logs
         path: screenpipe_output.log
     
     - name: Upload captured data
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: screenpipe-data
         path: |
@@ -68,6 +66,7 @@ jobs:
     
     - name: Upload test image
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: test-image
         path: test_image.png

--- a/.github/workflows/linux-integration-test.yml
+++ b/.github/workflows/linux-integration-test.yml
@@ -1,6 +1,10 @@
 name: Linux Integration Test
 
-on: [push]
+on:
+  push:
+    branches: [ main  ]
+  pull_request:
+    branches: [ main  ]
 
 jobs:
   test-linux:


### PR DESCRIPTION


* [`.github/scripts/check_logs.sh`](diffhunk://#diff-692894038c99bd1e945c34082ffa4a539a8965f838e187255757c63e09cc3f4dL7-R7): Updated the server start check to look for the server listening on `[::]:3030` instead of `127.0.0.1:3030`.
* [`.github/workflows/linux-integration-test.yml`](diffhunk://#diff-f68f8dda61a056de9750f9e069f98eee8d07a3682a8c40f6bcf8c70aeaf4463dR58-R73): Added conditions to always upload logs, captured data, and test images, ensuring these artifacts are available even if the job fails.