### PR TITLE
Remove all vcpkg references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,6 @@ jobs:
         with:
           bun-version: 1.2.2
 
-      - name: Install vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: "2a3138723698306f4261632c92dc782f586167e3"
-
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -82,11 +82,6 @@ jobs:
         target: x86_64-pc-windows-msvc
         rustflags: ""
 
-    - name: Install vcpkg
-      uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgGitCommitId: "7adc2e4d49e8d0efc07a369079faa6bc3dbb90f3"
-
     - name: Install 7zip
       shell: powershell
       run: |

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -499,12 +499,6 @@ jobs:
         working-directory: ${{ github.workspace }}/apps/screenpipe-app-tauri
         run: bun install
 
-      - name: Install vcpkg
-        if: matrix.os_type == 'windows'
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: "7adc2e4d49e8d0efc07a369079faa6bc3dbb90f3"
-
       - name: Set up MSVC
         if: matrix.os_type == 'windows'
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/release-enterprise-windows.yml
+++ b/.github/workflows/release-enterprise-windows.yml
@@ -93,11 +93,6 @@ jobs:
         working-directory: apps/screenpipe-app-tauri
         run: bun install
 
-      - name: Install vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgGitCommitId: "7adc2e4d49e8d0efc07a369079faa6bc3dbb90f3"
-
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,30 +71,18 @@ before you begin:
    irm https://bun.sh/install.ps1 | iex
    ```
 
-3. **clone and setup vcpkg**:
+3. **set environment variables**:
    ```powershell
-   cd C:\dev
-   $env:DEV_DIR = $(pwd)
-   git clone https://github.com/microsoft/vcpkg.git
-   cd vcpkg
-   ./bootstrap-vcpkg.bat -disableMetrics
-   ./vcpkg.exe integrate install --disable-metrics
-   ./vcpkg.exe install ffmpeg:x64-windows
-   ```
-
-4. **set environment variables**:
-   ```powershell
-   [System.Environment]::SetEnvironmentVariable('PKG_CONFIG_PATH', "$env:DEV_DIR\vcpkg\packages\ffmpeg_x64-windows\lib\pkgconfig", 'User')
-   [System.Environment]::SetEnvironmentVariable('VCPKG_ROOT', "$env:DEV_DIR\vcpkg", 'User')
    [System.Environment]::SetEnvironmentVariable('LIBCLANG_PATH', 'C:\Program Files\LLVM\bin', 'User')
    [System.Environment]::SetEnvironmentVariable('PATH', "$([System.Environment]::GetEnvironmentVariable('PATH', 'User'));C:\Program Files (x86)\GnuWin32\bin", 'User')
    ```
-5. **clone the project**:
+
+4. **clone the project**:
    ```powershell
       git clone https://github.com/screenpipe/screenpipe.git
       cd screenpipe
    ```
-6. **make sure vcredist is present on system**:
+5. **make sure vcredist is present on system**:
    - make sure your in root of the project i.e screenpipe
 
    ```powershell
@@ -126,7 +114,7 @@ before you begin:
    Write-Host "vcruntime140.dll copied successfully!"
    ```
 
-8. **build**:
+6. **build**:
    ```powershell
    cd screenpipe
    cargo build --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ crossbeam = "0.8.4"
 dashmap = "6.1.0"
 image = "0.25"
 criterion = { version = "0.5.1", features = ["async_tokio"] }
-vcpkg = "0.2"
 cc = "1.0"
 oasgen = { version = "0.22.0", features = ["axum", "chrono"] }
 once_cell = "1.20.2"
@@ -43,11 +42,6 @@ reqwest-middleware = "0.4.1"
 [patch.crates-io]
 # enables chinese mirror (hf is banned in china) and native-tls
 hf-hub = { git = "https://github.com/neo773/hf-hub" }
-
-[workspace.metadata.vcpkg]
-git = "https://github.com/microsoft/vcpkg"
-rev = "2023.04.15"
-dynamic = true
 
 [profile.release]
 codegen-units = 1

--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -26,7 +26,6 @@ const config = {
 	windows: {
 		ffmpegName: 'ffmpeg-8.0.1-full_build-shared',
 		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-8.0.1-full_build-shared.7z',
-		vcpkgPackages: ['opencl', 'onnxruntime-gpu'],
 	},
 	linux: {
 		aptPackages: [
@@ -334,12 +333,8 @@ if (platform == 'windows') {
 				await copyVcredistDlls();
 			} catch (err) {
 				console.warn('Skipping VC redist DLL copy (optional outside CI):', err.message);
-			}
 		}
-
-	// Setup vcpkg packages with environment variables set inline
-	// TODO is this even used? dont we use build.rs for this?
-	// await $`SystemDrive=${process.env.SYSTEMDRIVE} SystemRoot=${process.env.SYSTEMROOT} windir=${process.env.WINDIR} ${process.env.VCPKG_ROOT}\\vcpkg.exe install ${config.windows.vcpkgPackages}`.quiet()
+	}
 }
 
 /* ########## macOS ########## */


### PR DESCRIPTION
- Remove vcpkg from root Cargo.toml (workspace dep and metadata)
- Remove Install vcpkg step from ci, release-app, e2e-test, release-enterprise-windows workflows
- Remove vcpkg setup and env vars from CONTRIBUTING.md Windows section
- Remove vcpkgPackages and commented vcpkg install from pre_build.js

