### PR TITLE
build(macos): force M1-safe C/C++ flags for Apple Silicon builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -32,6 +32,12 @@ rustflags = "-lc++ -l framework=Accelerate"
 [env]
 CMAKE_POLICY_VERSION_MINIMUM = "3.5"
 
+# Ensure native C/C++ dependencies (e.g. whisper.cpp/ggml) stay M1-compatible
+# when building on newer Apple Silicon (M2/M3/M4). Rust target-cpu alone does
+# not affect external C/C++ compilation done via cc/cmake.
+CFLAGS_aarch64_apple_darwin = "-mcpu=apple-m1"
+CXXFLAGS_aarch64_apple_darwin = "-mcpu=apple-m1"
+
 # Faster builds - use more threads for codegen
 [build]
 jobs = 16  # Parallel compilation jobs (adjust to your CPU cores)


### PR DESCRIPTION
## What this fixes

Issue #2246 asks to make Screenpipe work reliably on Mac M1.

A subtle compatibility gap existed in the build pipeline:
- Rust code was already pinned to `target-cpu=apple-m1` for `aarch64-apple-darwin`
- But native C/C++ dependencies (compiled via `cc`/`cmake`, e.g. whisper.cpp/ggml) can still compile with host defaults when building on newer chips (M2/M3/M4)
- That can generate instructions unavailable on M1, causing runtime/build incompatibilities for M1 users

## Change

In `.cargo/config.toml`, add:

```toml
CFLAGS_aarch64_apple_darwin = "-mcpu=apple-m1"
CXXFLAGS_aarch64_apple_darwin = "-mcpu=apple-m1"
```

This ensures native C/C++ parts are compiled with an M1-safe baseline too, not just Rust code.

## Why this is safe

- Scope is minimal: 1 file, 6 lines
- Applies only to `aarch64-apple-darwin`
- No behavior change outside Apple Silicon macOS builds
- Prevents M1 regressions when release artifacts are built on newer Apple Silicon hosts

## Validation

- Config parses successfully (`cargo metadata --no-deps`)
- Change is build-tooling only (no runtime logic changes)

Closes #2246
