### PR TITLE
fix: skip auto-update install for non-admin macOS users

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -299,6 +299,8 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
 
 // Hook to listen for update events from Rust
 export function useUpdateListener() {
+  const { toast } = useToast();
+
   const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired } = useUpdateBanner();
 
   useEffect(() => {
@@ -307,6 +309,7 @@ export function useUpdateListener() {
     let unlistenDownloading: (() => void) | undefined;
     let unlistenProgress: (() => void) | undefined;
     let unlistenAuth: (() => void) | undefined;
+    let unlistenNeedsAdmin: (() => void) | undefined;
 
     const setupListeners = async () => {
       // Listen for download starting (shows banner immediately)
@@ -335,6 +338,16 @@ export function useUpdateListener() {
       });
 
       // Listen for auth-required (user needs to sign in to download update)
+      const unlistenNeedsAdmin = await listen<UpdateInfo>("update-needs-admin", (event) => {
+        toast({
+          title: "Update requires admin privileges",
+          description: `v${event.payload.version} is ready — ask your admin to install it.`,
+          variant: "destructive",
+        });
+        setIsDownloading(false);
+        setDownloadProgress(null);
+      });
+
       unlistenAuth = await listen<AuthRequiredInfo>("update-auth-required", (event) => {
         setAuthRequired(event.payload);
         setIsDownloading(false);
@@ -350,6 +363,7 @@ export function useUpdateListener() {
       unlistenDownloading?.();
       unlistenProgress?.();
       unlistenAuth?.();
+      unlistenNeedsAdmin?.();
     };
   }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired]);
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -120,6 +120,31 @@ pub fn is_enterprise_build(_app: &tauri::AppHandle) -> bool {
     cfg!(feature = "enterprise-build")
 }
 
+use std::sync::OnceLock;
+
+/// Check if the user is a macOS admin.
+/// Standard users cannot rename apps in /Applications, causing the updater to freeze.
+fn is_macos_admin() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        static IS_ADMIN: OnceLock<bool> = OnceLock::new();
+        *IS_ADMIN.get_or_init(|| {
+            match std::process::Command::new("id").arg("-Gn").output() {
+                Ok(output) => {
+                    let groups = String::from_utf8_lossy(&output.stdout);
+                    groups.split_whitespace().any(|g| g == "admin")
+                }
+                Err(_) => false,
+            }
+        })
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+
 pub struct UpdatesManager {
     interval: Duration,
     update_available: Arc<Mutex<bool>>,
@@ -247,6 +272,39 @@ impl UpdatesManager {
         }
         if let Some(update) = check_result? {
             *self.update_available.lock().await = true;
+
+            if !is_macos_admin() {
+                warn!("skipping auto-update: user is not a macOS admin");
+                let update_info = serde_json::json!({
+                    "version": update.version,
+                    "body": update.body.clone().unwrap_or_default()
+                });
+                let _ = self.app.emit("update-needs-admin", update_info);
+                if show_dialog {
+                    self.app
+                        .dialog()
+                        .message(format!("v{} is ready — ask your admin to install it", update.version))
+                        .title("update requires admin")
+                        .buttons(MessageDialogButtons::Ok)
+                        .show(|_| {});
+                } else {
+                    let app_notif = self.app.clone();
+                    let version_str = update.version.clone();
+                    let _ = std::thread::spawn(move || {
+                        let _ = app_notif
+                            .notification()
+                            .builder()
+                            .title("screenpipe update available")
+                            .body(format!("v{} is ready — ask your admin to install it", version_str))
+                            .show();
+                    });
+                }
+                if let Some(ref item) = self.update_menu_item {
+                    let _ = item.set_enabled(true);
+                    let _ = item.set_text("Ask admin to update");
+                }
+                return Ok(true);
+            }
 
             // Emit "update-downloading" immediately so user sees feedback
             let download_info = serde_json::json!({


### PR DESCRIPTION
Fixes #2388

**Description:**
The Tauri updater's `download_and_install` freezes the entire app for non-admin macOS users because `std::fs::rename()` fails and it falls back to an AppleScript prompt that runs on the main thread, blocking the app. 

To prevent this:
- We use `id -Gn` to check if the current macOS user is in the `admin` group.
- If not, we skip the `download_and_install` step entirely.
- We emit an `update-needs-admin` event to the frontend (which shows a toast).
- We show a native OS notification prompting the user to ask their admin to install the update.
- We disable the update button text to show 'Ask admin to update'.