### PR TITLE
fix: ignore minimized windows during capture

### DIFF
--- a/screenpipe-vision/src/capture_screenshot_by_window.rs
+++ b/screenpipe-vision/src/capture_screenshot_by_window.rs
@@ -219,6 +219,20 @@ pub async fn capture_all_visible_windows(
                 }
             };
 
+            match window.is_minimized() {
+                Ok(is_minimized) => {
+                    if is_minimized {
+                        debug!("Window {} ({}) is_minimized", app_name, title);
+                        return None;
+                    }
+                },
+                Err(e) => {
+                    // Log warning and skip this window
+                    // mostly noise
+                    error!("Failed to get is_minimized for window {}: {}", app_name, e);
+                }
+            };
+
             let is_focused = match window.is_focused() {
                 Ok(focused) => focused,
                 Err(e) => {


### PR DESCRIPTION
On Linux, minimized windows cannot be captured by the system, resulting in repeated error messages and cluttered log files.

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

On Linux, minimized windows cannot be captured by the system, resulting in repeated error messages and cluttered log files.

brief description of the changes in this pr.

Ignore minimized windows 

related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
