### PR TITLE
fix: arbitrary file access during archive extraction zipslip on index

### DIFF
--- a/screenpipe-js/cli/dist/index.js
+++ b/screenpipe-js/cli/dist/index.js
@@ -1455,7 +1455,13 @@ async function extractTarball(buffer, tempDir, targetSubdir) {
         extractedDirName = parts[0];
       }
       if (header.name.includes(`/${targetSubdir}/`) || header.name.endsWith(`/${targetSubdir}`)) {
-        const filePath = path3.join(tempDir, header.name);
+        const resolvedPath = path3.resolve(tempDir, header.name);
+        if (!resolvedPath.startsWith(tempDir)) {
+          console.warn(`Skipping potentially unsafe path: ${header.name}`);
+          stream.resume();
+          return next();
+        }
+        const filePath = resolvedPath;
         if (header.type === "directory") {
           await fs4.ensureDir(filePath);
           stream.resume();


### PR DESCRIPTION
/bounty 500
---
name: Fix arbitrary file access during archive extraction zipslip on index
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## Description

Fix the issue need to validate the `header.name` field before using it to construct file paths. Specifically, we should ensure that the path does not contain directory traversal elements (`..`) and is confined to the intended directory (`tempDir`). This can be achieved by checking if the resolved path starts with the `tempDir` prefix after normalization.

**Steps to fix:**
1. Add a validation step for `header.name` before constructing `filePath`.
2. Use `path.resolve` to normalize the constructed path and ensure it remains within `tempDir`.
3. Skip processing the entry if the validation fails, logging a warning for debugging purposes.

**Required changes:**
- Modify the `extractTarball` function to include path validation logic.
- Ensure that only safe paths are used for file system operations.

[Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability)

---


if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
