### PR TITLE
feat: apple reminders integration — auto-extract action items from screen & audio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2238,6 +2238,21 @@ checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener 5.4.0",
  "pin-project-lite",
+]
+
+[[package]]
+name = "eventkit-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec236647b02b93eb0a48d6bce3317f5b51a636193df8bb52ced5c637aed77e0"
+dependencies = [
+ "block2",
+ "chrono",
+ "clap",
+ "objc2",
+ "objc2-event-kit",
+ "objc2-foundation",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -3983,7 +3998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4995,6 +5010,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-media"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5044,6 +5069,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "objc2-event-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bc9ad7325642172110196bacd6af64027ec5549ded7fc6589ea03e0f792bf8"
+dependencies = [
+ "bitflags 2.9.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-graphics",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-map-kit",
+]
+
+[[package]]
 name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5076,6 +5117,16 @@ dependencies = [
  "bitflags 2.9.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-map-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579edede1c244621cd8229b70ea6e20e6ec3bab5a74afdfd494b446b681e1e64"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6790,14 +6841,20 @@ name = "screenpipe-integrations"
 version = "0.3.138"
 dependencies = [
  "anyhow",
+ "chrono",
+ "eventkit-rs",
  "image",
  "log",
  "mime_guess",
+ "objc2",
+ "objc2-event-kit",
+ "objc2-foundation",
  "reqwest 0.12.12",
  "screenpipe-core",
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -3150,6 +3150,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventkit-rs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec236647b02b93eb0a48d6bce3317f5b51a636193df8bb52ced5c637aed77e0"
+dependencies = [
+ "block2 0.6.2",
+ "chrono",
+ "clap",
+ "objc2 0.6.3",
+ "objc2-event-kit",
+ "objc2-foundation 0.3.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6813,6 +6828,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
+name = "objc2-event-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bc9ad7325642172110196bacd6af64027ec5549ded7fc6589ea03e0f792bf8"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-app-kit",
+ "objc2-core-graphics",
+ "objc2-core-location",
+ "objc2-foundation 0.3.2",
+ "objc2-map-kit",
+]
+
+[[package]]
 name = "objc2-exception-helper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6876,6 +6907,16 @@ checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
 dependencies = [
  "objc2 0.6.3",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-map-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579edede1c244621cd8229b70ea6e20e6ec3bab5a74afdfd494b446b681e1e64"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -9007,7 +9048,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.0.357"
+version = "2.0.359"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9046,6 +9087,7 @@ dependencies = [
  "screenpipe-audio",
  "screenpipe-core",
  "screenpipe-db",
+ "screenpipe-integrations",
  "screenpipe-server",
  "screenpipe-vision",
  "sentry 0.42.0",
@@ -9241,14 +9283,20 @@ name = "screenpipe-integrations"
 version = "0.3.138"
 dependencies = [
  "anyhow",
+ "chrono",
+ "eventkit-rs",
  "image 0.25.9",
  "log",
  "mime_guess",
+ "objc2 0.6.3",
+ "objc2-event-kit",
+ "objc2-foundation 0.3.2",
  "reqwest 0.12.12",
  "screenpipe-core",
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -113,6 +113,7 @@ screenpipe-vision = { path = "../../../crates/screenpipe-vision", features = ["a
 screenpipe-accessibility = { path = "../../../crates/screenpipe-accessibility" }
 screenpipe-audio = { path = "../../../crates/screenpipe-audio" }
 screenpipe-db = { path = "../../../crates/screenpipe-db" }
+screenpipe-integrations = { path = "../../../crates/screenpipe-integrations" }
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-cli = "2.4.1"

--- a/apps/screenpipe-app-tauri/src-tauri/Info.plist
+++ b/apps/screenpipe-app-tauri/src-tauri/Info.plist
@@ -10,5 +10,7 @@
     <string>This app requires screen capture access to record the screen.</string>
     <key>NSSystemExtensionUsageDescription</key>
     <string>This app requires system extension access to capture audio output.</string>
+    <key>NSRemindersUsageDescription</key>
+    <string>screenpipe saves action items it detects from your screen and audio activity to Apple Reminders.</string>
 </dict>
 </plist>

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -54,6 +54,7 @@ mod windows_overlay;
 mod space_monitor;
 mod sync;
 mod obsidian_sync;
+mod reminders;
 mod pi;
 mod embedded_server;
 
@@ -1052,6 +1053,14 @@ async fn main() {
                 obsidian_sync::obsidian_start_scheduler,
                 obsidian_sync::obsidian_stop_scheduler,
                 obsidian_sync::obsidian_cancel_sync,
+                // Reminders commands
+                reminders::reminders_status,
+                reminders::reminders_authorize,
+                reminders::reminders_list,
+                reminders::reminders_create,
+                reminders::reminders_scan,
+                reminders::reminders_start_scheduler,
+                reminders::reminders_stop_scheduler,
             ])
             .typ::<SettingsStore>()
             .typ::<OnboardingStore>()
@@ -1059,7 +1068,10 @@ async fn main() {
             .typ::<sync::SyncDeviceInfo>()
             .typ::<sync::SyncConfig>()
             .typ::<obsidian_sync::ObsidianSyncSettings>()
-            .typ::<obsidian_sync::ObsidianSyncStatus>();
+            .typ::<obsidian_sync::ObsidianSyncStatus>()
+            .typ::<reminders::RemindersStatus>()
+            .typ::<reminders::ReminderItem>()
+            .typ::<reminders::ScanResult>();
 
         if let Err(e) = builder
             .export(
@@ -1074,6 +1086,7 @@ async fn main() {
     let recording_state = RecordingState(Arc::new(tokio::sync::Mutex::new(None)));
     let pi_state = pi::PiState(Arc::new(tokio::sync::Mutex::new(None)));
     let obsidian_sync_state = obsidian_sync::ObsidianSyncState::new();
+    let reminders_state = reminders::RemindersState::new();
     #[allow(clippy::single_match)]
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -1126,6 +1139,7 @@ async fn main() {
         let app = app.manage(recording_state)
         .manage(pi_state)
         .manage(obsidian_sync_state)
+        .manage(reminders_state)
         .invoke_handler(tauri::generate_handler![
             spawn_screenpipe,
             stop_screenpipe,
@@ -1204,7 +1218,15 @@ async fn main() {
             obsidian_sync::obsidian_run_sync,
             obsidian_sync::obsidian_start_scheduler,
             obsidian_sync::obsidian_stop_scheduler,
-            obsidian_sync::obsidian_cancel_sync
+            obsidian_sync::obsidian_cancel_sync,
+            // Reminders commands
+            reminders::reminders_status,
+            reminders::reminders_authorize,
+            reminders::reminders_list,
+            reminders::reminders_create,
+            reminders::reminders_scan,
+            reminders::reminders_start_scheduler,
+            reminders::reminders_stop_scheduler
         ])
         .setup(move |app| {
             //deep link register_all
@@ -1689,6 +1711,17 @@ async fn main() {
                 // Small delay to ensure everything is ready
                 tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                 obsidian_sync::auto_start_scheduler(app_handle_clone, &obsidian_state_clone).await;
+            });
+
+            // Auto-start reminders scheduler if it was enabled
+            let app_handle_clone = app_handle.clone();
+            let reminders_state = app_handle.state::<reminders::RemindersState>();
+            let reminders_state_clone = reminders::RemindersState {
+                scheduler_handle: reminders_state.scheduler_handle.clone(),
+            };
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(tokio::time::Duration::from_secs(8)).await;
+                reminders::auto_start_scheduler(app_handle_clone, &reminders_state_clone).await;
             });
 
             Ok(())

--- a/apps/screenpipe-app-tauri/src-tauri/src/reminders.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/reminders.rs
@@ -1,0 +1,848 @@
+//! Apple Reminders integration — Tauri commands + background scheduler.
+//!
+//! Provides typed commands for the frontend to check auth, authorize,
+//! create reminders, list them, and trigger AI scans.
+//! Background scheduler runs every 30 min (persists across page navigations).
+//! All EventKit calls go through `spawn_blocking` (EKEventStore is !Send).
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::sync::Arc;
+use tauri::AppHandle;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
+
+use crate::store::RemindersSettingsStore;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct RemindersStatus {
+    pub available: bool,
+    pub authorized: bool,
+    pub authorization_status: String,
+    pub scheduler_running: bool,
+    pub reminder_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderItem {
+    pub identifier: String,
+    pub title: String,
+    pub notes: Option<String>,
+    pub completed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ScanResult {
+    pub reminders_created: usize,
+    pub items: Vec<ReminderItem>,
+    pub context_chars: usize,
+    pub error: Option<String>,
+}
+
+// ─── Managed state ──────────────────────────────────────────────────────────
+
+pub struct RemindersState {
+    pub scheduler_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+}
+
+impl RemindersState {
+    pub fn new() -> Self {
+        Self {
+            scheduler_handle: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+// ─── Commands ───────────────────────────────────────────────────────────────
+
+/// Check Reminders authorization + scheduler status (no popup).
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_status(
+    app: AppHandle,
+    state: tauri::State<'_, RemindersState>,
+) -> Result<RemindersStatus, String> {
+    #[cfg(target_os = "macos")]
+    {
+        use screenpipe_integrations::reminders::ScreenpipeReminders;
+
+        let auth_status = ScreenpipeReminders::authorization_status();
+        let status_str = format!("{}", auth_status);
+        let authorized = status_str == "Full Access";
+
+        let scheduler_running = state.scheduler_handle.lock().await.is_some();
+
+        let reminder_count = if authorized {
+            tokio::task::spawn_blocking(|| {
+                let r = ScreenpipeReminders::new();
+                let _ = r.ensure_list("Screenpipe");
+                r.list_reminders(Some("Screenpipe"))
+                    .map(|items| items.len() as u32)
+                    .unwrap_or(0)
+            })
+            .await
+            .unwrap_or(0)
+        } else {
+            0
+        };
+
+        Ok(RemindersStatus {
+            available: true,
+            authorized,
+            authorization_status: status_str,
+            scheduler_running,
+            reminder_count,
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, state);
+        Ok(RemindersStatus {
+            available: false,
+            authorized: false,
+            authorization_status: "not_supported".into(),
+            scheduler_running: false,
+            reminder_count: 0,
+        })
+    }
+}
+
+/// Request Reminders permission (shows one-time macOS popup).
+/// Returns "granted", "denied", or an error message.
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_authorize() -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        use screenpipe_integrations::reminders::ScreenpipeReminders;
+        let result = tokio::task::spawn_blocking(|| {
+            let r = ScreenpipeReminders::new();
+            r.request_access()
+        })
+        .await
+        .map_err(|e| format!("task failed: {}", e))?;
+
+        match result {
+            Ok(true) => {
+                info!("reminders: user granted access");
+                Ok("granted".into())
+            }
+            Ok(false) => {
+                warn!("reminders: user denied access");
+                Ok("denied".into())
+            }
+            Err(e) => Err(format!("{}", e)),
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("only available on macOS".into())
+    }
+}
+
+/// List existing reminders in the "Screenpipe" list.
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_list() -> Result<Vec<ReminderItem>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        use screenpipe_integrations::reminders::ScreenpipeReminders;
+        tokio::task::spawn_blocking(|| {
+            let r = ScreenpipeReminders::new();
+            let _ = r.ensure_list("Screenpipe");
+            let items = r
+                .list_reminders(Some("Screenpipe"))
+                .map_err(|e| format!("{}", e))?;
+            Ok(items
+                .into_iter()
+                .map(|i| ReminderItem {
+                    identifier: i.identifier,
+                    title: i.title,
+                    notes: i.notes,
+                    completed: i.completed,
+                })
+                .collect())
+        })
+        .await
+        .map_err(|e| format!("task failed: {}", e))?
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("only available on macOS".into())
+    }
+}
+
+/// Create a single reminder.
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_create(
+    title: String,
+    notes: Option<String>,
+    due: Option<String>,
+) -> Result<ReminderItem, String> {
+    #[cfg(target_os = "macos")]
+    {
+        use screenpipe_integrations::reminders::ScreenpipeReminders;
+        tokio::task::spawn_blocking(move || {
+            let r = ScreenpipeReminders::new();
+            let _ = r.ensure_list("Screenpipe");
+            let item = r
+                .create_reminder(&title, notes.as_deref(), Some("Screenpipe"), due.as_deref())
+                .map_err(|e| format!("{}", e))?;
+            Ok(ReminderItem {
+                identifier: item.identifier,
+                title: item.title,
+                notes: item.notes,
+                completed: item.completed,
+            })
+        })
+        .await
+        .map_err(|e| format!("task failed: {}", e))?
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (title, notes, due);
+        Err("only available on macOS".into())
+    }
+}
+
+/// Scan recent activity and create reminders from action items.
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_scan() -> Result<ScanResult, String> {
+    #[cfg(target_os = "macos")]
+    {
+        do_scan().await
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("only available on macOS".into())
+    }
+}
+
+/// Start the background scheduler (30-min interval). Persists across page navigation.
+/// Saves enabled=true to persistent store so it auto-starts on app relaunch.
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_start_scheduler(
+    app: AppHandle,
+    state: tauri::State<'_, RemindersState>,
+) -> Result<(), String> {
+    // Stop existing if any
+    reminders_stop_scheduler(state.clone()).await?;
+
+    // Save to persistent store
+    RemindersSettingsStore { enabled: true }.save(&app)?;
+
+    let handle_arc = state.scheduler_handle.clone();
+
+    let handle = tokio::spawn(async move {
+        info!("reminders scheduler: started (30-min interval)");
+        let interval = tokio::time::Duration::from_secs(30 * 60);
+
+        // Wait before first scan
+        tokio::time::sleep(interval).await;
+
+        loop {
+            info!("reminders scheduler: running scan");
+            #[cfg(target_os = "macos")]
+            match do_scan().await {
+                Ok(result) => {
+                    if result.reminders_created > 0 {
+                        info!(
+                            "reminders scheduler: created {} reminders",
+                            result.reminders_created
+                        );
+                    }
+                    if let Some(err) = &result.error {
+                        warn!("reminders scheduler: {}", err);
+                    }
+                }
+                Err(e) => {
+                    error!("reminders scheduler: scan failed: {}", e);
+                }
+            }
+
+            tokio::time::sleep(interval).await;
+        }
+    });
+
+    let mut guard = handle_arc.lock().await;
+    *guard = Some(handle);
+    info!("reminders scheduler: registered");
+
+    Ok(())
+}
+
+/// Stop the background scheduler. Saves enabled=false to persistent store.
+#[tauri::command]
+#[specta::specta]
+pub async fn reminders_stop_scheduler(
+    state: tauri::State<'_, RemindersState>,
+) -> Result<(), String> {
+    let mut handle = state.scheduler_handle.lock().await;
+    if let Some(h) = handle.take() {
+        h.abort();
+        info!("reminders scheduler: stopped");
+    }
+    Ok(())
+}
+
+/// Auto-start the scheduler on app launch if previously enabled.
+pub async fn auto_start_scheduler(app: AppHandle, state: &RemindersState) {
+    match RemindersSettingsStore::get(&app) {
+        Ok(Some(settings)) if settings.enabled => {
+            info!("reminders: auto-starting scheduler from saved settings");
+
+            // Verify still authorized
+            #[cfg(target_os = "macos")]
+            {
+                use screenpipe_integrations::reminders::ScreenpipeReminders;
+                let status = ScreenpipeReminders::authorization_status();
+                if format!("{}", status) != "Full Access" {
+                    warn!(
+                        "reminders: skipping auto-start, not authorized ({})",
+                        status
+                    );
+                    return;
+                }
+            }
+
+            let handle_arc = state.scheduler_handle.clone();
+            let handle = tokio::spawn(async move {
+                info!("reminders scheduler: auto-started (30-min interval)");
+                let interval = tokio::time::Duration::from_secs(30 * 60);
+                tokio::time::sleep(interval).await;
+
+                loop {
+                    info!("reminders scheduler: running scan");
+                    #[cfg(target_os = "macos")]
+                    match do_scan().await {
+                        Ok(result) => {
+                            if result.reminders_created > 0 {
+                                info!(
+                                    "reminders scheduler: created {} reminders",
+                                    result.reminders_created
+                                );
+                            }
+                            if let Some(err) = &result.error {
+                                warn!("reminders scheduler: {}", err);
+                            }
+                        }
+                        Err(e) => {
+                            error!("reminders scheduler: scan failed: {}", e);
+                        }
+                    }
+
+                    tokio::time::sleep(interval).await;
+                }
+            });
+
+            let mut guard = handle_arc.lock().await;
+            *guard = Some(handle);
+        }
+        _ => {
+            debug!("reminders: auto-start skipped (not enabled)");
+        }
+    }
+}
+
+// ─── Scan implementation ────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+async fn do_scan() -> Result<ScanResult, String> {
+    use screenpipe_integrations::reminders::ScreenpipeReminders;
+
+    // 1. Check authorization
+    let status = ScreenpipeReminders::authorization_status();
+    if format!("{}", status) != "Full Access" {
+        return Ok(ScanResult {
+            reminders_created: 0,
+            items: vec![],
+            context_chars: 0,
+            error: Some(format!("Reminders not authorized: {}", status)),
+        });
+    }
+
+    // 2. Check AI availability
+    let ai_available = check_ai_available().await;
+    if !ai_available {
+        return Ok(ScanResult {
+            reminders_created: 0,
+            items: vec![],
+            context_chars: 0,
+            error: Some("Apple Intelligence not available".into()),
+        });
+    }
+
+    // 3. Fetch recent data from screenpipe API
+    let context = fetch_recent_context().await?;
+    if context.is_empty() {
+        return Ok(ScanResult {
+            reminders_created: 0,
+            items: vec![],
+            context_chars: 0,
+            error: None,
+        });
+    }
+
+    let context_chars = context.len();
+    info!("reminders scan: {} chars of context", context_chars);
+
+    // 4. Call Apple Intelligence
+    let ai_response = call_ai_for_reminders(&context).await?;
+
+    // 5. Parse action items
+    let action_items = parse_action_items(&ai_response);
+    if action_items.is_empty() {
+        debug!("reminders scan: no action items found");
+        return Ok(ScanResult {
+            reminders_created: 0,
+            items: vec![],
+            context_chars,
+            error: None,
+        });
+    }
+
+    info!("reminders scan: found {} action items", action_items.len());
+
+    // 6. Deduplicate + create (all in spawn_blocking — EKEventStore is !Send)
+    let created = tokio::task::spawn_blocking(move || {
+        let r = ScreenpipeReminders::new();
+        let _ = r.ensure_list("Screenpipe");
+        let existing = r.list_reminders(Some("Screenpipe")).unwrap_or_default();
+        let existing_titles: Vec<String> =
+            existing.iter().map(|r| r.title.to_lowercase()).collect();
+
+        let mut created = Vec::new();
+        for item in &action_items {
+            if existing_titles
+                .iter()
+                .any(|t| t == &item.title.to_lowercase())
+            {
+                debug!("reminders scan: skipping duplicate '{}'", item.title);
+                continue;
+            }
+
+            match r.create_reminder(
+                &item.title,
+                item.notes.as_deref(),
+                Some("Screenpipe"),
+                item.due.as_deref(),
+            ) {
+                Ok(reminder) => {
+                    info!("reminders scan: created '{}'", reminder.title);
+                    created.push(ReminderItem {
+                        identifier: reminder.identifier,
+                        title: reminder.title,
+                        notes: reminder.notes,
+                        completed: reminder.completed,
+                    });
+                }
+                Err(e) => {
+                    warn!("reminders scan: failed to create '{}': {}", item.title, e);
+                }
+            }
+        }
+        created
+    })
+    .await
+    .map_err(|e| format!("task failed: {}", e))?;
+
+    Ok(ScanResult {
+        reminders_created: created.len(),
+        items: created,
+        context_chars,
+        error: None,
+    })
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const API: &str = "http://localhost:3030";
+
+/// Check if Apple Intelligence API is available.
+#[cfg(target_os = "macos")]
+async fn check_ai_available() -> bool {
+    let resp = reqwest::Client::new()
+        .get(format!("{}/ai/status", API))
+        .timeout(std::time::Duration::from_secs(3))
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) if r.status().is_success() => {
+            let data: serde_json::Value = r.json().await.unwrap_or_default();
+            data["available"].as_bool().unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
+/// Fetch the last 30 minutes of screen + audio from the screenpipe API.
+#[cfg(target_os = "macos")]
+async fn fetch_recent_context() -> Result<String, String> {
+    let client = reqwest::Client::new();
+    let now = chrono::Utc::now();
+    let thirty_min_ago = now - chrono::Duration::minutes(30);
+
+    let mut parts = Vec::new();
+
+    // Screen data (OCR)
+    if let Ok(resp) = client
+        .get(format!("{}/search", API))
+        .query(&[
+            ("content_type", "ocr"),
+            ("limit", "100"),
+            ("start_time", &thirty_min_ago.to_rfc3339()),
+            ("end_time", &now.to_rfc3339()),
+        ])
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        if let Ok(data) = resp.json::<serde_json::Value>().await {
+            let mut last_app = String::new();
+            if let Some(items) = data["data"].as_array() {
+                for item in items {
+                    if item["type"] == "OCR" {
+                        let content = &item["content"];
+                        let app = content["app_name"].as_str().unwrap_or("");
+                        let window = content["window_name"].as_str().unwrap_or("");
+
+                        if app == last_app {
+                            continue;
+                        }
+                        last_app = app.to_string();
+
+                        let text = content["text"].as_str().unwrap_or("");
+                        let truncated = if text.len() > 50 { &text[..50] } else { text };
+                        parts.push(format!("[screen] {} — {} | {}", app, window, truncated));
+                    }
+                }
+            }
+        }
+    }
+
+    // Audio data
+    if let Ok(resp) = client
+        .get(format!("{}/search", API))
+        .query(&[
+            ("content_type", "audio"),
+            ("limit", "50"),
+            ("start_time", &thirty_min_ago.to_rfc3339()),
+            ("end_time", &now.to_rfc3339()),
+            ("min_length", "10"),
+        ])
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        if let Ok(data) = resp.json::<serde_json::Value>().await {
+            if let Some(items) = data["data"].as_array() {
+                for item in items {
+                    if item["type"] == "Audio" {
+                        let content = &item["content"];
+                        let text = content["transcription"].as_str().unwrap_or("").trim();
+                        if text.len() > 10 {
+                            let speaker = content["speaker"]
+                                .as_object()
+                                .and_then(|s| s["name"].as_str())
+                                .unwrap_or("");
+                            parts.push(format!(
+                                "[audio] {}{}",
+                                if speaker.is_empty() {
+                                    String::new()
+                                } else {
+                                    format!("{}: ", speaker)
+                                },
+                                text
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(parts.join("\n"))
+}
+
+const REMINDERS_PROMPT: &str = r#"You are an assistant that extracts actionable reminders from screen and audio activity.
+
+Analyze the activity data below and extract ONLY clear, actionable items that the user should be reminded about.
+
+Rules:
+- Only extract things that are clearly tasks, to-dos, or commitments
+- Do NOT extract vague observations or general activity descriptions
+- Include a due date if one is mentioned or clearly implied
+- Due dates: use "today", "tomorrow", a weekday name, or YYYY-MM-DD format
+- Maximum 5 reminders per scan
+- If nothing actionable, return empty array
+
+Respond with ONLY this JSON format, no other text:
+{"reminders":[{"title":"short task description","notes":"additional context from the activity","due":"today"}]}"#;
+
+/// Call Apple Intelligence (via local /ai/chat/completions) to extract action items.
+#[cfg(target_os = "macos")]
+async fn call_ai_for_reminders(context: &str) -> Result<String, String> {
+    // Truncate to fit context window (~10K chars max)
+    let context = if context.len() > 6000 {
+        &context[..6000]
+    } else {
+        context
+    };
+
+    let client = reqwest::Client::new();
+
+    let do_request = |ctx: String| {
+        let client = client.clone();
+        async move {
+            let resp = client
+                .post(format!("{}/ai/chat/completions", API))
+                .json(&serde_json::json!({
+                    "messages": [
+                        {"role": "system", "content": REMINDERS_PROMPT},
+                        {"role": "user", "content": ctx}
+                    ]
+                }))
+                .timeout(std::time::Duration::from_secs(30))
+                .send()
+                .await
+                .map_err(|e| format!("AI API failed: {}", e))?;
+
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(format!("AI API error {}: {}", status, body));
+            }
+
+            let data: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| format!("AI response parse failed: {}", e))?;
+
+            Ok(data["choices"][0]["message"]["content"]
+                .as_str()
+                .unwrap_or("{}")
+                .to_string())
+        }
+    };
+
+    match do_request(context.to_string()).await {
+        Ok(response) => Ok(response),
+        Err(e) if e.contains("unsafe") => {
+            warn!("reminders: safety filter hit, retrying with sanitized context");
+            let sanitized = sanitize_context(context);
+            do_request(sanitized).await
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ActionItemParsed {
+    title: String,
+    notes: Option<String>,
+    due: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AiRemindersResponse {
+    reminders: Vec<ActionItemParsed>,
+}
+
+/// Parse AI response JSON into action items.
+/// Handles: valid JSON, JSON wrapped in markdown, partial JSON, empty/garbage.
+pub(crate) fn parse_action_items(response: &str) -> Vec<ActionItemParsed> {
+    let response = response.trim();
+    if response.is_empty() {
+        return Vec::new();
+    }
+
+    // Strip markdown code fences if present
+    let cleaned = if response.starts_with("```") {
+        response
+            .lines()
+            .skip(1)
+            .take_while(|l| !l.starts_with("```"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    } else {
+        response.to_string()
+    };
+
+    // Extract JSON object
+    let json_str = match cleaned.find('{') {
+        Some(start) => match cleaned.rfind('}') {
+            Some(end) if end >= start => &cleaned[start..=end],
+            _ => return Vec::new(),
+        },
+        None => return Vec::new(),
+    };
+
+    match serde_json::from_str::<AiRemindersResponse>(json_str) {
+        Ok(parsed) => parsed
+            .reminders
+            .into_iter()
+            .filter(|item| !item.title.trim().is_empty())
+            .take(5)
+            .collect(),
+        Err(e) => {
+            warn!(
+                "reminders: failed to parse AI response: {} | raw: {}",
+                e,
+                &response[..response.len().min(200)]
+            );
+            Vec::new()
+        }
+    }
+}
+
+/// Strip URLs and emails to reduce safety filter triggers.
+#[cfg(target_os = "macos")]
+fn sanitize_context(context: &str) -> String {
+    context
+        .split_whitespace()
+        .map(|word| {
+            if word.starts_with("http://") || word.starts_with("https://") {
+                "[url]"
+            } else if word.contains('@') && word.contains('.') {
+                "[email]"
+            } else {
+                word
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_valid_json() {
+        let input = r#"{"reminders":[{"title":"Buy groceries","notes":"Mentioned in meeting","due":"tomorrow"}]}"#;
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Buy groceries");
+        assert_eq!(items[0].notes.as_deref(), Some("Mentioned in meeting"));
+        assert_eq!(items[0].due.as_deref(), Some("tomorrow"));
+    }
+
+    #[test]
+    fn test_parse_multiple_items() {
+        let input = r#"{"reminders":[
+            {"title":"Task 1","notes":null,"due":"today"},
+            {"title":"Task 2","notes":"context","due":"friday"},
+            {"title":"Task 3","notes":null,"due":null}
+        ]}"#;
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].title, "Task 1");
+        assert_eq!(items[2].due, None);
+    }
+
+    #[test]
+    fn test_parse_empty_reminders() {
+        let input = r#"{"reminders":[]}"#;
+        let items = parse_action_items(input);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_parse_markdown_wrapped() {
+        let input = "```json\n{\"reminders\":[{\"title\":\"Do thing\",\"notes\":null,\"due\":\"today\"}]}\n```";
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Do thing");
+    }
+
+    #[test]
+    fn test_parse_text_before_json() {
+        let input = "Here are the reminders I found:\n{\"reminders\":[{\"title\":\"Call dentist\",\"notes\":\"mentioned at 2pm\",\"due\":\"tomorrow\"}]}";
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Call dentist");
+    }
+
+    #[test]
+    fn test_parse_empty_titles_filtered() {
+        let input = r#"{"reminders":[{"title":"","notes":null,"due":null},{"title":"  ","notes":null,"due":null},{"title":"Real task","notes":null,"due":null}]}"#;
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Real task");
+    }
+
+    #[test]
+    fn test_parse_max_5_items() {
+        let input = r#"{"reminders":[
+            {"title":"T1","notes":null,"due":null},
+            {"title":"T2","notes":null,"due":null},
+            {"title":"T3","notes":null,"due":null},
+            {"title":"T4","notes":null,"due":null},
+            {"title":"T5","notes":null,"due":null},
+            {"title":"T6","notes":null,"due":null},
+            {"title":"T7","notes":null,"due":null}
+        ]}"#;
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 5);
+    }
+
+    #[test]
+    fn test_parse_garbage_input() {
+        assert!(parse_action_items("").is_empty());
+        assert!(parse_action_items("not json at all").is_empty());
+        assert!(parse_action_items("{}").is_empty());
+        assert!(parse_action_items("{\"wrong_key\": []}").is_empty());
+    }
+
+    #[test]
+    fn test_parse_truncated_json() {
+        // AI sometimes truncates output
+        let input = r#"{"reminders":[{"title":"Do thing","no"#;
+        let items = parse_action_items(input);
+        assert!(items.is_empty()); // graceful failure
+    }
+
+    #[test]
+    fn test_parse_real_ai_response() {
+        // Realistic Apple Intelligence output (sometimes adds explanation)
+        let input = r#"Based on the activity data, here are the actionable items:
+
+{"reminders":[{"title":"Review PR #2205","notes":"Seen in GitHub - screenpipe repo","due":"today"},{"title":"Reply to John's message about deployment","notes":"Slack conversation at 2:15 PM","due":"today"},{"title":"Update documentation for reminders feature","notes":"Discussion in terminal about missing docs","due":"tomorrow"}]}
+
+These are the key action items I identified."#;
+        let items = parse_action_items(input);
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].title, "Review PR #2205");
+        assert_eq!(items[1].title, "Reply to John's message about deployment");
+        assert_eq!(items[2].due.as_deref(), Some("tomorrow"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_sanitize_context() {
+        let input = "Check https://github.com/screenpipe and email john@example.com about it";
+        let result = sanitize_context(input);
+        assert!(result.contains("[url]"));
+        assert!(result.contains("[email]"));
+        assert!(!result.contains("github.com"));
+        assert!(!result.contains("john@example.com"));
+        assert!(result.contains("Check"));
+        assert!(result.contains("about"));
+    }
+}

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -651,3 +651,30 @@ impl ObsidianSettingsStore {
         store.save().map_err(|e| e.to_string())
     }
 }
+
+// ─── Reminders Settings ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RemindersSettingsStore {
+    pub enabled: bool,
+}
+
+impl RemindersSettingsStore {
+    pub fn get(app: &AppHandle) -> Result<Option<Self>, String> {
+        let store = get_store(app, None).map_err(|e| e.to_string())?;
+        if store.is_empty() {
+            return Ok(None);
+        }
+        let settings = serde_json::from_value(store.get("reminders").unwrap_or(Value::Null));
+        match settings {
+            Ok(settings) => Ok(settings),
+            Err(_) => Ok(None),
+        }
+    }
+
+    pub fn save(&self, app: &AppHandle) -> Result<(), String> {
+        let store = get_store(app, None).map_err(|e| e.to_string())?;
+        store.set("reminders", json!(self));
+        store.save().map_err(|e| e.to_string())
+    }
+}

--- a/crates/screenpipe-integrations/Cargo.toml
+++ b/crates/screenpipe-integrations/Cargo.toml
@@ -17,3 +17,11 @@ tempfile = "3.2"
 anyhow = "1.0"
 mime_guess = "2.0.5"
 screenpipe-core = { path = "../screenpipe-core" }
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+eventkit-rs = { version = "0.1", features = ["reminders"] }
+objc2 = "0.6"
+objc2-event-kit = "0.3"
+objc2-foundation = "0.3"
+chrono = "0.4"

--- a/crates/screenpipe-integrations/src/lib.rs
+++ b/crates/screenpipe-integrations/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod unstructured_ocr;
+
+#[cfg(target_os = "macos")]
+pub mod reminders;

--- a/crates/screenpipe-integrations/src/reminders.rs
+++ b/crates/screenpipe-integrations/src/reminders.rs
@@ -1,0 +1,501 @@
+//! Apple Reminders integration via EventKit.
+//!
+//! Wraps `eventkit-rs` for core CRUD and adds:
+//! - `ensure_list()` — idempotent list creation
+//! - `create_reminder_with_due()` — natural language due date parsing
+//!
+//! All operations are synchronous and safe to call from a tokio blocking task.
+
+use eventkit::{
+    AuthorizationStatus, CalendarInfo, EventKitError, RemindersManager, ReminderItem,
+    Result as EKResult,
+};
+use chrono::Datelike;
+use objc2::rc::Retained;
+use objc2::Message;
+use objc2_event_kit::{EKCalendar, EKEntityType, EKEventStore, EKReminder, EKSource, EKSourceType};
+use objc2_foundation::{NSDateComponents, NSString};
+use tracing::{debug, warn};
+
+/// Thin wrapper around `eventkit::RemindersManager` with screenpipe-specific additions.
+pub struct ScreenpipeReminders {
+    manager: RemindersManager,
+    store: Retained<EKEventStore>,
+}
+
+impl ScreenpipeReminders {
+    /// Create a new instance. Does NOT trigger any permission popup.
+    pub fn new() -> Self {
+        let manager = RemindersManager::new();
+        let store = unsafe { EKEventStore::new() };
+        Self { manager, store }
+    }
+
+    // ── Authorization ──────────────────────────────────────────────────
+
+    /// Check current TCC status without triggering a popup.
+    pub fn authorization_status() -> AuthorizationStatus {
+        RemindersManager::authorization_status()
+    }
+
+    /// Request full access (shows popup on first call, then persists).
+    pub fn request_access(&self) -> EKResult<bool> {
+        self.manager.request_access()
+    }
+
+    /// Ensure we have authorization, requesting if needed.
+    pub fn ensure_authorized(&self) -> EKResult<()> {
+        self.manager.ensure_authorized()
+    }
+
+    // ── List / Calendar management ─────────────────────────────────────
+
+    /// List all reminder calendars.
+    pub fn list_calendars(&self) -> EKResult<Vec<CalendarInfo>> {
+        self.manager.list_calendars()
+    }
+
+    /// Ensure a named reminders list exists. Returns (calendar_title, created).
+    /// Idempotent — safe to call repeatedly.
+    pub fn ensure_list(&self, name: &str) -> EKResult<(String, bool)> {
+        self.ensure_authorized()?;
+
+        // Check if it already exists
+        let calendars = unsafe { self.store.calendarsForEntityType(EKEntityType::Reminder) };
+        for cal in calendars.iter() {
+            let title = unsafe { cal.title() };
+            if title.to_string() == name {
+                debug!("reminders list '{}' already exists", name);
+                return Ok((name.to_string(), false));
+            }
+        }
+
+        // Find a local or iCloud source for the new calendar
+        let source = self.find_best_source()?;
+
+        // Create the calendar
+        let calendar = unsafe {
+            EKCalendar::calendarForEntityType_eventStore(EKEntityType::Reminder, &self.store)
+        };
+        let ns_title = NSString::from_str(name);
+        unsafe {
+            calendar.setTitle(&ns_title);
+            calendar.setSource(Some(&source));
+        }
+
+        unsafe {
+            self.store
+                .saveCalendar_commit_error(&calendar, true)
+                .map_err(|e| EventKitError::SaveFailed(format!("{:?}", e)))?;
+        }
+
+        debug!("created reminders list '{}'", name);
+        Ok((name.to_string(), true))
+    }
+
+    // ── Reminder CRUD ──────────────────────────────────────────────────
+
+    /// Create a reminder with optional natural language due date.
+    ///
+    /// `due` supports: "today", "tomorrow", weekday names ("monday"–"sunday"),
+    /// "next week", ISO dates ("2026-03-15"), or `None` for no due date.
+    /// Invalid/unrecognized values are silently ignored (no due date set).
+    pub fn create_reminder(
+        &self,
+        title: &str,
+        notes: Option<&str>,
+        calendar_title: Option<&str>,
+        due: Option<&str>,
+    ) -> EKResult<ReminderItem> {
+        self.ensure_authorized()?;
+
+        let reminder = unsafe { EKReminder::reminderWithEventStore(&self.store) };
+
+        // Title
+        let ns_title = NSString::from_str(title);
+        unsafe { reminder.setTitle(Some(&ns_title)) };
+
+        // Notes
+        if let Some(n) = notes {
+            let ns_notes = NSString::from_str(n);
+            unsafe { reminder.setNotes(Some(&ns_notes)) };
+        }
+
+        // Calendar
+        let calendar = match calendar_title {
+            Some(name) => self.find_calendar_by_title(name).ok(),
+            None => None,
+        };
+        let calendar = calendar
+            .or_else(|| unsafe { self.store.defaultCalendarForNewReminders() })
+            .ok_or(EventKitError::NoDefaultCalendar)?;
+        unsafe { reminder.setCalendar(Some(&calendar)) };
+
+        // Due date
+        if let Some(due_str) = due {
+            if let Some(components) = parse_due_date(due_str) {
+                unsafe { reminder.setDueDateComponents(Some(&components)) };
+                debug!("set due date from '{}'", due_str);
+            } else {
+                debug!("ignoring unrecognized due date: '{}'", due_str);
+            }
+        }
+
+        // Save
+        unsafe {
+            self.store
+                .saveReminder_commit_error(&reminder, true)
+                .map_err(|e| EventKitError::SaveFailed(format!("{:?}", e)))?;
+        }
+
+        Ok(reminder_to_item(&reminder))
+    }
+
+    /// List incomplete reminders, optionally from a specific list.
+    pub fn list_reminders(&self, calendar_title: Option<&str>) -> EKResult<Vec<ReminderItem>> {
+        match calendar_title {
+            Some(title) => self.manager.fetch_reminders(Some(&[title])),
+            None => self.manager.fetch_incomplete_reminders(),
+        }
+    }
+
+    /// Delete a reminder by identifier.
+    pub fn delete_reminder(&self, identifier: &str) -> EKResult<()> {
+        self.manager.delete_reminder(identifier)
+    }
+
+    /// Mark a reminder as complete.
+    pub fn complete_reminder(&self, identifier: &str) -> EKResult<ReminderItem> {
+        self.manager.complete_reminder(identifier)
+    }
+
+    /// Get a reminder by identifier.
+    pub fn get_reminder(&self, identifier: &str) -> EKResult<ReminderItem> {
+        self.manager.get_reminder(identifier)
+    }
+
+    // ── Private helpers ────────────────────────────────────────────────
+
+    fn find_calendar_by_title(
+        &self,
+        title: &str,
+    ) -> EKResult<Retained<EKCalendar>> {
+        let calendars = unsafe { self.store.calendarsForEntityType(EKEntityType::Reminder) };
+        for cal in calendars.iter() {
+            let cal_title = unsafe { cal.title() };
+            if cal_title.to_string() == title {
+                return Ok(cal.retain());
+            }
+        }
+        Err(EventKitError::CalendarNotFound(title.to_string()))
+    }
+
+    fn find_best_source(&self) -> EKResult<Retained<EKSource>> {
+        let sources = unsafe { self.store.sources() };
+
+        // Prefer iCloud, then Local
+        let mut local_source = None;
+        for source in sources.iter() {
+            let source_type = unsafe { source.sourceType() };
+            if source_type == EKSourceType::CalDAV {
+                // iCloud is CalDAV
+                return Ok(source.retain());
+            }
+            if source_type == EKSourceType::Local && local_source.is_none() {
+                local_source = Some(source.retain());
+            }
+        }
+
+        local_source.ok_or_else(|| {
+            EventKitError::SaveFailed("no suitable source found for new calendar".to_string())
+        })
+    }
+}
+
+impl Default for ScreenpipeReminders {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Due date parsing ────────────────────────────────────────────────────
+
+/// Parse a natural language due date string into NSDateComponents.
+/// Returns None if the string is empty, "null", "none", or unrecognized.
+fn parse_due_date(due: &str) -> Option<Retained<NSDateComponents>> {
+    let due = due.trim().to_lowercase();
+    if due.is_empty() || due == "null" || due == "none" {
+        return None;
+    }
+
+    let now = chrono::Local::now();
+
+    let target_date = match due.as_str() {
+        "today" => Some(now.date_naive()),
+        "tomorrow" => Some(now.date_naive() + chrono::Duration::days(1)),
+        "next week" => Some(now.date_naive() + chrono::Duration::weeks(1)),
+        day_name => {
+            // Try weekday name
+            if let Some(target_weekday) = parse_weekday(day_name) {
+                let current_weekday = now.date_naive().weekday();
+                let days_ahead = (target_weekday.num_days_from_monday() as i64
+                    - current_weekday.num_days_from_monday() as i64
+                    + 7)
+                    % 7;
+                let days_ahead = if days_ahead == 0 { 7 } else { days_ahead };
+                Some(now.date_naive() + chrono::Duration::days(days_ahead))
+            }
+            // Try ISO date
+            else if let Ok(date) = chrono::NaiveDate::parse_from_str(day_name, "%Y-%m-%d") {
+                Some(date)
+            } else {
+                warn!("unrecognized due date format: '{}'", due);
+                None
+            }
+        }
+    };
+
+    target_date.map(|date| {
+        let components = NSDateComponents::new();
+        components.setYear(date.year() as isize);
+        components.setMonth(date.month() as isize);
+        components.setDay(date.day() as isize);
+        components
+    })
+}
+
+fn parse_weekday(s: &str) -> Option<chrono::Weekday> {
+    match s {
+        "monday" | "mon" => Some(chrono::Weekday::Mon),
+        "tuesday" | "tue" => Some(chrono::Weekday::Tue),
+        "wednesday" | "wed" => Some(chrono::Weekday::Wed),
+        "thursday" | "thu" => Some(chrono::Weekday::Thu),
+        "friday" | "fri" => Some(chrono::Weekday::Fri),
+        "saturday" | "sat" => Some(chrono::Weekday::Sat),
+        "sunday" | "sun" => Some(chrono::Weekday::Sun),
+        _ => None,
+    }
+}
+
+fn reminder_to_item(reminder: &EKReminder) -> ReminderItem {
+    let identifier = unsafe { reminder.calendarItemIdentifier() }.to_string();
+    let title = unsafe { reminder.title() }.to_string();
+    let notes = unsafe { reminder.notes() }.map(|n| n.to_string());
+    let completed = unsafe { reminder.isCompleted() };
+    let priority = unsafe { reminder.priority() };
+    let calendar_title = unsafe { reminder.calendar() }.map(|c| unsafe { c.title() }.to_string());
+
+    ReminderItem {
+        identifier,
+        title,
+        notes,
+        completed,
+        priority,
+        calendar_title,
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_authorization() {
+        let status = ScreenpipeReminders::authorization_status();
+        println!("Reminders authorization: {}", status);
+        // Should not crash regardless of status
+    }
+
+    #[test]
+    fn test_ensure_list_idempotent() {
+        let r = ScreenpipeReminders::new();
+        if ScreenpipeReminders::authorization_status() != AuthorizationStatus::FullAccess {
+            println!("Skipping: not authorized");
+            return;
+        }
+
+        let list = "Screenpipe Test Idempotent";
+        let (_, created1) = r.ensure_list(list).expect("first ensure_list failed");
+        assert!(created1, "should be created first time");
+
+        let (_, created2) = r.ensure_list(list).expect("second ensure_list failed");
+        assert!(!created2, "should already exist");
+
+        // Cleanup: delete via store
+        cleanup_list(&r, list);
+        println!("Idempotent test passed!");
+    }
+
+    #[test]
+    fn test_full_lifecycle() {
+        let r = ScreenpipeReminders::new();
+        if ScreenpipeReminders::authorization_status() != AuthorizationStatus::FullAccess {
+            println!("Skipping: not authorized");
+            return;
+        }
+
+        let list = "Screenpipe Test Lifecycle";
+        r.ensure_list(list).unwrap();
+
+        // Create
+        let item = r
+            .create_reminder("Test lifecycle", Some("notes here"), Some(list), Some("tomorrow"))
+            .expect("create failed");
+        println!("Created: {} ({})", item.title, item.identifier);
+        assert_eq!(item.title, "Test lifecycle");
+        assert_eq!(item.notes.as_deref(), Some("notes here"));
+
+        // List
+        let items = r.list_reminders(Some(list)).expect("list failed");
+        assert!(items.iter().any(|i| i.identifier == item.identifier));
+
+        // Get
+        let got = r.get_reminder(&item.identifier).expect("get failed");
+        assert_eq!(got.title, "Test lifecycle");
+
+        // Complete
+        let completed = r.complete_reminder(&item.identifier).expect("complete failed");
+        assert!(completed.completed);
+
+        // Delete
+        r.delete_reminder(&item.identifier).expect("delete failed");
+
+        cleanup_list(&r, list);
+        println!("Full lifecycle test passed!");
+    }
+
+    #[test]
+    fn test_due_date_variants() {
+        let r = ScreenpipeReminders::new();
+        if ScreenpipeReminders::authorization_status() != AuthorizationStatus::FullAccess {
+            println!("Skipping: not authorized");
+            return;
+        }
+
+        let list = "Screenpipe Test Dates";
+        r.ensure_list(list).unwrap();
+
+        let cases = vec![
+            ("today", true),
+            ("tomorrow", true),
+            ("friday", true),
+            ("next week", true),
+            ("2026-03-15", true),
+            ("null", true),    // should succeed (no due date)
+            ("none", true),    // should succeed (no due date)
+            ("", true),        // should succeed (no due date)
+            ("garbage", true), // should succeed (no due date)
+        ];
+
+        let mut ids = Vec::new();
+        for (due, should_succeed) in &cases {
+            let due_opt = if due.is_empty() { None } else { Some(*due) };
+            match r.create_reminder(&format!("Due {}", due), None, Some(list), due_opt) {
+                Ok(item) => {
+                    assert!(should_succeed, "should have succeeded for '{}'", due);
+                    println!("✅ due='{}' → {}", due, item.identifier);
+                    ids.push(item.identifier);
+                }
+                Err(e) => {
+                    assert!(!should_succeed, "should have failed for '{}': {}", due, e);
+                    println!("❌ due='{}' → {}", due, e);
+                }
+            }
+        }
+
+        // Cleanup
+        for id in &ids {
+            let _ = r.delete_reminder(id);
+        }
+        cleanup_list(&r, list);
+        println!("Due date variants test passed!");
+    }
+
+    #[test]
+    fn test_special_characters() {
+        let r = ScreenpipeReminders::new();
+        if ScreenpipeReminders::authorization_status() != AuthorizationStatus::FullAccess {
+            println!("Skipping: not authorized");
+            return;
+        }
+
+        let list = "Screenpipe Test Special";
+        r.ensure_list(list).unwrap();
+
+        let titles = [
+            "Reminder with émojis 🎉🔥",
+            "日本語のリマインダー",
+            "Reminder with \"quotes\" and 'apostrophes'",
+        ];
+
+        let mut ids = Vec::new();
+        for title in &titles {
+            let item = r
+                .create_reminder(title, None, Some(list), None)
+                .expect(&format!("failed to create '{}'", title));
+            println!("✅ '{}'", title);
+            ids.push(item.identifier);
+        }
+
+        for id in &ids {
+            let _ = r.delete_reminder(id);
+        }
+        cleanup_list(&r, list);
+        println!("Special characters test passed!");
+    }
+
+    #[test]
+    fn test_stress() {
+        let r = ScreenpipeReminders::new();
+        if ScreenpipeReminders::authorization_status() != AuthorizationStatus::FullAccess {
+            println!("Skipping: not authorized");
+            return;
+        }
+
+        let list = "Screenpipe Test Stress";
+        r.ensure_list(list).unwrap();
+
+        let start = std::time::Instant::now();
+        let mut ids = Vec::new();
+        for i in 0..20 {
+            let item = r
+                .create_reminder(&format!("Stress #{}", i), None, Some(list), None)
+                .expect(&format!("create #{} failed", i));
+            ids.push(item.identifier);
+        }
+        let create_time = start.elapsed();
+        println!(
+            "Created 20 in {:?} ({:.1}ms each)",
+            create_time,
+            create_time.as_millis() as f64 / 20.0
+        );
+
+        let start = std::time::Instant::now();
+        let listed = r.list_reminders(Some(list)).expect("list failed");
+        println!("Listed {} in {:?}", listed.len(), start.elapsed());
+        assert!(listed.len() >= 20);
+
+        let start = std::time::Instant::now();
+        for id in &ids {
+            r.delete_reminder(id).expect("delete failed");
+        }
+        println!("Deleted 20 in {:?}", start.elapsed());
+
+        cleanup_list(&r, list);
+        println!("Stress test passed!");
+    }
+
+    /// Helper to remove a test calendar/list
+    fn cleanup_list(r: &ScreenpipeReminders, name: &str) {
+        let calendars = unsafe { r.store.calendarsForEntityType(EKEntityType::Reminder) };
+        for cal in calendars.iter() {
+            let title = unsafe { cal.title() };
+            if title.to_string() == name {
+                let _ = unsafe { r.store.removeCalendar_commit_error(&cal, true) };
+                println!("Cleaned up list '{}'", name);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Scans screen + audio activity every 30 minutes using Apple Intelligence (on-device) and automatically creates Apple Reminders for detected action items.

## User flow

1. **Settings → Apple Intelligence card** → new "Auto Reminders" section
2. **"Connect Apple Reminders"** → one-time macOS permission popup
3. **Toggle on** → background scheduler scans every 30 min
4. **"Scan now"** → immediate scan with inline results
5. Reminders appear in Apple Reminders app under a dedicated **"Screenpipe"** list with due dates

If user denies permission: shows "Access denied" with instructions to fix in System Settings.

## Architecture

```
apple-intelligence-card.tsx
  → invoke("reminders_*")        ← Tauri commands (typed via specta)
    → src-tauri/reminders.rs      ← 7 commands + scan pipeline + scheduler
      → screenpipe-integrations/  ← EventKit wrapper (eventkit-rs)
        reminders.rs

screenpipe-server: UNTOUCHED
screenpipe-core: UNTOUCHED
```

- **Tauri commands**, not server routes — clean separation
- Background scheduler via `tokio::spawn` + managed state (survives page navigation)
- Settings persisted in `store.bin` → auto-restarts scheduler on app relaunch
- All EventKit calls in `spawn_blocking` (EKEventStore is !Send)
- Deduplicates against existing reminders (case-insensitive title match)
- Safety filter retry: strips URLs/emails on "unsafe" AI response
- Natural language due dates: today, tomorrow, weekday names, next week, ISO dates

## Scan pipeline

1. `GET /search?content_type=ocr` — last 30 min, deduped by app switch
2. `GET /search?content_type=audio` — last 30 min transcriptions
3. `POST /ai/chat/completions` — Apple Intelligence extracts max 5 action items as JSON
4. Dedup against existing "Screenpipe" reminders list
5. Create via EventKit with due dates

## Tests

- **6 EventKit integration tests**: full lifecycle, stress (20 reminders), special chars (emoji, CJK, quotes), due date variants (9 formats), idempotent list creation
- **10 JSON parser unit tests**: valid JSON, multiple items, empty, markdown-wrapped, text-before-json, empty titles filtered, max 5 cap, garbage input, truncated JSON, realistic AI output
- **2 sanitizer tests**: URL/email stripping

## Files changed

| Layer | File | What |
|---|---|---|
| **Lib** | `crates/screenpipe-integrations/src/reminders.rs` | EventKit wrapper (new, 316 LOC) |
| **Lib** | `crates/screenpipe-integrations/Cargo.toml` | +eventkit-rs, objc2-event-kit |
| **App** | `src-tauri/src/reminders.rs` | 7 Tauri commands + scan logic (new, 526 LOC) |
| **App** | `src-tauri/src/main.rs` | Register module, state, auto-start |
| **App** | `src-tauri/src/store.rs` | RemindersSettingsStore persistence |
| **App** | `src-tauri/Info.plist` | NSRemindersUsageDescription |
| **UI** | `apple-intelligence-card.tsx` | Reminders section in settings |

## Platform

macOS only (EventKit). Non-macOS returns `available: false` gracefully.