### PR TITLE
fix: ignored apps autocomplete — query frames directly, fix case filter

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -2089,6 +2089,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                     value={settings.ignoredWindows}
                     onValueChange={handleIgnoredWindowsChange}
                     placeholder="Select apps to ignore..."
+                    allowCustomValues
                   />
                   {filterView === "all" && (settings.teamFilters?.ignoredWindows?.length ?? 0) > 0 && (
                     <div className="flex flex-wrap gap-1 mt-1">
@@ -2142,6 +2143,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                     value={settings.includedWindows}
                     onValueChange={handleIncludedWindowsChange}
                     placeholder="Only capture these apps (optional)..."
+                    allowCustomValues
                   />
                   {filterView === "all" && (settings.teamFilters?.includedWindows?.length ?? 0) > 0 && (
                     <div className="flex flex-wrap gap-1 mt-1">

--- a/apps/screenpipe-app-tauri/components/ui/multi-select.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/multi-select.tsx
@@ -389,7 +389,7 @@ export const MultiSelect = React.forwardRef<
             className="w-full"
             filter={(value, search) => {
               if (!search) return 1;
-              return filterOptions(search).some((opt) => opt.value === value)
+              return filterOptions(search).some((opt) => opt.value.toLowerCase() === value.toLowerCase())
                 ? 1
                 : 0;
             }}

--- a/apps/screenpipe-app-tauri/lib/hooks/use-sql-autocomplete.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-sql-autocomplete.tsx
@@ -59,27 +59,24 @@ export function useSqlAutocomplete(type: "app" | "window" | "url") {
             LIMIT 100
           `;
         } else if (type === "window") {
-          // For windows, also fetch app_name for context
+          // Distinct app names — ignoredWindows matches against app_name and window_name
           query = `
-            SELECT f.window_name as name, MAX(f.app_name) as app_name, COUNT(*) as count
-            FROM ocr_text ocr
-            JOIN frames f ON ocr.frame_id = f.id
-            WHERE f.timestamp > datetime('now', '-7 days')
-            AND f.window_name IS NOT NULL
-            AND f.window_name != ''
-            GROUP BY f.window_name
+            SELECT app_name as name, app_name, COUNT(*) as count
+            FROM frames
+            WHERE timestamp > datetime('now', '-7 days')
+            AND app_name IS NOT NULL AND app_name != ''
+            GROUP BY app_name
             ORDER BY count DESC
-            LIMIT 100
+            LIMIT 200
           `;
         } else {
           query = `
-            SELECT f.app_name as name, COUNT(*) as count
-            FROM ocr_text ocr
-            JOIN frames f ON ocr.frame_id = f.id
-            WHERE f.timestamp > datetime('now', '-7 days')
-            AND f.app_name IS NOT NULL
-            AND f.app_name != ''
-            GROUP BY f.app_name
+            SELECT app_name as name, COUNT(*) as count
+            FROM frames
+            WHERE timestamp > datetime('now', '-7 days')
+            AND app_name IS NOT NULL
+            AND app_name != ''
+            GROUP BY app_name
             ORDER BY count DESC
             LIMIT 100
           `;


### PR DESCRIPTION
## Summary
- SQL query joined `ocr_text` table, missing apps captured only via accessibility (e.g. Tor Browser, Monero GUI). Now queries `frames` table directly for `app_name`
- cmdk lowercases filter values internally but comparison was case-sensitive — fixed with `toLowerCase()` on both sides
- Added `allowCustomValues` to ignored/included apps MultiSelect so users can type custom app names

## Test plan
- [ ] Open Settings → Recording → Ignored apps dropdown
- [ ] Type a partial app name (e.g. "tor") and verify matching apps appear
- [ ] Type a custom value and press Enter — should be added
- [ ] Verify case-insensitive search works

🤖 Generated with [Claude Code](https://claude.com/claude-code)