### PR TITLE
fix: shortcut system — Ctrl+Cmd+K dies after Esc, recording blocks shortcuts, conflict detection

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils.ts
+++ b/apps/screenpipe-app-tauri/lib/utils.ts
@@ -92,10 +92,10 @@ export function parseKeyboardShortcut(shortcut: string): string {
 
     return Array.from(uniqueKeys)
       .map((key) => {
-        if (key === "super") {
+        if (key === "super" || key === "meta" || key === "command" || key === "cmd") {
           return os === "macos" ? "⌘" : "⊞";
         }
-        if (key === "ctrl") return "⌃";
+        if (key === "ctrl" || key === "control") return "⌃";
         if (key === "alt") return os === "macos" ? "⌥" : "Alt";
         if (key === "shift") return "⇧";
         return key.charAt(0).toUpperCase() + key.slice(1);


### PR DESCRIPTION
## fixes

### 1. Ctrl+Cmd+K stops working after pressing Escape
Search shortcut was registered in **two** places (global in `apply_shortcuts` + window in `register_window_shortcuts`). When the overlay closed, `unregister_window_shortcuts` killed the global registration too. Nothing re-registered it → shortcut dead until restart.

**Fix:** Search shortcut is now global-only. Removed the duplicate window registration and stopped unregistering it on hide.

### 2. Shortcut recording now suspends all global shortcuts
Pressing Ctrl+Cmd+K while recording a new shortcut would trigger the existing shortcut instead of capturing it. Other apps' shortcuts (Notion Calendar etc) also fire.

**Fix:** Calls `suspend_global_shortcuts` when entering recording mode, `resume_global_shortcuts` when done.

### 3. Duplicate shortcut conflict detection
Could assign the same key combo to two features with no warning.

**Fix:** Checks all other enabled shortcuts before accepting. Shows error toast on conflict.

### 4. "Control" vs ⌃ symbol inconsistency
Sometimes showed the word "Control" instead of ⌃. Tauri stores "Control" but the parser only handled "ctrl".

**Fix:** `parseKeyboardShortcut` now normalizes "control" → ⌃, "meta"/"command"/"cmd" → ⌘.

### 5. Net deletion: -85 lines, +48 lines
Removed the entire duplicate search shortcut registration block from `register_window_shortcuts` (was ~50 lines).

## files changed
- `src-tauri/src/commands.rs` — remove duplicate search shortcut registration, stop unregistering global shortcuts on hide
- `components/settings/shortcut-row.tsx` — suspend/resume shortcuts during recording, conflict detection
- `lib/utils.ts` — normalize control/meta/command in display