### PR TITLE
fix: Windows prebuild 7z resolution and simplify CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,39 +82,7 @@ before you begin:
       git clone https://github.com/screenpipe/screenpipe.git
       cd screenpipe
    ```
-5. **make sure vcredist is present on system**:
-   - make sure your in root of the project i.e screenpipe
-
-   ```powershell
-   cd screenpipe
-   $path = "C:\Windows\System32\vcruntime140.dll"
-   
-   if (-Not (Test-Path $path)) {
-       Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile -ExecutionPolicy Bypass -Command "& {
-           Set-ExecutionPolicy Bypass -Scope Process -Force
-           [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-           $url = ''https://vcredist.com/install.ps1''
-           $scriptPath = ''$env:TEMP\install_vcredist.ps1''
-           Invoke-WebRequest -Uri $url -OutFile $scriptPath
-           & $scriptPath
-       }"' -Wait
-   }
-   
-   # Verify installation
-   if (-Not (Test-Path $path)) {
-       Write-Host "Installation failed. Exiting."
-       exit 1
-   }
-   
-   # Copy vcruntime140.dll to the specified directory
-   $vcredist_dir = (pwd).Path + "\apps\screenpipe-app-tauri\src-tauri\vcredist"
-   New-Item -ItemType Directory -Force -Path $vcredist_dir | Out-Null
-   Copy-Item $path -Destination $vcredist_dir -Force
-   
-   Write-Host "vcruntime140.dll copied successfully!"
-   ```
-
-6. **build**:
+5. **build**:
    ```powershell
    cd screenpipe
    cargo build --release

--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -88,6 +88,36 @@ async function findWget() {
 	process.exit(1);
 }
 
+async function find7z() {
+	const possiblePaths = [
+		'C:\\Program Files\\7-Zip\\7z.exe',
+		'C:\\Program Files (x86)\\7-Zip\\7z.exe',
+		path.join(process.env.LOCALAPPDATA || '', 'Programs', '7-Zip', '7z.exe'),
+	];
+
+	for (const p of possiblePaths) {
+		if (p && (await fs.stat(p).catch(() => null))) {
+			console.log(`7z found at: ${p}`);
+			return p;
+		}
+	}
+
+	// Last resort: 7z in PATH (e.g. after restarting terminal post winget install)
+	try {
+		await $`7z`.quiet();
+	} catch {
+		try {
+			await $`7z --help`.quiet();
+		} catch {
+			console.error('7-Zip (7z) not found. Install it with: winget install -e --id 7zip.7zip');
+			console.error('Then restart your terminal so PATH is updated (see CONTRIBUTING.md Windows setup).');
+			process.exit(1);
+		}
+	}
+	console.log('7z found in PATH');
+	return '7z';
+}
+
 // Export for Github actions
 const exports = {
 	ffmpeg: path.join(cwd, config.ffmpegRealname),
@@ -394,12 +424,13 @@ async function copyVcredistDlls(arch = 'x64') {
 /* ########## Windows ########## */
 if (platform == 'windows') {
 	const wgetPath = await findWget();
+	const sevenZ = await find7z();
 
 	// Setup FFMPEG (x64: gyan.dev; arm64: tordona/ffmpeg-win-arm64)
 	if (!(await fs.exists(config.ffmpegRealname))) {
 		if (winArch === 'arm64') {
 			await $`${wgetPath} --no-config --tries=10 --retry-connrefused --waitretry=10 --secure-protocol=auto --no-check-certificate --show-progress ${config.windows.ffmpegUrlArm64} -O ${config.windows.ffmpegNameArm64}.7z`
-			await $`7z x ${config.windows.ffmpegNameArm64}.7z`
+			await $`${sevenZ} x ${config.windows.ffmpegNameArm64}.7z`
 			// tordona 7z extracts to a single folder; move its contents to ffmpeg (or rename if single top-level dir)
 			const entries = await fs.readdir(cwd, { withFileTypes: true })
 			const extractedDir = entries.find((d) => d.isDirectory() && d.name.startsWith('ffmpeg-') && d.name.includes('win-arm64'))
@@ -415,7 +446,7 @@ if (platform == 'windows') {
 			await fs.rm(path.join(cwd, `${config.windows.ffmpegNameArm64}.7z`), { force: true }).catch(() => {})
 		} else {
 			await $`${wgetPath} --no-config --tries=10 --retry-connrefused --waitretry=10 --secure-protocol=auto --no-check-certificate --show-progress ${config.windows.ffmpegUrl} -O ${config.windows.ffmpegName}.7z`
-			await $`7z x ${config.windows.ffmpegName}.7z`
+			await $`${sevenZ} x ${config.windows.ffmpegName}.7z`
 			await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 			await $`rm -rf ${config.windows.ffmpegName}.7z`
 		}


### PR DESCRIPTION
## description

* Fixed Windows prebuild failure when `7z` isn’t on PATH by detecting it in common install locations (e.g., Program Files).

* Updated CONTRIBUTING: removed manual `vcredist` step, renumbered build steps, and noted that `winget` installs don’t require admin but may need a terminal restart for PATH updates.



## how to test

1. On a Windows machine with 7-Zip installed via winget but **without** restarting the terminal (or with 7z not on PATH), run `cd apps/screenpipe-app-tauri && bun run build` (or `bun tauri build`).

2. Confirm the prebuild script finds `7z` (e.g. from `C:\Program Files\7-Zip\7z.exe`) and FFmpeg extraction completes without "command not found: 7z".

3. Optionally, open a new terminal and run the same build to confirm it still works when `7z` is on PATH.



<img width="1909" height="942" alt="image" src="https://github.com/user-attachments/assets/fc7c0fe9-2068-466a-80fb-945e01acac66" />
