### PR TITLE
chore: add .claude/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ screenpipe-app-tauri/src-tauri/.next/
 
 .playwright*
 crates/screenpipe-audio/onnxruntime-win-x64-1.19.2.zip
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.claude/` directory to `.gitignore` so Claude Code agent workspace files aren't tracked

## Test plan
- Verify `.claude/` files no longer show up in `git status`