### PR TITLE
fix: required file name change for loom pipe

### DIFF
--- a/screenpipe-server/src/video_utils.rs
+++ b/screenpipe-server/src/video_utils.rs
@@ -142,7 +142,8 @@ pub async fn merge_videos(
         ));
     }
 
-    let output_filename = format!("output_{}.mp4", Uuid::new_v4());
+    let current_time = chrono::Local::now().format("%Y_%m_%d_%H_%M_%S").to_string();
+    let output_filename = format!("loom_{}.mp4", current_time);
     let output_path = output_dir.join(&output_filename);
 
     // create a temporary file to store the list of input videos


### PR DESCRIPTION
just a little change, 
cz `output` keyword is reserved for determining whether a media file is a video or an audio

https://github.com/mediar-ai/screenpipe/blob/71a3caa84e3e9e305ea68c065fd3852b2565d1a0/pipes/rewind/src/lib/actions/video-actions.ts#L19