### PR TITLE
fix: custom provider presets broken in pipe execution

### DIFF
--- a/crates/screenpipe-core/src/agents/mod.rs
+++ b/crates/screenpipe-core/src/agents/mod.rs
@@ -47,6 +47,8 @@ pub trait AgentExecutor: Send + Sync {
         model: &str,
         working_dir: &Path,
         provider: Option<&str>,
+        provider_url: Option<&str>,
+        provider_api_key: Option<&str>,
         pid_tx: Option<tokio::sync::oneshot::Sender<u32>>,
     ) -> Result<AgentOutput>;
 


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible provider presets (e.g. llama-server, vLLM, LocalAI) fail when used by pipes — three separate bugs in the core pipe executor prevent them from working, even though the Tauri desktop chat path handles them correctly.

**Bugs fixed:**

- **Wrong provider name → "Model openai/... not found"**: `resolve_preset()` mapped `"custom"` → `"openai"`, but `ensure_pi_config()` registered the model under `"openai-byok"` in `models.json`. Pi was then invoked with `--provider openai`, which didn't match — causing the model lookup to fail. Fixed by mapping `"custom"` → `"custom"`, consistent with the Tauri desktop path.

- **Custom URL overwritten**: `PiExecutor::run()` called `ensure_pi_config()` with `None` for the URL parameter, overwriting the correctly pre-configured custom endpoint URL. Fixed by threading `provider_url` through the `AgentExecutor::run()` trait.

- **API key not passed → 401 auth failed**: The preset's API key was never set as an environment variable when spawning the pi subprocess. Pi resolves `apiKey` values in `models.json` as env var names, but `CUSTOM_API_KEY` was never set. Fixed by threading `provider_api_key` through to `spawn_pi`, which now sets the appropriate env var — matching the Tauri desktop app behavior (lines 714–724 of `apps/.../pi.rs`).

## How to reproduce

1. Configure a Custom Provider Preset pointing at any OpenAI-compatible endpoint (e.g. llama-server)
2. Assign it as the default preset
3. Run any pipe (e.g. reminders)
4. Observe: "Model openai/\<model-name\> not found"

After fixing bug 1, bug 3 surfaces as a 401 "auth failed" error.

## Test plan

- [x] `cargo test -p screenpipe-core` — 92 tests pass
- [x] `cargo check` passes for screenpipe-core, screenpipe-server, and screenpipe-app
- [x] Manual testing: custom provider preset with llama-server endpoint successfully executes pipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)