### PR TITLE
clarify 15 GB/month

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ https://github.com/user-attachments/assets/973ee8e5-5240-4d36-83fe-d38c53efe6a9
 
 # how it works?
 
-- we record everything 24/7, 100% locally, uses 10% CPU, 4 GB ram, 15 gb/m
+- we record everything 24/7, 100% locally, uses 10% CPU, 4 GB ram, 15 GB/month
 - we index it into an api
 - dev build ai apps w user's full context, desktop native, nextjs, publish, monetize
 


### PR DESCRIPTION
---
name: clarify 15 GB/month
about: clarify 15 GB/month
title: "[pr] "
labels: ''
assignees: ''
---

## description

I had not submitted a PR to a project in a while, so I figured I'd go through the motions for practice. Feel free to reject or patch yourself!

From the contents of issue 1974:

> The README mentions that this is 15 gb/m. Per month seems too low, and per minute seems way too high. Maybe I don't realized how much media is discarded after processing? Either way, it might be nice to clarity this.

> (While you're at it, GB vs Gb/Gbit might be nice to clarity, although the casual nature of 15 gb/m would be lost 🙁)

related issue: #
https://github.com/mediar-ai/screenpipe/issues/1974

## how to test
n/a