### PR TITLE
fix: skip auto-update install for non-admin macOS users

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -38,6 +38,7 @@ interface UpdateBannerState {
   downloadProgress: DownloadProgress | null;
   pendingUpdate: Update | null;
   authRequired: AuthRequiredInfo | null;
+  needsAdmin: { version: string } | null;
   setIsVisible: (visible: boolean) => void;
   setUpdateInfo: (info: UpdateInfo | null) => void;
   setIsInstalling: (installing: boolean) => void;
@@ -45,6 +46,7 @@ interface UpdateBannerState {
   setDownloadProgress: (progress: DownloadProgress | null) => void;
   setPendingUpdate: (update: Update | null) => void;
   setAuthRequired: (info: AuthRequiredInfo | null) => void;
+  setNeedsAdmin: (info: { version: string } | null) => void;
 }
 
 export const useUpdateBanner = create<UpdateBannerState>((set) => ({
@@ -55,6 +57,7 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   downloadProgress: null,
   pendingUpdate: null,
   authRequired: null,
+  needsAdmin: null,
   setIsVisible: (visible) => set({ isVisible: visible }),
   setUpdateInfo: (info) => set({ updateInfo: info }),
   setIsInstalling: (installing) => set({ isInstalling: installing }),
@@ -62,6 +65,7 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   setDownloadProgress: (progress) => set({ downloadProgress: progress }),
   setPendingUpdate: (update) => set({ pendingUpdate: update }),
   setAuthRequired: (info) => set({ authRequired: info }),
+  setNeedsAdmin: (info) => set({ needsAdmin: info }),
 }));
 
 interface UpdateBannerProps {
@@ -71,7 +75,7 @@ interface UpdateBannerProps {
 
 export function UpdateBanner({ className, compact = false }: UpdateBannerProps) {
   const isEnterprise = useIsEnterpriseBuild();
-  const { isVisible, updateInfo, isInstalling, isDownloading, downloadProgress, setIsVisible, setIsInstalling, pendingUpdate, authRequired, setAuthRequired } = useUpdateBanner();
+  const { isVisible, updateInfo, isInstalling, isDownloading, downloadProgress, setIsVisible, setIsInstalling, pendingUpdate, authRequired, setAuthRequired, needsAdmin, setNeedsAdmin } = useUpdateBanner();
   const { toast } = useToast();
 
   if (isEnterprise) return null;
@@ -181,6 +185,41 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
             size="sm"
             className="h-7 w-7 p-0"
             onClick={() => setAuthRequired(null)}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Show needs-admin state — user needs to ask admin to install update
+  if (needsAdmin) {
+    if (compact) {
+      return (
+        <div className={cn("flex items-center gap-2 text-xs text-muted-foreground", className)}>
+          <Sparkles className="h-3 w-3 text-primary" />
+          <span>v{needsAdmin.version} ready — ask admin to install</span>
+        </div>
+      );
+    }
+    return (
+      <div className={cn(
+        "flex items-center justify-between gap-3 px-3 py-2 bg-muted/50 border-b text-sm",
+        className
+      )}>
+        <div className="flex items-center gap-2 flex-1">
+          <Sparkles className="h-4 w-4 text-primary" />
+          <span>
+            screenpipe <span className="font-medium">v{needsAdmin.version}</span> is available — ask your admin to install it
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0"
+            onClick={() => setNeedsAdmin(null)}
           >
             <X className="h-4 w-4" />
           </Button>
@@ -299,7 +338,7 @@ export function UpdateBanner({ className, compact = false }: UpdateBannerProps) 
 
 // Hook to listen for update events from Rust
 export function useUpdateListener() {
-  const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired } = useUpdateBanner();
+  const { setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired, setNeedsAdmin } = useUpdateBanner();
 
   useEffect(() => {
     let unlistenAvailable: (() => void) | undefined;
@@ -307,6 +346,7 @@ export function useUpdateListener() {
     let unlistenDownloading: (() => void) | undefined;
     let unlistenProgress: (() => void) | undefined;
     let unlistenAuth: (() => void) | undefined;
+    let unlistenNeedsAdmin: (() => void) | undefined;
 
     const setupListeners = async () => {
       // Listen for download starting (shows banner immediately)
@@ -340,6 +380,12 @@ export function useUpdateListener() {
         setIsDownloading(false);
         setDownloadProgress(null);
       });
+
+      unlistenNeedsAdmin = await listen<{ version: string }>("update-needs-admin", (event) => {
+        setNeedsAdmin(event.payload);
+        setIsDownloading(false);
+        setDownloadProgress(null);
+      });
     };
 
     setupListeners();
@@ -350,6 +396,7 @@ export function useUpdateListener() {
       unlistenDownloading?.();
       unlistenProgress?.();
       unlistenAuth?.();
+      unlistenNeedsAdmin?.();
     };
-  }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired]);
+  }, [setIsVisible, setUpdateInfo, setIsDownloading, setDownloadProgress, setAuthRequired, setNeedsAdmin]);
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -279,6 +279,35 @@ impl UpdatesManager {
                 }
             }
 
+            if !is_macos_admin() {
+                warn!("skipping auto-update: user is not a macOS admin");
+                let _ = self.app.emit(
+                    "update-needs-admin",
+                    serde_json::json!({
+                        "version": update.version
+                    }),
+                );
+
+                let app_notif = self.app.clone();
+                let version_str = update.version.clone();
+                std::thread::spawn(move || {
+                    if let Err(e) = app_notif
+                        .notification()
+                        .builder()
+                        .title("screenpipe update available")
+                        .body(format!(
+                            "update v{} available — ask your admin to install it",
+                            version_str
+                        ))
+                        .show()
+                    {
+                        error!("failed to send update notification: {}", e);
+                    }
+                });
+
+                return Result::Ok(true);
+            }
+
             // Download and install on all platforms
             {
                 #[cfg(target_os = "windows")]
@@ -642,4 +671,36 @@ pub fn start_update_check(
     });
 
     Ok(updates_manager)
+}
+
+pub fn is_macos_admin() -> bool {
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+    #[cfg(target_os = "macos")]
+    {
+        static IS_ADMIN: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *IS_ADMIN.get_or_init(
+            || match std::process::Command::new("id").arg("-Gn").output() {
+                Ok(output) => {
+                    let groups = String::from_utf8_lossy(&output.stdout);
+                    groups.split_whitespace().any(|g| g == "admin")
+                }
+                Err(_) => true,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_macos_admin() {
+        // Just verify it doesn't panic and returns a boolean
+        let is_admin = is_macos_admin();
+        println!("is_admin: {}", is_admin);
+    }
 }


### PR DESCRIPTION
Fixes #2388. Adds  check before auto-update. Emits event and notification if the user does not have admin privileges.