### PR TITLE
feat: add custom host/port settings for remote screenpipe instances

### DIFF
--- a/screenpipe-app-tauri/components/breaking-changes-instructions-dialog.tsx
+++ b/screenpipe-app-tauri/components/breaking-changes-instructions-dialog.tsx
@@ -11,9 +11,11 @@ import { Trash2, Loader2 } from "lucide-react";
 import localforage from "localforage";
 import { useToast } from "@/components/ui/use-toast";
 import { Command } from "@tauri-apps/plugin-shell";
+import { useApiUrl } from "@/lib/hooks/use-api-url";
 
 export function BreakingChangesInstructionsDialog() {
   const { toast } = useToast();
+  const { baseUrl } = useApiUrl();
   const [open, setOpen] = useState(false);
   const [hasShownDialog, setHasShownDialog] = useState(false);
   const [hasPipes, setHasPipes] = useState(false);
@@ -25,7 +27,7 @@ export function BreakingChangesInstructionsDialog() {
       setHasShownDialog(!!shown);
 
       try {
-        const response = await fetch("http://localhost:3030/pipes/list");
+        const response = await fetch(`${baseUrl}/pipes/list`);
         const data = await response.json();
         setHasPipes(data.data.length > 0);
       } catch (error) {
@@ -33,7 +35,7 @@ export function BreakingChangesInstructionsDialog() {
       }
     };
     init();
-  }, []);
+  }, [baseUrl]);
 
   useEffect(() => {
     if (!hasShownDialog && hasPipes) {
@@ -45,7 +47,7 @@ export function BreakingChangesInstructionsDialog() {
   const handleResetAllPipes = async () => {
     setIsDeleting(true);
     try {
-      const response = await fetch(`http://localhost:3030/pipes/purge`, {
+      const response = await fetch(`${baseUrl}/pipes/purge`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/screenpipe-app-tauri/components/onboarding/pipe-store.tsx
+++ b/screenpipe-app-tauri/components/onboarding/pipe-store.tsx
@@ -7,6 +7,7 @@ import { invoke } from "@tauri-apps/api/core";
 import posthog from "posthog-js";
 import { PipeApi } from "@/lib/api/store";
 import { useSettings } from "@/lib/hooks/use-settings";
+import { useApiUrl } from "@/lib/hooks/use-api-url";
 
 interface OnboardingPipeStoreProps {
   className?: string;
@@ -22,6 +23,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
   const [isLoading, setIsLoading] = React.useState(false);
   const [status, setStatus] = React.useState<string>("");
   const { settings } = useSettings();
+  const { baseUrl } = useApiUrl();
   const handleOpenSearchPipe = async () => {
     setIsLoading(true);
     try {
@@ -36,7 +38,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
 
       // Check if screenpipe is running, if not spawn it
       try {
-        await fetch("http://localhost:3030/health");
+        await fetch(`${baseUrl}/health`);
       } catch (error) {
         // Screenpipe not running, try to spawn it
         await invoke("stop_screenpipe");
@@ -46,7 +48,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
       }
 
       // First check if pipe is installed by listing pipes
-      const listResponse = await fetch("http://localhost:3030/pipes/list");
+      const listResponse = await fetch(`${baseUrl}/pipes/list`);
       const listData = await listResponse.json();
       const searchPipe = listData.data.find(
         (p: any) => p.config?.id === "search"
@@ -61,7 +63,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
           storePlugins.find((p) => p.name === "search")?.id!
         );
 
-        await fetch("http://localhost:3030/pipes/download-private", {
+        await fetch(`${baseUrl}/pipes/download-private`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -79,7 +81,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
 
       // Enable the search pipe
       setStatus("enabling search pipe... (~10s)");
-      await fetch("http://localhost:3030/pipes/enable", {
+      await fetch(`${baseUrl}/pipes/enable`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -92,7 +94,7 @@ const OnboardingPipeStore: React.FC<OnboardingPipeStoreProps> = ({
       await new Promise((resolve) => setTimeout(resolve, 2000));
 
       // Get updated pipe info to find the port
-      const response = await fetch("http://localhost:3030/pipes/list");
+      const response = await fetch(`${baseUrl}/pipes/list`);
       const data = await response.json();
       const updatedSearchPipe = data.data.find(
         (p: any) => p.config?.id === "search"

--- a/screenpipe-app-tauri/components/onboarding/status.tsx
+++ b/screenpipe-app-tauri/components/onboarding/status.tsx
@@ -11,6 +11,7 @@ import {
   TooltipContent,
 } from "../ui/tooltip";
 import { useSettings } from "@/lib/hooks/use-settings";
+import { useApiUrl } from "@/lib/hooks/use-api-url";
 import { Label } from "../ui/label";
 import { LogFileButton } from "../log-file-button";
 import { Separator } from "../ui/separator";
@@ -38,6 +39,7 @@ const OnboardingStatus: React.FC<OnboardingStatusProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [useChineseMirror, setUseChineseMirror] = useState(false);
   const { updateSettings } = useSettings();
+  const { baseUrl } = useApiUrl();
   const { isMac: isMacOS } = usePlatform();
   const [stats, setStats] = useState<{
     screenshots: number;
@@ -51,7 +53,7 @@ const OnboardingStatus: React.FC<OnboardingStatusProps> = ({
     const fetchStats = async () => {
       try {
         const screenshotsResponse = await fetch(
-          "http://localhost:3030/raw_sql",
+          `${baseUrl}/raw_sql`,
           {
             method: "POST",
             headers: {
@@ -64,7 +66,7 @@ const OnboardingStatus: React.FC<OnboardingStatusProps> = ({
         );
         const screenshotsResult = await screenshotsResponse.json();
 
-        const audioResponse = await fetch("http://localhost:3030/raw_sql", {
+        const audioResponse = await fetch(`${baseUrl}/raw_sql`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -98,7 +100,7 @@ const OnboardingStatus: React.FC<OnboardingStatusProps> = ({
 
     // cleanup interval on unmount
     return () => clearInterval(interval);
-  }, []);
+  }, [baseUrl]);
 
   // Add effect for streaming screenshots when recording starts
   useEffect(() => {

--- a/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/screenpipe-app-tauri/components/pipe-store.tsx
@@ -26,6 +26,7 @@ import { PipeDetails } from "./pipe-store/pipe-details";
 import { PipeCard } from "./pipe-store/pipe-card";
 import { AddPipeForm } from "./pipe-store/add-pipe-form";
 import { useSettings } from "@/lib/hooks/use-settings";
+import { useApiUrl } from "@/lib/hooks/use-api-url";
 import posthog from "posthog-js";
 import { Progress } from "./ui/progress";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -64,6 +65,7 @@ const corePipes: string[] = [];
 
 export const PipeStore: React.FC = () => {
   const { health } = useHealthCheck();
+  const { baseUrl } = useApiUrl();
   const [selectedPipe, setSelectedPipe] = useState<PipeWithStatus | null>(null);
   const { settings, updateSettings } = useSettings();
   const [pipes, setPipes] = useState<PipeWithStatus[]>([]);
@@ -284,7 +286,7 @@ export const PipeStore: React.FC = () => {
         });
       }, 500);
 
-      const response = await fetch("http://localhost:3030/pipes/download", {
+      const response = await fetch(`${baseUrl}/pipes/download`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -356,7 +358,7 @@ export const PipeStore: React.FC = () => {
       const response = await pipeApi.downloadPipe(pipe.id);
 
       const downloadResponse = await fetch(
-        "http://localhost:3030/pipes/download-private",
+        `${baseUrl}/pipes/download-private`,
         {
           method: "POST",
           headers: {
@@ -426,7 +428,7 @@ export const PipeStore: React.FC = () => {
   const fetchInstalledPipes = async () => {
     if (!health || health?.status === "error") return;
     try {
-      const response = await fetch("http://localhost:3030/pipes/list");
+      const response = await fetch(`${baseUrl}/pipes/list`);
       const data = (await response.json()) as {
         data: InstalledPipe[];
         success: boolean;
@@ -472,7 +474,7 @@ export const PipeStore: React.FC = () => {
         duration: 100000,
       });
 
-      const response = await fetch(`http://localhost:3030/pipes/purge`, {
+      const response = await fetch(`${baseUrl}/pipes/purge`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
@@ -647,7 +649,7 @@ export const PipeStore: React.FC = () => {
       console.log("toggel", pipe, endpoint);
 
       const id = pipe.is_local ? pipe.id : pipe.name;
-      const response = await fetch(`http://localhost:3030/pipes/${endpoint}`, {
+      const response = await fetch(`${baseUrl}/pipes/${endpoint}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -724,7 +726,7 @@ export const PipeStore: React.FC = () => {
     if (selectedPipe) {
       try {
         const id = selectedPipe.is_local ? selectedPipe.id : selectedPipe.name;
-        const response = await fetch("http://localhost:3030/pipes/update", {
+        const response = await fetch(`${baseUrl}/pipes/update`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -772,7 +774,7 @@ export const PipeStore: React.FC = () => {
       setSelectedPipe(null);
 
       const id = pipe.is_local ? pipe.id : pipe.name;
-      const response = await fetch("http://localhost:3030/pipes/delete", {
+      const response = await fetch(`${baseUrl}/pipes/delete`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -811,7 +813,7 @@ export const PipeStore: React.FC = () => {
         description: "please wait...",
       });
 
-      const response = await fetch(`http://localhost:3030/pipes/download`, {
+      const response = await fetch(`${baseUrl}/pipes/download`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -928,7 +930,7 @@ export const PipeStore: React.FC = () => {
       }
 
       const response = await fetch(
-        `http://localhost:3030/pipes/update-version`,
+        `${baseUrl}/pipes/update-version`,
         {
           method: "POST",
           headers: {

--- a/screenpipe-app-tauri/components/pipe-store/pipe-card.tsx
+++ b/screenpipe-app-tauri/components/pipe-store/pipe-card.tsx
@@ -16,6 +16,7 @@ import { toast } from "@/components/ui/use-toast";
 import { motion } from "framer-motion";
 import posthog from "posthog-js";
 import { useSettings } from "@/lib/hooks/use-settings";
+import { useApiUrl } from "@/lib/hooks/use-api-url";
 import {
   Tooltip,
   TooltipContent,
@@ -90,6 +91,7 @@ export const PipeCard: React.FC<PipeCardProps> = ({
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const { settings } = useSettings();
+  const { baseUrl } = useApiUrl();
 
   const handleOpenWindow = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -115,7 +117,7 @@ export const PipeCard: React.FC<PipeCardProps> = ({
       const id = pipe.is_local ? pipe.id : pipe.name;
       try {
         const response = await fetch(
-          `http://localhost:3030/pipes/build-status/${id}`
+          `${baseUrl}/pipes/build-status/${id}`
         );
 
         if (!response.ok) {

--- a/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 
 export default function GeneralSettings() {
   const { settings, updateSettings } = useSettings();
@@ -46,6 +48,41 @@ export default function GeneralSettings() {
               handleSettingsChange({ autoUpdatePipes: checked })
             }
           />
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <h4 className="font-medium">screenpipe server</h4>
+            <p className="text-sm text-muted-foreground">
+              configure the host and port for connecting to a screenpipe instance
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="screenpipe-host">host</Label>
+              <Input
+                id="screenpipe-host"
+                type="text"
+                value={settings.screenpipeHost}
+                onChange={(e) =>
+                  handleSettingsChange({ screenpipeHost: e.target.value })
+                }
+                placeholder="localhost"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="screenpipe-port">port</Label>
+              <Input
+                id="screenpipe-port"
+                type="number"
+                value={settings.port}
+                onChange={(e) =>
+                  handleSettingsChange({ port: parseInt(e.target.value) || 3030 })
+                }
+                placeholder="3030"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/screenpipe-app-tauri/components/share-logs-button.tsx
+++ b/screenpipe-app-tauri/components/share-logs-button.tsx
@@ -19,6 +19,7 @@ import {
   TooltipProvider,
 } from "./ui/tooltip";
 import { useHealthCheck } from "@/lib/hooks/use-health-check";
+import { useApiUrl } from "@/lib/hooks/use-api-url";
 
 interface LogFile {
   name: string;
@@ -89,6 +90,7 @@ export const ShareLogsButton = ({
   const [screenshot, setScreenshot] = useState<string | null>(null);
   const [mergedVideoPath, setMergedVideoPath] = useState<string | null>(null);
   const { health } = useHealthCheck();
+  const { baseUrl } = useApiUrl();
 
   useEffect(() => {
     const loadMachineId = async () => {
@@ -116,7 +118,7 @@ export const ShareLogsButton = ({
     setIsLoadingVideo(true);
     try {
       // Fetch last video chunks
-      const response = await fetch("http://localhost:3030/raw_sql", {
+      const response = await fetch(`${baseUrl}/raw_sql`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -133,7 +135,7 @@ export const ShareLogsButton = ({
 
       // Merge frames
       const mergeResponse = await fetch(
-        "http://localhost:3030/experimental/frames/merge",
+        `${baseUrl}/experimental/frames/merge`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/screenpipe-app-tauri/lib/hooks/use-api-url.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-api-url.tsx
@@ -1,0 +1,12 @@
+import { useSettings } from "./use-settings";
+
+export function useApiUrl() {
+	const { settings } = useSettings();
+	const host = settings.screenpipeHost || "localhost";
+	const port = settings.port || 3030;
+
+	return {
+		baseUrl: `http://${host}:${port}`,
+		wsUrl: `ws://${host}:${port}`,
+	};
+}

--- a/screenpipe-app-tauri/lib/hooks/use-health-check.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-health-check.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { debounce } from "lodash";
+import { useApiUrl } from "./use-api-url";
 
 interface HealthCheckResponse {
   status: string;
@@ -42,6 +43,7 @@ interface HealthCheckHook {
 }
 
 export function useHealthCheck() {
+  const { wsUrl } = useApiUrl();
   const [health, setHealth] = useState<HealthCheckResponse | null>(null);
   const [isServerDown, setIsServerDown] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -56,7 +58,7 @@ export function useHealthCheck() {
       wsRef.current.close();
     }
 
-    const ws = new WebSocket("ws://127.0.0.1:3030/ws/health");
+    const ws = new WebSocket(`${wsUrl}/ws/health`);
     wsRef.current = ws;
 
     ws.onopen = () => {
@@ -123,7 +125,7 @@ export function useHealthCheck() {
         retryIntervalRef.current = setInterval(fetchHealth, 2000);
       }
     };
-  }, []);
+  }, [wsUrl]);
 
   const debouncedFetchHealth = useCallback(() => {
     return new Promise<void>((resolve) => {

--- a/screenpipe-app-tauri/lib/hooks/use-pipes.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-pipes.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useApiUrl } from "./use-api-url";
 
 export type Pipe = {
   enabled: boolean;
@@ -138,6 +139,7 @@ const fetchPipeConfig = async (
 };
 
 export const usePipes = (initialRepoUrls: string[]) => {
+  const { baseUrl } = useApiUrl();
   const [pipes, setPipes] = useState<Pipe[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -287,7 +289,7 @@ export const usePipes = (initialRepoUrls: string[]) => {
       }
 
       // get pipes from local api /pipes/list and add them to the list
-      const localPipes = await fetch(`http://localhost:3030/pipes/list`).then(
+      const localPipes = await fetch(`${baseUrl}/pipes/list`).then(
         (res) => res.json()
       );
       // console.log("localPipes", localPipes);
@@ -305,7 +307,7 @@ export const usePipes = (initialRepoUrls: string[]) => {
     return () => {
       isMounted = false;
     };
-  }, [repoUrls]);
+  }, [repoUrls, baseUrl]);
 
   const addCustomPipe = async (newRepoUrl: string) => {
     setError(null);

--- a/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -98,6 +98,7 @@ export type Settings = {
 	usePiiRemoval: boolean;
 	restartInterval: number;
 	port: number;
+	screenpipeHost: string;
 	dataDir: string;
 	disableAudio: boolean;
 	ignoredWindows: string[];
@@ -164,6 +165,7 @@ const DEFAULT_SETTINGS: Settings = {
 	usePiiRemoval: false,
 	restartInterval: 0,
 	port: 3030,
+	screenpipeHost: "localhost",
 	dataDir: "default",
 	disableAudio: false,
 	ignoredWindows: [],

--- a/screenpipe-app-tauri/lib/hooks/use-sql-autocomplete.tsx
+++ b/screenpipe-app-tauri/lib/hooks/use-sql-autocomplete.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useApiUrl } from "./use-api-url";
 
 interface AutocompleteItem {
   name: string;
@@ -11,6 +12,7 @@ const cache: Record<string, { data: AutocompleteItem[]; timestamp: number }> =
   {};
 
 export function useSqlAutocomplete(type: "app" | "window") {
+  const { baseUrl } = useApiUrl();
   const [items, setItems] = useState<AutocompleteItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -32,7 +34,7 @@ export function useSqlAutocomplete(type: "app" | "window") {
           ORDER BY count DESC
           LIMIT 100
         `;
-        const response = await fetch("http://localhost:3030/raw_sql", {
+        const response = await fetch(`${baseUrl}/raw_sql`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -51,7 +53,7 @@ export function useSqlAutocomplete(type: "app" | "window") {
     } finally {
       setIsLoading(false);
     }
-  }, [type]);
+  }, [type, baseUrl]);
 
   useEffect(() => {
     fetchItems();


### PR DESCRIPTION
## Summary

Adds the ability to configure a custom host and port for connecting to remote screenpipe instances, as requested in #775.

### Changes
- Add `screenpipeHost` field to Settings type (defaults to "localhost")
- Create `useApiUrl()` hook that returns the configured HTTP and WebSocket base URLs
- Add host/port input fields in General Settings UI
- Replace all hardcoded `localhost:3030` URLs in the frontend with the dynamic URL from settings

### Files Modified
- `lib/hooks/use-settings.tsx` - Added `screenpipeHost` to Settings type and defaults
- `lib/hooks/use-api-url.tsx` - **New file** - Hook to get configured API URLs
- `components/settings/general-settings.tsx` - Added host/port input UI
- `components/pipe-store.tsx` - Updated 9 hardcoded URLs
- `components/share-logs-button.tsx` - Updated 2 hardcoded URLs
- `components/pipe-store/pipe-card.tsx` - Updated 1 hardcoded URL
- `components/onboarding/pipe-store.tsx` - Updated 5 hardcoded URLs
- `components/onboarding/status.tsx` - Updated 2 hardcoded URLs
- `components/breaking-changes-instructions-dialog.tsx` - Updated 2 hardcoded URLs
- `lib/hooks/use-health-check.tsx` - Updated WebSocket URL
- `lib/hooks/use-pipes.tsx` - Updated 1 hardcoded URL
- `lib/hooks/use-sql-autocomplete.tsx` - Updated 1 hardcoded URL

### Out of Scope
- Rust backend files in `src-tauri/` (the backend already reads port from store correctly)
- Pipes (plugins) - they're sandboxed and have separate concerns

## Test Plan

- [ ] Change host in settings and verify API calls use the new host
- [ ] Change port in settings and verify API calls use the new port
- [ ] Verify WebSocket health check connects to configured host/port
- [ ] Verify default behavior unchanged (localhost:3030 by default)
- [ ] Start screenpipe on different port (e.g., 3035), change settings, verify all features work

/claim #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)