### PR TITLE
fix: Search highlight issues persist in v2.2.64 (regression) (#2403)

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/text-overlay.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/text-overlay.test.tsx
@@ -395,3 +395,33 @@ describe("normalizeUrl", () => {
 		expect(normalizeUrl("example.com")).toBe("https://example.com");
 	});
 });
+
+describe("TextOverlay highlight terms", () => {
+	it("should prefer smaller matching blocks and reject huge overlapping ones as duplicates", () => {
+		const positions = [
+			// Huge paragraph block
+			{ text: "Hello search term", confidence: 1, bounds: { left: 0.1, top: 0.1, width: 0.8, height: 0.8 } },
+			// Small precise word block
+			{ text: "search term", confidence: 1, bounds: { left: 0.5, top: 0.5, width: 0.1, height: 0.1 } },
+		];
+		const { container } = render(
+			<TextOverlay
+				textPositions={positions}
+				originalWidth={1000}
+				originalHeight={1000}
+				displayedWidth={1000}
+				displayedHeight={1000}
+				highlightTerms={["search term"]}
+			/>
+		);
+		// It should only render one highlight, which is the smaller one.
+		// Since TextOverlay has pointer-events-none and background color, let's find the highlights
+		const highlights = container.querySelectorAll('div[style*="background-color: rgba(250, 204, 21, 0.35)"]');
+		// There are two blocks matching "search term". Since they overlap, it should keep the smaller one and skip the large one.
+		expect(highlights.length).toBe(1);
+		
+		const style = highlights[0].getAttribute("style");
+		expect(style).toContain("width: 100px"); // 0.1 * 1000
+		expect(style).toContain("height: 100px"); // 0.1 * 1000
+	});
+});

--- a/apps/screenpipe-app-tauri/components/rewind/thumbnail-highlight-overlay.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/thumbnail-highlight-overlay.tsx
@@ -48,11 +48,9 @@ export const ThumbnailHighlightOverlay = memo(function ThumbnailHighlightOverlay
 
 		if (matches.length === 0) return [];
 
-		// Skip if the smallest match already covers >15% of the frame area —
-		// that means we only have paragraph-level blocks, not useful highlights.
-		const smallest = matches[0];
-		if (smallest.bounds.width * smallest.bounds.height > 0.15) return [];
-
+		// We used to skip if the smallest match covered >15% of the frame area,
+		// but users reported this as "missing highlights" (issue #2403, #2401).
+		// Better to show a large paragraph highlight than none at all.
 		return matches.slice(0, 3);
 	}, [textPositions, highlightTerms]);
 

--- a/apps/screenpipe-app-tauri/components/text-overlay.tsx
+++ b/apps/screenpipe-app-tauri/components/text-overlay.tsx
@@ -270,13 +270,16 @@ export const TextOverlay = memo(function TextOverlay({
 
 		const result: { key: string; left: number; top: number; width: number; height: number }[] = [];
 
-		for (const pos of textPositions) {
-			if (pos.confidence < minConfidence) continue;
-
+		const matches = textPositions.filter((pos) => {
+			if (pos.confidence < minConfidence) return false;
 			const textLower = pos.text.toLowerCase();
-			const matches = terms.some(term => textLower.includes(term));
-			if (!matches) continue;
+			return terms.some(term => textLower.includes(term));
+		});
 
+		// Sort by area so we prioritize tighter word-level OCR boxes over massive paragraph nodes
+		matches.sort((a, b) => (a.bounds.width * a.bounds.height) - (b.bounds.width * b.bounds.height));
+
+		for (const pos of matches) {
 			const blockLeft = pos.bounds.left * displayedWidth;
 			const blockTop = pos.bounds.top * displayedHeight;
 			const blockWidth = pos.bounds.width * displayedWidth;
@@ -294,7 +297,10 @@ export const TextOverlay = memo(function TextOverlay({
 				if (overlapRight <= overlapLeft || overlapBottom <= overlapTop) return false;
 				const overlapArea = (overlapRight - overlapLeft) * (overlapBottom - overlapTop);
 				const thisArea = blockWidth * blockHeight;
-				return overlapArea > thisArea * 0.5;
+				const existingArea = existing.width * existing.height;
+				// If overlap covers > 50% of the SMALLER box, consider it a duplicate.
+				// We keep the one already in result, which is the smaller one due to the sort above.
+				return overlapArea > Math.min(thisArea, existingArea) * 0.5;
 			});
 			if (isDuplicate) continue;
 


### PR DESCRIPTION
This PR fixes two missing highlight issues:
1. Thumbnail highlight overlay discarded matches that covered >15% area, making highlights missing if the only match was an accessibility node paragraph. Removed this limit to prefer drawing a large highlight over no highlight.
2. Text overlay expanded view processed text nodes sequentially, meaning large accessibility paragraphs would register first and cause tighter, precise OCR word blocks to be discarded as duplicates. We now sort matches by area to keep the tightest bounding boxes and discard large overlapping nodes.
3. Added a unit test proving that smaller overlapping blocks are preferred over larger ones.

Fixes #2403

Test output:
```
components/__tests__/text-overlay.test.tsx:
(pass) TextOverlay highlight terms > should prefer smaller matching blocks and reject huge overlapping ones as duplicates [7.46ms]
```