### PR TITLE
Fix: Shortcut reminder overlay respects disabled setting on startup

### DIFF
--- a/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -186,12 +186,8 @@ pub struct SettingsStore {
     pub use_all_monitors: bool,
     #[serde(rename = "enableRealtimeVision")]
     pub enable_realtime_vision: bool,
-    #[serde(rename = "showShortcutOverlay", default = "default_true")]
+    #[serde(rename = "showShortcutOverlay")]
     pub show_shortcut_overlay: bool,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 #[derive(Serialize, Deserialize, Type,Clone,Default)]
@@ -432,7 +428,7 @@ impl Default for SettingsStore {
             disable_vision: false,
             use_all_monitors: false,
             enable_realtime_vision: true,
-            show_shortcut_overlay: true,
+            show_shortcut_overlay: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

* Fixes issue where the floating shortcut reminder overlay appears on app startup even when "show shortcut reminder" is toggled OFF in Settings → Shortcuts
* Changes the default value of `showShortcutOverlay` from `true` to `false`
* Removes the serde `default = "default_true"` attribute that was forcing `true` when the key was missing from stored settings

## Root Cause

Two defaults were set to `true`:
1. The serde `default` attribute explicitly defaulted to `true` when deserializing settings that lacked this key
2. The `Default` trait implementation set `true` for new stores

Both have been changed to `false`, making the overlay opt-in.

## Test plan

- [ ] Fresh install: overlay should NOT appear by default
- [ ] Settings → Shortcuts: toggle should work immediately without needing on/off cycle
- [ ] Existing users who have explicitly enabled the overlay should still see it (their stored value persists)

## Risk

Low. Changes default value only — existing users with an explicit preference are unaffected since their stored value takes precedence over defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)