### PR TITLE
Fix intermittent tray/menu crash on macOS (panic across Obj-C FFI)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -281,7 +281,7 @@ pub async fn open_pipe_window(
     let window_clone = window.clone();
     window.on_window_event(move |event| {
         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-            let mut is_closing = is_closing_clone.lock().unwrap();
+            let mut is_closing = is_closing_clone.lock().unwrap_or_else(|e| e.into_inner());
             if *is_closing {
                 return;
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -57,20 +57,20 @@ static RECORDING_INFO: Lazy<RwLock<RecordingInfo>> = Lazy::new(|| {
 });
 
 pub fn get_recording_status() -> RecordingStatus {
-    RECORDING_INFO.read().unwrap().status
+    RECORDING_INFO.read().unwrap_or_else(|e| e.into_inner()).status
 }
 
 pub fn get_recording_info() -> RecordingInfo {
-    RECORDING_INFO.read().unwrap().clone()
+    RECORDING_INFO.read().unwrap_or_else(|e| e.into_inner()).clone()
 }
 
 #[allow(dead_code)]
 fn set_recording_status(status: RecordingStatus) {
-    RECORDING_INFO.write().unwrap().status = status;
+    RECORDING_INFO.write().unwrap_or_else(|e| e.into_inner()).status = status;
 }
 
 fn set_recording_info(status: RecordingStatus, devices: Vec<DeviceInfo>) {
-    let mut info = RECORDING_INFO.write().unwrap();
+    let mut info = RECORDING_INFO.write().unwrap_or_else(|e| e.into_inner());
     info.status = status;
     info.devices = devices;
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/window_api.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window_api.rs
@@ -46,7 +46,7 @@ fn save_frontmost_app() {
         let frontmost: id = msg_send![workspace, frontmostApplication];
         if frontmost != nil {
             let _: () = msg_send![frontmost, retain];
-            let mut prev = PREVIOUS_FRONTMOST_APP.lock().unwrap();
+            let mut prev = PREVIOUS_FRONTMOST_APP.lock().unwrap_or_else(|e| e.into_inner());
             if *prev != 0 {
                 let old = *prev as id;
                 let _: () = msg_send![old, release];
@@ -62,7 +62,7 @@ fn save_frontmost_app() {
 pub fn restore_frontmost_app() {
     use objc::{msg_send, sel, sel_impl};
     let ptr = {
-        let mut prev = PREVIOUS_FRONTMOST_APP.lock().unwrap();
+        let mut prev = PREVIOUS_FRONTMOST_APP.lock().unwrap_or_else(|e| e.into_inner());
         let p = *prev;
         *prev = 0;
         p
@@ -85,7 +85,7 @@ pub fn restore_frontmost_app() {
 pub fn clear_frontmost_app() {
     use objc::{msg_send, sel, sel_impl};
     let ptr = {
-        let mut prev = PREVIOUS_FRONTMOST_APP.lock().unwrap();
+        let mut prev = PREVIOUS_FRONTMOST_APP.lock().unwrap_or_else(|e| e.into_inner());
         let p = *prev;
         *prev = 0;
         p
@@ -666,7 +666,7 @@ impl ShowRewindWindow {
 
             // No existing window for this mode — fall through to creation below
             // (record the mode so we know what was created)
-            *MAIN_CREATED_MODE.lock().unwrap() = overlay_mode.clone();
+            *MAIN_CREATED_MODE.lock().unwrap_or_else(|e| e.into_inner()) = overlay_mode.clone();
         // === Other windows: standard show path ===
         } else if let Some(window) = id.get(app) {
 
@@ -795,7 +795,7 @@ impl ShowRewindWindow {
                 #[allow(unused_variables)] // used only on macOS
                 let show_in_recording = settings.show_overlay_in_screen_recording;
                 // Record what mode we're creating so we can detect changes later
-                *MAIN_CREATED_MODE.lock().unwrap() = overlay_mode.clone();
+                *MAIN_CREATED_MODE.lock().unwrap_or_else(|e| e.into_inner()) = overlay_mode.clone();
                 let use_window_mode = overlay_mode == "window";
 
                 if use_window_mode {
@@ -1191,7 +1191,7 @@ impl ShowRewindWindow {
                                 {
                                     use objc::{msg_send, sel, sel_impl};
                                     let lbl = {
-                                        let mode = MAIN_CREATED_MODE.lock().unwrap().clone();
+                                        let mode = MAIN_CREATED_MODE.lock().unwrap_or_else(|e| e.into_inner()).clone();
                                         main_label_for_mode(&mode).to_string()
                                     };
                                     if let Ok(panel) = app_clone.get_webview_panel(&lbl) {
@@ -1218,7 +1218,7 @@ impl ShowRewindWindow {
                                     {
                                         let app2 = app.clone();
                                         let lbl = {
-                                            let mode = MAIN_CREATED_MODE.lock().unwrap().clone();
+                                            let mode = MAIN_CREATED_MODE.lock().unwrap_or_else(|e| e.into_inner()).clone();
                                             main_label_for_mode(&mode).to_string()
                                         };
                                         let _ = app.run_on_main_thread(move || {
@@ -1242,7 +1242,7 @@ impl ShowRewindWindow {
                                 {
                                     use objc::{msg_send, sel, sel_impl};
                                     let lbl = {
-                                        let mode = MAIN_CREATED_MODE.lock().unwrap().clone();
+                                        let mode = MAIN_CREATED_MODE.lock().unwrap_or_else(|e| e.into_inner()).clone();
                                         main_label_for_mode(&mode).to_string()
                                     };
                                     if let Ok(panel) = app_clone.get_webview_panel(&lbl) {


### PR DESCRIPTION
Tray (and other) menu events are delivered from the macOS/Obj-C event loop into Rust (tao::send_event). That call is nounwind, so a panic in the handler cannot unwind back across the FFI boundary and the process aborts (SIGABRT / panic_cannot_unwind).


# Changes

- Defer all tray, dock, app menu, global shortcut, single-instance, and run-event actions that open windows or touch store to run_on_main_thread so the sync path only clones and schedules work.
- Make mutex/lock usage on those paths poison-safe (unwrap_or_else(|e| e.into_inner())) in commands, health, tray, window_api.
- Add eprintln of the panic payload at the start of the panic hook so the real panic message is visible before abort.



https://github.com/user-attachments/assets/4ae66469-fb97-4d8b-a982-93971899166f



