### PR TITLE
refactor(windows): remove static CRT and use dynamic MSVC runtime

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,18 +1,3 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = [
-  "-C",
-  "target-feature=+crt-static",
-  "-C",
-  "link-args=/DEFAULTLIB:ucrt.lib /DEFAULTLIB:libvcruntime.lib libcmt.lib",
-  "-C",
-  "link-args=/NODEFAULTLIB:libvcruntimed.lib /NODEFAULTLIB:vcruntime.lib /NODEFAULTLIB:vcruntimed.lib",
-  "-C",
-  "link-args=/NODEFAULTLIB:libcmtd.lib /NODEFAULTLIB:msvcrt.lib /NODEFAULTLIB:msvcrtd.lib",
-  "-C",
-  "link-args=/NODEFAULTLIB:libucrt.lib /NODEFAULTLIB:libucrtd.lib /NODEFAULTLIB:ucrtd.lib",
-
-]
-
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,26 +150,23 @@ jobs:
 
       - name: Run specific Windows OCR cargo test
         env:
-          RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
+          RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
           ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
-          KNF_STATIC_CRT: 1
         run: cargo test test_process_ocr_task_windows --release --target x86_64-pc-windows-msvc
 
       - name: Run PII removal tests
         env:
-          RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
+          RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
           ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
-          KNF_STATIC_CRT: 1
         run: cargo test -p screenpipe-core pii_removal --release --target x86_64-pc-windows-msvc
 
       - name: Run PII redaction tests
         env:
-          RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
+          RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
           ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
-          KNF_STATIC_CRT: 1
         run: cargo test -p screenpipe-server --lib pii_redaction_tests --release --target x86_64-pc-windows-msvc
 
       # pipes_test removed — pipe manager system deleted in #2212

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -121,11 +121,9 @@ jobs:
         CARGO_PROFILE_RELEASE_STRIP: symbols
         CARGO_PROFILE_RELEASE_PANIC: abort
         CARGO_PROFILE_RELEASE_INCREMENTAL: false
-        RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
+        RUSTFLAGS: "-C link-arg=/LTCG"
         ORT_STRATEGY: system
         ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
-        VCPKG_STATIC_LINKAGE: "true"
-        KNF_STATIC_CRT: 1
       run: cargo build --release -p screenpipe-server --target x86_64-pc-windows-msvc
 
     - name: Install frontend dependencies
@@ -148,9 +146,8 @@ jobs:
         CARGO_PROFILE_RELEASE_STRIP: symbols
         CARGO_PROFILE_RELEASE_PANIC: abort
         CARGO_PROFILE_RELEASE_INCREMENTAL: false
-        RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
-        VCPKG_STATIC_LINKAGE: "true"
-        KNF_STATIC_CRT: "1"
+        RUSTFLAGS: "-C link-arg=/LTCG"
+
       with:
         args: "--target x86_64-pc-windows-msvc --no-bundle"
         projectPath: "./apps/screenpipe-app-tauri"
@@ -322,7 +319,6 @@ jobs:
         CARGO_PROFILE_RELEASE_STRIP: none
         CARGO_PROFILE_RELEASE_PANIC: unwind
         CARGO_PROFILE_RELEASE_INCREMENTAL: true
-        VCPKG_STATIC_LINKAGE: "true"
       with:
         args: "--target x86_64-unknown-linux-gnu --no-bundle"
         projectPath: "./apps/screenpipe-app-tauri"

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -853,9 +853,7 @@ jobs:
           CARGO_PROFILE_RELEASE_STRIP: none
           CARGO_PROFILE_RELEASE_PANIC: ${{ matrix.os_type == 'windows' && 'abort' || 'unwind' }}
           CARGO_PROFILE_RELEASE_INCREMENTAL: ${{ matrix.os_type == 'windows' && 'false' || 'true' }}
-          RUSTFLAGS: ${{ matrix.os_type == 'windows' && '-C target-feature=+crt-static -C link-arg=/LTCG' || '' }}
-          VCPKG_STATIC_LINKAGE: "true"
-          KNF_STATIC_CRT: ${{ matrix.os_type == 'windows' && '1' || '' }}
+          RUSTFLAGS: ${{ matrix.os_type == 'windows' && '-C link-arg=/LTCG' || '' }}
           # ORT_STRATEGY and ORT_LIB_LOCATION set via GITHUB_ENV in Windows-only step above
           # Fix whisper.cpp crash on newer CPUs (Lunar Lake, etc.) that lack AVX-512
           # GitHub windows-2022 runners have Xeon CPUs with AVX-512, but GGML_NATIVE=ON

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -295,11 +295,9 @@ jobs:
           CARGO_PROFILE_RELEASE_STRIP: "none"
           CARGO_PROFILE_RELEASE_PANIC: "abort"
           CARGO_PROFILE_RELEASE_INCREMENTAL: "false"
-          RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
+          RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
           ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
-          VCPKG_STATIC_LINKAGE: "true"
-          KNF_STATIC_CRT: 1
         run: |
           cargo build --release --target x86_64-pc-windows-msvc
 

--- a/.github/workflows/release-enterprise-windows.yml
+++ b/.github/workflows/release-enterprise-windows.yml
@@ -193,9 +193,7 @@ jobs:
           CARGO_PROFILE_RELEASE_STRIP: none
           CARGO_PROFILE_RELEASE_PANIC: abort
           CARGO_PROFILE_RELEASE_INCREMENTAL: "false"
-          RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
-          VCPKG_STATIC_LINKAGE: "true"
-          KNF_STATIC_CRT: "1"
+          RUSTFLAGS: "-C link-arg=/LTCG"
           CMAKE_ARGS: "-DGGML_NATIVE=OFF -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF -DGGML_AVX512_BF16=OFF"
         with:
           args: "--target x86_64-pc-windows-msvc --features enterprise-build"

--- a/.github/workflows/windows-integration-test.yml
+++ b/.github/workflows/windows-integration-test.yml
@@ -93,11 +93,9 @@ jobs:
 
     - name: Build CLI
       env:
-        RUSTFLAGS: "-C target-feature=+crt-static -C link-arg=/LTCG"
+        RUSTFLAGS: "-C link-arg=/LTCG"
         ORT_STRATEGY: system
         ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
-        VCPKG_STATIC_LINKAGE: "true"
-        KNF_STATIC_CRT: 1
       run: cargo build --release --target x86_64-pc-windows-msvc
 
     - name: Run CLI and generate activity

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -4728,8 +4728,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "knf-rs"
-version = "0.2.4"
-source = "git+https://github.com/Neptune650/knf-rs.git#b782e6bb02db495ce767f0094c0aa6bca5dba61c"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ebe7cf9eae245a44ab76cabdd06c0b3769972fd06050ed9aea6a22ff0d682f"
 dependencies = [
  "eyre",
  "knf-rs-sys",
@@ -4738,8 +4739,9 @@ dependencies = [
 
 [[package]]
 name = "knf-rs-sys"
-version = "0.2.4"
-source = "git+https://github.com/Neptune650/knf-rs.git#b782e6bb02db495ce767f0094c0aa6bca5dba61c"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9aa7679fdc0ecdaab1f4e7c9603413f303765f33c8e34e6ca4f26e7d61d6023"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",
@@ -8223,7 +8225,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.2.36"
+version = "2.2.37"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -78,7 +78,7 @@ realfft = "3.4.0"
 ndarray = "0.16"
 ort = "=2.0.0-rc.6"
 ort-sys = "=2.0.0-rc.6"
-knf-rs = { git = "https://github.com/Neptune650/knf-rs.git" }
+knf-rs = "0.3.2"
 futures = "0.3.31"
 deepgram = "0.6.4"
 audiopipe = { git = "https://github.com/screenpipe/audiopipe.git", rev = "c92760e", default-features = false, features = ["qwen3-asr-ggml"], optional = true }

--- a/crates/screenpipe-audio/build.rs
+++ b/crates/screenpipe-audio/build.rs
@@ -84,11 +84,6 @@ fn install_onnxruntime() {
     use reqwest::blocking::Client;
     use std::time::Duration;
     use std::{path::Path, process::Command};
-    // Set static CRT for Windows MSVC target
-    if env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default() == "msvc" {
-        println!("cargo:rustc-env=KNF_STATIC_CRT=1");
-        println!("cargo:rustc-flag=-C target-feature=+crt-static");
-    }
 
     // Use CPU-only onnxruntime — GPU (DirectML) causes issues on Intel integrated GPUs
     let target_dir =


### PR DESCRIPTION
The project previously forced the **static MSVC runtime (`/MT`)**, while several native dependencies (including **ONNX Runtime**) are built using the **dynamic runtime (`/MD`)**.

This caused runtime mismatches such as:

```
LNK2038: mismatch detected for 'RuntimeLibrary'
```

This PR removes the static CRT configuration so the project uses the **default MSVC dynamic runtime**, aligning it with upstream dependencies and simplifying the Windows build configuration.

Since the application already distributes the Visual C++ runtime DLLs, using the dynamic runtime avoids embedding multiple CRT copies across binaries.





## Impacts

| Impact | Before | After |
|------|------|------|
| Runtime usage | Each binary embeds its own MSVC runtime (`/MT`) | All components share the VC runtime DLLs (`/MD`) |
| Linker configuration | Manual overrides like `/DEFAULTLIB` and `/NODEFAULTLIB` | Default MSVC linker behavior |
| Dependency compatibility | Conflicts with prebuilt libraries compiled with `/MD` | Runtime matches upstream dependencies (e.g. ONNX Runtime) |
| Build complexity | Static CRT enforced in Cargo config, CI, and build scripts | No manual CRT overrides |