### PR TITLE
feat(pii): enable PII removal by default

### DIFF
--- a/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -1452,9 +1452,9 @@ export function RecordingSettings() {
 
           <div className="flex items-center justify-between">
             <div className="space-y-1">
-              <Label htmlFor="usePiiRemoval">PII removal</Label>
+              <Label htmlFor="usePiiRemoval">PII removal (recommended)</Label>
               <p className="text-sm text-muted-foreground">
-                Redact emails, phone numbers, and addresses from screen text
+                Redact sensitive data from OCR and audio: emails, phones, SSNs, credit cards, IP addresses, API keys
               </p>
             </div>
             <Switch

--- a/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -407,7 +407,7 @@ impl Default for SettingsStore {
             ocr_engine: "tesseract".to_string(),
             monitor_ids: vec!["default".to_string()],
             audio_devices: vec!["default".to_string()],
-            use_pii_removal: false,
+            use_pii_removal: true,
             restart_interval: 0,
             port: 3030,
             data_dir: "default".to_string(),

--- a/screenpipe-server/src/cli.rs
+++ b/screenpipe-server/src/cli.rs
@@ -235,8 +235,9 @@ pub struct Cli {
     #[arg(short = 'l', long, value_enum)]
     pub language: Vec<Language>,
 
-    /// Enable PII removal from OCR text property that is saved to db and returned in search results
-    #[arg(long, default_value_t = false)]
+    /// Enable PII removal from OCR text and audio transcriptions saved to db and returned in search results.
+    /// When enabled, sensitive data like emails, phone numbers, credit cards, SSNs, and API keys are redacted.
+    #[arg(long, default_value_t = true)]
     pub use_pii_removal: bool,
 
     /// Disable vision recording


### PR DESCRIPTION
## Summary
- Changes CLI flag `--use-pii-removal` to default to `true`
- Updates desktop app to enable PII removal by default
- Updates settings UI label to indicate "(recommended)"
- Expands description to list all detected PII types: emails, phones, SSNs, credit cards, IP addresses, API keys

## Rationale
PII removal is now on by default to protect user privacy. This is especially important since:
1. Screenpipe captures screen content which often contains sensitive information
2. Audio transcriptions may contain spoken PII
3. Users may send this data to AI APIs where it could be logged

Users can still disable it via CLI flag (`--use-pii-removal=false`) or the settings UI toggle.

## Test plan
- [x] Server compiles
- [x] Settings UI shows updated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)