### PR TITLE
fix: Improve timeline app icon rendering with PNG transparency and consistent sizing

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
@@ -149,7 +149,7 @@ export function AppContextPopover({
 						<img
 							key={i}
 							src={`http://localhost:11435/app-icon?name=${encodeURIComponent(name)}`}
-							className="w-4 h-4 rounded flex-shrink-0"
+							className="w-5 h-5 rounded flex-shrink-0 object-contain"
 							alt={name}
 							style={i > 0 ? { marginLeft: -6 } : undefined}
 						/>

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -526,8 +526,12 @@ export const TimelineSlider = ({
 								{/* Vertical stacked app icons - click for context popover */}
 								{groupWidth > 30 && (
 									<motion.div
-										className="absolute top-1 left-1/2 -translate-x-1/2 z-10 flex flex-col cursor-pointer"
-										style={{ direction: 'ltr' }}
+										className="absolute top-1 left-1/2 -translate-x-1/2 z-10 flex flex-col cursor-pointer p-1.5"
+										style={{ 
+											direction: 'ltr',
+											pointerEvents: 'auto',
+											isolation: 'isolate'
+										}}
 										whileHover="expanded"
 										initial="collapsed"
 										onClick={(e) => {
@@ -542,17 +546,26 @@ export const TimelineSlider = ({
 										{group.appNames.slice(0, 2).map((appName, idx) => (
 											<motion.div
 												key={`${appName}-${idx}`}
-												className="w-4 h-4 rounded bg-background/90 p-0.5 shadow-sm border border-background/50"
-												style={{ zIndex: 10 - idx }}
+												className="w-8 h-8 rounded flex-shrink-0 overflow-hidden flex items-center justify-center"
+												style={{ 
+													zIndex: 10 - idx,
+													position: 'relative'
+												}}
 												variants={{
-													collapsed: { marginTop: idx === 0 ? 0 : -6 },
-													expanded: { marginTop: idx === 0 ? 0 : 2 }
+													collapsed: { 
+														marginTop: idx === 0 ? 0 : -10,
+														scale: 1
+													},
+													expanded: { 
+														marginTop: idx === 0 ? 0 : 4,
+														scale: 1.1
+													}
 												}}
 												transition={{ type: "spring", stiffness: 400, damping: 25 }}
 											>
 												<img
 													src={`http://localhost:11435/app-icon?name=${encodeURIComponent(appName)}`}
-													className="w-full h-full rounded-sm"
+													className="w-full h-full rounded-sm object-contain scale-110"
 													alt={appName}
 													loading="lazy"
 													decoding="async"

--- a/apps/screenpipe-app-tauri/src-tauri/src/icons.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/icons.rs
@@ -47,10 +47,10 @@ pub async fn get_app_icon(
 
             let tiff_data: id = msg_send![icon, TIFFRepresentation];
             let image_rep: id = msg_send![class!(NSBitmapImageRep), imageRepWithData: tiff_data];
-            let jpeg_data: id = msg_send![image_rep, representationUsingType:3 properties:nil]; // Type 3 is JPEG
+            let png_data: id = msg_send![image_rep, representationUsingType:0 properties:nil]; // Type 0 is PNG (supports transparency)
 
-            let length = NSData::length(jpeg_data);
-            let bytes = NSData::bytes(jpeg_data);
+            let length = NSData::length(png_data);
+            let bytes = NSData::bytes(png_data);
             let data = std::slice::from_raw_parts(bytes as *const u8, length as usize).to_vec();
 
             Ok(Some(AppIcon {

--- a/apps/screenpipe-app-tauri/src-tauri/src/server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server.rs
@@ -353,7 +353,7 @@ async fn get_app_icon_handler(
         match crate::icons::get_app_icon(&app_name.name, app_name.path).await {
             Ok(Some(icon)) => {
                 let headers = [
-                    (CONTENT_TYPE, HeaderValue::from_static("image/jpeg")),
+                    (CONTENT_TYPE, HeaderValue::from_static("image/png")),
                     (
                         http::header::CACHE_CONTROL,
                         HeaderValue::from_static("public, max-age=604800"),


### PR DESCRIPTION
# Description
### Root Problems
1. White backgrounds on icons: macOS generated icons as JPEG (no transparency), causing white backgrounds that didn't match the dark UI.
2. Icons too small: 16px icons were hard to see and interact with on the timeline.
3. Inconsistent icon sizes: Different padding in source images made icons appear different sizes even with the same CSS dimensions.
4. Icon distortion: Missing `object-contain` caused icons to stretch/squash.

## Before

https://github.com/user-attachments/assets/86fe3ebe-236a-4d3d-87d4-37c302b48da9



<img width="1361" height="161" alt="Screenshot 2026-02-11 at 2 42 57 AM" src="https://github.com/user-attachments/assets/0aa4f442-5266-4412-a796-10c5d8d8c20d" />





## After 


https://github.com/user-attachments/assets/7b9514dd-be7d-44f9-9ea8-b610187a7d8a

<img width="1387" height="196" alt="Screenshot 2026-02-11 at 2 39 08 AM" src="https://github.com/user-attachments/assets/8817d239-7249-40e3-9a04-58b979f03d80" />





