### PR TITLE
fix: remove hardcoded signing identity so any dev can build

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -39,7 +39,6 @@
       "assets/*"
     ],
     "macOS": {
-      "signingIdentity": "Apple Development: Louis Beaumont (NJ372MT773)",
       "entitlements": "entitlements.plist",
       "hardenedRuntime": true
     }


### PR DESCRIPTION
## Summary
- Removes the hardcoded Apple Development signing identity from `tauri.conf.json`
- Lets macOS auto-select an available identity, so any developer can build without hitting signing errors

## Test plan
- Build the Tauri app on macOS with a different (or no) signing identity and verify it succeeds