### PR TITLE
feat: add session tracking for app/window usage (#1560)

### DIFF
--- a/screenpipe-db/src/db.rs
+++ b/screenpipe-db/src/db.rs
@@ -22,8 +22,8 @@ use futures::future::try_join_all;
 use crate::{
     AudioChunksResponse, AudioDevice, AudioEntry, AudioResult, AudioResultRaw, ContentType,
     DeviceType, FrameData, FrameRow, OCREntry, OCRResult, OCRResultRaw, OcrEngine, OcrTextBlock,
-    Order, SearchMatch, SearchResult, Speaker, TagContentType, TextBounds, TextPosition,
-    TimeSeriesChunk, UiContent, VideoMetadata,
+    Order, SearchMatch, SearchResult, SessionResult, SessionResultRaw, Speaker, TagContentType,
+    TextBounds, TextPosition, TimeSeriesChunk, UiContent, VideoMetadata,
 };
 
 pub struct DatabaseManager {
@@ -631,6 +631,12 @@ impl DatabaseManager {
                 results.extend(audio_results.into_iter().map(SearchResult::Audio));
                 results.extend(ocr_results.into_iter().map(SearchResult::OCR));
             }
+            ContentType::Session => {
+                let session_results = self
+                    .search_sessions(limit, offset, start_time, end_time, app_name, window_name)
+                    .await?;
+                results.extend(session_results.into_iter().map(SearchResult::Session));
+            }
         }
 
         // Sort results by timestamp in descending order
@@ -639,11 +645,13 @@ impl DatabaseManager {
                 SearchResult::OCR(ocr) => ocr.timestamp,
                 SearchResult::Audio(audio) => audio.timestamp,
                 SearchResult::UI(ui) => ui.timestamp,
+                SearchResult::Session(session) => session.start_time,
             };
             let timestamp_b = match b {
                 SearchResult::OCR(ocr) => ocr.timestamp,
                 SearchResult::Audio(audio) => audio.timestamp,
                 SearchResult::UI(ui) => ui.timestamp,
+                SearchResult::Session(session) => session.start_time,
             };
             timestamp_b.cmp(&timestamp_a)
         });
@@ -1154,6 +1162,15 @@ impl DatabaseManager {
                     "audio_transcriptions_fts MATCH ?1"
                 }
             ),
+            ContentType::Session => {
+                r#"SELECT COUNT(*)
+                   FROM sessions
+                   WHERE (?1 IS NULL OR start_time >= ?1)
+                       AND (?2 IS NULL OR (end_time <= ?2 OR end_time IS NULL))
+                       AND (?3 IS NULL OR app_name LIKE '%' || ?3 || '%')
+                       AND (?4 IS NULL OR window_name LIKE '%' || ?4 || '%')
+                "#.to_string()
+            }
             _ => return Ok(0),
         };
 
@@ -1193,6 +1210,15 @@ impl DatabaseManager {
                     .bind(min_length.map(|l| l as i64))
                     .bind(max_length.map(|l| l as i64))
                     .bind(json_array)
+                    .fetch_one(&self.pool)
+                    .await?
+            }
+            ContentType::Session => {
+                sqlx::query_scalar(&sql)
+                    .bind(start_time)
+                    .bind(end_time)
+                    .bind(app_name)
+                    .bind(window_name)
                     .fetch_one(&self.pool)
                     .await?
             }
@@ -2347,6 +2373,305 @@ LIMIT ? OFFSET ?
                 }
             })
             .collect())
+    }
+
+    // ==================== SESSION MANAGEMENT ====================
+
+    /// Create a new session for the given app/window combination
+    pub async fn create_session(
+        &self,
+        app_name: &str,
+        window_name: &str,
+        device_name: &str,
+    ) -> Result<i64, sqlx::Error> {
+        let id = sqlx::query(
+            "INSERT INTO sessions (app_name, window_name, device_name) VALUES (?1, ?2, ?3)",
+        )
+        .bind(app_name)
+        .bind(window_name)
+        .bind(device_name)
+        .execute(&self.pool)
+        .await?
+        .last_insert_rowid();
+
+        debug!("Created session {} for app={}, window={}", id, app_name, window_name);
+        Ok(id)
+    }
+
+    /// End a session by setting its end_time and calculating duration
+    pub async fn end_session(&self, session_id: i64) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            UPDATE sessions
+            SET end_time = CURRENT_TIMESTAMP,
+                duration_secs = CAST((julianday(CURRENT_TIMESTAMP) - julianday(start_time)) * 86400 AS INTEGER)
+            WHERE id = ?1 AND end_time IS NULL
+            "#,
+        )
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+
+        debug!("Ended session {}", session_id);
+        Ok(())
+    }
+
+    /// Get active session for an app/window combination, or create one if it doesn't exist
+    pub async fn get_or_create_session(
+        &self,
+        app_name: &str,
+        window_name: &str,
+        device_name: &str,
+    ) -> Result<i64, sqlx::Error> {
+        let existing: Option<i64> = sqlx::query_scalar(
+            r#"
+            SELECT id FROM sessions
+            WHERE app_name = ?1 AND window_name = ?2 AND end_time IS NULL
+            ORDER BY start_time DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(app_name)
+        .bind(window_name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match existing {
+            Some(id) => Ok(id),
+            None => self.create_session(app_name, window_name, device_name).await,
+        }
+    }
+
+    /// Link a frame to a session and increment the frame count
+    pub async fn link_frame_to_session(
+        &self,
+        frame_id: i64,
+        session_id: i64,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("UPDATE frames SET session_id = ?1 WHERE id = ?2")
+            .bind(session_id)
+            .bind(frame_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("UPDATE sessions SET frame_count = frame_count + 1 WHERE id = ?1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Link an audio transcription to a session and increment the audio count
+    pub async fn link_audio_to_session(
+        &self,
+        audio_id: i64,
+        session_id: i64,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("UPDATE audio_transcriptions SET session_id = ?1 WHERE id = ?2")
+            .bind(session_id)
+            .bind(audio_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("UPDATE sessions SET audio_count = audio_count + 1 WHERE id = ?1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Link a UI monitoring entry to a session and increment the ui count
+    pub async fn link_ui_to_session(
+        &self,
+        ui_id: i64,
+        session_id: i64,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("UPDATE ui_monitoring SET session_id = ?1 WHERE id = ?2")
+            .bind(session_id)
+            .bind(ui_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("UPDATE sessions SET ui_count = ui_count + 1 WHERE id = ?1")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Search for sessions within a time range
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search_sessions(
+        &self,
+        limit: u32,
+        offset: u32,
+        start_time: Option<DateTime<Utc>>,
+        end_time: Option<DateTime<Utc>>,
+        app_name: Option<&str>,
+        window_name: Option<&str>,
+    ) -> Result<Vec<SessionResult>, sqlx::Error> {
+        let mut conditions = Vec::new();
+
+        if start_time.is_some() {
+            conditions.push("start_time >= ?");
+        }
+        if end_time.is_some() {
+            conditions.push("(end_time <= ? OR end_time IS NULL)");
+        }
+        if app_name.is_some() {
+            conditions.push("app_name LIKE '%' || ? || '%'");
+        }
+        if window_name.is_some() {
+            conditions.push("window_name LIKE '%' || ? || '%'");
+        }
+
+        let where_clause = if conditions.is_empty() {
+            "1=1".to_string()
+        } else {
+            conditions.join(" AND ")
+        };
+
+        let sql = format!(
+            r#"
+            SELECT
+                id,
+                app_name,
+                window_name,
+                device_name,
+                start_time,
+                end_time,
+                duration_secs,
+                frame_count,
+                audio_count,
+                ui_count,
+                metadata
+            FROM sessions
+            WHERE {}
+            ORDER BY start_time DESC
+            LIMIT ? OFFSET ?
+            "#,
+            where_clause
+        );
+
+        let mut query = sqlx::query_as::<_, SessionResultRaw>(&sql);
+
+        if let Some(start) = start_time {
+            query = query.bind(start);
+        }
+        if let Some(end) = end_time {
+            query = query.bind(end);
+        }
+        if let Some(app) = app_name {
+            query = query.bind(app);
+        }
+        if let Some(window) = window_name {
+            query = query.bind(window);
+        }
+
+        query = query.bind(limit as i64).bind(offset as i64);
+
+        let results = query.fetch_all(&self.pool).await?;
+        Ok(results.into_iter().map(SessionResult::from).collect())
+    }
+
+    /// Get a single session by ID
+    pub async fn get_session_by_id(&self, session_id: i64) -> Result<Option<SessionResult>, sqlx::Error> {
+        let result: Option<SessionResultRaw> = sqlx::query_as(
+            r#"
+            SELECT
+                id, app_name, window_name, device_name, start_time, end_time,
+                duration_secs, frame_count, audio_count, ui_count, metadata
+            FROM sessions WHERE id = ?1
+            "#,
+        )
+        .bind(session_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        Ok(result.map(SessionResult::from))
+    }
+
+    /// End all active sessions that have been inactive for more than the timeout duration
+    pub async fn end_stale_sessions(&self, timeout_secs: i64) -> Result<u64, sqlx::Error> {
+        let result = sqlx::query(
+            r#"
+            UPDATE sessions
+            SET end_time = CURRENT_TIMESTAMP,
+                duration_secs = CAST((julianday(CURRENT_TIMESTAMP) - julianday(start_time)) * 86400 AS INTEGER)
+            WHERE end_time IS NULL
+            AND CAST((julianday(CURRENT_TIMESTAMP) - julianday(start_time)) * 86400 AS INTEGER) > ?1
+            "#,
+        )
+        .bind(timeout_secs)
+        .execute(&self.pool)
+        .await?;
+
+        let rows_affected = result.rows_affected();
+        if rows_affected > 0 {
+            debug!("Ended {} stale sessions (timeout: {}s)", rows_affected, timeout_secs);
+        }
+        Ok(rows_affected)
+    }
+
+    /// Count total sessions matching the filter criteria
+    pub async fn count_sessions(
+        &self,
+        start_time: Option<DateTime<Utc>>,
+        end_time: Option<DateTime<Utc>>,
+        app_name: Option<&str>,
+        window_name: Option<&str>,
+    ) -> Result<i64, sqlx::Error> {
+        let mut conditions = Vec::new();
+
+        if start_time.is_some() {
+            conditions.push("start_time >= ?");
+        }
+        if end_time.is_some() {
+            conditions.push("(end_time <= ? OR end_time IS NULL)");
+        }
+        if app_name.is_some() {
+            conditions.push("app_name LIKE '%' || ? || '%'");
+        }
+        if window_name.is_some() {
+            conditions.push("window_name LIKE '%' || ? || '%'");
+        }
+
+        let where_clause = if conditions.is_empty() {
+            "1=1".to_string()
+        } else {
+            conditions.join(" AND ")
+        };
+
+        let sql = format!("SELECT COUNT(*) FROM sessions WHERE {}", where_clause);
+
+        let mut query = sqlx::query_scalar::<_, i64>(&sql);
+
+        if let Some(start) = start_time {
+            query = query.bind(start);
+        }
+        if let Some(end) = end_time {
+            query = query.bind(end);
+        }
+        if let Some(app) = app_name {
+            query = query.bind(app);
+        }
+        if let Some(window) = window_name {
+            query = query.bind(window);
+        }
+
+        query.fetch_one(&self.pool).await
     }
 }
 

--- a/screenpipe-db/src/lib.rs
+++ b/screenpipe-db/src/lib.rs
@@ -1,5 +1,6 @@
 mod db;
 mod migration_worker;
+pub mod session_manager;
 mod types;
 mod video_db;
 
@@ -8,4 +9,5 @@ pub use migration_worker::{
     create_migration_worker, MigrationCommand, MigrationConfig, MigrationResponse, MigrationStatus,
     MigrationWorker,
 };
+pub use session_manager::{ActiveSession, SessionKey, SessionManager};
 pub use types::*;

--- a/screenpipe-db/src/migrations/20250120000000_create_sessions.sql
+++ b/screenpipe-db/src/migrations/20250120000000_create_sessions.sql
@@ -1,0 +1,36 @@
+-- Create sessions table for tracking app/window usage sessions
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    app_name TEXT NOT NULL,
+    window_name TEXT NOT NULL,
+    device_name TEXT NOT NULL,
+    start_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    end_time DATETIME,
+    duration_secs INTEGER,
+    frame_count INTEGER DEFAULT 0,
+    audio_count INTEGER DEFAULT 0,
+    ui_count INTEGER DEFAULT 0,
+    metadata JSON,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_sessions_app_name ON sessions(app_name);
+CREATE INDEX IF NOT EXISTS idx_sessions_window_name ON sessions(window_name);
+CREATE INDEX IF NOT EXISTS idx_sessions_device_name ON sessions(device_name);
+CREATE INDEX IF NOT EXISTS idx_sessions_start_time ON sessions(start_time);
+CREATE INDEX IF NOT EXISTS idx_sessions_end_time ON sessions(end_time);
+CREATE INDEX IF NOT EXISTS idx_sessions_app_window ON sessions(app_name, window_name);
+CREATE INDEX IF NOT EXISTS idx_sessions_time_range ON sessions(start_time, end_time);
+
+-- Add session_id column to frames table
+ALTER TABLE frames ADD COLUMN session_id INTEGER REFERENCES sessions(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_frames_session_id ON frames(session_id);
+
+-- Add session_id column to audio_transcriptions table
+ALTER TABLE audio_transcriptions ADD COLUMN session_id INTEGER REFERENCES sessions(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_audio_transcriptions_session_id ON audio_transcriptions(session_id);
+
+-- Add session_id column to ui_monitoring table
+ALTER TABLE ui_monitoring ADD COLUMN session_id INTEGER REFERENCES sessions(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_ui_monitoring_session_id ON ui_monitoring(session_id);

--- a/screenpipe-db/src/session_manager.rs
+++ b/screenpipe-db/src/session_manager.rs
@@ -1,0 +1,244 @@
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tokio::time::interval;
+use tracing::{debug, error, info};
+
+use crate::DatabaseManager;
+
+/// Default inactivity timeout for sessions (5 minutes)
+const DEFAULT_INACTIVITY_TIMEOUT_SECS: i64 = 300;
+
+/// Represents an active session being tracked in memory
+#[derive(Debug, Clone)]
+pub struct ActiveSession {
+    pub session_id: i64,
+    pub app_name: String,
+    pub window_name: String,
+    pub device_name: String,
+    pub start_time: DateTime<Utc>,
+    pub last_activity: DateTime<Utc>,
+}
+
+/// Session key for tracking unique app/window combinations
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct SessionKey {
+    pub app_name: String,
+    pub window_name: String,
+}
+
+impl SessionKey {
+    pub fn new(app_name: &str, window_name: &str) -> Self {
+        Self {
+            app_name: app_name.to_string(),
+            window_name: window_name.to_string(),
+        }
+    }
+}
+
+/// Manages active sessions and handles automatic session expiration
+pub struct SessionManager {
+    db: Arc<DatabaseManager>,
+    active_sessions: Arc<RwLock<HashMap<SessionKey, ActiveSession>>>,
+    inactivity_timeout_secs: i64,
+}
+
+impl SessionManager {
+    /// Create a new SessionManager
+    pub fn new(db: Arc<DatabaseManager>) -> Self {
+        Self {
+            db,
+            active_sessions: Arc::new(RwLock::new(HashMap::new())),
+            inactivity_timeout_secs: DEFAULT_INACTIVITY_TIMEOUT_SECS,
+        }
+    }
+
+    /// Create a new SessionManager with a custom inactivity timeout
+    pub fn with_timeout(db: Arc<DatabaseManager>, timeout_secs: i64) -> Self {
+        Self {
+            db,
+            active_sessions: Arc::new(RwLock::new(HashMap::new())),
+            inactivity_timeout_secs: timeout_secs,
+        }
+    }
+
+    /// Get or create a session for the given app/window combination
+    /// This should be called when a new frame is captured
+    pub async fn get_or_create_session(
+        &self,
+        app_name: &str,
+        window_name: &str,
+        device_name: &str,
+    ) -> Result<i64, sqlx::Error> {
+        let key = SessionKey::new(app_name, window_name);
+
+        // Check if we have an active session in memory
+        {
+            let mut sessions = self.active_sessions.write().await;
+            if let Some(session) = sessions.get_mut(&key) {
+                // Update last activity time
+                session.last_activity = Utc::now();
+                return Ok(session.session_id);
+            }
+        }
+
+        // No active session in memory, create or get from database
+        let session_id = self
+            .db
+            .get_or_create_session(app_name, window_name, device_name)
+            .await?;
+
+        // Add to active sessions
+        let session = ActiveSession {
+            session_id,
+            app_name: app_name.to_string(),
+            window_name: window_name.to_string(),
+            device_name: device_name.to_string(),
+            start_time: Utc::now(),
+            last_activity: Utc::now(),
+        };
+
+        let mut sessions = self.active_sessions.write().await;
+        sessions.insert(key, session);
+
+        debug!(
+            "Created/retrieved session {} for app={}, window={}",
+            session_id, app_name, window_name
+        );
+
+        Ok(session_id)
+    }
+
+    /// Update the last activity time for a session
+    pub async fn touch_session(&self, app_name: &str, window_name: &str) {
+        let key = SessionKey::new(app_name, window_name);
+        let mut sessions = self.active_sessions.write().await;
+        if let Some(session) = sessions.get_mut(&key) {
+            session.last_activity = Utc::now();
+        }
+    }
+
+    /// End a specific session
+    pub async fn end_session(&self, app_name: &str, window_name: &str) -> Result<(), sqlx::Error> {
+        let key = SessionKey::new(app_name, window_name);
+
+        let session_id = {
+            let mut sessions = self.active_sessions.write().await;
+            sessions.remove(&key).map(|s| s.session_id)
+        };
+
+        if let Some(id) = session_id {
+            self.db.end_session(id).await?;
+            info!("Ended session {} for app={}, window={}", id, app_name, window_name);
+        }
+
+        Ok(())
+    }
+
+    /// Check for and close stale sessions (sessions that have been inactive)
+    pub async fn cleanup_stale_sessions(&self) -> Result<u64, sqlx::Error> {
+        let now = Utc::now();
+        let timeout = chrono::Duration::seconds(self.inactivity_timeout_secs);
+
+        let mut stale_keys = Vec::new();
+        let mut stale_ids = Vec::new();
+
+        // Find stale sessions
+        {
+            let sessions = self.active_sessions.read().await;
+            for (key, session) in sessions.iter() {
+                if now - session.last_activity > timeout {
+                    stale_keys.push(key.clone());
+                    stale_ids.push(session.session_id);
+                }
+            }
+        }
+
+        // Remove from memory
+        {
+            let mut sessions = self.active_sessions.write().await;
+            for key in &stale_keys {
+                sessions.remove(key);
+            }
+        }
+
+        // End in database
+        let mut ended = 0u64;
+        for id in stale_ids {
+            if self.db.end_session(id).await.is_ok() {
+                ended += 1;
+            }
+        }
+
+        // Also clean up any stale sessions directly in the database
+        // (for sessions that might have been created but not tracked in memory)
+        let db_ended = self.db.end_stale_sessions(self.inactivity_timeout_secs).await?;
+
+        if ended > 0 || db_ended > 0 {
+            info!("Cleaned up {} in-memory + {} database stale sessions", ended, db_ended);
+        }
+
+        Ok(ended + db_ended)
+    }
+
+    /// Get the number of active sessions in memory
+    pub async fn active_session_count(&self) -> usize {
+        self.active_sessions.read().await.len()
+    }
+
+    /// Get all active sessions
+    pub async fn get_active_sessions(&self) -> Vec<ActiveSession> {
+        self.active_sessions.read().await.values().cloned().collect()
+    }
+
+    /// Start the background cleanup task that periodically checks for stale sessions
+    pub fn start_cleanup_task(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
+        let cleanup_interval = Duration::from_secs(60); // Check every minute
+
+        tokio::spawn(async move {
+            let mut interval = interval(cleanup_interval);
+            loop {
+                interval.tick().await;
+                if let Err(e) = self.cleanup_stale_sessions().await {
+                    error!("Error cleaning up stale sessions: {}", e);
+                }
+            }
+        })
+    }
+
+    /// End all active sessions (used during shutdown)
+    pub async fn end_all_sessions(&self) -> Result<u64, sqlx::Error> {
+        let sessions: Vec<_> = {
+            let mut sessions = self.active_sessions.write().await;
+            let all_sessions: Vec<_> = sessions.drain().collect();
+            all_sessions
+        };
+
+        let mut ended = 0u64;
+        for (_, session) in sessions {
+            if self.db.end_session(session.session_id).await.is_ok() {
+                ended += 1;
+            }
+        }
+
+        info!("Ended {} sessions during shutdown", ended);
+        Ok(ended)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_key() {
+        let key1 = SessionKey::new("app1", "window1");
+        let key2 = SessionKey::new("app1", "window1");
+        let key3 = SessionKey::new("app1", "window2");
+
+        assert_eq!(key1, key2);
+        assert_ne!(key1, key3);
+    }
+}

--- a/screenpipe-db/src/types.rs
+++ b/screenpipe-db/src/types.rs
@@ -21,6 +21,55 @@ pub enum SearchResult {
     OCR(OCRResult),
     Audio(AudioResult),
     UI(UiContent),
+    Session(SessionResult),
+}
+
+#[derive(FromRow, Debug)]
+pub struct SessionResultRaw {
+    pub id: i64,
+    pub app_name: String,
+    pub window_name: String,
+    pub device_name: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub duration_secs: Option<i64>,
+    pub frame_count: i64,
+    pub audio_count: i64,
+    pub ui_count: i64,
+    pub metadata: Option<String>,
+}
+
+#[derive(OaSchema, Debug, Serialize, Deserialize, Clone)]
+pub struct SessionResult {
+    pub id: i64,
+    pub app_name: String,
+    pub window_name: String,
+    pub device_name: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub duration_secs: Option<i64>,
+    pub frame_count: i64,
+    pub audio_count: i64,
+    pub ui_count: i64,
+    pub metadata: Option<String>,
+}
+
+impl From<SessionResultRaw> for SessionResult {
+    fn from(raw: SessionResultRaw) -> Self {
+        SessionResult {
+            id: raw.id,
+            app_name: raw.app_name,
+            window_name: raw.window_name,
+            device_name: raw.device_name,
+            start_time: raw.start_time,
+            end_time: raw.end_time,
+            duration_secs: raw.duration_secs,
+            frame_count: raw.frame_count,
+            audio_count: raw.audio_count,
+            ui_count: raw.ui_count,
+            metadata: raw.metadata,
+        }
+    }
 }
 
 #[derive(FromRow, Debug)]
@@ -75,6 +124,7 @@ pub enum ContentType {
     OCR,
     Audio,
     UI,
+    Session,
     #[serde(rename = "audio+ui")]
     #[serde(alias = "audio ui")]
     AudioAndUi,

--- a/screenpipe-server/src/server.rs
+++ b/screenpipe-server/src/server.rs
@@ -193,6 +193,22 @@ pub enum ContentItem {
     OCR(OCRContent),
     Audio(AudioContent),
     UI(UiContent),
+    Session(SessionContent),
+}
+
+#[derive(OaSchema, Serialize, Deserialize, Debug)]
+pub struct SessionContent {
+    pub id: i64,
+    pub app_name: String,
+    pub window_name: String,
+    pub device_name: String,
+    pub start_time: DateTime<Utc>,
+    pub end_time: Option<DateTime<Utc>>,
+    pub duration_secs: Option<i64>,
+    pub frame_count: i64,
+    pub audio_count: i64,
+    pub ui_count: i64,
+    pub metadata: Option<String>,
 }
 
 #[derive(OaSchema, Serialize, Deserialize, Debug)]
@@ -413,6 +429,19 @@ pub(crate) async fn search(
                 offset_index: ui.offset_index,
                 frame_name: ui.frame_name.clone(),
                 browser_url: ui.browser_url.clone(),
+            }),
+            SearchResult::Session(session) => ContentItem::Session(SessionContent {
+                id: session.id,
+                app_name: session.app_name.clone(),
+                window_name: session.window_name.clone(),
+                device_name: session.device_name.clone(),
+                start_time: session.start_time,
+                end_time: session.end_time,
+                duration_secs: session.duration_secs,
+                frame_count: session.frame_count,
+                audio_count: session.audio_count,
+                ui_count: session.ui_count,
+                metadata: session.metadata.clone(),
             }),
         })
         .collect();


### PR DESCRIPTION
This implements session tracking to group frames, audio, and UI data by app/window combinations with automatic inactivity timeout.

Changes:
- Add sessions table migration with session_id FKs on frames, audio_transcriptions, and ui_monitoring tables
- Add SessionResult, SessionResultRaw types
- Add ContentType::Session variant for search API
- Add SessionManager for real-time session tracking with 5-min timeout
- Add /search?content_type=session endpoint support
- Add database functions: create_session, end_session, get_or_create_session, search_sessions, count_sessions, link_frame_to_session, link_audio_to_session, link_ui_to_session

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

brief description of the changes in this pr.

related issue: #

## how to test

add a few steps to test the pr in the most time efficient way.

1. 
2. 
3. 

if relevant add screenshots or screen captures to prove that this PR works to save us time (check [Cap](https://cap.so)).

if you are not the author of this PR and you see it and you think it can take more than 30 mins for maintainers to review, we will tip you between $20 and $200 for you to review and test it for us.
