### PR TITLE
docs: add environment variables reference

### DIFF
--- a/content/docs-mintlify-mig-tmp/cli-reference.mdx
+++ b/content/docs-mintlify-mig-tmp/cli-reference.mdx
@@ -334,6 +334,90 @@ Invoke-Item $profile
 . $PROFILE  
 ```
 
+### Environment Variables
+
+screenpipe supports various environment variables for configuration. These are particularly useful for users in regions with restricted access to certain services or for advanced customization.
+
+#### Hugging Face Configuration
+
+- **HF_ENDPOINT**: Custom Hugging Face mirror URL
+  - use case: Users in China or regions where huggingface.co is blocked
+  - example: `export HF_ENDPOINT=https://hf-mirror.com`
+  - note: Set this before running screenpipe to download Whisper models from a mirror
+
+#### Deepgram (Cloud Transcription)
+
+- **DEEPGRAM_API_KEY**: Your Deepgram API key for cloud transcription
+  - required when using `--audio-transcription-engine deepgram`
+  - get your key at: https://deepgram.com
+- **DEEPGRAM_API_URL**: Custom Deepgram API endpoint
+  - default: `https://api.deepgram.com/v1/listen`
+  - use case: Custom proxy or enterprise endpoints
+- **DEEPGRAM_WEBSOCKET_URL**: Custom Deepgram WebSocket endpoint for realtime transcription
+  - use case: Custom proxy or enterprise endpoints
+- **CUSTOM_DEEPGRAM_API_TOKEN**: Alternative token for Deepgram (used by screenpipe cloud)
+
+#### OCR Configuration
+
+- **UNSTRUCTURED_API_KEY**: API key for Unstructured.io OCR service
+  - required when using `--ocr-engine unstructured`
+  - get your key at: https://unstructured.io
+- **SCREENPIPE_CUSTOM_OCR_CONFIG**: JSON configuration for custom OCR engine
+  - example:
+    ```bash
+    export SCREENPIPE_CUSTOM_OCR_CONFIG='{
+      "api_url": "http://localhost:8000/ocr",
+      "api_key": "",
+      "timeout_ms": 5000
+    }'
+    ```
+- **TESSDATA_PREFIX**: Path to Tesseract data files
+  - auto-configured on most systems
+  - use case: Custom Tesseract installation
+
+#### Screenpipe Core
+
+- **SCREENPIPE_DIR**: Override default data directory
+  - default: `$HOME/.screenpipe`
+  - use case: Custom storage location
+- **SCREENPIPE_LOG**: Log level filter
+  - options: `error`, `warn`, `info`, `debug`, `trace`
+  - example: `export SCREENPIPE_LOG=debug`
+
+#### LLM Integration
+
+- **OLLAMA_ORIGINS**: CORS origins for Ollama integration
+  - auto-set by desktop app
+  - use case: Allow cross-origin requests to Ollama
+
+#### Development & Debugging
+
+- **SAVE_RESOURCE_USAGE**: Enable resource usage logging to file
+  - example: `export SAVE_RESOURCE_USAGE=1`
+- **TAURI_ENV_DEBUG**: Enable debug mode in Tauri app
+  - example: `export TAURI_ENV_DEBUG=true`
+- **SENTRY_RELEASE_NAME_APPEND**: Append to Sentry release name for error tracking
+
+#### Example: Running in China
+
+```bash
+# Set Hugging Face mirror
+export HF_ENDPOINT=https://hf-mirror.com
+
+# Run screenpipe
+screenpipe
+```
+
+#### Example: Using Deepgram Cloud
+
+```bash
+# Set Deepgram API key
+export DEEPGRAM_API_KEY=your_api_key_here
+
+# Run with Deepgram transcription
+screenpipe --audio-transcription-engine deepgram
+```
+
 ### LLM links
 
 paste these links into your Cursor chat for context:

--- a/pipes/data-manager/next-env.d.ts
+++ b/pipes/data-manager/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for all environment variables supported by screenpipe CLI.

### Documented Variables:

**Hugging Face:**
- `HF_ENDPOINT` - Mirror URL for China/blocked regions

**Deepgram (Cloud Transcription):**
- `DEEPGRAM_API_KEY` - API key
- `DEEPGRAM_API_URL` - Custom API endpoint
- `DEEPGRAM_WEBSOCKET_URL` - Custom WebSocket for realtime
- `CUSTOM_DEEPGRAM_API_TOKEN` - Alternative token

**OCR:**
- `UNSTRUCTURED_API_KEY` - Unstructured.io API key
- `SCREENPIPE_CUSTOM_OCR_CONFIG` - Custom OCR engine config
- `TESSDATA_PREFIX` - Tesseract data path

**Core:**
- `SCREENPIPE_DIR` - Custom data directory
- `SCREENPIPE_LOG` - Log level filter

**LLM:**
- `OLLAMA_ORIGINS` - CORS origins for Ollama

**Development:**
- `SAVE_RESOURCE_USAGE` - Resource logging
- `TAURI_ENV_DEBUG` - Debug mode
- `SENTRY_RELEASE_NAME_APPEND` - Error tracking

### Includes practical examples:
- Running in China with HF mirror
- Setting up Deepgram cloud transcription

Closes #1298

🤖 Generated with [Claude Code](https://claude.ai/code)