### PR TITLE
Fix: consolidate OpenAI-compatible client pooling and constants

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -4,6 +4,8 @@
 
 "use client";
 
+const DEFAULT_OPENAI_COMPATIBLE_ENDPOINT = "http://127.0.0.1:8080";
+
 import React, { useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { Label } from "@/components/ui/label";
 import {
@@ -568,7 +570,7 @@ export function RecordingSettings() {
     if (settings.audioTranscriptionEngine === 'openai-compatible') {
       const apiKey = settings.openaiCompatibleApiKey;
       // Use default endpoint if not set
-      const endpoint = settings.openaiCompatibleEndpoint || 'http://127.0.0.1:8080';
+      const endpoint = settings.openaiCompatibleEndpoint || DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
       fetchOpenAIModels(endpoint, apiKey);
     }
   }, [settings.audioTranscriptionEngine, settings.openaiCompatibleApiKey, fetchOpenAIModels]);
@@ -588,7 +590,7 @@ export function RecordingSettings() {
     });
     setTxDiagnosticsOpen(true);
 
-    const endpoint = settings.openaiCompatibleEndpoint || "http://127.0.0.1:8080";
+    const endpoint = settings.openaiCompatibleEndpoint || DEFAULT_OPENAI_COMPATIBLE_ENDPOINT;
     const apiKey = settings.openaiCompatibleApiKey;
 
     const headers: Record<string, string> = {};
@@ -1400,12 +1402,12 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                 <ValidatedInput
                   id="openaiCompatibleEndpoint"
                   label=""
-                  value={settings.openaiCompatibleEndpoint || "http://127.0.0.1:8080"}
+                  value={settings.openaiCompatibleEndpoint || DEFAULT_OPENAI_COMPATIBLE_ENDPOINT}
                   onChange={(value: string) => handleSettingsChange({ openaiCompatibleEndpoint: value }, true)}
-                  onBlur={() => fetchOpenAIModels(settings.openaiCompatibleEndpoint || 'http://127.0.0.1:8080', settings.openaiCompatibleApiKey)}
+                  onBlur={() => fetchOpenAIModels(settings.openaiCompatibleEndpoint || DEFAULT_OPENAI_COMPATIBLE_ENDPOINT, settings.openaiCompatibleApiKey)}
                   onKeyDown={(e: React.KeyboardEvent) => {
                     if (e.key === 'Enter') {
-                      fetchOpenAIModels(settings.openaiCompatibleEndpoint || 'http://127.0.0.1:8080', settings.openaiCompatibleApiKey);
+                      fetchOpenAIModels(settings.openaiCompatibleEndpoint || DEFAULT_OPENAI_COMPATIBLE_ENDPOINT, settings.openaiCompatibleApiKey);
                     }
                   }}
                   placeholder="API Endpoint (e.g., http://127.0.0.1:8080)"

--- a/apps/screenpipe-app-tauri/src-tauri/src/embedded_server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/embedded_server.rs
@@ -155,17 +155,17 @@ pub async fn start_embedded_server(
 
     // Build audio manager
     use screenpipe_audio::core::engine::AudioTranscriptionEngine;
-    use screenpipe_audio::transcription::stt::OpenAICompatibleConfig;
-    
+    use screenpipe_audio::transcription::stt::{OpenAICompatibleConfig, DEFAULT_OPENAI_COMPATIBLE_ENDPOINT, DEFAULT_OPENAI_COMPATIBLE_MODEL};
+
     // Build OpenAI Compatible config if applicable
     let openai_compatible_config = if config.audio_transcription_engine == AudioTranscriptionEngine::OpenAICompatible {
         Some(OpenAICompatibleConfig {
             endpoint: config.openai_compatible_endpoint.clone()
-                .unwrap_or_else(|| "http://127.0.0.1:8080".to_string()),
+                .unwrap_or_else(|| DEFAULT_OPENAI_COMPATIBLE_ENDPOINT.to_string()),
             api_key: config.openai_compatible_api_key.clone(),
             model: config.openai_compatible_model.clone()
-                .unwrap_or_else(|| "whisper-1".to_string()),
-            client: None, // Will be created in TranscriptionEngine::new() if needed
+                .unwrap_or_else(|| DEFAULT_OPENAI_COMPATIBLE_MODEL.to_string()),
+            client: None, // Will be created in TranscriptionEngine::new() via get_or_create_client()
         })
     } else {
         None

--- a/crates/screenpipe-audio/src/lib.rs
+++ b/crates/screenpipe-audio/src/lib.rs
@@ -10,7 +10,7 @@ pub use transcription::{AudioInput, TranscriptionResult};
 pub use transcription::engine::TranscriptionEngine;
 pub mod speaker;
 pub mod transcription;
-pub use transcription::stt::OpenAICompatibleConfig;
+pub use transcription::stt::{OpenAICompatibleConfig, DEFAULT_OPENAI_COMPATIBLE_ENDPOINT, DEFAULT_OPENAI_COMPATIBLE_MODEL, OPENAI_COMPATIBLE_TIMEOUT_SECS};
 pub use utils::audio::pcm_decode;
 pub use utils::audio::resample;
 pub mod audio_manager;

--- a/crates/screenpipe-audio/src/transcription/engine.rs
+++ b/crates/screenpipe-audio/src/transcription/engine.rs
@@ -72,15 +72,8 @@ impl TranscriptionEngine {
             }
 
             AudioTranscriptionEngine::OpenAICompatible => {
-                let oc_config = openai_compatible_config.unwrap_or_default();
-                let client = oc_config.client.unwrap_or_else(|| {
-                    Arc::new(
-                        Client::builder()
-                            .timeout(std::time::Duration::from_secs(55))
-                            .build()
-                            .expect("failed to create reqwest client"),
-                    )
-                });
+                let mut oc_config = openai_compatible_config.unwrap_or_default();
+                let client = oc_config.get_or_create_client();
                 Ok(Self::OpenAICompatible {
                     endpoint: oc_config.endpoint,
                     api_key: oc_config.api_key,

--- a/crates/screenpipe-audio/src/transcription/openai_compatible/batch.rs
+++ b/crates/screenpipe-audio/src/transcription/openai_compatible/batch.rs
@@ -9,8 +9,9 @@ use screenpipe_core::Language;
 use serde_json::Value;
 use std::io::Cursor;
 use std::sync::Arc;
-use std::time::Duration;
 use tracing::{debug, error, info};
+
+use crate::transcription::stt::OPENAI_COMPATIBLE_TIMEOUT_SECS;
 
 /// Transcribe audio using an OpenAI-compatible API endpoint.
 ///
@@ -52,11 +53,10 @@ pub async fn transcribe_with_openai_compatible(
         Some(c) => c,
         None => Arc::new(
             Client::builder()
-                .timeout(Duration::from_secs(55))
-                .build()?
+                .timeout(std::time::Duration::from_secs(OPENAI_COMPATIBLE_TIMEOUT_SECS))
+                .build()?,
         ),
     };
-    
     // Build multipart form
     let mut form = multipart::Form::new()
         .text("model", model.to_string())


### PR DESCRIPTION
## Summary
- Extract `DEFAULT_OPENAI_COMPATIBLE_ENDPOINT`, `DEFAULT_OPENAI_COMPATIBLE_MODEL`, and `OPENAI_COMPATIBLE_TIMEOUT_SECS` constants — previously hardcoded in 6+ places across Rust and TypeScript
- Add `get_or_create_client()` to `OpenAICompatibleConfig` for lazy client init with connection pooling — the legacy `stt()` code path now reuses the same client instead of creating a new one per request
- Standardize timeout to 30s (was inconsistent: 30s in old code, 55s after #2347)
- Remove trailing whitespace in `batch.rs`

## Test plan
- [ ] Set transcription engine to OpenAI Compatible, verify transcription still works
- [ ] Confirm no regression in connection behavior (pooling should reduce TLS handshakes)
- [ ] Check frontend default endpoint still shows correctly in settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)