### PR TITLE
fix: force reload user data before pipe purchases to prevent stale cr…

### DIFF
--- a/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/screenpipe-app-tauri/components/pipe-store.tsx
@@ -62,7 +62,7 @@ const corePipes: string[] = [];
 export const PipeStore: React.FC = () => {
   const { health } = useHealthCheck();
   const [selectedPipe, setSelectedPipe] = useState<PipeWithStatus | null>(null);
-  const { settings, updateSettings } = useSettings();
+  const { settings, updateSettings, loadUser } = useSettings();
   const [pipes, setPipes] = useState<PipeWithStatus[]>([]);
   const [installedPipes, setInstalledPipes] = useState<InstalledPipe[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -202,6 +202,11 @@ export const PipeStore: React.FC = () => {
       if (!checkLogin(settings.user)) return;
 
       setLoadingPurchases((prev) => new Set(prev).add(pipe.id));
+
+      // Force reload user data to get the latest credit balance
+      if (settings.user?.token) {
+        await loadUser(settings.user.token, true);
+      }
 
       const pipeApi = await PipeApi.create(settings.user!.token!);
       const response = await pipeApi.purchasePipe(pipe.id);
@@ -347,6 +352,11 @@ export const PipeStore: React.FC = () => {
         ),
         duration: 10000,
       });
+
+      // Force reload user data to get the latest credit balance
+      if (settings.user?.token) {
+        await loadUser(settings.user.token, true);
+      }
 
       const pipeApi = await PipeApi.create(settings.user!.token!);
       const response = await pipeApi.downloadPipe(pipe.id);
@@ -842,6 +852,11 @@ export const PipeStore: React.FC = () => {
         ),
       );
 
+      // Force reload user data to get the latest credit balance
+      if (settings.user?.token) {
+        await loadUser(settings.user.token, true);
+      }
+
       const currentVersion = pipe.installed_config?.version!;
       const storeApi = await PipeApi.create(settings.user!.token!);
       const update = await storeApi.checkUpdate(pipe.id, currentVersion);
@@ -1048,6 +1063,10 @@ export const PipeStore: React.FC = () => {
 		setIsUpdating(false)
         return;
       }
+      
+      // Force reload user data to get the latest credit balance
+      await loadUser(settings.user.token, true);
+      
       // Get last check time from local storage
       const lastCheckTime =
         await localforage.getItem<number>("lastUpdateCheck");
@@ -1235,6 +1254,11 @@ export const PipeStore: React.FC = () => {
             }
 
             await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            // Force reload user data to get the latest credit balance
+            if (settings.user?.token) {
+              await loadUser(settings.user.token, true);
+            }
 
             // First update purchase history to reflect the new purchase
             await fetchPurchaseHistory();


### PR DESCRIPTION
## Fix credits purchase issue (#1782)

Some users were unable to use credits to purchase pipes despite having sufficient balance.

### Root cause :
Client-side caching in `useSettings` stores user data for 30 seconds, causing stale credit information to be sent to the server when buying apps immediately after purchasing credits.

### Solution :
Force reload user data from server before pipe purchase operations by adding `loadUser(token, true)` calls to:
- handlePurchasePipe
- handleInstallPipe
- handleUpdatePipe
- checkForUpdates
- Deep link purchase handler

This ensures we always use up-to-date credit balance information when purchasing.
/claim #1782