### PR TITLE
feat: add device_name in frame table and search query return

### DIFF
--- a/screenpipe-db/src/db.rs
+++ b/screenpipe-db/src/db.rs
@@ -341,7 +341,7 @@ impl DatabaseManager {
 
         // Insert the new frame with file_path as name and app/window metadata
         let id = sqlx::query(
-            "INSERT INTO frames (video_chunk_id, offset_index, timestamp, name, browser_url, app_name, window_name, focused) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO frames (video_chunk_id, offset_index, timestamp, name, browser_url, app_name, window_name, focused, device_name) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
         )
         .bind(video_chunk_id)
         .bind(offset_index)
@@ -351,6 +351,7 @@ impl DatabaseManager {
         .bind(app_name)
         .bind(window_name)
         .bind(focused)
+        .bind(device_name)
         .execute(&mut *tx)
         .await?
         .last_insert_rowid();
@@ -714,6 +715,7 @@ impl DatabaseManager {
             frames.app_name,
             ocr_text.ocr_engine,
             frames.window_name,
+            video_chunks.device_name,
             GROUP_CONCAT(tags.name, ',') as tags,
             frames.browser_url,
             frames.focused
@@ -792,6 +794,7 @@ impl DatabaseManager {
                 app_name: raw.app_name,
                 ocr_engine: raw.ocr_engine,
                 window_name: raw.window_name,
+                device_name: raw.device_name,
                 tags: raw
                     .tags
                     .map(|t| t.split(',').map(String::from).collect())
@@ -2092,6 +2095,7 @@ impl DatabaseManager {
                 ocr_engine: raw.ocr_engine,
                 window_name: raw.window_name,
                 frame_name: raw.frame_name,
+                device_name: raw.device_name,
                 tags: raw
                     .tags
                     .map(|t| t.split(',').map(String::from).collect())

--- a/screenpipe-db/src/migrations/20250131232938_add_device_name_to_frame.sql
+++ b/screenpipe-db/src/migrations/20250131232938_add_device_name_to_frame.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE frames ADD COLUMN device_name TEXT NOT NULL DEFAULT '';

--- a/screenpipe-db/src/types.rs
+++ b/screenpipe-db/src/types.rs
@@ -46,6 +46,7 @@ pub struct OCRResultRaw {
     pub tags: Option<String>,
     pub browser_url: Option<String>,
     pub focused: Option<bool>,
+    pub device_name: String,
 }
 
 #[derive(OaSchema, Debug, Serialize, Deserialize)]
@@ -63,6 +64,7 @@ pub struct OCRResult {
     pub tags: Vec<String>,
     pub browser_url: Option<String>,
     pub focused: Option<bool>,
+    pub device_name: String,
 }
 
 #[derive(OaSchema, Debug, Deserialize, PartialEq, Default, Clone)]

--- a/screenpipe-js/common/types.ts
+++ b/screenpipe-js/common/types.ts
@@ -75,6 +75,7 @@ export interface OCRContent {
   frameName?: string;
   browserUrl?: string;
   focused?: boolean;
+  deviceName: string;
 }
 
 /**

--- a/screenpipe-server/src/server.rs
+++ b/screenpipe-server/src/server.rs
@@ -208,6 +208,7 @@ pub struct OCRContent {
     pub frame_name: Option<String>,
     pub browser_url: Option<String>,
     pub focused: Option<bool>,
+    pub device_name: String,
 }
 
 #[derive(OaSchema, Serialize, Deserialize, Debug)]
@@ -385,6 +386,7 @@ pub(crate) async fn search(
                 frame_name: Some(ocr.frame_name.clone()),
                 browser_url: ocr.browser_url.clone(),
                 focused: ocr.focused,
+                device_name: ocr.device_name.clone(),
             }),
             SearchResult::Audio(audio) => ContentItem::Audio(AudioContent {
                 chunk_id: audio.audio_chunk_id,


### PR DESCRIPTION
```bash
  "data": [
    {
      "type": "OCR",
      "content": {
        "frame_id": 495,
        "text": "[bounty] script to fin X O Add FTS for app nan X https:// mediar-ai/screenpip X O [bounty] add monitc X github.com/mediar-ai/screenpipe/compare/main...divanshu-go:screenpipe:device name?expand=l Rahul faces Lucknow Q I.:Y Insights x Comparing mediar-L localhost:3030/searc X o mediar-ai screenpipe @ Issues 215 n Pull requests 27 Open a pull request Type L] to search Discussions Actions Security Create a new pull request by comparing changes across two branches. If you need to, you can also compare across forks. Leam more about diff comparisons here. base repository. base: main repository: compare: device_name Able to merge. These branches can be automatically merged. Add a title feat: add device_name in frame table and search query retum Add a description Helpful resources Contributing GitHub Community Guidelines Write Preview 69 Add your description here... Markdown is supported Paste, drop, or click to add files",
        "timestamp": "2025-04-21T15:39:03.836472Z",
        "file_path": "C:\\Users\\divan\\.screenpipe\\data\\monitor_65537_2025-04-21_15-37-39.mp4",
        "offset_index": 15,
        "app_name": "Microsoft Edge",
        "window_name": "Comparing mediar-ai:main...divanshu-go:device_name · mediar-ai/screenpipe and 6 more pages - Personal - Microsoft​ Edge",
        "tags": [],
        "frame": null,
        "frame_name": "C:\\Users\\divan\\.screenpipe\\data\\monitor_65537_2025-04-21_15-37-39.mp4",
        "browser_url": "https://github.com/mediar-ai/screenpipe/compare/main...divanshu-go:screenpipe:device_name?expand=1",
        "focused": true,
        "device_name": "monitor_65537"
      }
   ```
   
  /claim #1250
  
  
  