### PR TITLE
fix: server-side request forgery in the `fetchOpenAIModels` 

### DIFF
--- a/pipes/search/src/components/ai-presets-dialog.tsx
+++ b/pipes/search/src/components/ai-presets-dialog.tsx
@@ -52,6 +52,29 @@ import {
 import { Textarea } from "./ui/textarea";
 import { Slider } from "./ui/slider";
 
+
+// Allow-list of trusted hostnames for AI providers
+const ALLOWED_HOSTNAMES = [
+  "api.openai.com",
+  // Add other trusted hostnames here as needed
+];
+
+// Helper to check if a URL is allowed
+function isAllowedBaseUrl(urlString: string): boolean {
+  try {
+    const url = new URL(urlString);
+    // Only allow https
+    if (url.protocol !== "https:") return false;
+    // Only allow hostnames in the allow-list
+    if (ALLOWED_HOSTNAMES.includes(url.hostname)) return true;
+    // Optionally, allow custom providers by further validation here
+    // For now, disallow all others
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export const Icons = {
 	openai: (props: any) => (
 		<svg
@@ -209,6 +232,9 @@ export function AIProviderConfig({
 	const fetchOpenAIModels = async (baseUrl: string, apiKey: string) => {
 		setIsLoadingModels(true);
 		try {
+			if (!isAllowedBaseUrl(baseUrl)) {
+				throw new Error("Invalid or untrusted base URL for model provider.");
+			}
 			const response = await fetch(`${baseUrl}/models`, {
 				headers: {
 					Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
https://github.com/mediar-ai/screenpipe/blob/c2a5a00107c85569dc383e4f29a4106434688309/pipes/search/src/components/ai-presets-dialog.tsx#L212-L217


Directly incorporating user input in the URL of an outgoing HTTP request can enable a request forgery attack, in which the request is altered to target an unintended API endpoint or resource. If the server performing the request is connected to an internal network, this can give an attacker the means to bypass the network boundary and make requests against internal services. A forged request may perform an unintended action on behalf of the attacker, or cause information leak if redirected to an external server or if the request response is fed back to the user. It may also compromise the server making the request, if the request response is handled in an unsafe way.


fix this SSRF risk, we should restrict the `baseUrl` used in the fetch call so that it cannot be set to arbitrary user-controlled values. The best approach is to maintain an allow-list of permitted base URLs (or at least permitted hostnames), and only allow fetches to those URLs. If custom URLs must be supported, we should validate that the URL is well-formed, uses HTTPS, and does not point to internal or private IP addresses or hostnames. For this code, the most robust fix is to check the `baseUrl` against a list of allowed domains (e.g., `api.openai.com` for OpenAI, or any other trusted providers), and reject or ignore any other values. If custom providers are allowed, we should at least validate that the URL is HTTPS and not a localhost or private address.

The changes should be made in `pipes/search/src/components/ai-presets-dialog.tsx`, specifically in the `fetchOpenAIModels` function, before making the fetch call. We can add a helper function to validate the `baseUrl`, and only proceed with the fetch if the URL passes validation. If not, we can set an error or show a message.