### PR TITLE
fix: skip auto-update install for non-admin macOS users (#2388)

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -38,6 +38,7 @@ interface UpdateBannerState {
   downloadProgress: DownloadProgress | null;
   pendingUpdate: Update | null;
   authRequired: AuthRequiredInfo | null;
+  needsAdmin: boolean;
   setIsVisible: (visible: boolean) => void;
   setUpdateInfo: (info: UpdateInfo | null) => void;
   setIsInstalling: (installing: boolean) => void;
@@ -45,6 +46,7 @@ interface UpdateBannerState {
   setDownloadProgress: (progress: DownloadProgress | null) => void;
   setPendingUpdate: (update: Update | null) => void;
   setAuthRequired: (info: AuthRequiredInfo | null) => void;
+  setNeedsAdmin: (needs: boolean) => void;
 }
 
 export const useUpdateBanner = create<UpdateBannerState>((set) => ({
@@ -55,6 +57,7 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   downloadProgress: null,
   pendingUpdate: null,
   authRequired: null,
+  needsAdmin: false,
   setIsVisible: (visible) => set({ isVisible: visible }),
   setUpdateInfo: (info) => set({ updateInfo: info }),
   setIsInstalling: (installing) => set({ isInstalling: installing }),
@@ -62,6 +65,7 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   setDownloadProgress: (progress) => set({ downloadProgress: progress }),
   setPendingUpdate: (update) => set({ pendingUpdate: update }),
   setAuthRequired: (info) => set({ authRequired: info }),
+  setNeedsAdmin: (needs) => set({ needsAdmin: needs }),
 }));
 
 interface UpdateBannerProps {
@@ -71,7 +75,7 @@ interface UpdateBannerProps {
 
 export function UpdateBanner({ className, compact = false }: UpdateBannerProps) {
   const isEnterprise = useIsEnterpriseBuild();
-  const { isVisible, updateInfo, isInstalling, isDownloading, downloadProgress, setIsVisible, setIsInstalling, pendingUpdate, authRequired, setAuthRequired } = useUpdateBanner();
+  const { isVisible, updateInfo, isInstalling, isDownloading, downloadProgress, setIsVisible, setIsInstalling, pendingUpdate, authRequired, setAuthRequired, needsAdmin, setNeedsAdmin } = useUpdateBanner();
   const { toast } = useToast();
 
   if (isEnterprise) return null;
@@ -181,6 +185,42 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
             size="sm"
             className="h-7 w-7 p-0"
             onClick={() => setAuthRequired(null)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show needs-admin state — user is a standard macOS user
+  if (needsAdmin && updateInfo) {
+    if (compact) {
+      return (
+        <div className={cn("flex items-center gap-2 text-xs text-muted-foreground", className)}>
+          <Sparkles className="h-3 w-3 text-primary" />
+          <span>v{updateInfo.version} available</span>
+          <span className="text-muted-foreground">ask admin to update</span>
+        </div>
+      );
+    }
+    return (
+      <div className={cn(
+        "flex items-center justify-between gap-3 px-3 py-2 bg-muted/50 border-b text-sm",
+        className
+      )}>
+        <div className="flex items-center gap-2 flex-1">
+          <Sparkles className="h-4 w-4 text-primary" />
+          <span>
+            screenpipe <span className="font-medium">v{updateInfo.version}</span> is available — ask your IT admin to update
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setNeedsAdmin(false)}
           >
             <X className="h-4 w-4" />
           </Button>
@@ -299,7 +339,7 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
 
 // Hook to listen for update events from Rust
 export function useUpdateListener() {
-  const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired } = useUpdateBanner();
+  const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired, setNeedsAdmin } = useUpdateBanner();
 
   useEffect(() => {
     let unlistenAvailable: (() => void) | undefined;
@@ -307,6 +347,7 @@ export function useUpdateListener() {
     let unlistenDownloading: (() => void) | undefined;
     let unlistenProgress: (() => void) | undefined;
     let unlistenAuth: (() => void) | undefined;
+    let unlistenNeedsAdmin: (() => void) | undefined;
 
     const setupListeners = async () => {
       // Listen for download starting (shows banner immediately)
@@ -326,6 +367,15 @@ export function useUpdateListener() {
         setIsDownloading(false);
         setDownloadProgress(null);
         setUpdateInfo(event.payload);
+        setIsVisible(true);
+      });
+
+      // Listen for update needs admin
+      unlistenNeedsAdmin = await listen<UpdateInfo>("update-needs-admin", (event) => {
+        setIsDownloading(false);
+        setDownloadProgress(null);
+        setUpdateInfo(event.payload);
+        setNeedsAdmin(true);
         setIsVisible(true);
       });
 
@@ -350,6 +400,7 @@ export function useUpdateListener() {
       unlistenDownloading?.();
       unlistenProgress?.();
       unlistenAuth?.();
+      unlistenNeedsAdmin?.();
     };
-  }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired]);
+  }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired, setNeedsAdmin]);
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -23,6 +23,26 @@ use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tokio::time::interval;
+use std::sync::OnceLock;
+
+fn is_macos_admin() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        static IS_ADMIN: OnceLock<bool> = OnceLock::new();
+        *IS_ADMIN.get_or_init(|| {
+            if let Ok(output) = std::process::Command::new("id").arg("-Gn").output() {
+                if let Ok(groups) = String::from_utf8(output.stdout) {
+                    return groups.split_whitespace().any(|g| g == "admin");
+                }
+            }
+            true // default to true if check fails
+        })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Rollback: download a specific older version from R2 via the website API
@@ -247,6 +267,35 @@ impl UpdatesManager {
         }
         if let Some(update) = check_result? {
             *self.update_available.lock().await = true;
+
+            if !is_macos_admin() {
+                warn!("skipping auto-update: user is not a macOS admin");
+                
+                let update_info = serde_json::json!({
+                    "version": update.version,
+                    "body": update.body.clone().unwrap_or_default()
+                });
+                let _ = self.app.emit("update-needs-admin", update_info);
+                
+                let app_notif = self.app.clone();
+                let version_str = update.version.clone();
+                // std::thread::spawn (not spawn_blocking) to escape tokio runtime context entirely.
+                let _ = std::thread::spawn(move || {
+                    let _ = app_notif
+                        .notification()
+                        .builder()
+                        .title("screenpipe update available")
+                        .body(format!("v{} is ready — ask your admin to install it", version_str))
+                        .show();
+                });
+                
+                if let Some(ref item) = self.update_menu_item {
+                    let _ = item.set_enabled(false);
+                    let _ = item.set_text("Update available (needs admin)");
+                }
+                
+                return Ok(true);
+            }
 
             // Emit "update-downloading" immediately so user sees feedback
             let download_info = serde_json::json!({
@@ -632,4 +681,19 @@ pub fn start_update_check(
     });
 
     Ok(updates_manager)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_macos_admin() {
+        // We just ensure it doesn't crash and returns a boolean.
+        let is_admin = is_macos_admin();
+        println!("test_is_macos_admin: {}", is_admin);
+        
+        #[cfg(not(target_os = "macos"))]
+        assert!(is_admin, "Should always be true on non-macos platforms");
+    }
 }


### PR DESCRIPTION
Closes #2388

**Description:**
This fixes an issue where the Tauri updater's `download_and_install` froze the entire app for standard macOS users (non-admin).

**Changes:**
- Added `is_macos_admin()` check before triggering the auto-update download.
- Emits `update-needs-admin` to the frontend to show an appropriate UI banner.
- Shows a native notification instructing the user to ask their admin.
- Skips the `download_and_install` step entirely for non-admins.