### PR TITLE
fix: macOS app panics Class with name ScreenpipeMagnifyHandler could not be found

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/window_api.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window_api.rs
@@ -34,114 +34,122 @@ use tracing::{debug, error, info};
 #[cfg(target_os = "macos")]
 static MAGNIFY_APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
 
+#[cfg(target_os = "macos")]
+pub fn ensure_magnify_classes_registered() {
+    use objc::declare::ClassDecl;
+    use objc::runtime::{Class, Object, Sel};
+    use std::sync::Once;
+
+    static REGISTER_CLASSES: Once = Once::new();
+
+    REGISTER_CLASSES.call_once(|| {
+        // Register ObjC class with handleMagnify: method (only once)
+        if Class::get("ScreenpipeMagnifyHandler").is_none() {
+            let superclass = Class::get("NSObject").unwrap();
+            let mut decl = ClassDecl::new("ScreenpipeMagnifyHandler", superclass).unwrap();
+            extern "C" fn handle_magnify(_this: &Object, _sel: Sel, recognizer: *mut Object) {
+                with_autorelease_pool(|| unsafe {
+                    use objc::{msg_send, sel, sel_impl};
+                    let magnification: f64 = msg_send![recognizer, magnification];
+                    // Reset so next callback gives delta, not cumulative
+                    let _: () = msg_send![recognizer, setMagnification: 0.0f64];
+                    if let Some(app) = MAGNIFY_APP_HANDLE.get() {
+                        let _ = app.emit("native-magnify", magnification);
+                    }
+                });
+            }
+            unsafe {
+                use objc::{sel, sel_impl};
+                decl.add_method(
+                    sel!(handleMagnify:),
+                    handle_magnify as extern "C" fn(&Object, Sel, *mut Object),
+                );
+            }
+            decl.register();
+            info!("magnify gesture handler registered");
+        }
+
+        // Register a custom ObjC class that handles scrollWheel forwarding.
+        // WKWebView in standard WebviewWindows (e.g. settings) consumes trackpad
+        // wheel events at the native level — they never reach JavaScript.
+        // We swizzle WKWebView's scrollWheel: to also emit "native-scroll" Tauri
+        // events so the JS timeline code can handle scroll navigation.
+        if Class::get("ScreenpipeScrollInterceptor").is_none() {
+            // Store original IMP so we can call it after emitting
+            static ORIGINAL_SCROLL_WHEEL: std::sync::OnceLock<
+                extern "C" fn(&Object, Sel, *mut Object),
+            > = std::sync::OnceLock::new();
+
+            extern "C" fn swizzled_scroll_wheel(this: &Object, sel: Sel, event: *mut Object) {
+                with_autorelease_pool(|| unsafe {
+                    use objc::{msg_send, sel, sel_impl};
+                    // Emit Tauri event with scroll data
+                    if let Some(app) = MAGNIFY_APP_HANDLE.get() {
+                        let delta_y: f64 = msg_send![event, scrollingDeltaY];
+                        let delta_x: f64 = msg_send![event, scrollingDeltaX];
+                        let modifier_flags: u64 = msg_send![event, modifierFlags];
+                        let ctrl_key = (modifier_flags & (1 << 18)) != 0;
+                        let meta_key = (modifier_flags & (1 << 20)) != 0;
+
+                        let _ = app.emit(
+                            "native-scroll",
+                            serde_json::json!({
+                                "deltaX": delta_x,
+                                "deltaY": delta_y,
+                                "ctrlKey": ctrl_key,
+                                "metaKey": meta_key,
+                            }),
+                        );
+                    }
+                    // Always call the original scrollWheel: so native CSS
+                    // overflow scrolling keeps working in all windows.
+                    // The native-scroll Tauri event is emitted above for
+                    // timeline/search components that need it.
+                    if let Some(original) = ORIGINAL_SCROLL_WHEEL.get() {
+                        original(this, sel, event);
+                    }
+                });
+            }
+
+            // Swizzle WKWebView scrollWheel:
+            unsafe {
+                use objc::runtime::{
+                    class_getInstanceMethod, method_getImplementation, method_setImplementation,
+                };
+                use objc::{sel, sel_impl};
+
+                let wk_class = Class::get("WKWebView");
+                if let Some(wk_class) = wk_class {
+                    let scroll_sel = sel!(scrollWheel:);
+                    let method = class_getInstanceMethod(wk_class as *const _ as *mut _, scroll_sel);
+                    if !method.is_null() {
+                        let original_imp = method_getImplementation(method as *const _);
+                        let original_fn: extern "C" fn(&Object, Sel, *mut Object) =
+                            std::mem::transmute(original_imp);
+                        let _ = ORIGINAL_SCROLL_WHEEL.set(original_fn);
+
+                        let new_imp: objc::runtime::Imp = std::mem::transmute(
+                            swizzled_scroll_wheel as extern "C" fn(&Object, Sel, *mut Object),
+                        );
+                        method_setImplementation(method as *mut _, new_imp);
+                        info!("WKWebView scrollWheel: swizzled for native-scroll events");
+                    }
+                }
+            }
+
+            // Register dummy class so we don't re-swizzle
+            let superclass = Class::get("NSObject").unwrap();
+            let decl = ClassDecl::new("ScreenpipeScrollInterceptor", superclass).unwrap();
+            decl.register();
+        }
+    });
+}
+
 /// Call once during app setup to store the AppHandle for the magnify handler.
 #[cfg(target_os = "macos")]
 pub fn init_magnify_handler(app: tauri::AppHandle) {
-    use objc::declare::ClassDecl;
-    use objc::runtime::{Class, Object, Sel};
-
     let _ = MAGNIFY_APP_HANDLE.set(app);
-
-    // Register ObjC class with handleMagnify: method (only once)
-    if Class::get("ScreenpipeMagnifyHandler").is_none() {
-        let superclass = Class::get("NSObject").unwrap();
-        let mut decl = ClassDecl::new("ScreenpipeMagnifyHandler", superclass).unwrap();
-        extern "C" fn handle_magnify(_this: &Object, _sel: Sel, recognizer: *mut Object) {
-            with_autorelease_pool(|| unsafe {
-                use objc::{msg_send, sel, sel_impl};
-                let magnification: f64 = msg_send![recognizer, magnification];
-                // Reset so next callback gives delta, not cumulative
-                let _: () = msg_send![recognizer, setMagnification: 0.0f64];
-                if let Some(app) = MAGNIFY_APP_HANDLE.get() {
-                    let _ = app.emit("native-magnify", magnification);
-                }
-            });
-        }
-        unsafe {
-            use objc::{sel, sel_impl};
-            decl.add_method(
-                sel!(handleMagnify:),
-                handle_magnify as extern "C" fn(&Object, Sel, *mut Object),
-            );
-        }
-        decl.register();
-    }
-
-    info!("magnify gesture handler registered");
-
-    // Register a custom ObjC class that handles scrollWheel forwarding.
-    // WKWebView in standard WebviewWindows (e.g. settings) consumes trackpad
-    // wheel events at the native level — they never reach JavaScript.
-    // We swizzle WKWebView's scrollWheel: to also emit "native-scroll" Tauri
-    // events so the JS timeline code can handle scroll navigation.
-    if Class::get("ScreenpipeScrollInterceptor").is_none() {
-        // Store original IMP so we can call it after emitting
-        static ORIGINAL_SCROLL_WHEEL: std::sync::OnceLock<
-            extern "C" fn(&Object, Sel, *mut Object),
-        > = std::sync::OnceLock::new();
-
-        extern "C" fn swizzled_scroll_wheel(this: &Object, sel: Sel, event: *mut Object) {
-            with_autorelease_pool(|| unsafe {
-                use objc::{msg_send, sel, sel_impl};
-                // Emit Tauri event with scroll data
-                if let Some(app) = MAGNIFY_APP_HANDLE.get() {
-                    let delta_y: f64 = msg_send![event, scrollingDeltaY];
-                    let delta_x: f64 = msg_send![event, scrollingDeltaX];
-                    let modifier_flags: u64 = msg_send![event, modifierFlags];
-                    let ctrl_key = (modifier_flags & (1 << 18)) != 0;
-                    let meta_key = (modifier_flags & (1 << 20)) != 0;
-
-                    let _ = app.emit(
-                        "native-scroll",
-                        serde_json::json!({
-                            "deltaX": delta_x,
-                            "deltaY": delta_y,
-                            "ctrlKey": ctrl_key,
-                            "metaKey": meta_key,
-                        }),
-                    );
-                }
-                // Always call the original scrollWheel: so native CSS
-                // overflow scrolling keeps working in all windows.
-                // The native-scroll Tauri event is emitted above for
-                // timeline/search components that need it.
-                if let Some(original) = ORIGINAL_SCROLL_WHEEL.get() {
-                    original(this, sel, event);
-                }
-            });
-        }
-
-        // Swizzle WKWebView scrollWheel:
-        unsafe {
-            use objc::runtime::{
-                class_getInstanceMethod, method_getImplementation, method_setImplementation,
-            };
-            use objc::{sel, sel_impl};
-
-            let wk_class = Class::get("WKWebView");
-            if let Some(wk_class) = wk_class {
-                let scroll_sel = sel!(scrollWheel:);
-                let method = class_getInstanceMethod(wk_class as *const _ as *mut _, scroll_sel);
-                if !method.is_null() {
-                    let original_imp = method_getImplementation(method as *const _);
-                    let original_fn: extern "C" fn(&Object, Sel, *mut Object) =
-                        std::mem::transmute(original_imp);
-                    let _ = ORIGINAL_SCROLL_WHEEL.set(original_fn);
-
-                    let new_imp: objc::runtime::Imp = std::mem::transmute(
-                        swizzled_scroll_wheel as extern "C" fn(&Object, Sel, *mut Object),
-                    );
-                    method_setImplementation(method as *mut _, new_imp);
-                    info!("WKWebView scrollWheel: swizzled for native-scroll events");
-                }
-            }
-        }
-
-        // Register dummy class so we don't re-swizzle
-        let superclass = Class::get("NSObject").unwrap();
-        let decl = ClassDecl::new("ScreenpipeScrollInterceptor", superclass).unwrap();
-        decl.register();
-    }
+    ensure_magnify_classes_registered();
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -151,6 +159,7 @@ pub fn init_magnify_handler(_app: tauri::AppHandle) {}
 /// Safe to call multiple times — skips if already attached.
 #[cfg(target_os = "macos")]
 unsafe fn attach_magnify_gesture_to_view(view: tauri_nspanel::cocoa::base::id) {
+    ensure_magnify_classes_registered();
     with_autorelease_pool(|| {
         use objc::{class, msg_send, sel, sel_impl};
         use tauri_nspanel::cocoa::base::{id, nil};
@@ -2189,5 +2198,22 @@ impl ShowRewindWindow {
             window.set_size(size).ok();
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_ensure_magnify_classes_registered() {
+        // This should not panic and shouldn't crash if called multiple times
+        ensure_magnify_classes_registered();
+        ensure_magnify_classes_registered();
+
+        use objc::runtime::Class;
+        assert!(Class::get("ScreenpipeMagnifyHandler").is_some(), "ScreenpipeMagnifyHandler not registered");
+        assert!(Class::get("ScreenpipeScrollInterceptor").is_some(), "ScreenpipeScrollInterceptor not registered");
     }
 }


### PR DESCRIPTION
Fixes #2459.

**Description**
The macOS app panics and crashes when attempting to attach the pinch-to-zoom gesture recognizer (`ScreenpipeMagnifyHandler`) if a window is shown and configures its webview before `init_magnify_handler` is executed later during app setup.

This PR pulls out the ObjC class registration logic into `ensure_magnify_classes_registered()` using `std::sync::Once` to guarantee thread-safe registration. It calls this lazily inside `attach_magnify_gesture_to_view()` to prevent panic without changing startup order.

**Test output**
```
test window_api::tests::test_ensure_magnify_classes_registered ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 73 filtered out; finished in 0.00s
```