### PR TITLE
fix: video quality preset now actually affects sharpness

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -838,21 +838,21 @@ export function RecordingSettings() {
               <Film className="h-4 w-4 text-muted-foreground shrink-0" />
               <div>
                 <h3 className="text-sm font-medium text-foreground">Video quality</h3>
-                <p className="text-xs text-muted-foreground">Higher quality = larger files</p>
+                <p className="text-xs text-muted-foreground">Higher quality = larger files & more CPU</p>
               </div>
             </div>
             <Select
               value={settings.videoQuality || "balanced"}
               onValueChange={(value) => handleSettingsChange({ videoQuality: value }, true)}
             >
-              <SelectTrigger className="w-[130px] h-7 text-xs">
+              <SelectTrigger className="w-[160px] h-7 text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="low">Low</SelectItem>
+                <SelectItem value="low">Low (smallest)</SelectItem>
                 <SelectItem value="balanced">Balanced</SelectItem>
-                <SelectItem value="high">High</SelectItem>
-                <SelectItem value="max">Max</SelectItem>
+                <SelectItem value="high">High (sharp text)</SelectItem>
+                <SelectItem value="max">Max (best, more CPU)</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/crates/screenpipe-server/src/lib.rs
+++ b/crates/screenpipe-server/src/lib.rs
@@ -37,7 +37,7 @@ pub use server::PaginatedResponse;
 pub use server::SCServer;
 pub use server::{api_list_monitors, MonitorInfo};
 pub use sleep_monitor::start_sleep_monitor;
-pub use video::{FrameWriteInfo, FrameWriteTracker, VideoCapture, video_quality_to_crf, video_quality_to_jpeg_q};
+pub use video::{FrameWriteInfo, FrameWriteTracker, VideoCapture, video_quality_to_crf, video_quality_to_jpeg_q, video_quality_to_preset};
 pub mod embedding;
 pub use cloud_search::{CloudSearchClient, CloudSearchMetadata, CloudStatus};
 pub use ui_recorder::{start_ui_recording, UiRecorderConfig, UiRecorderHandle};


### PR DESCRIPTION
## Problem

The video quality setting (`low`, `balanced`, `high`, `max`) only changed the H.265 CRF value but **hardcoded `-preset ultrafast`** for all quality levels. This meant even CRF 14 (`max`) produced blurry output — the encoder didn't spend enough CPU effort to use the bits effectively.

Additionally, **`yuv420p` (4:2:0 chroma subsampling)** was hardcoded for all levels, which halves color resolution and causes visible fringing on sharp text/UI edges — exactly the kind of content screenpipe captures.

## Changes

### `crates/screenpipe-server/src/video.rs`
- **New `video_quality_to_preset()`** — maps quality to x265 preset:
  - `low`/`balanced` → `ultrafast` (no CPU increase)
  - `high` → `fast` (noticeable quality bump, still real-time)
  - `max` → `medium` (best quality, uses more CPU)
- **New `video_quality_to_pix_fmt()`** — maps quality to pixel format:
  - `low`/`balanced` → `yuv420p` (smaller files)
  - `high`/`max` → `yuv444p` (full chroma, crisp text)
- **`start_ffmpeg_process()`** now uses the quality-dependent preset and pixel format instead of hardcoded values
- Added info log for encoding params (quality, crf, preset, pix_fmt) for debugging

### `apps/.../recording-settings.tsx`
- Updated dropdown labels to clarify trade-offs: "High (sharp text)", "Max (best, more CPU)"
- Widened select trigger to fit new labels

## Before → After

| Quality | Before | After |
|---------|--------|-------|
| low | crf=32, ultrafast, yuv420p | crf=32, ultrafast, yuv420p (unchanged) |
| balanced | crf=23, ultrafast, yuv420p | crf=23, ultrafast, yuv420p (unchanged) |
| high | crf=18, ultrafast, yuv420p | crf=18, **fast**, **yuv444p** |
| max | crf=14, ultrafast, yuv420p | crf=14, **medium**, **yuv444p** |

## Note
`low` and `balanced` are completely unchanged — no risk of regression for default users. Only `high` and `max` get the encoder improvements, which is what users selecting those levels expect.