### PR TITLE
feat: timeline context menu (copy image, OCR, frame deeplink, ask about frame)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -184,6 +184,7 @@ commits: `f1255eac`, `25cbdc6b`, `2529367d`, `d9821624`
 - [ ] **app context popover** — clicking app icon in timeline shows context (time, windows, urls, audio) (`be3ecffb`).
 - [ ] **daily summary in timeline** — Apple Intelligence summary shows in timeline, compact when no summary (`d9821624`).
 - [ ] **window-focused refresh** — opening app via shortcut/tray refreshes timeline data immediately (`0b057046`).
+- [ ] **frame deep link navigation** — `screenpipe://frame/N` or `screenpipe://frames/N` opens main window and jumps to frame N. works from cold start; invalid IDs show clear error.
 
 ### 13. sync & cloud
 

--- a/apps/screenpipe-app-tauri/bun.lock
+++ b/apps/screenpipe-app-tauri/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "screenpipe-app",

--- a/apps/screenpipe-app-tauri/components/deeplink-handler.tsx
+++ b/apps/screenpipe-app-tauri/components/deeplink-handler.tsx
@@ -106,9 +106,19 @@ export function DeeplinkHandler() {
             }
           }
 
-          // Handle frame deep links: screenpipe://frame/12345
-          if (parsedUrl.pathname?.startsWith("/frame/") || parsedUrl.host === "frame") {
-            const frameId = url.split("frame/")[1]?.replace(/^\//, "");
+          // Handle frame deep links: screenpipe://frame/12345 or screenpipe://frames/12345
+          if (
+            parsedUrl.pathname?.startsWith("/frame/") ||
+            parsedUrl.pathname?.startsWith("/frames/") ||
+            parsedUrl.host === "frame" ||
+            parsedUrl.host === "frames"
+          ) {
+            // Extract frame ID: screenpipe://frame/23 → "23", screenpipe://frame/23?foo=1 → "23"
+            const pathAfterFrame =
+              parsedUrl.host === "frame" || parsedUrl.host === "frames"
+                ? parsedUrl.pathname?.replace(/^\//, "")
+                : parsedUrl.pathname?.replace(/^\/frames?\/?/, "");
+            const frameId = pathAfterFrame?.split("/")[0]?.split("?")[0]?.trim();
             if (frameId) {
               try {
                 // Store frame navigation — timeline will resolve frame → timestamp
@@ -168,7 +178,7 @@ export function DeeplinkHandler() {
         unsubscribes.forEach((unsubscribe) => unsubscribe());
       });
     };
-  }, [toast, setShowChangelogDialog, openStatusDialog, loadUser, reloadStore]);
+  }, [toast, setShowChangelogDialog, openStatusDialog, loadUser, reloadStore, setPendingNavigation]);
 
   return null; // This component doesn't render anything
 } 

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -251,6 +251,29 @@ async unregisterWindowShortcuts() : Promise<Result<null, string>> {
 }
 },
 /**
+ * Copy a frame image to the system clipboard (native API, works in Tauri webview).
+ * Fetches the frame from the local server and uses arboard for clipboard access.
+ */
+async copyFrameToClipboard(frameId: bigint) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("copy_frame_to_clipboard", { frameId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Copy a frame deeplink (screenpipe://frame/N) to clipboard. Native API only.
+ */
+async copyDeeplinkToClipboard(frameId: bigint) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("copy_deeplink_to_clipboard", { frameId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Install a specific older version from R2. Downloads and installs via Tauri updater,
  * then restarts the app.
  */

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -402,6 +402,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image 0.25.9",
+ "log",
+ "objc2 0.6.3",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1638,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "cmake"
@@ -2942,6 +2971,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -8690,6 +8725,7 @@ name = "screenpipe-app"
 version = "2.0.448"
 dependencies = [
  "anyhow",
+ "arboard",
  "async-stream",
  "axum 0.6.20",
  "base64 0.22.1",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -70,6 +70,7 @@ tracing-appender = "0.2.3"
 
 
 anyhow = "1.0.71"
+arboard = "3.4"
 
 # System information
 sysinfo = "=0.29.0"

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1108,6 +1108,9 @@ async fn main() {
                 // Window-specific shortcut commands (dynamic registration)
                 commands::register_window_shortcuts,
                 commands::unregister_window_shortcuts,
+                // Frame quick actions: copy frame image, copy deeplink
+                commands::copy_frame_to_clipboard,
+                commands::copy_deeplink_to_clipboard,
                 // Rollback commands
                 commands::rollback_to_version,
                 // Commands from tray.rs
@@ -1279,6 +1282,9 @@ async fn main() {
             // Window-specific shortcut commands (dynamic registration)
             commands::register_window_shortcuts,
             commands::unregister_window_shortcuts,
+            // Frame quick actions: copy frame image to clipboard
+            commands::copy_frame_to_clipboard,
+            commands::copy_deeplink_to_clipboard,
             // Overlay commands (Windows)
             commands::enable_overlay_click_through,
             commands::disable_overlay_click_through,

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1647,6 +1647,20 @@ impl DatabaseManager {
         .await
     }
 
+    /// Get timestamp for a frame. Used for deep link navigation (screenpipe://frame/123).
+    pub async fn get_frame_timestamp(
+        &self,
+        frame_id: i64,
+    ) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+        Ok(sqlx::query_scalar::<_, Option<DateTime<Utc>>>(
+            "SELECT timestamp FROM frames WHERE id = ?1",
+        )
+        .bind(frame_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten())
+    }
+
     /// Get frames after a given frame_id for validation checking
     /// Returns frame_id, file_path, offset_index, and timestamp
     /// Direction: true = forward (newer frames), false = backward (older frames)

--- a/crates/screenpipe-server/src/server.rs
+++ b/crates/screenpipe-server/src/server.rs
@@ -23,7 +23,7 @@ use crate::{
             add_tags, add_to_database, execute_raw_sql, merge_frames_handler, remove_tags,
             validate_media_handler,
         },
-        frames::{get_frame_data, get_frame_ocr_data, get_next_valid_frame},
+        frames::{get_frame_data, get_frame_metadata, get_frame_ocr_data, get_next_valid_frame},
         health::{
             api_list_monitors, api_vision_status, audio_metrics_handler, health_check,
             vision_metrics_handler,
@@ -366,6 +366,7 @@ impl SCServer {
             .delete("/tags/:content_type/:id", remove_tags)
             .get("/frames/:frame_id", get_frame_data)
             .get("/frames/:frame_id/ocr", get_frame_ocr_data)
+            .get("/frames/:frame_id/metadata", get_frame_metadata)
             .get("/frames/next-valid", get_next_valid_frame)
             .get("/health", health_check)
             .post("/raw_sql", execute_raw_sql)


### PR DESCRIPTION


## Summary

- **Frame deep links**: `screenpipe://frame/N` and `screenpipe://frames/N` open the main window and jump to frame N. Works from cold start. Invalid or missing frame IDs show clear toasts.
- **Timeline frame context menu**: Right-click the current frame to copy image, copy OCR text, copy deeplink, or ask about the frame.
- **Keyboard shortcut**: **⌘+Shift+C** (Mac) / **Ctrl+Shift+C** (Win/Linux) copies the current frame image to the clipboard from anywhere on the timeline.
- **Backend**: New `GET /frames/:frame_id/metadata` endpoint and Tauri commands `copy_frame_to_clipboard` and `copy_deeplink_to_clipboard` using `arboard` for native clipboard support.

---

## Screenshot


https://github.com/user-attachments/assets/aadf88fb-b4cd-4a80-a6c2-3a0835233ba7



---




---

## What changed




### Deep links

- **URLs supported**:  
  `screenpipe://frame/12345`  
  `screenpipe://frames/12345`  
  Path-style variants supported. Query params and trailing slashes are ignored.

- **Cold start**:  
  Opening a frame link when the app is closed starts the app, shows the main window, waits briefly for the backend, then fetches `/frames/:id/metadata` and navigates to the frame timestamp. Retries up to 3 times if the server is not ready.

- **Validation**:  
  - Non-integer or non-positive IDs → `"invalid frame ID — expected a positive integer"`  
  - Missing frame → `"frame not found"`  
  - Server error → `"navigation failed"`

---

### Timeline context menu

Triggered by right-clicking the current frame in Rewind.

Actions:

- **Copy image**  
  Fetches `http://127.0.0.1:3030/frames/:id`, decodes the image, and sets it on the system clipboard via Tauri and `arboard`.  
  Toast: `"copied image"`

https://github.com/user-attachments/assets/a3de5ba0-7b76-4008-95a3-1a42f2749c63

---


- **Copy OCR text**  
  Uses in-memory OCR if available. Otherwise fetches `/frames/:id/ocr`, joins `text_positions`, and copies to clipboard.  
  Toast: `"copied OCR text"` or `"no OCR text"`
  
  https://github.com/user-attachments/assets/aff7b64b-ac5c-46b6-920f-7e46f0e9e403

---

- **Copy deeplink**  
  Copies `screenpipe://frame/{id}` to clipboard via Tauri.  
  Toast: `"copied deeplink"`
  

https://github.com/user-attachments/assets/1a20c017-b913-44e1-bcba-02e2d06a84ef


  
  ---

- **Ask about this frame**  
  Opens Chat and emits `chat-prefill` with:
  - App name  
  - Window name  
  - Timestamp  
  - OCR snippet  
  - `frameId`  

  Toast: `"ask about this frame"`
 


https://github.com/user-attachments/assets/4037fcc6-06de-4092-8644-d9f40f28f1b7


  

---

### Keyboard shortcut

- **⌘+Shift+C / Ctrl+Shift+C**
  - Copies the current frame image to clipboard
  - Disabled when focus is inside an input or textarea
  - Disabled when the search modal is open


https://github.com/user-attachments/assets/61e0e015-9754-4af6-8c99-8bb28e4c2dda