### PR TITLE
feat: cloud transcription metering for subscribed users

### DIFF
--- a/packages/ai-gateway/migrations/0002_create_transcription_usage.sql
+++ b/packages/ai-gateway/migrations/0002_create_transcription_usage.sql
@@ -1,0 +1,14 @@
+-- Migration: Create transcription usage tracking table for minute-based metering
+-- Run with: wrangler d1 execute screenpipe-usage --file=./migrations/0002_create_transcription_usage.sql
+
+CREATE TABLE IF NOT EXISTS transcription_usage (
+  user_id TEXT PRIMARY KEY,           -- clerk_id or device_id for anonymous
+  minutes_used REAL DEFAULT 0,        -- total minutes consumed (cumulative, never resets)
+  minutes_granted REAL DEFAULT 500,   -- total minutes granted (500 for new signups)
+  tier TEXT DEFAULT 'anonymous',
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Index for tier-based analytics
+CREATE INDEX IF NOT EXISTS idx_transcription_tier ON transcription_usage(tier);

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -194,6 +194,22 @@ export interface UsageStatus {
 	};
 }
 
+// Transcription usage result (minute-based, not daily-reset)
+export interface TranscriptionUsageResult {
+	minutesUsed: number;
+	minutesGranted: number;
+	minutesRemaining: number;
+	allowed: boolean;
+	/** Set when request was allowed by deducting a credit */
+	paidVia?: 'free' | 'credits';
+	creditsRemaining?: number;
+}
+
+// Transcription tier limits (minutes, not queries)
+export interface TranscriptionTierLimits {
+	totalMinutes: number; // lifetime minutes granted (0 = unlimited)
+}
+
 export interface ResponseUtils {
 	createSuccessResponse: (body: string | object, status?: number) => Response;
 	createErrorResponse: (status: number, message: string) => Response;


### PR DESCRIPTION
## Summary
- Subscribed users (lifetime/monthly) auto-upgrade to screenpipe-cloud transcription with unlimited Deepgram Nova usage
- Free/anonymous users stay on local Whisper — zero Deepgram cost for non-paying users
- Graceful fallback: if cloud returns 429 or any error, Rust client silently falls back to local Whisper (model always pre-downloaded)

## Changes
- **AI Gateway**: Auth + minute-based metering on `/v1/listen` (POST + WebSocket), new D1 migration, quota headers, `/v1/transcription/usage` endpoint
- **Rust client**: Detects 429 → `TRANSCRIPTION_QUOTA_EXHAUSTED` → `stt()` falls back to Whisper
- **Tauri**: Auto-upgrades subscribed users to screenpipe-cloud engine in `embedded_server.rs`

## Test plan
- [x] 57 bun tests pass (tier config, duration estimation, response shapes, cost math, fallback behavior)
- [ ] Deploy AI gateway to staging, test with curl: auth required, quota headers returned, 429 on exhaustion
- [ ] Test Rust client against staging: verify seamless Whisper fallback on 429
- [ ] Verify subscribed user auto-upgrades to cloud engine on app restart
- [ ] Verify non-subscribed user selecting "screenpipe-cloud" in settings gets forced to local whisper

🤖 Generated with [Claude Code](https://claude.com/claude-code)