### PR TITLE
chore: move benchmarks to self-hosted runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,14 +16,15 @@ env:
 jobs:
   apple_ocr_benchmark:
     name: Run Apple OCR benchmark
-    runs-on: macos-latest
+    runs-on: [self-hosted, macos-test]
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install dependencies
         run: |
-          brew install ffmpeg
+          brew install ffmpeg || true  # may already be installed on self-hosted
 
       - name: Run OCR benchmarks
         env:
@@ -61,7 +62,8 @@ jobs:
 
   windows_ocr_benchmark:
     name: Run Windows OCR benchmark
-    runs-on: windows-latest
+    runs-on: [self-hosted, windows-desktop-test]
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Move apple_ocr_benchmark from macos-latest to self-hosted macos-test and windows_ocr_benchmark from windows-latest to self-hosted windows-desktop-test. Saves approx 3.9K/month in GH Actions billing.