### PR TITLE
Update CONTRIBUTING for Tauri setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ app.py
 *.py3z
 __pycache__/
 
+screenpipe-audio/onnxruntime-win-x64-gpu-1.19.2.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,12 @@ before you begin:
    Write-Host "vcruntime140.dll copied successfully!"
    ```
 
-8. **build**:
+8. **setup tauri before build**
+   ```bunx tauri signer generate -w /Users/{CHANGE_TO_YOUR_USERNAME}/.tauri/myapp.key
+   $env:TAURI_SIGNING_PRIVATE_KEY="$HOME\.tauri\myapp.key"
+   $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD="{ADD_YOUR_PASSWORD_DURING_SETUP_TAURI}"
+
+9. **build**:
    ```powershell
    cd screenpipe
    cargo build --release

--- a/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -5409,7 +5409,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screenpipe-app"
-version = "0.44.3"
+version = "0.44.4"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION

---
name: Update CONTRIBUTING for Tauri setup
about: Updated CONTRIBUTING.md with Tauri signing key setup instructions and incremented build step number. Cargo.lock updated for screenpipe-app version bump. Added onnxruntime-win-x64-gpu-1.19.2.zip to .gitignore. 
title: "Update .gitignore and CONTRIBUTING for Tauri setup"
labels: 'setup, doc enhancement'
assignees: ''

---

## description

Updated CONTRIBUTING.md with Tauri signing key setup instructions and incremented build step number. Cargo.lock updated for screenpipe-app version bump. Added onnxruntime-win-x64-gpu-1.19.2.zip to .gitignore. 

related issue: Current build step for windows not including tauri setup. Get @louis030195 support from Discord and hence adding this.

## how to test

it's only a docs enhancement hence no test is needed.
