### PR TITLE
fix: parallelize ICS calendar fetching + fix broken tests

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/ics_calendar.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/ics_calendar.rs
@@ -13,6 +13,7 @@ use crate::store::IcsCalendarEntry;
 use crate::store::IcsCalendarSettingsStore;
 use chrono::{DateTime, Local, TimeZone, Utc};
 use chrono_tz::Tz;
+use futures::stream::{self, StreamExt};
 use icalendar::{Calendar, CalendarDateTime, Component, DatePerhapsTime, EventLike};
 use std::collections::HashSet;
 use std::str::FromStr;
@@ -316,11 +317,17 @@ pub async fn start_ics_calendar_poller(app: AppHandle) {
                 .collect();
 
             if !enabled_entries.is_empty() {
-                let mut all_events = Vec::new();
-                for entry in &enabled_entries {
-                    let events = fetch_and_parse_feed(&client, entry).await;
-                    all_events.extend(events);
-                }
+                let all_events: Vec<CalendarEventItem> = stream::iter(enabled_entries)
+                    .map(|entry| {
+                        let client = client.clone();
+                        async move { fetch_and_parse_feed(&client, &entry).await }
+                    })
+                    .buffer_unordered(10)
+                    .collect::<Vec<_>>()
+                    .await
+                    .into_iter()
+                    .flatten()
+                    .collect();
 
                 if !all_events.is_empty() {
                     if let Err(e) = screenpipe_events::send_event("calendar_events", all_events) {
@@ -383,12 +390,17 @@ pub async fn ics_calendar_get_upcoming(app: AppHandle) -> Result<Vec<CalendarEve
     }
 
     let client = reqwest::Client::new();
-    let mut all_events = Vec::new();
-
-    for entry in &enabled {
-        let events = fetch_and_parse_feed(&client, entry).await;
-        all_events.extend(events);
-    }
+    let mut all_events: Vec<CalendarEventItem> = stream::iter(enabled)
+        .map(|entry| {
+            let client = client.clone();
+            async move { fetch_and_parse_feed(&client, &entry).await }
+        })
+        .buffer_unordered(10)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .flatten()
+        .collect();
 
     // Filter to next 8 hours only
     let now = Utc::now();
@@ -408,4 +420,40 @@ pub async fn ics_calendar_get_upcoming(app: AppHandle) -> Result<Vec<CalendarEve
     all_events.sort_by(|a, b| a.start.cmp(&b.start));
 
     Ok(all_events)
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream::{self, StreamExt};
+    use std::time::Duration;
+    use tokio::time::Instant;
+
+    #[tokio::test]
+    async fn test_parallel_fetching_logic() {
+        // Mock function that simulates network delay
+        async fn mock_fetch(id: usize) -> Vec<usize> {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            vec![id]
+        }
+
+        let start = Instant::now();
+        let items: Vec<usize> = (0..10).collect();
+        
+        let results: Vec<usize> = stream::iter(items)
+            .map(|id| mock_fetch(id))
+            .buffer_unordered(10) // Limit concurrency to 10
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
+            
+        let duration = start.elapsed();
+        
+        // Sequential would be 10 * 200ms = 2000ms.
+        // Parallel should be ~200ms + overhead.
+        println!("Duration: {:?}", duration);
+        assert!(duration < Duration::from_millis(1000), "Should finish in well under 1 second (took {:?})", duration);
+        assert_eq!(results.len(), 10);
+    }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/suggestions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/suggestions.rs
@@ -1261,31 +1261,31 @@ mod tests {
     #[test]
     fn test_parse_ai_suggestions_valid_json() {
         let input = r#"["What did I code?", "Show my git commits"]"#;
-        let result = parse_ai_suggestions(input);
+        let result = parse_ai_response(input);
         assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 2);
+        assert_eq!(result.unwrap().suggestions.len(), 2);
     }
 
     #[test]
     fn test_parse_ai_suggestions_wrapped_json() {
         let input = "Here are your suggestions:\n```json\n[\"question 1\", \"question 2\"]\n```";
-        let result = parse_ai_suggestions(input);
+        let result = parse_ai_response(input);
         assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 2);
+        assert_eq!(result.unwrap().suggestions.len(), 2);
     }
 
     #[test]
     fn test_parse_ai_suggestions_garbage() {
         let input = "I cannot generate suggestions right now.";
-        let result = parse_ai_suggestions(input);
+        let result = parse_ai_response(input);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_parse_ai_suggestions_caps_at_4() {
         let input = r#"["a", "b", "c", "d", "e", "f"]"#;
-        let result = parse_ai_suggestions(input).unwrap();
-        assert_eq!(result.len(), 4);
+        let result = parse_ai_response(input).unwrap();
+        assert_eq!(result.suggestions.len(), 4);
     }
 
     // ─── Benchmark tests ─────────────────────────────────────────────────────
@@ -1485,7 +1485,7 @@ mod tests {
             match result {
                 Some(suggestions) => {
                     let mut run_scores = Vec::new();
-                    for s in &suggestions {
+                    for s in &suggestions.suggestions {
                         let (spec, act, nat, brev) =
                             score_suggestion(&s.text, &top_apps, &speakers);
                         let total = weighted_score(spec, act, nat, brev);
@@ -1495,14 +1495,14 @@ mod tests {
                     all_scores.push(avg);
 
                     println!("\n  Run {}: avg={:.2}/3.00", run + 1, avg);
-                    for (i, s) in suggestions.iter().enumerate() {
+                    for (i, s) in suggestions.suggestions.iter().enumerate() {
                         let (spec, act, nat, brev) =
                             score_suggestion(&s.text, &top_apps, &speakers);
                         let total = weighted_score(spec, act, nat, brev);
                         println!("    [{}] \"{}\"\n        spec={:.1} act={:.1} nat={:.1} brev={:.1} → {:.2}",
                             i + 1, s.text, spec, act, nat, brev, total);
                     }
-                    all_suggestions.extend(suggestions);
+                    all_suggestions.extend(suggestions.suggestions);
                 }
                 None => {
                     println!("\n  Run {}: AI returned no results", run + 1);


### PR DESCRIPTION
This PR speeds up the ICS calendar poller by fetching calendar feeds in parallel instead of sequentially.

## Changes
- Updated `start_ics_calendar_poller` and `ics_calendar_get_upcoming` to use `futures::stream::buffer_unordered(10)`.
- Added a unit test `test_parallel_fetching_logic` to verify concurrency (parallel execution is significantly faster than sequential).
- Fixed `suggestions.rs` which was broken on main (compilation errors in tests) to allow running tests.

## Verification
Ran `cargo test -p screenpipe-app --lib ics_calendar::tests::test_parallel_fetching_logic` which passed in ~200ms (sequential would be ~2000ms).