### PR TITLE
chore: add .claude/*.local* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,7 @@ screenpipe-app-tauri/src-tauri/.next/
 
 
 .playwright*
-crates/screenpipe-audio/onnxruntime-win-x64-1.19.2.zip
+
+# Claude Code
 .claude/worktrees/
+.claude/*.local* # local changes are specific to the individual developer, let's not check them in for everyone.


### PR DESCRIPTION
doing https://github.com/screenpipe/screenpipe/pull/2325 correctly -- this was the actual intent. i don't want the local settings claude comes up with to pollute the repo