### PR TITLE
Fix typo in installation instructions for git-lfs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ before you begin:
 1. **install dependencies**:
    ```bash
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-   brew install pkg-config ffmpeg jq cmake wget git-ls
+   brew install pkg-config ffmpeg jq cmake wget git-lfs
    ```
    Install Xcode via App Store (or elsewhere) and initialize. Xcode command line tools only installation is insufficent. 
    ```


### PR DESCRIPTION
Took me a bit to figure this one out.

---
name: Fix typo in installation instructions for git-lfs
about: In the "built it from source" instructions, `brew install git-ls` was listed, but there is no such package. It became obvious when cloning the repo, which failed.
title: "[pr] Fix typo in installation instructions for git-lfs"
labels: ''
assignees: ''

---

## description

Improved the docs by fixing a typo.

## how to test

I ran `git clone https://github.com/mediar-ai/screenpipe`, it failed before but worked after the change.