### PR TITLE
fix: skip auto-update install for non-admin macOS users

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -30,6 +30,11 @@ interface AuthRequiredInfo {
   message: string;
 }
 
+interface NeedsAdminInfo {
+  version: string;
+  body: string;
+}
+
 interface UpdateBannerState {
   isVisible: boolean;
   updateInfo: UpdateInfo | null;
@@ -38,6 +43,7 @@ interface UpdateBannerState {
   downloadProgress: DownloadProgress | null;
   pendingUpdate: Update | null;
   authRequired: AuthRequiredInfo | null;
+  needsAdmin: NeedsAdminInfo | null;
   setIsVisible: (visible: boolean) => void;
   setUpdateInfo: (info: UpdateInfo | null) => void;
   setIsInstalling: (installing: boolean) => void;
@@ -45,6 +51,7 @@ interface UpdateBannerState {
   setDownloadProgress: (progress: DownloadProgress | null) => void;
   setPendingUpdate: (update: Update | null) => void;
   setAuthRequired: (info: AuthRequiredInfo | null) => void;
+  setNeedsAdmin: (info: NeedsAdminInfo | null) => void;
 }
 
 export const useUpdateBanner = create<UpdateBannerState>((set) => ({
@@ -55,6 +62,7 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   downloadProgress: null,
   pendingUpdate: null,
   authRequired: null,
+  needsAdmin: null,
   setIsVisible: (visible) => set({ isVisible: visible }),
   setUpdateInfo: (info) => set({ updateInfo: info }),
   setIsInstalling: (installing) => set({ isInstalling: installing }),
@@ -62,6 +70,7 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   setDownloadProgress: (progress) => set({ downloadProgress: progress }),
   setPendingUpdate: (update) => set({ pendingUpdate: update }),
   setAuthRequired: (info) => set({ authRequired: info }),
+  setNeedsAdmin: (info) => set({ needsAdmin: info }),
 }));
 
 interface UpdateBannerProps {
@@ -71,7 +80,7 @@ interface UpdateBannerProps {
 
 export function UpdateBanner({ className, compact = false }: UpdateBannerProps) {
   const isEnterprise = useIsEnterpriseBuild();
-  const { isVisible, updateInfo, isInstalling, isDownloading, downloadProgress, setIsVisible, setIsInstalling, pendingUpdate, authRequired, setAuthRequired } = useUpdateBanner();
+  const { isVisible, updateInfo, isInstalling, isDownloading, downloadProgress, setIsVisible, setIsInstalling, pendingUpdate, authRequired, setAuthRequired, needsAdmin, setNeedsAdmin } = useUpdateBanner();
   const { toast } = useToast();
 
   if (isEnterprise) return null;
@@ -137,6 +146,41 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
       });
     }
   };
+
+  // Show admin required state
+  if (needsAdmin) {
+    if (compact) {
+      return (
+        <div className={cn("flex items-center gap-2 text-xs text-muted-foreground", className)}>
+          <Sparkles className="h-3 w-3 text-orange-500" />
+          <span>v{needsAdmin.version} requires admin</span>
+        </div>
+      );
+    }
+    return (
+      <div className={cn(
+        "flex items-center justify-between gap-3 px-3 py-2 bg-muted/50 border-b text-sm border-orange-500/20 bg-orange-500/5",
+        className
+      )}>
+        <div className="flex items-center gap-2 flex-1">
+          <Sparkles className="h-4 w-4 text-orange-500" />
+          <span className="text-orange-600 dark:text-orange-400">
+            screenpipe <span className="font-medium">v{needsAdmin.version}</span> is available — ask your admin to install it
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setNeedsAdmin(null)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   // Show auth-required state — user needs to sign in to download updates
   if (authRequired) {
@@ -299,7 +343,7 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
 
 // Hook to listen for update events from Rust
 export function useUpdateListener() {
-  const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired } = useUpdateBanner();
+  const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired, setNeedsAdmin } = useUpdateBanner();
 
   useEffect(() => {
     let unlistenAvailable: (() => void) | undefined;
@@ -307,6 +351,7 @@ export function useUpdateListener() {
     let unlistenDownloading: (() => void) | undefined;
     let unlistenProgress: (() => void) | undefined;
     let unlistenAuth: (() => void) | undefined;
+    let unlistenNeedsAdmin: (() => void) | undefined;
 
     const setupListeners = async () => {
       // Listen for download starting (shows banner immediately)
@@ -340,6 +385,13 @@ export function useUpdateListener() {
         setIsDownloading(false);
         setDownloadProgress(null);
       });
+
+      // Listen for needs-admin (macOS non-admin user)
+      unlistenNeedsAdmin = await listen<NeedsAdminInfo>("update-needs-admin", (event) => {
+        setNeedsAdmin(event.payload);
+        setIsDownloading(false);
+        setDownloadProgress(null);
+      });
     };
 
     setupListeners();
@@ -350,6 +402,7 @@ export function useUpdateListener() {
       unlistenDownloading?.();
       unlistenProgress?.();
       unlistenAuth?.();
+      unlistenNeedsAdmin?.();
     };
-  }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired]);
+  }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired, setNeedsAdmin]);
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -11,7 +11,8 @@ use dark_light::Mode;
 use log::{debug, error, info, warn};
 use serde_json;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::process::Command;
 use std::time::Duration;
 use tauri::menu::{MenuItem, MenuItemBuilder};
 use tauri::{Emitter, Manager, Wry};
@@ -118,6 +119,24 @@ pub fn is_source_build(_app: &tauri::AppHandle) -> bool {
 /// Enterprise build: updates are managed by IT (Intune/RoboPack), not in-app.
 pub fn is_enterprise_build(_app: &tauri::AppHandle) -> bool {
     cfg!(feature = "enterprise-build")
+}
+
+pub fn is_macos_admin() -> bool {
+    static IS_ADMIN: OnceLock<bool> = OnceLock::new();
+    *IS_ADMIN.get_or_init(|| {
+        #[cfg(target_os = "macos")]
+        {
+            if let Ok(output) = Command::new("id").arg("-Gn").output() {
+                let groups = String::from_utf8_lossy(&output.stdout);
+                return groups.split_whitespace().any(|g| g == "admin");
+            }
+            false
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            true
+        }
+    })
 }
 
 pub struct UpdatesManager {
@@ -247,6 +266,37 @@ impl UpdatesManager {
         }
         if let Some(update) = check_result? {
             *self.update_available.lock().await = true;
+
+            if !is_macos_admin() {
+                warn!("skipping auto-update: user is not a macOS admin");
+                
+                let download_info = serde_json::json!({
+                    "version": update.version,
+                    "body": update.body.clone().unwrap_or_default(),
+                    "stage": "needs-admin",
+                });
+                let _ = self.app.emit("update-needs-admin", download_info);
+                
+                let app_notif = self.app.clone();
+                let version_str = update.version.clone();
+                std::thread::spawn(move || {
+                    let _ = app_notif
+                        .notification()
+                        .builder()
+                        .title("screenpipe update available")
+                        .body(format!(
+                            "v{} is ready — ask your admin to install it",
+                            version_str
+                        ))
+                        .show();
+                });
+                
+                if let Some(ref item) = self.update_menu_item {
+                    let _ = item.set_text("Update requires admin");
+                }
+                
+                return Ok(true);
+            }
 
             // Emit "update-downloading" immediately so user sees feedback
             let download_info = serde_json::json!({
@@ -642,4 +692,16 @@ pub fn start_update_check(
     });
 
     Ok(updates_manager)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_macos_admin_executes() {
+        let is_admin = is_macos_admin();
+        // Since we don't know the exact environment, we just ensure it doesn't panic.
+        println!("test_is_macos_admin_executes returned: {}", is_admin);
+    }
 }


### PR DESCRIPTION
Resolves #2388.

- Intercept `download_and_install` in the Tauri updater.
- Added `is_macos_admin()` to check if the current user is an admin.
- Skips download & install for standard users, emitting `update-needs-admin` event and triggering a notification.
- Updated `components/update-banner.tsx` to parse the event and display a non-blocking toast/banner asking the user to ping their admin.

Tested with `cargo test -p screenpipe-app tests::test_is_macos_admin_executes`:
```
test updates::tests::test_is_macos_admin_executes ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 73 filtered out; finished in 0.03s
```