### PR TITLE
Fix macOS focused-app capture with AX observers

### DIFF
--- a/crates/screenpipe-accessibility/src/platform/macos.rs
+++ b/crates/screenpipe-accessibility/src/platform/macos.rs
@@ -688,6 +688,108 @@ extern "C" fn tap_callback(
 // App/Window Observer
 // ============================================================================
 
+struct FocusState {
+    last_app: Option<String>,
+    last_pid: i32,
+    last_window: Option<String>,
+}
+
+struct ObserverCallbackState {
+    tx: Sender<UiEvent>,
+    start: Instant,
+    config: UiCaptureConfig,
+    current_app: Arc<Mutex<Option<String>>>,
+    current_window: Arc<Mutex<Option<String>>>,
+    focus: Mutex<FocusState>,
+    refresh_requested: Arc<AtomicBool>,
+}
+
+fn emit_focus_state(state: &ObserverCallbackState) {
+    let Some((pid, name)) = get_focused_app_info() else {
+        return;
+    };
+
+    if !state.config.should_capture_app(&name) {
+        return;
+    }
+
+    let mut focus = state.focus.lock();
+    let app_changed = focus.last_app.as_ref() != Some(&name) || focus.last_pid != pid;
+
+    if app_changed {
+        *state.current_app.lock() = Some(name.clone());
+
+        if state.config.capture_app_switch {
+            let focused_element = get_focused_element_context(&state.config);
+
+            let mut event = UiEvent::app_switch(
+                Utc::now(),
+                state.start.elapsed().as_millis() as u64,
+                name.clone(),
+                pid,
+            );
+            event.element = focused_element;
+            let _ = state.tx.try_send(event);
+        }
+
+        focus.last_app = Some(name.clone());
+        focus.last_pid = pid;
+    }
+
+    let window_title = get_focused_window_title(pid);
+    let should_capture = window_title
+        .as_ref()
+        .map(|w| state.config.should_capture_window(w))
+        .unwrap_or(true);
+
+    if should_capture && (window_title != focus.last_window || app_changed) {
+        *state.current_window.lock() = window_title.clone();
+
+        if state.config.capture_window_focus {
+            let focused_element = get_focused_element_context(&state.config);
+
+            let event = UiEvent {
+                id: None,
+                timestamp: Utc::now(),
+                relative_ms: state.start.elapsed().as_millis() as u64,
+                data: EventData::WindowFocus {
+                    app: name,
+                    title: window_title.clone().map(|s| truncate(&s, 200)),
+                },
+                app_name: None,
+                window_title: None,
+                browser_url: None,
+                element: focused_element,
+                frame_id: None,
+            };
+            let _ = state.tx.try_send(event);
+        }
+
+        focus.last_window = window_title;
+    }
+}
+
+extern "C" fn ax_focus_observer_callback(
+    _observer: &mut ax::Observer,
+    _elem: &mut ax::UiElement,
+    notification: &ax::Notification,
+    context: *mut std::ffi::c_void,
+) {
+    if context.is_null() {
+        return;
+    }
+
+    let state = unsafe { &*(context as *const ObserverCallbackState) };
+
+    if notification == ax::notification::app_activated()
+        || notification == ax::notification::app_deactivated()
+    {
+        state.refresh_requested.store(true, Ordering::SeqCst);
+    }
+
+    emit_focus_state(state);
+}
+
 fn run_app_observer(
     tx: Sender<UiEvent>,
     stop: Arc<AtomicBool>,
@@ -697,90 +799,159 @@ fn run_app_observer(
     current_window: Arc<Mutex<Option<String>>>,
 ) {
     let workspace = ns::Workspace::shared();
+    let mut notification_center = workspace.notification_center();
+    let refresh_requested = Arc::new(AtomicBool::new(true));
+    let callback_state = Box::new(ObserverCallbackState {
+        tx,
+        start,
+        config,
+        current_app,
+        current_window,
+        focus: Mutex::new(FocusState {
+            last_app: None,
+            last_pid: 0,
+            last_window: None,
+        }),
+        refresh_requested: refresh_requested.clone(),
+    });
+    let callback_state_ptr = Box::into_raw(callback_state);
 
-    let mut last_app: Option<String> = None;
-    let mut last_pid: i32 = 0;
-    let mut last_window: Option<String> = None;
-
-    while !stop.load(Ordering::Relaxed) {
-        let apps = workspace.running_apps();
-        let active_app = apps.iter().find(|app| app.is_active());
-
-        if let Some(app) = active_app {
-            let name = app
-                .localized_name()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| "?".to_string());
-            let pid = app.pid();
-
-            // Check exclusions
-            if !config.should_capture_app(&name) {
-                std::thread::sleep(std::time::Duration::from_millis(100));
-                continue;
-            }
-
-            let app_changed = last_app.as_ref() != Some(&name) || last_pid != pid;
-
-            if app_changed {
-                // Update shared state for event tap thread
-                *current_app.lock() = Some(name.clone());
-
-                if config.capture_app_switch {
-                    // Capture focused element's context (including text field values)
-                    let focused_element = get_focused_element_context(&config);
-
-                    let mut event = UiEvent::app_switch(
-                        Utc::now(),
-                        start.elapsed().as_millis() as u64,
-                        name.clone(),
-                        pid,
-                    );
-                    event.element = focused_element;
-                    let _ = tx.try_send(event);
+    // NSWorkspace still helps for session/space lifecycle changes, but app-to-app
+    // reattachment comes from AX notifications on the observed app itself.
+    let _workspace_observers = vec![
+        notification_center.add_observer_guard(
+            ns::workspace::notification::did_activate_app(),
+            None,
+            None,
+            {
+                let refresh_requested = refresh_requested.clone();
+                move |_note| {
+                    refresh_requested.store(true, Ordering::SeqCst);
                 }
-                last_app = Some(name.clone());
-                last_pid = pid;
-            }
-
-            // Check window change
-            let window_title = get_focused_window_title(pid);
-
-            // Check window exclusions
-            let should_capture = window_title
-                .as_ref()
-                .map(|w| config.should_capture_window(w))
-                .unwrap_or(true);
-
-            if should_capture && (window_title != last_window || app_changed) {
-                // Update shared state for event tap thread
-                *current_window.lock() = window_title.clone();
-
-                if config.capture_window_focus {
-                    // Capture focused element's context (including text field values)
-                    let focused_element = get_focused_element_context(&config);
-
-                    let event = UiEvent {
-                        id: None,
-                        timestamp: Utc::now(),
-                        relative_ms: start.elapsed().as_millis() as u64,
-                        data: EventData::WindowFocus {
-                            app: name,
-                            title: window_title.clone().map(|s| truncate(&s, 200)),
-                        },
-                        app_name: None,
-                        window_title: None,
-                        browser_url: None,
-                        element: focused_element,
-                        frame_id: None,
-                    };
-                    let _ = tx.try_send(event);
+            },
+        ),
+        notification_center.add_observer_guard(
+            ns::workspace::notification::active_space_did_change(),
+            None,
+            None,
+            {
+                let refresh_requested = refresh_requested.clone();
+                move |_note| {
+                    refresh_requested.store(true, Ordering::SeqCst);
                 }
-                last_window = window_title;
+            },
+        ),
+        notification_center.add_observer_guard(
+            ns::workspace::notification::did_unhide_app(),
+            None,
+            None,
+            {
+                let refresh_requested = refresh_requested.clone();
+                move |_note| {
+                    refresh_requested.store(true, Ordering::SeqCst);
+                }
+            },
+        ),
+        notification_center.add_observer_guard(
+            ns::workspace::notification::did_wake(),
+            None,
+            None,
+            {
+                let refresh_requested = refresh_requested.clone();
+                move |_note| {
+                    refresh_requested.store(true, Ordering::SeqCst);
+                }
+            },
+        ),
+        notification_center.add_observer_guard(
+            ns::workspace::notification::session_did_become_active(),
+            None,
+            None,
+            {
+                let refresh_requested = refresh_requested.clone();
+                move |_note| {
+                    refresh_requested.store(true, Ordering::SeqCst);
+                }
+            },
+        ),
+    ];
+
+    let run_loop = cf::RunLoop::current();
+    let run_loop_mode = cf::RunLoopMode::default();
+    let mut observed_pid: i32 = 0;
+    let mut observer: Option<cidre::arc::R<ax::Observer>> = None;
+
+    let mut reattach_observer = || {
+        let Some((pid, _name)) = get_focused_app_info() else {
+            return;
+        };
+
+        if observed_pid == pid {
+            emit_focus_state(unsafe { &*callback_state_ptr });
+            return;
+        }
+
+        if let Some(existing) = observer.take() {
+            run_loop.remove_src(existing.run_loop_src(), run_loop_mode);
+        }
+
+        let app = ax::UiElement::with_app_pid(pid);
+        let mut new_observer = match ax::Observer::with_cb(pid, ax_focus_observer_callback) {
+            Ok(observer) => observer,
+            Err(err) => {
+                error!("failed to create AXObserver for pid {}: {:?}", pid, err);
+                observed_pid = 0;
+                return;
+            }
+        };
+
+        let context = callback_state_ptr as *mut std::ffi::c_void;
+        for notification in [
+            ax::notification::app_activated(),
+            ax::notification::app_deactivated(),
+            ax::notification::focused_window_changed(),
+            ax::notification::focused_ui_element_changed(),
+        ] {
+            if let Err(err) = new_observer.add_notification(&app, notification, context) {
+                debug!(
+                    "failed to register AX notification {:?} for pid {}: {:?}",
+                    notification, pid, err
+                );
             }
         }
 
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        run_loop.add_src(new_observer.run_loop_src(), run_loop_mode);
+        observed_pid = pid;
+        observer = Some(new_observer);
+        emit_focus_state(unsafe { &*callback_state_ptr });
+    };
+
+    while !stop.load(Ordering::Relaxed) {
+        cf::RunLoop::run_in_mode(run_loop_mode, 0.1, true);
+
+        if refresh_requested.swap(false, Ordering::SeqCst) {
+            reattach_observer();
+        }
     }
+
+    if let Some(existing) = observer.take() {
+        run_loop.remove_src(existing.run_loop_src(), run_loop_mode);
+    }
+
+    unsafe {
+        drop(Box::from_raw(callback_state_ptr));
+    }
+}
+
+fn get_focused_app_info() -> Option<(i32, String)> {
+    let sys = ax::UiElement::sys_wide();
+    let app = sys.focused_app().ok()?;
+    let pid = app.pid().ok()?;
+    let name = ns::RunningApp::with_pid(pid)
+        .and_then(|app| app.localized_name())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "?".to_string());
+    Some((pid, name))
 }
 
 // ============================================================================

--- a/crates/screenpipe-accessibility/src/tree/macos.rs
+++ b/crates/screenpipe-accessibility/src/tree/macos.rs
@@ -213,11 +213,19 @@ impl MacosTreeWalker {
     fn walk_focused_window_inner(&self) -> Result<Option<TreeSnapshot>> {
         let start = Instant::now();
 
-        // 1. Get the focused (active) application via NSWorkspace
-        let workspace = ns::Workspace::shared();
-        let apps = workspace.running_apps();
-        let active_app = apps.iter().find(|app| app.is_active());
-        let Some(app) = active_app else {
+        // 1. Get the focused application via the AX system-wide element.
+        // This stays within the accessibility stack instead of relying on
+        // NSWorkspace's foreground-app state from a background thread.
+        let sys = ax::UiElement::sys_wide();
+        let focused_app = match sys.focused_app() {
+            Ok(app) => app,
+            Err(_) => return Ok(None),
+        };
+        let pid = match focused_app.pid() {
+            Ok(pid) => pid,
+            Err(_) => return Ok(None),
+        };
+        let Some(app) = ns::RunningApp::with_pid(pid) else {
             return Ok(None);
         };
 
@@ -225,7 +233,6 @@ impl MacosTreeWalker {
             .localized_name()
             .map(|s| s.to_string())
             .unwrap_or_default();
-        let pid = app.pid();
 
         // Skip excluded apps (password managers, etc.)
         let app_lower = app_name.to_lowercase();
@@ -252,7 +259,7 @@ impl MacosTreeWalker {
         }
 
         // 2. Get the focused window via AX API
-        let mut ax_app = ax::UiElement::with_app_pid(pid);
+        let mut ax_app = focused_app;
         let _ = ax_app.set_messaging_timeout_secs(self.config.element_timeout_secs);
 
         // Enable accessibility for Chromium/Electron apps. These apps only build

--- a/crates/screenpipe-server/src/event_driven_capture.rs
+++ b/crates/screenpipe-server/src/event_driven_capture.rs
@@ -549,6 +549,48 @@ struct CaptureOutput {
     image: image::DynamicImage,
 }
 
+fn resolve_capture_metadata(
+    tree_snapshot: Option<&screenpipe_accessibility::tree::TreeSnapshot>,
+    trigger: &CaptureTrigger,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let (mut app_name, mut window_name, browser_url) = match tree_snapshot {
+        Some(snap) => (
+            Some(snap.app_name.clone()),
+            Some(snap.window_name.clone()),
+            snap.browser_url.clone(),
+        ),
+        None => (None, None, None),
+    };
+
+    match trigger {
+        CaptureTrigger::AppSwitch {
+            app_name: trigger_app_name,
+        } if !trigger_app_name.is_empty() => {
+            if app_name.as_deref() != Some(trigger_app_name.as_str()) {
+                debug!(
+                    "focused app mismatch on app_switch: trigger='{}', tree={:?}; using trigger value",
+                    trigger_app_name, app_name
+                );
+            }
+            app_name = Some(trigger_app_name.clone());
+        }
+        CaptureTrigger::WindowFocus {
+            window_name: trigger_window_name,
+        } if !trigger_window_name.is_empty() => {
+            if window_name.as_deref() != Some(trigger_window_name.as_str()) {
+                debug!(
+                    "focused window mismatch on window_focus: trigger='{}', tree={:?}; using trigger value",
+                    trigger_window_name, window_name
+                );
+            }
+            window_name = Some(trigger_window_name.clone());
+        }
+        _ => {}
+    }
+
+    (app_name, window_name, browser_url)
+}
+
 /// Perform a single event-driven capture.
 ///
 /// When `previous_content_hash` is `Some` and matches the current accessibility
@@ -611,15 +653,10 @@ async fn do_capture(
         }
     }
 
-    // Use tree snapshot metadata for app/window/url if available
-    let (app_name_owned, window_name_owned, browser_url_owned) = match &tree_snapshot {
-        Some(snap) => (
-            Some(snap.app_name.clone()),
-            Some(snap.window_name.clone()),
-            snap.browser_url.clone(),
-        ),
-        None => (None, None, None),
-    };
+    // Use tree metadata by default, but for focus-change triggers prefer the
+    // event payload when the tree lags or reports the wrong frontmost target.
+    let (app_name_owned, window_name_owned, browser_url_owned) =
+        resolve_capture_metadata(tree_snapshot.as_ref(), trigger);
 
     // Skip lock screen / screensaver — these waste disk and pollute timeline.
     // Also update the global SCREEN_IS_LOCKED flag so subsequent loop iterations


### PR DESCRIPTION
## Summary

This replaces the macOS focused-app observer's background polling loop with a run-loop-backed `AXObserver` flow.

On macOS Tahoe, the old implementation could capture the first focused app at startup and then stop tracking later app changes. The observer was using `NSWorkspace` foreground-app polling from a background Rust thread, which proved unreliable in real CLI runs.

This change moves the observer onto a real `CFRunLoop`, attaches an `AXObserver` to the currently focused app, and reattaches when accessibility activation/deactivation notifications indicate focus moved to another app.

## Root Cause

The previous observer logic in `crates/screenpipe-accessibility/src/platform/macos.rs`:

- polled `NSWorkspace` for the active app
- slept in a manual loop
- emitted app/window focus changes from that polled state

On Tahoe, that path could get stuck on the startup app. In live tests it stayed pinned to `Codex` even after switching to Chrome and VS Code.

## What Changed

### `crates/screenpipe-accessibility/src/platform/macos.rs`

- added `FocusState` to track the last emitted app, pid, and window title
- added `ObserverCallbackState` to share capture state with the AX callback
- added `emit_focus_state(...)` to centralize app/window focus event emission
- replaced the `NSWorkspace` sleep loop with:
  - `CFRunLoop::run_in_mode(...)`
  - `AXObserver::with_cb(...)`
  - `AXObserverAddNotification` via `add_notification(...)`
- subscribed to:
  - `AXApplicationActivated`
  - `AXApplicationDeactivated`
  - `AXFocusedWindowChanged`
  - `AXFocusedUIElementChanged`
- reattach logic now follows the AX-focused pid instead of relying only on workspace activation notifications
- kept `NSWorkspace` notifications only for lifecycle events like wake/space/session changes
- added `get_focused_app_info()` using the AX system-wide focused app

### `crates/screenpipe-accessibility/src/tree/macos.rs`

- changed focused-app lookup in the AX tree walker from `NSWorkspace` active-app discovery to the AX system-wide focused app
- reuses the focused AX app element directly when walking the focused window

### `crates/screenpipe-server/src/event_driven_capture.rs`

- when a capture is triggered by `AppSwitch` or `WindowFocus`, trigger metadata now overrides stale or mismatched tree metadata for that field
- this prevents frame metadata drift when the tree lags behind the focus event

## Verification

### Build checks

- `cargo check -p screenpipe-accessibility`
- `cargo check -p screenpipe-server`

### Runtime reproduction before fix

In an earlier live CLI run on macOS Tahoe:

- `ui_events` stayed pinned to the startup app (`Codex`)
- `accessibility` rows also stayed pinned to the startup app
- switches to Chrome and VS Code never appeared

### Runtime verification after fix

Live CLI run:

```bash
cargo run -p screenpipe-server --bin screenpipe -- \
  record --enable-input-capture --enable-accessibility \
  --disable-audio --disable-telemetry --debug --port 3136
