### PR TITLE
fix: URL/text overlay highlight desync on timeline frames

### DIFF
--- a/crates/screenpipe-vision/src/apple.rs
+++ b/crates/screenpipe-vision/src/apple.rs
@@ -171,9 +171,11 @@ pub fn perform_ocr_apple(
                     };
                     let bbox = bbox_result.bounding_box();
                     let x = bbox.origin.x;
-                    let y = bbox.origin.y;
+                    let y_vision = bbox.origin.y; // Vision: bottom-left origin, Y up
                     let height = bbox.size.height;
                     let width = bbox.size.width;
+                    // Convert to top-left origin (same as other OCR engines) so pipeline/DB stay consistent
+                    let top = 1.0 - y_vision - height;
 
                     ocr_results_vec.push(serde_json::json!({
                         "level": "0",
@@ -183,7 +185,7 @@ pub fn perform_ocr_apple(
                         "line_num": "0",
                         "word_num": "0",
                         "left": x.to_string(),
-                        "top": y.to_string(),
+                        "top": top.to_string(),
                         "width": width.to_string(),
                         "height": height.to_string(),
                         "conf": confidence.to_string(),


### PR DESCRIPTION
**Description:**

Stored OCR bounds are already in screen space (top-left). The DB was applying an extra Y-flip meant for Apple Vision, which mirrored highlights vertically (e.g. URL highlight drawn below the URL).



Closes #2260.


### Before

https://github.com/user-attachments/assets/daeb414d-94fe-43d7-b457-9c03a19036ef



### After



https://github.com/user-attachments/assets/460ae749-4a35-4e5e-a02b-ab160cc818a5



