### PR TITLE
fix: explicitly set Tauri publisher to "Mediar, Inc."

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
@@ -11,7 +11,7 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "publisher": "Screenpipe Inc.",
+    "publisher": "Mediar, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
   },
   "bundle": {
     "active": true,
-    "publisher": "Screenpipe Inc.",
+    "publisher": "Mediar, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -1,6 +1,6 @@
 {
     "bundle": {
-        "publisher": "Screenpipe Inc.",
+        "publisher": "Mediar, Inc.",
         "externalBin": [
             "bun"
         ],

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.macos.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,6 @@
 {
     "bundle": {
-        "publisher": "Screenpipe Inc.",
+        "publisher": "Mediar, Inc.",
         "macOS": {
             "entitlements": "entitlements.plist",
             "hardenedRuntime": true,

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
@@ -11,7 +11,7 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "publisher": "Screenpipe Inc.",
+    "publisher": "Mediar, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
@@ -1,6 +1,6 @@
 {
     "bundle": {
-        "publisher": "Screenpipe Inc.",
+        "publisher": "Mediar, Inc.",
         "windows": {
             "nsis": {
                 "headerImage": "assets/nsis-header.bmp",


### PR DESCRIPTION
## Description

Windows installers were showing the publisher as **“pe”** instead of **Mediar, Inc**.

Our identifier is:

```json
"identifier": "screenpi.pe"
```

When `bundle.publisher` is not set, Tauri derives the publisher from the identifier.
Because the identifier is `screenpi.pe`, the derived publisher becomes `pe`.



Reference:
[https://v2.tauri.app/distribute/microsoft-store/#publisher](https://v2.tauri.app/distribute/microsoft-store/#publisher)


<img width="1221" height="637" alt="image" src="https://github.com/user-attachments/assets/d9d72616-5278-4edf-a837-782ecfbe1bf2" />

