### PR TITLE
Update mcp-server.mdx

### DIFF
--- a/content/docs-mintlify-mig-tmp/mcp-server.mdx
+++ b/content/docs-mintlify-mig-tmp/mcp-server.mdx
@@ -181,7 +181,7 @@ That's it\! Now Cursor IDE should recognize and use the Screenpipe MCP server.
 ## Mintlify MCP (use our docs in Cursor, Claude, etc.)
 
 ```shellscript
-npx mintlify/mcp add mediar-ai
+npx mint-mcp add mediar-ai
 ```
 
 ## Important Note


### PR DESCRIPTION
fix the wrong command for mcp server generation

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: 'docs'
assignees: ''

---

## description

the `npx mintlify/mcp add mediar-ai` command is wrong and doesn't resolve to anything

## how to test

1. run `npx mintlify/mcp add mediar-ai` and get an error
2. run `npx mint-mcp add mediar-ai` and see it execute correctly
