### PR TITLE
fix: give audio start/stop shortcuts non-empty defaults (fixes #2400)

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -252,8 +252,8 @@ let DEFAULT_SETTINGS: Settings = {
 			showScreenpipeShortcut: "Control+Super+S",
 			startRecordingShortcut: "Super+Alt+U",
 			stopRecordingShortcut: "Super+Alt+X",
-			startAudioShortcut: "",
-			stopAudioShortcut: "",
+			startAudioShortcut: "Control+Super+A",
+			stopAudioShortcut: "Control+Super+Z",
 			showChatShortcut: "Control+Super+L",
 			searchShortcut: "Control+Super+K",
 			realtimeAudioTranscriptionEngine: "deepgram",
@@ -289,6 +289,8 @@ export function createDefaultSettingsObject(): Settings {
 		DEFAULT_SETTINGS.showScreenpipeShortcut = p === "windows" ? "Alt+S" : "Control+Super+S";
 		DEFAULT_SETTINGS.showChatShortcut = p === "windows" ? "Alt+L" : "Control+Super+L";
 		DEFAULT_SETTINGS.searchShortcut = p === "windows" ? "Alt+K" : "Control+Super+K";
+		DEFAULT_SETTINGS.startAudioShortcut = p === "windows" ? "Alt+Shift+A" : "Control+Super+A";
+		DEFAULT_SETTINGS.stopAudioShortcut = p === "windows" ? "Alt+Shift+Z" : "Control+Super+Z";
 
 		if (p === "windows") {
 			DEFAULT_SETTINGS.enableAccessibility = true;
@@ -391,6 +393,18 @@ function createSettingsStore() {
 		if (!settings.showChatShortcut || settings.showChatShortcut.trim() === "") {
 			const p = platform();
 			settings.showChatShortcut = p === "windows" ? "Alt+L" : "Control+Super+L";
+			needsUpdate = true;
+		}
+
+		// Migration: Fill empty audio shortcuts with platform defaults
+		if (!settings.startAudioShortcut || settings.startAudioShortcut.trim() === "") {
+			const p = platform();
+			settings.startAudioShortcut = p === "windows" ? "Alt+Shift+A" : "Control+Super+A";
+			needsUpdate = true;
+		}
+		if (!settings.stopAudioShortcut || settings.stopAudioShortcut.trim() === "") {
+			const p = platform();
+			settings.stopAudioShortcut = p === "windows" ? "Alt+Shift+Z" : "Control+Super+Z";
 			needsUpdate = true;
 		}
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -280,12 +280,31 @@ impl ShortcutConfig {
             .unwrap_or_default()
             .unwrap_or_default();
 
+        let default_start_audio = if cfg!(target_os = "windows") {
+            "Alt+Shift+A"
+        } else {
+            "Super+Ctrl+A"
+        };
+        let default_stop_audio = if cfg!(target_os = "windows") {
+            "Alt+Shift+Z"
+        } else {
+            "Super+Ctrl+Z"
+        };
+
         Ok(Self {
             show: store.show_screenpipe_shortcut,
             start: store.start_recording_shortcut,
             stop: store.stop_recording_shortcut,
-            start_audio: store.start_audio_shortcut,
-            stop_audio: store.stop_audio_shortcut,
+            start_audio: if store.start_audio_shortcut.trim().is_empty() {
+                default_start_audio.to_string()
+            } else {
+                store.start_audio_shortcut
+            },
+            stop_audio: if store.stop_audio_shortcut.trim().is_empty() {
+                default_stop_audio.to_string()
+            } else {
+                store.stop_audio_shortcut
+            },
             show_chat: store.show_chat_shortcut,
             search: store.search_shortcut,
             disabled: store.disabled_shortcuts,

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -537,8 +537,14 @@ impl Default for SettingsStore {
             stop_recording_shortcut: "Alt+Shift+X".to_string(),
             #[cfg(not(target_os = "windows"))]
             stop_recording_shortcut: "Super+Ctrl+X".to_string(),
-            start_audio_shortcut: "".to_string(),
-            stop_audio_shortcut: "".to_string(),
+            #[cfg(target_os = "windows")]
+            start_audio_shortcut: "Alt+Shift+A".to_string(),
+            #[cfg(not(target_os = "windows"))]
+            start_audio_shortcut: "Super+Ctrl+A".to_string(),
+            #[cfg(target_os = "windows")]
+            stop_audio_shortcut: "Alt+Shift+Z".to_string(),
+            #[cfg(not(target_os = "windows"))]
+            stop_audio_shortcut: "Super+Ctrl+Z".to_string(),
             #[cfg(target_os = "windows")]
             show_chat_shortcut: "Alt+L".to_string(),
             #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary
- assign platform defaults for `startAudioShortcut` / `stopAudioShortcut` instead of empty strings
- add startup fallback in Rust shortcut loader so existing users with blank values still get working audio hotkeys
- add frontend migration to backfill blank audio shortcut settings for existing installs

## Testing
- Could not run Rust build checks in this environment because `cargo` is unavailable (`cargo: command not found`).
- Scope kept minimal to shortcut default + migration paths only.

## Related
Fixes #2400
