### PR TITLE
Fix: Fixed Headphones/airpods configration issue

### DIFF
--- a/screenpipe-audio/src/core/device.rs
+++ b/screenpipe-audio/src/core/device.rs
@@ -193,10 +193,27 @@ pub async fn get_cpal_device_and_config(
     }
     .ok_or_else(|| anyhow!("Audio device not found: {}", device_name))?;
 
+    // Get the highest quality configuration based on device type
     let config = if is_output_device && !is_display {
-        cpal_audio_device.default_output_config()?
+        let configs = cpal_audio_device.supported_output_configs()?;
+        let best_config = configs
+            .max_by(|a, b| {
+                a.max_sample_rate().0.cmp(&b.max_sample_rate().0)
+                    .then(a.channels().cmp(&b.channels()))
+            })
+            .ok_or_else(|| anyhow!("No supported output configurations found"))?;
+        
+        best_config.with_sample_rate(best_config.max_sample_rate())
     } else {
-        cpal_audio_device.default_input_config()?
+        let configs = cpal_audio_device.supported_input_configs()?;
+        let best_config = configs
+            .max_by(|a, b| {
+                a.max_sample_rate().0.cmp(&b.max_sample_rate().0)
+                    .then(a.channels().cmp(&b.channels()))
+            })
+            .ok_or_else(|| anyhow!("No supported input configurations found"))?;
+        
+        best_config.with_sample_rate(best_config.max_sample_rate())
     };
 
     Ok((cpal_audio_device, config))


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "[pr] fix noise cancellation being disabled on headphones"
labels: 'bug'
assignees: '@Anmol202005'

---

## description

This PR fixes an issue where screenpipe would sometimes disable noise cancellation on headphones. The root cause was that we were using default audio configurations instead of the device's native highest quality configuration, which could override device-specific features like noise cancellation.

Changes:
- Modified `get_cpal_device_and_config` to use device's highest quality supported configuration
- Added proper handling of `SupportedStreamConfigRange` to preserve device features
- Improved configuration selection logic to prioritize sample rate and channel count

related issue: #55

## how to test

1. Connect a pair of headphones with noise cancellation (like AirPods Pro, Sony WH-1000XM4, etc.)
2. Start screenpipe and verify that noise cancellation remains active:
   - On macOS: Check the Control Center to see if noise cancellation is still enabled
   - On Windows: Check the device properties in Sound settings
   - On Linux: Check the device settings in your audio control panel
3. Record some audio and verify that:
   - The noise cancellation remains active during recording
   - The audio quality is maintained
   - The device's native features are preserved
