### PR TITLE
fix(windows): add platform guards for macOS-specific code

### DIFF
--- a/screenpipe-app-tauri/scripts/pre_build.js
+++ b/screenpipe-app-tauri/scripts/pre_build.js
@@ -20,8 +20,8 @@ console.log('cwd', cwd)
 const config = {
 	ffmpegRealname: 'ffmpeg',
 	windows: {
-		ffmpegName: 'ffmpeg-7.0.2-full_build-shared',
-		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.0.2-full_build-shared.7z',
+		ffmpegName: 'ffmpeg-8.0.1-full_build-shared',
+		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-8.0.1-full_build-shared.7z',
 		vcpkgPackages: ['opencl', 'onnxruntime-gpu'],
 	},
 	linux: {
@@ -308,7 +308,7 @@ if (platform == 'windows') {
 	// Setup FFMPEG
 	if (!(await fs.exists(config.ffmpegRealname))) {
 		await $`${wgetPath} --no-config --tries=10 --retry-connrefused --waitretry=10 --secure-protocol=auto --no-check-certificate --show-progress ${config.windows.ffmpegUrl} -O ${config.windows.ffmpegName}.7z`
-		await $`'C:\\Program Files\\7-Zip\\7z.exe' x ${config.windows.ffmpegName}.7z`
+		await $`7z x ${config.windows.ffmpegName}.7z`
 		await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 		await $`rm -rf ${config.windows.ffmpegName}.7z`
 	}

--- a/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -120,6 +120,7 @@ winreg = "0.52.0"
 lazy_static = "1.5.0"
 image = "0.25.5"
 windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git" }
+base64 = "0.22.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = "0.18.1"

--- a/screenpipe-app-tauri/src-tauri/src/window_api.rs
+++ b/screenpipe-app-tauri/src-tauri/src/window_api.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, str::FromStr};
 use axum::{extract::State, http::StatusCode, Json};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, LogicalSize, Manager, Size, WebviewUrl, WebviewWindow, WebviewWindowBuilder, Wry};
+#[cfg(target_os = "macos")]
 use tauri_nspanel::ManagerExt;
 use tracing::{error, info};
 #[cfg(target_os = "macos")]
@@ -285,13 +286,19 @@ impl ShowRewindWindow {
 
             if id.label() == RewindWindowId::Main.label() {
                     info!("showing panel");
-                    let app_clone = app.clone();
-                     
-                    app.run_on_main_thread(move || {
-                        if let Ok(panel) = app_clone.get_webview_panel(RewindWindowId::Main.label()) {
-                            panel.show();
-                        }
-                    }).ok();
+                    #[cfg(target_os = "macos")]
+                    {
+                        let app_clone = app.clone();
+                        app.run_on_main_thread(move || {
+                            if let Ok(panel) = app_clone.get_webview_panel(RewindWindowId::Main.label()) {
+                                panel.show();
+                            }
+                        }).ok();
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        window.show().ok();
+                    }
                     return Ok(window);
             }
 
@@ -329,7 +336,6 @@ impl ShowRewindWindow {
                 let monitor = app.primary_monitor().unwrap().unwrap();
                 let logical_size = monitor.size().to_logical(monitor.scale_factor());
                 let builder = self.window_builder(app, "/")
-                    .hidden_title(true)
                     .visible_on_all_workspaces(true)
                     .always_on_top(true)
                     .decorations(false)
@@ -340,6 +346,8 @@ impl ShowRewindWindow {
                     .inner_size(logical_size.width, logical_size.height)
                     .max_inner_size(logical_size.width, logical_size.height)
                     .position(0.0, 0.0);
+                #[cfg(target_os = "macos")]
+                let builder = builder.hidden_title(true);
                     
                     
                 
@@ -419,7 +427,9 @@ impl ShowRewindWindow {
                 window
             }
             ShowRewindWindow::Settings {  page: _  } => {
-                let builder = self.window_builder(app, "/settings").hidden_title(true).focused(true);
+                let builder = self.window_builder(app, "/settings").focused(true);
+                #[cfg(target_os = "macos")]
+                let builder = builder.hidden_title(true);
                 let window = builder.build()?;
                 window
             }
@@ -431,7 +441,9 @@ impl ShowRewindWindow {
                     // let encoded_query = q.replace(' ', "%20").replace('#', "%23").replace('&', "%26");
                     url.push_str(&format!("{}", q));
                 }
-                let builder = self.window_builder(app, url).hidden_title(true).focused(true);
+                let builder = self.window_builder(app, url).focused(true);
+                #[cfg(target_os = "macos")]
+                let builder = builder.hidden_title(true);
 
                 let window = builder.build()?;
                 window


### PR DESCRIPTION
## Summary
- Add `#[cfg(target_os = "macos")]` guards for tauri_nspanel imports and usage
- Fix `get_webview_panel` -> `get_webview_window` for non-macOS platforms  
- Fix `hidden_title()` method calls with platform conditionals
- Add `base64` crate to Windows dependencies (was only in macOS deps)
- Update ffmpeg URL from 7.0.2 to 8.0.1 (old version returns 404)
- Use `7z` command instead of hardcoded `C:\Program Files\7-Zip\7z.exe` path

## Test plan
- [x] `cargo build --release` succeeds on Windows
- [x] `bun tauri build` produces working installer on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves cross-platform stability and Windows build setup.
> 
> - Add `#[cfg(target_os = "macos")]` guards around `tauri_nspanel` imports/usages and `hidden_title()` so macOS-specific APIs aren’t used on other platforms
> - Fix non-macOS window retrieval by using `get_webview_window("main")` instead of `get_webview_panel()`; conditionally initialize `tauri_nspanel` plugin only on macOS
> - Update Windows prebuild: bump ffmpeg to `8.0.1` and switch extraction to `7z x` (no hardcoded path)
> - Add `base64` crate to Windows target dependencies; use it in `get_media_file` for base64 encoding
> - Minor window behavior tweaks in `window_api`: show/hide logic and builder flags made platform-conditional
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 571c49ed05f5d232f53ffdc8d78592b237601ef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->