### PR TITLE
fix: keyboard shortcuts on windows

### DIFF
--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -191,7 +191,7 @@ const DEFAULT_SETTINGS: Settings = {
 	disabledShortcuts: [],
 	user: {},
 	showScreenpipeShortcut: "Super+Alt+S",
-	startRecordingShortcut: "Super+Alt+R",
+	startRecordingShortcut: "Super+Alt+U", // Super+Alt+R is used on windows by Xbox Game Bar
 	stopRecordingShortcut: "Super+Alt+X",
 	startAudioShortcut: "",
 	stopAudioShortcut: "",

--- a/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -134,15 +134,15 @@ impl ShortcutConfig {
             show: store
                 .get("showScreenpipeShortcut")
                 .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| "Alt+Space".to_string()),
+                .unwrap_or_else(|| "Super+Alt+S".to_string()),
             start: store
                 .get("startRecordingShortcut")
                 .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| "Alt+Shift+R".to_string()),
+                .unwrap_or_else(|| "Super+Alt+U".to_string()),
             stop: store
                 .get("stopRecordingShortcut")
                 .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| "Alt+Shift+S".to_string()),
+                .unwrap_or_else(|| "Super+Alt+X".to_string()),
             start_audio: store
                 .get("startAudioShortcut")
                 .and_then(|v| v.as_str().map(String::from))

--- a/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -52,7 +52,7 @@ fn create_dynamic_menu(
     let show_shortcut = store
         .get("showScreenpipeShortcut")
         .and_then(|v| v.as_str().map(String::from))
-        .unwrap_or_else(|| "Alt+Space".to_string());
+        .unwrap_or_else(|| "Super+Alt+S".to_string());
 
     // Show item with formatted shortcut in label
     menu_builder = menu_builder.item(


### PR DESCRIPTION
Super+Alt+R is used on windows by Xbox Game Bar
therefore we need to use something else