### PR TITLE
Fix: Fix getting app icons on Linux

### DIFF
--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -144,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +539,17 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -963,6 +980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "configparser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1d7dcda7d1da79e444bdfba1465f2f849a58b07774e1df473ee77030cb47a7"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1178,15 @@ dependencies = [
  "libc",
  "metal",
  "objc",
+]
+
+[[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1776,6 +1808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1831,29 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1843,6 +1904,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "freedesktop-desktop-entry"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbcb2951884fd80c5b3093ce762bebcc4ec351fadff3c253f9d09cb91917ddd2"
+dependencies = [
+ "gettext-rs",
+ "log",
+ "memchr",
+ "thiserror 2.0.5",
+ "unicase",
+ "xdg",
+]
+
+[[package]]
+name = "freedesktop-icon-lookup"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3da575afdeef56733a55325c607492bb9871e098d008a37297cedcac356bf33"
+dependencies = [
+ "either",
+ "thiserror 1.0.69",
+ "tini",
 ]
 
 [[package]]
@@ -2116,6 +2202,26 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gettext-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a"
+dependencies = [
+ "gettext-sys",
+ "locale_config",
+]
+
+[[package]]
+name = "gettext-sys"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb45773f5b8945f12aecd04558f545964f943dacda1b1155b3d738f5469ef661"
+dependencies = [
+ "cc",
+ "temp-dir",
 ]
 
 [[package]]
@@ -2834,6 +2940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "imgref"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +2980,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc150e5ce2330295b8616ce0e3f53250e53af31759a9dbedad1621ba29151847"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "ini"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9271a5dfd4228fa56a78d7508a35c321639cc71f783bb7a5723552add87bce"
+dependencies = [
+ "configparser",
 ]
 
 [[package]]
@@ -3098,6 +3219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,6 +3342,19 @@ name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+
+[[package]]
+name = "locale_config"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
+dependencies = [
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "regex",
+ "winapi",
+]
 
 [[package]]
 name = "lock_api"
@@ -4370,7 +4520,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -4379,7 +4529,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -4388,8 +4538,14 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -5009,6 +5165,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5036,6 +5209,9 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -5051,6 +5227,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rust-ini"
@@ -5145,6 +5327,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,11 +5409,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenpipe-app"
-version = "0.44.0"
+version = "0.44.3"
 dependencies = [
  "anyhow",
  "async-stream",
  "axum",
+ "axum-macros",
  "base64 0.22.1",
  "chrono",
  "cocoa 0.26.0",
@@ -5222,10 +5423,14 @@ dependencies = [
  "dark-light",
  "dirs 5.0.1",
  "fix-path-env",
+ "freedesktop-desktop-entry",
+ "freedesktop-icon-lookup",
  "futures",
+ "futures-channel",
  "gtk",
  "http 0.2.12",
  "image 0.25.5",
+ "ini",
  "lazy_static",
  "libc",
  "log",
@@ -5234,6 +5439,7 @@ dependencies = [
  "objc",
  "once_cell",
  "reqwest",
+ "resvg",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5265,6 +5471,7 @@ dependencies = [
  "tracing-subscriber",
  "windows-icons",
  "winreg 0.52.0",
+ "xdg",
 ]
 
 [[package]]
@@ -5681,10 +5888,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -5696,10 +5918,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.13.2"
+name = "slotmap"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smart-default"
@@ -5793,6 +6024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5838,6 +6078,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher 1.0.1",
+]
 
 [[package]]
 name = "swift-rs"
@@ -6569,6 +6819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "temp-dir"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6690,12 +6946,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "tini"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004df4c5f0805eb5f55883204a514cfa43a6d924741be29e871753a53d5565a"
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if 1.0.0",
+ "log",
+ "png",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -7028,6 +7316,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7122,6 +7419,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7137,10 +7446,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb421b350c9aff471779e262955939f565ec18b86c15364e6bdf0d662ca7c1f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "untrusted"
@@ -7183,6 +7510,33 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.1",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -8147,6 +8501,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
 name = "xdg-home"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8155,6 +8515,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yoke"

--- a/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -71,6 +71,8 @@ fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 # server
 axum = "0.6.0" # or your current version
+axum-macros = "0.5.0"
+
 
 
 dirs = "5.0.1"
@@ -115,6 +117,15 @@ windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git" }
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.1"
 base64 = "0.22.1"
+freedesktop-desktop-entry = "0.7.0"
+freedesktop-icon-lookup = "0.1.3"
+xdg = "2.5.2"
+ini = "1.3"
+resvg = "0.45.1"
+image = "0.25.5"
+futures-channel = "0.3.30"
+lazy_static = "1.5.0"
+
 
 [features]
 cudart = []

--- a/screenpipe-app-tauri/src-tauri/src/icons.rs
+++ b/screenpipe-app-tauri/src-tauri/src/icons.rs
@@ -319,34 +319,231 @@ async fn get_exe_by_appx(app_name: &str) -> Option<String> {
 }
 
 #[cfg(target_os = "linux")]
+mod linux_icon_cache {
+    use crate::AppIcon;
+    use freedesktop_desktop_entry::DesktopEntry;
+    use gtk::glib::{clone, MainContext};
+    use gtk::prelude::{DeviceExt, IconThemeExt};
+    use image::codecs::png::PngEncoder;
+    use image::{
+        ColorType, DynamicImage, ExtendedColorType, ImageEncoder, ImageFormat, ImageReader,
+    };
+    use ini::configparser::ini::Ini;
+    use lazy_static::lazy_static;
+    use log::{error, info};
+    use resvg::tiny_skia::PixmapMut;
+    use resvg::{tiny_skia, usvg};
+    use std::collections::HashMap;
+    use std::io::Cursor;
+    use std::path::{Path, PathBuf};
+    use std::{env, fs};
+    use xdg::BaseDirectories;
+
+    pub struct IconCache {
+        map: HashMap<String, String>,
+    }
+
+    lazy_static! {
+        static ref ICON_CACHE: IconCache = IconCache::new();
+    }
+
+    impl IconCache {
+        pub fn new() -> Self {
+            let map = Self::load_icons();
+            Self { map }
+        }
+
+        fn load_icons() -> HashMap<String, String> {
+            let mut map = HashMap::new();
+
+            let xdg_data_dirs =
+                env::var("XDG_DATA_DIRS").unwrap_or_else(|_| "/usr/share".to_string());
+            let app_directories: Vec<PathBuf> = xdg_data_dirs
+                .split(':')
+                .map(|dir| Path::new(dir).join("applications"))
+                .collect();
+
+            let mut search_paths = vec![
+                Path::new("/usr/share/applications").to_path_buf(),
+                Path::new("/usr/local/share/applications").to_path_buf(),
+            ];
+
+            if let Ok(base_dirs) = BaseDirectories::new() {
+                if let Some(config_directory) = base_dirs.find_config_file("") {
+                    search_paths.push(config_directory);
+                }
+            }
+
+            search_paths.extend(app_directories);
+
+            let local = env::var("LANG").unwrap_or_else(|_| "".to_string());
+            let fallback_locale = "en_US"; // Fallback locale
+            let locales = if local.is_empty() {
+                vec![fallback_locale]
+            } else {
+                vec![local.as_str(), fallback_locale]
+            };
+
+            for search_path in &search_paths {
+                if let Ok(entries) = fs::read_dir(search_path) {
+                    for entry in entries.flatten() {
+                        if let Some(file_name) = entry.file_name().to_str() {
+                            if file_name.ends_with(".desktop") {
+                                if let Ok(desktop_entry) =
+                                    DesktopEntry::from_path::<&str>(&entry.path(), None)
+                                {
+                                    if let Some(icon) = desktop_entry.icon() {
+                                        let desktop_entry_name =
+                                            file_name.trim_end_matches(".desktop");
+                                        if let Some(app_name) = desktop_entry.name(&locales) {
+                                            map.insert(app_name.to_lowercase(), icon.to_string());
+                                        }
+                                        map.insert(
+                                            desktop_entry_name.to_string(),
+                                            icon.to_string(),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            map
+        }
+
+        pub async fn get_app_icon(&self, app_name: &str) -> Result<Option<AppIcon>, String> {
+            if let Some(icon) = self.map.get(app_name) {
+                let icon_path = if Path::new(&icon).exists() {
+                    icon.to_string()
+                } else {
+                    self.get_icon_path_from_name(&icon)
+                        .await
+                        .unwrap_or_default()
+                };
+                return self.load_icon_from_path(icon_path.as_str());
+            }
+
+            // If icon isn't in the map, try loading the icon path
+            if let icon_path = self.get_icon_path_from_name(app_name).await? {
+                return self.load_icon_from_path(&icon_path);
+            }
+
+            Err(format!("Icon for App '{}' not found", app_name))
+        }
+
+        async fn get_icon_path_from_name(&self, icon_name: &str) -> Result<String, String> {
+            let main_context = MainContext::default();
+            let (sender, receiver) = futures_channel::oneshot::channel();
+            {
+                let icon_name = icon_name.to_string();
+
+                MainContext::default().invoke(clone!(@strong icon_name => move || {
+                    let result = gtk::IconTheme::default()
+                        .and_then(|icon_theme| {
+                            icon_theme
+                                .lookup_icon(&icon_name, 64, gtk::IconLookupFlags::empty())
+                                .and_then(|info| info.filename())
+                                .map(|p| p.to_string_lossy().into_owned())
+                        });
+
+                    if result.is_some() {
+                        info!("Icon path found for '{}'", icon_name);
+                    } else {
+                        error!("No icon found for '{}'", icon_name);
+                    }
+
+                    let _ = sender.send(result);
+                }));
+            }
+
+            match receiver.await {
+                Ok(Some(path)) => Ok(path),
+                Ok(None) => {
+                    error!("Could not find icon path for '{}'", icon_name);
+                    Err(format!("Could not find icon path for '{}'", icon_name))
+                }
+                Err(e) => {
+                    error!("Failed to receive icon path: {}", e);
+                    Err("Failed to receive icon path from main context".to_string())
+                }
+            }
+        }
+
+        fn load_icon_from_path(&self, path: &str) -> Result<Option<AppIcon>, String> {
+            let path = Path::new(path);
+            if path.extension().map(|e| e == "svg").unwrap_or(false) {
+                return self.convert_svg_to_jpeg(path);
+            }
+            // Load PNG/JPEG or other formats directly
+            self.load_image(path)
+        }
+
+        fn load_image(&self, path: &Path) -> Result<Option<AppIcon>, String> {
+            let data = fs::read(path).map_err(|e| format!("Failed to read icon file: {}", e))?;
+            Ok(Some(AppIcon {
+                data,
+                path: Some(path.to_string_lossy().into_owned()),
+            }))
+        }
+
+        fn convert_svg_to_jpeg(&self, svg_path: &Path) -> Result<Option<AppIcon>, String> {
+            // Load SVG file
+            let svg_data = std::fs::read(svg_path).map_err(|e| e.to_string())?;
+
+            // Parse the SVG using usvg
+            let options = usvg::Options::default();
+            let svg_tree = resvg::usvg::Tree::from_data(&svg_data, &options)
+                .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+
+            let svg_size = svg_tree.size();
+            let width = svg_size.width() as u32;
+            let height = svg_size.height() as u32;
+
+            // Create a rendering context with the intrinsic dimensions
+            let mut pixmap =
+                tiny_skia::Pixmap::new(width, height).ok_or("Failed to create pixmap")?;
+
+            // Apply the rendering and transformation
+            resvg::render(
+                &svg_tree,
+                tiny_skia::Transform::default(),
+                &mut pixmap.as_mut(),
+            );
+
+            // Convert image to JPEG format
+            let mut cursor = Cursor::new(Vec::new());
+            let encoder = PngEncoder::new(&mut cursor);
+            encoder
+                .write_image(
+                    &pixmap.data(),
+                    pixmap.width(),
+                    pixmap.height(),
+                    ExtendedColorType::Rgba8,
+                )
+                .map_err(|e| e.to_string())?;
+
+            // Return the icon as a vector of bytes
+            Ok(Some(AppIcon {
+                data: cursor.into_inner(),
+                path: svg_path.to_str().map(|s| s.to_string()),
+            }))
+        }
+    }
+
+    pub async fn get_app_icon(
+        app_name: &str,
+        app_path: Option<String>,
+    ) -> Result<Option<AppIcon>, String> {
+        ICON_CACHE.get_app_icon(app_name).await
+    }
+}
+
+#[cfg(target_os = "linux")]
 pub async fn get_app_icon(
     app_name: &str,
     app_path: Option<String>,
 ) -> Result<Option<AppIcon>, String> {
-    use gtk::prelude::IconThemeExt;
-    use std::fs;
-
-    if gtk::init().is_err() {
-        return Err("failed to initialize GTK".to_string());
-    }
-
-    fn find_icon_path(app_name: &str) -> Option<String> {
-        let icon_theme = gtk::IconTheme::default().unwrap();
-        let icon_info = icon_theme.lookup_icon(app_name, 64, gtk::IconLookupFlags::empty())?;
-        icon_info
-            .filename()
-            .map(|s| s.to_string_lossy().into_owned())
-    }
-
-    let path = match app_path {
-        Some(p) => p,
-        None => find_icon_path(app_name).ok_or_else(|| "could not find icon path".to_string())?,
-    };
-
-    let data = fs::read(&path).map_err(|e| e.to_string())?;
-
-    Ok(Some(AppIcon {
-        data,
-        path: Some(path),
-    }))
+    linux_icon_cache::get_app_icon(app_name.to_lowercase().as_str(), app_path).await
 }


### PR DESCRIPTION
This commit addresses issues with fetching app icons on Linux:

- Ensures GTK functions are called from the main thread to avoid errors.
- Extends icon lookup to multiple locations to find more icons


---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

This PR improves app icon fetching on Linux by addressing two main issues:

Thread Safety: GTK icon lookup functions must be called from the main UI thread. This PR ensures those calls are made correctly, preventing errors caused by calling them from background threads.

Expanded Icon Lookup: The icon search logic is extended to include additional locations, improving the chances of finding the correct icon. However, the lookup is still not 100% reliable—some icons may still be missed.

brief description of the changes in this pr.


related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).
![image](https://github.com/user-attachments/assets/4ee42cd3-76c1-4a52-b3ef-0674f9f91666)

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
