### PR TITLE
add python script to fine-tune llms on screenpipe data

### DIFF
--- a/examples/python/finetune-llm/README.md
+++ b/examples/python/finetune-llm/README.md
@@ -1,0 +1,175 @@
+# Screenpipe LLM Fine-tuning
+
+Fine-tune local LLMs (Llama, Mistral) or OpenAI models on your screenpipe data. Create a personal AI assistant trained on YOUR digital activity.
+
+## Quick Start
+
+### Export Data Only
+
+```bash
+# Export your screenpipe data to a training file
+python finetune_screenpipe.py --export-only --output my_data.jsonl
+```
+
+### Fine-tune Locally with Llama
+
+```bash
+# Install dependencies
+pip install -r requirements-local.txt
+
+# Fine-tune Llama 3.2 1B on your data
+python finetune_screenpipe.py --mode local --model unsloth/Llama-3.2-1B-Instruct
+```
+
+### Fine-tune with OpenAI
+
+```bash
+# Install dependencies
+pip install -r requirements-openai.txt
+
+# Set your API key
+export OPENAI_API_KEY="your-key-here"
+
+# Fine-tune GPT-4o-mini
+python finetune_screenpipe.py --mode openai --model gpt-4o-mini-2024-07-18
+```
+
+## Prerequisites
+
+- Python 3.10+
+- Screenpipe running with captured data (`~/.screenpipe/db.sqlite`)
+- For local training: NVIDIA GPU with 8GB+ VRAM (recommended)
+- For OpenAI: API key with fine-tuning access
+
+## Command Line Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--mode` | `export` | `local`, `openai`, or `export` |
+| `--model` | `unsloth/Llama-3.2-1B-Instruct` | Model to fine-tune |
+| `--db-path` | `~/.screenpipe/db.sqlite` | Path to screenpipe database |
+| `--output` | `screenpipe_training.jsonl` | Output training data file |
+| `--output-dir` | `./screenpipe-model` | Output directory for local model |
+| `--days` | `30` | Days of data to export |
+| `--limit` | `5000` | Max examples per source |
+| `--max-steps` | `100` | Training steps (local only) |
+| `--format` | `instruction` | `instruction` or `completion` |
+| `--export-only` | `false` | Only export, don't train |
+
+## Using Your Fine-tuned Model
+
+### With Ollama (Local Model)
+
+After local fine-tuning, convert and use with Ollama:
+
+```bash
+# 1. Convert to GGUF format (requires llama.cpp)
+python -m unsloth.save_to_gguf ./screenpipe-model screenpipe-model.gguf
+
+# 2. Create Modelfile
+cat > Modelfile << 'EOF'
+FROM ./screenpipe-model.gguf
+TEMPLATE """{{ if .System }}<|start_header_id|>system<|end_header_id|>
+{{ .System }}<|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|>
+{{ .Prompt }}<|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|>
+{{ .Response }}<|eot_id|>"""
+PARAMETER stop "<|eot_id|>"
+EOF
+
+# 3. Create Ollama model
+ollama create screenpipe-assistant -f Modelfile
+
+# 4. Test it
+ollama run screenpipe-assistant "What was I working on yesterday?"
+```
+
+### In Screenpipe Settings
+
+1. Go to Screenpipe Settings → AI
+2. For Ollama: Set model to `screenpipe-assistant`
+3. For OpenAI: Use your fine-tuned model name (e.g., `ft:gpt-4o-mini-2024-07-18:your-org::abc123`)
+
+### In Custom Pipes
+
+```typescript
+// In your pipe code
+const response = await pipe.llm({
+  model: "screenpipe-assistant", // or your OpenAI fine-tuned model
+  messages: [
+    { role: "user", content: "What meetings did I have this week?" }
+  ]
+});
+```
+
+## Data Sources
+
+The script exports three types of screenpipe data:
+
+| Source | Description | Training Use |
+|--------|-------------|--------------|
+| **OCR** | Screen captures with text | Context about apps/websites used |
+| **Audio** | Transcribed conversations | Meeting summaries, spoken context |
+| **UI** | UI element monitoring | Detailed interaction patterns |
+
+## Training Data Formats
+
+### Instruction Format (default)
+
+Creates Q&A pairs for chat-style models:
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant..."},
+    {"role": "user", "content": "What was I looking at in Chrome?"},
+    {"role": "assistant", "content": "Based on your screen capture..."}
+  ]
+}
+```
+
+### Completion Format
+
+Simple prompt/completion pairs for base models:
+
+```json
+{
+  "prompt": "Screen content from Chrome:",
+  "completion": " [extracted text content]"
+}
+```
+
+## Tips for Better Results
+
+1. **More data = better model**: Run screenpipe for at least a week before training
+2. **Increase training steps**: Use `--max-steps 500` for better quality
+3. **Filter by app**: Modify the SQL queries to focus on specific apps
+4. **Use recent data**: `--days 7` for most relevant context
+5. **GPU matters**: Local training is 10-50x faster on GPU vs CPU
+
+## Troubleshooting
+
+### "Database not found"
+
+Make sure screenpipe is running and has captured data:
+```bash
+ls -la ~/.screenpipe/db.sqlite
+```
+
+### "CUDA out of memory"
+
+Reduce batch size or use a smaller model:
+```bash
+python finetune_screenpipe.py --mode local --model unsloth/Llama-3.2-1B-Instruct
+```
+
+### OpenAI rate limits
+
+Wait and retry, or use `--limit 1000` to reduce training data size.
+
+## Privacy Note
+
+Your screenpipe data contains sensitive information about your digital activity. The training data and fine-tuned models should be treated as private. When using OpenAI, your data is sent to their servers for training.
+
+## License
+
+MIT - Same as screenpipe

--- a/examples/python/finetune-llm/finetune_screenpipe.py
+++ b/examples/python/finetune-llm/finetune_screenpipe.py
@@ -1,0 +1,559 @@
+#!/usr/bin/env python3
+"""
+Screenpipe LLM Fine-tuning Script
+
+Fine-tune local LLMs (Llama, Mistral) or OpenAI models on your screenpipe data.
+Your personal AI assistant trained on YOUR digital activity.
+
+Usage:
+    # Export data and fine-tune locally with Llama
+    python finetune_screenpipe.py --mode local --model unsloth/Llama-3.2-1B-Instruct
+
+    # Export data and fine-tune with OpenAI
+    python finetune_screenpipe.py --mode openai --model gpt-4o-mini-2024-07-18
+
+    # Just export data without training
+    python finetune_screenpipe.py --export-only --output training_data.jsonl
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Default screenpipe data directory
+DEFAULT_SCREENPIPE_DIR = Path.home() / ".screenpipe"
+DEFAULT_DB_PATH = DEFAULT_SCREENPIPE_DIR / "db.sqlite"
+
+
+def get_db_connection(db_path: Path) -> sqlite3.Connection:
+    """Connect to the screenpipe SQLite database."""
+    if not db_path.exists():
+        # Try alternative paths
+        alt_paths = [
+            DEFAULT_SCREENPIPE_DIR / "db.sqlite",
+            DEFAULT_SCREENPIPE_DIR / "screenpipe.db",
+        ]
+        for alt in alt_paths:
+            if alt.exists():
+                db_path = alt
+                break
+        else:
+            raise FileNotFoundError(
+                f"Screenpipe database not found. Tried: {db_path}, {alt_paths}\n"
+                f"Make sure screenpipe is running and has captured some data."
+            )
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def export_ocr_data(conn: sqlite3.Connection, days: int = 30, limit: int = 10000) -> list[dict]:
+    """Export OCR (screen capture) data from screenpipe."""
+    cutoff_date = datetime.now() - timedelta(days=days)
+
+    query = """
+    SELECT
+        f.timestamp,
+        ot.app_name,
+        ot.window_name,
+        ot.text as ocr_text
+    FROM frames f
+    JOIN ocr_text ot ON f.id = ot.frame_id
+    WHERE f.timestamp > ?
+    AND ot.text IS NOT NULL
+    AND length(ot.text) > 50
+    ORDER BY f.timestamp DESC
+    LIMIT ?
+    """
+
+    cursor = conn.execute(query, (cutoff_date.isoformat(), limit))
+    results = []
+
+    for row in cursor:
+        results.append({
+            "timestamp": row["timestamp"],
+            "app_name": row["app_name"] or "Unknown",
+            "window_name": row["window_name"] or "",
+            "text": row["ocr_text"],
+            "source": "screen"
+        })
+
+    return results
+
+
+def export_audio_data(conn: sqlite3.Connection, days: int = 30, limit: int = 10000) -> list[dict]:
+    """Export audio transcription data from screenpipe."""
+    cutoff_date = datetime.now() - timedelta(days=days)
+
+    query = """
+    SELECT
+        at.timestamp,
+        at.transcription,
+        at.device as device_name,
+        at.is_input_device
+    FROM audio_transcriptions at
+    WHERE at.timestamp > ?
+    AND at.transcription IS NOT NULL
+    AND length(at.transcription) > 20
+    ORDER BY at.timestamp DESC
+    LIMIT ?
+    """
+
+    cursor = conn.execute(query, (cutoff_date.isoformat(), limit))
+    results = []
+
+    for row in cursor:
+        results.append({
+            "timestamp": row["timestamp"],
+            "transcription": row["transcription"],
+            "device_name": row["device_name"] or "Unknown",
+            "is_input": bool(row["is_input_device"]),
+            "speaker": None,
+            "source": "audio"
+        })
+
+    return results
+
+
+def export_ui_data(conn: sqlite3.Connection, days: int = 30, limit: int = 5000) -> list[dict]:
+    """Export UI monitoring data from screenpipe."""
+    cutoff_date = datetime.now() - timedelta(days=days)
+
+    query = """
+    SELECT
+        timestamp,
+        text_output as text,
+        app_name,
+        window_name,
+        browser_url
+    FROM ui_monitoring
+    WHERE timestamp > ?
+    AND text_output IS NOT NULL
+    AND length(text_output) > 30
+    ORDER BY timestamp DESC
+    LIMIT ?
+    """
+
+    try:
+        cursor = conn.execute(query, (cutoff_date.isoformat(), limit))
+        results = []
+
+        for row in cursor:
+            results.append({
+                "timestamp": row["timestamp"],
+                "text": row["text"],
+                "app_name": row["app_name"],
+                "window_name": row["window_name"],
+                "browser_url": row["browser_url"],
+                "source": "ui"
+            })
+
+        return results
+    except sqlite3.OperationalError:
+        # UI monitoring table might not exist in older versions
+        return []
+
+
+def format_for_instruction_tuning(data: list[dict]) -> list[dict]:
+    """
+    Format data as instruction-following examples.
+    Creates Q&A pairs based on screen/audio context.
+    """
+    formatted = []
+
+    for item in data:
+        if item["source"] == "screen":
+            # Create contextual Q&A from screen content
+            context = f"App: {item.get('app_name', 'Unknown')}"
+            if item.get("window_name"):
+                context += f" | Window: {item['window_name']}"
+            if item.get("browser_url"):
+                context += f" | URL: {item['browser_url']}"
+
+            text = item.get("text", "")[:2000]  # Limit text length
+
+            formatted.append({
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant with knowledge about the user's digital activities."
+                    },
+                    {
+                        "role": "user",
+                        "content": f"What was I looking at in {item.get('app_name', 'this app')}?"
+                    },
+                    {
+                        "role": "assistant",
+                        "content": f"Based on your screen capture ({context}), you were viewing:\n\n{text}"
+                    }
+                ]
+            })
+
+        elif item["source"] == "audio":
+            speaker = item.get("speaker") or ("You" if item.get("is_input") else "Someone")
+            transcription = item.get("transcription", "")[:1500]
+
+            formatted.append({
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant that remembers conversations."
+                    },
+                    {
+                        "role": "user",
+                        "content": "What did I say or hear recently?"
+                    },
+                    {
+                        "role": "assistant",
+                        "content": f"{speaker} said: \"{transcription}\""
+                    }
+                ]
+            })
+
+        elif item["source"] == "ui":
+            context = f"App: {item.get('app_name', 'Unknown')}"
+            if item.get("window_name"):
+                context += f" | Window: {item['window_name']}"
+            text = item.get("text", "")[:2000]
+
+            formatted.append({
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant with knowledge about the user's UI interactions."
+                    },
+                    {
+                        "role": "user",
+                        "content": f"What UI elements were visible in {item.get('app_name', 'this app')}?"
+                    },
+                    {
+                        "role": "assistant",
+                        "content": f"Based on UI monitoring ({context}), I saw:\n\n{text}"
+                    }
+                ]
+            })
+
+    return formatted
+
+
+def format_for_completion(data: list[dict]) -> list[dict]:
+    """
+    Format data as completion examples (simpler format).
+    Good for base model fine-tuning.
+    """
+    formatted = []
+
+    for item in data:
+        if item["source"] == "screen":
+            text = item.get("text", "")[:2000]
+            app = item.get("app_name", "Unknown")
+            formatted.append({
+                "prompt": f"Screen content from {app}:",
+                "completion": f" {text}"
+            })
+
+        elif item["source"] == "audio":
+            transcription = item.get("transcription", "")[:1500]
+            formatted.append({
+                "prompt": "Audio transcription:",
+                "completion": f" {transcription}"
+            })
+
+        elif item["source"] == "ui":
+            text = item.get("text", "")[:2000]
+            app = item.get("app_name", "Unknown")
+            formatted.append({
+                "prompt": f"UI content from {app}:",
+                "completion": f" {text}"
+            })
+
+    return formatted
+
+
+def save_training_data(data: list[dict], output_path: Path):
+    """Save formatted training data to file."""
+    with open(output_path, "w", encoding="utf-8") as f:
+        for item in data:
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
+
+    print(f"saved {len(data)} training examples to {output_path}")
+
+
+def finetune_local(
+    training_file: Path,
+    model_name: str = "unsloth/Llama-3.2-1B-Instruct",
+    output_dir: str = "./screenpipe-model",
+    max_steps: int = 100,
+):
+    """Fine-tune a local model using unsloth (fast LoRA training)."""
+    try:
+        from unsloth import FastLanguageModel
+        from trl import SFTTrainer
+        from transformers import TrainingArguments
+        from datasets import load_dataset
+    except ImportError:
+        print("required packages not installed. install with:")
+        print("  pip install unsloth transformers trl datasets")
+        sys.exit(1)
+
+    print(f"loading model: {model_name}")
+
+    # Load model with 4-bit quantization for efficiency
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=model_name,
+        max_seq_length=2048,
+        dtype=None,  # Auto-detect
+        load_in_4bit=True,
+    )
+
+    # Add LoRA adapters
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=16,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj",
+                        "gate_proj", "up_proj", "down_proj"],
+        lora_alpha=16,
+        lora_dropout=0,
+        bias="none",
+        use_gradient_checkpointing="unsloth",
+        random_state=42,
+    )
+
+    # Load training data
+    dataset = load_dataset("json", data_files=str(training_file), split="train")
+
+    # Format for chat template
+    def formatting_func(examples):
+        texts = []
+        for messages in examples["messages"]:
+            text = tokenizer.apply_chat_template(messages, tokenize=False)
+            texts.append(text)
+        return {"text": texts}
+
+    dataset = dataset.map(formatting_func, batched=True)
+
+    # Training arguments
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=4,
+        warmup_steps=5,
+        max_steps=max_steps,
+        learning_rate=2e-4,
+        fp16=True,
+        logging_steps=10,
+        save_steps=50,
+        save_total_limit=2,
+    )
+
+    # Train
+    trainer = SFTTrainer(
+        model=model,
+        tokenizer=tokenizer,
+        train_dataset=dataset,
+        dataset_text_field="text",
+        max_seq_length=2048,
+        args=training_args,
+    )
+
+    print("starting training...")
+    trainer.train()
+
+    # Save the model
+    model.save_pretrained(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    print(f"\nmodel saved to {output_dir}")
+    print("\nto use with ollama:")
+    print(f"  1. convert to gguf format")
+    print(f"  2. create modelfile and run: ollama create screenpipe-model -f Modelfile")
+
+
+def finetune_openai(
+    training_file: Path,
+    model_name: str = "gpt-4o-mini-2024-07-18",
+    suffix: str = "screenpipe",
+):
+    """Fine-tune an OpenAI model."""
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print("openai package not installed. install with:")
+        print("  pip install openai")
+        sys.exit(1)
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print("error: OPENAI_API_KEY environment variable not set")
+        sys.exit(1)
+
+    client = OpenAI(api_key=api_key)
+
+    # Upload training file
+    print(f"uploading training file: {training_file}")
+    with open(training_file, "rb") as f:
+        file_response = client.files.create(file=f, purpose="fine-tune")
+
+    print(f"file uploaded: {file_response.id}")
+
+    # Create fine-tuning job
+    print(f"creating fine-tuning job for model: {model_name}")
+    job = client.fine_tuning.jobs.create(
+        training_file=file_response.id,
+        model=model_name,
+        suffix=suffix,
+    )
+
+    print(f"\nfine-tuning job created!")
+    print(f"  job id: {job.id}")
+    print(f"  status: {job.status}")
+    print(f"\nmonitor progress with:")
+    print(f"  openai api fine_tuning.jobs.retrieve -i {job.id}")
+    print(f"\nonce complete, use your model with:")
+    print(f"  model_name = '{model_name}:{suffix}'")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fine-tune LLMs on your screenpipe data",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Export data only
+  python finetune_screenpipe.py --export-only --output my_data.jsonl
+
+  # Fine-tune locally with Llama
+  python finetune_screenpipe.py --mode local --model unsloth/Llama-3.2-1B-Instruct
+
+  # Fine-tune with OpenAI (requires OPENAI_API_KEY)
+  python finetune_screenpipe.py --mode openai --model gpt-4o-mini-2024-07-18
+        """
+    )
+
+    parser.add_argument(
+        "--mode",
+        choices=["local", "openai", "export"],
+        default="export",
+        help="Fine-tuning mode: local (unsloth), openai, or export only"
+    )
+    parser.add_argument(
+        "--model",
+        default="unsloth/Llama-3.2-1B-Instruct",
+        help="Model to fine-tune (default: unsloth/Llama-3.2-1B-Instruct)"
+    )
+    parser.add_argument(
+        "--db-path",
+        type=Path,
+        default=DEFAULT_DB_PATH,
+        help=f"Path to screenpipe database (default: {DEFAULT_DB_PATH})"
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("screenpipe_training.jsonl"),
+        help="Output path for training data"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./screenpipe-model",
+        help="Output directory for fine-tuned model"
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Number of days of data to export (default: 30)"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5000,
+        help="Maximum number of examples per source (default: 5000)"
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=100,
+        help="Maximum training steps for local training (default: 100)"
+    )
+    parser.add_argument(
+        "--format",
+        choices=["instruction", "completion"],
+        default="instruction",
+        help="Training data format (default: instruction)"
+    )
+    parser.add_argument(
+        "--export-only",
+        action="store_true",
+        help="Only export data, don't train"
+    )
+
+    args = parser.parse_args()
+
+    # Connect to database
+    print(f"connecting to screenpipe database: {args.db_path}")
+    try:
+        conn = get_db_connection(args.db_path)
+    except FileNotFoundError as e:
+        print(f"error: {e}")
+        sys.exit(1)
+
+    # Export data
+    print(f"\nexporting data from last {args.days} days...")
+
+    ocr_data = export_ocr_data(conn, days=args.days, limit=args.limit)
+    print(f"  ocr (screen) data: {len(ocr_data)} entries")
+
+    audio_data = export_audio_data(conn, days=args.days, limit=args.limit)
+    print(f"  audio data: {len(audio_data)} entries")
+
+    ui_data = export_ui_data(conn, days=args.days, limit=args.limit)
+    print(f"  ui data: {len(ui_data)} entries")
+
+    conn.close()
+
+    # Combine all data
+    all_data = ocr_data + audio_data + ui_data
+
+    if not all_data:
+        print("\nno data found! make sure screenpipe has been running and capturing data.")
+        sys.exit(1)
+
+    print(f"\ntotal: {len(all_data)} entries")
+
+    # Format data
+    print(f"\nformatting data for {args.format} tuning...")
+    if args.format == "instruction":
+        formatted_data = format_for_instruction_tuning(all_data)
+    else:
+        formatted_data = format_for_completion(all_data)
+
+    # Save training data
+    save_training_data(formatted_data, args.output)
+
+    # Train if requested
+    if args.export_only or args.mode == "export":
+        print("\ndata export complete. use --mode local or --mode openai to fine-tune.")
+        return
+
+    if args.mode == "local":
+        finetune_local(
+            args.output,
+            model_name=args.model,
+            output_dir=args.output_dir,
+            max_steps=args.max_steps,
+        )
+    elif args.mode == "openai":
+        finetune_openai(
+            args.output,
+            model_name=args.model,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/finetune-llm/requirements-local.txt
+++ b/examples/python/finetune-llm/requirements-local.txt
@@ -1,0 +1,8 @@
+# Requirements for local LLM fine-tuning
+# Install with: pip install -r requirements-local.txt
+
+unsloth
+transformers>=4.36.0
+trl>=0.7.0
+datasets>=2.14.0
+torch>=2.0.0

--- a/examples/python/finetune-llm/requirements-openai.txt
+++ b/examples/python/finetune-llm/requirements-openai.txt
@@ -1,0 +1,4 @@
+# Requirements for OpenAI fine-tuning
+# Install with: pip install -r requirements-openai.txt
+
+openai>=1.0.0

--- a/examples/python/finetune-llm/requirements.txt
+++ b/examples/python/finetune-llm/requirements.txt
@@ -1,0 +1,12 @@
+# Core dependencies (always required)
+# None - uses Python standard library for data export
+
+# Local fine-tuning (optional - install with: pip install -r requirements-local.txt)
+# unsloth
+# transformers
+# trl
+# datasets
+# torch
+
+# OpenAI fine-tuning (optional - install with: pip install openai)
+# openai

--- a/examples/python/finetune-llm/test_finetune.py
+++ b/examples/python/finetune-llm/test_finetune.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Test script for finetune_screenpipe.py
+Creates a mock database and verifies export functionality.
+"""
+
+import json
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Import functions from main script
+from finetune_screenpipe import (
+    export_ocr_data,
+    export_audio_data,
+    export_ui_data,
+    format_for_instruction_tuning,
+    format_for_completion,
+    save_training_data,
+)
+
+
+def create_mock_database(db_path: Path) -> None:
+    """Create a mock screenpipe database with test data."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    # Create frames table
+    cursor.execute("""
+        CREATE TABLE frames (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            browser_url TEXT,
+            app_name TEXT,
+            window_name TEXT
+        )
+    """)
+
+    # Create ocr_text table (matches real screenpipe schema)
+    cursor.execute("""
+        CREATE TABLE ocr_text (
+            frame_id INTEGER NOT NULL,
+            text TEXT NOT NULL,
+            text_json TEXT,
+            app_name TEXT NOT NULL DEFAULT '',
+            ocr_engine TEXT NOT NULL DEFAULT 'unknown',
+            window_name TEXT,
+            focused BOOLEAN DEFAULT FALSE,
+            FOREIGN KEY (frame_id) REFERENCES frames(id)
+        )
+    """)
+
+    # Create speakers table
+    cursor.execute("""
+        CREATE TABLE speakers (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        )
+    """)
+
+    # Create audio_transcriptions table
+    cursor.execute("""
+        CREATE TABLE audio_transcriptions (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            transcription TEXT,
+            device TEXT,
+            is_input_device INTEGER,
+            speaker_id INTEGER,
+            FOREIGN KEY (speaker_id) REFERENCES speakers(id)
+        )
+    """)
+
+    # Create ui_monitoring table
+    cursor.execute("""
+        CREATE TABLE ui_monitoring (
+            id INTEGER PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            text_output TEXT,
+            app_name TEXT,
+            window_name TEXT,
+            browser_url TEXT
+        )
+    """)
+
+    # Insert test data
+    now = datetime.now()
+    yesterday = now - timedelta(days=1)
+
+    # Insert frames with OCR data
+    cursor.execute("""
+        INSERT INTO frames (id, timestamp, browser_url, app_name, window_name)
+        VALUES (1, ?, 'https://github.com/mediar-ai/screenpipe', 'Chrome', 'screenpipe GitHub')
+    """, (yesterday.isoformat(),))
+
+    cursor.execute("""
+        INSERT INTO ocr_text (frame_id, text, app_name, window_name)
+        VALUES (1, 'This is a test OCR text from a GitHub page about screenpipe. It contains enough text to pass the length filter and be included in the training data export.', 'Chrome', 'screenpipe GitHub')
+    """)
+
+    cursor.execute("""
+        INSERT INTO frames (id, timestamp, browser_url, app_name, window_name)
+        VALUES (2, ?, NULL, 'VS Code', 'finetune_screenpipe.py - screenpipe')
+    """, (now.isoformat(),))
+
+    cursor.execute("""
+        INSERT INTO ocr_text (frame_id, text, app_name, window_name)
+        VALUES (2, 'def export_ocr_data(conn, days=30, limit=10000): Export OCR screen capture data from screenpipe database for fine-tuning language models.', 'VS Code', 'finetune_screenpipe.py - screenpipe')
+    """)
+
+    # Insert speaker
+    cursor.execute("INSERT INTO speakers (id, name) VALUES (1, 'John Doe')")
+
+    # Insert audio transcriptions
+    cursor.execute("""
+        INSERT INTO audio_transcriptions (timestamp, transcription, device, is_input_device, speaker_id)
+        VALUES (?, 'Hey, have you seen the new screenpipe fine-tuning feature? It allows you to train your own AI on your captured data.', 'MacBook Pro Microphone', 1, 1)
+    """, (yesterday.isoformat(),))
+
+    cursor.execute("""
+        INSERT INTO audio_transcriptions (timestamp, transcription, device, is_input_device, speaker_id)
+        VALUES (?, 'Yes, I think it is a great addition. Personal AI assistants trained on your own data could be very useful.', 'MacBook Pro Speakers', 0, NULL)
+    """, (now.isoformat(),))
+
+    # Insert UI monitoring data
+    cursor.execute("""
+        INSERT INTO ui_monitoring (timestamp, text_output, app_name, window_name, browser_url)
+        VALUES (?, 'File menu opened. Options: New, Open, Save, Save As, Export, Close', 'VS Code', 'finetune_screenpipe.py', NULL)
+    """, (yesterday.isoformat(),))
+
+    conn.commit()
+    conn.close()
+
+
+def test_export_functions():
+    """Test all export functions with mock database."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "db.sqlite3"
+        output_path = Path(tmpdir) / "training.jsonl"
+
+        print("creating mock database...")
+        create_mock_database(db_path)
+
+        print("connecting to database...")
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+
+        # Test OCR export
+        print("\n--- testing ocr export ---")
+        ocr_data = export_ocr_data(conn, days=30, limit=100)
+        print(f"exported {len(ocr_data)} ocr entries")
+        assert len(ocr_data) == 2, f"expected 2 ocr entries, got {len(ocr_data)}"
+        print(f"  sample: {ocr_data[0]['app_name']} - {ocr_data[0]['text'][:50]}...")
+
+        # Test Audio export
+        print("\n--- testing audio export ---")
+        audio_data = export_audio_data(conn, days=30, limit=100)
+        print(f"exported {len(audio_data)} audio entries")
+        assert len(audio_data) == 2, f"expected 2 audio entries, got {len(audio_data)}"
+        print(f"  sample: {audio_data[0]['speaker'] or 'unknown'} - {audio_data[0]['transcription'][:50]}...")
+
+        # Test UI export
+        print("\n--- testing ui export ---")
+        ui_data = export_ui_data(conn, days=30, limit=100)
+        print(f"exported {len(ui_data)} ui entries")
+        assert len(ui_data) == 1, f"expected 1 ui entry, got {len(ui_data)}"
+        print(f"  sample: {ui_data[0]['app_name']} - {ui_data[0]['text'][:50]}...")
+
+        conn.close()
+
+        # Test formatting (include all data types)
+        all_data = ocr_data + audio_data + ui_data
+
+        print("\n--- testing instruction format ---")
+        instruction_data = format_for_instruction_tuning(all_data)
+        print(f"formatted {len(instruction_data)} instruction examples")
+        assert len(instruction_data) == 5, f"expected 5 examples, got {len(instruction_data)}"
+        assert "messages" in instruction_data[0]
+        print(f"  sample messages: {len(instruction_data[0]['messages'])} messages")
+
+        print("\n--- testing completion format ---")
+        completion_data = format_for_completion(all_data)
+        print(f"formatted {len(completion_data)} completion examples")
+        assert len(completion_data) == 5, f"expected 5 examples, got {len(completion_data)}"
+        assert "prompt" in completion_data[0]
+        assert "completion" in completion_data[0]
+        print(f"  sample prompt: {completion_data[0]['prompt']}")
+
+        # Test save
+        print("\n--- testing save function ---")
+        save_training_data(instruction_data, output_path)
+        assert output_path.exists(), "output file not created"
+
+        with open(output_path) as f:
+            lines = f.readlines()
+        assert len(lines) == 5, f"expected 5 lines, got {len(lines)}"
+
+        # Verify JSON format
+        for i, line in enumerate(lines):
+            try:
+                json.loads(line)
+            except json.JSONDecodeError as e:
+                raise AssertionError(f"line {i+1} is not valid json: {e}")
+
+        print(f"  saved to {output_path} ({len(lines)} lines)")
+
+        print("\n" + "=" * 50)
+        print("all tests passed!")
+        print("=" * 50)
+
+
+if __name__ == "__main__":
+    test_export_functions()


### PR DESCRIPTION
## description
Python script to export screenpipe data (OCR, audio, UI) for LLM fine-tuning.
- Supports local training with unsloth (Llama 3.2, Mistral)
- Supports OpenAI fine-tuning API
- Includes documentation for using trained models with Ollama

## how to test
```bash
cd examples/python/finetune-llm
python test_finetune.py  # run tests
python finetune_screenpipe.py --mode export --days 7  # export real data
```

/claim #717