### PR TITLE
fix: screenpipe disk usage does not detect custom data directory

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/disk-usage-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/disk-usage-section.tsx
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
 import { Progress } from "../ui/progress";
 
 export function DiskUsageSection() {
-  const { diskUsage, isLoading, error, refetch } = useDiskUsage();
+  const { diskUsage, isLoading, error, refetch, dataDirPath } = useDiskUsage();
 
   const handleRefresh = () => {
     refetch();
@@ -61,7 +61,7 @@ export function DiskUsageSection() {
           </Button>
         </div>
         <p className="text-muted-foreground text-sm">
-          Storage usage at ~/.screenpipe
+          Storage usage at {dataDirPath || "~/.screenpipe"}
         </p>
       </div>
 
@@ -194,7 +194,7 @@ export function DiskUsageSection() {
                 <span className={cn("font-medium", diskUsage?.other?.logs_size?.includes("GB") && "text-destructive")}>{diskUsage?.other?.logs_size || "0 KB"}</span>
               </div>
               {diskUsage?.other?.logs_size?.includes("GB") && (
-                <p className="text-[11px] text-destructive mt-1">⚠️ Logs are large. Delete old ones at ~/.screenpipe/*.log</p>
+                <p className="text-[11px] text-destructive mt-1">⚠️ Logs are large. Delete old ones at {dataDirPath || "~/.screenpipe"}/*.log</p>
               )}
             </div>
           )}

--- a/apps/screenpipe-app-tauri/lib/hooks/use-disk-usage.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-disk-usage.tsx
@@ -38,6 +38,7 @@ export function useDiskUsage() {
   const [diskUsage, setDiskUsage] = useState<DiskUsage | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [dataDirPath, setDataDirPath] = useState<string>("~/.screenpipe");
 
   const fetchDiskUsage = async (forceRefresh: boolean = false) => {
     try {
@@ -45,6 +46,7 @@ export function useDiskUsage() {
       setError(null);
 
       const dataDir = await getDataDir();
+      setDataDirPath(dataDir);
       // Add a small delay to show loading state for very fast calculations
       const [result] = await Promise.all([
         invoke<DiskUsage>("get_disk_usage", { forceRefresh, dataDir }),
@@ -89,5 +91,6 @@ export function useDiskUsage() {
     isLoading,
     error,
     refetch: () => fetchDiskUsage(true), // Force refresh when user clicks refresh
+    dataDirPath,
   };
 } 

--- a/apps/screenpipe-app-tauri/src-tauri/src/disk_usage.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/disk_usage.rs
@@ -46,6 +46,8 @@ pub struct DiskUsedByOther {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CachedDiskUsage {
     pub timestamp: i64,
+    #[serde(default)]
+    pub screenpipe_dir: Option<String>,
     pub usage: DiskUsage,
 }
 
@@ -111,7 +113,12 @@ pub async fn disk_usage(
     };
 
     fs::create_dir_all(&cache_dir).map_err(|e| e.to_string())?;
-    let cache_file = cache_dir.join("disk_usage.json");
+    
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    use std::hash::{Hash, Hasher};
+    screenpipe_dir.hash(&mut hasher);
+    let path_hash = hasher.finish();
+    let cache_file = cache_dir.join(format!("disk_usage_{}.json", path_hash));
 
     // Skip cache if force_refresh is requested
     if !force_refresh {
@@ -121,12 +128,16 @@ pub async fn disk_usage(
             } else if let Ok(cached) = serde_json::from_str::<CachedDiskUsage>(&content) {
                 let now = chrono::Local::now().timestamp();
                 let one_hour = 60 * 60; // 1 hour cache (reduced from 2 days)
-                if now - cached.timestamp < one_hour {
+                let is_same_dir = cached.screenpipe_dir.as_deref() == Some(screenpipe_dir.to_string_lossy().as_ref());
+                
+                if now - cached.timestamp < one_hour && is_same_dir {
                     info!(
                         "Using cached disk usage data (age: {}s)",
                         now - cached.timestamp
                     );
                     return Ok(Some(cached.usage));
+                } else if !is_same_dir {
+                    info!("Cache is for different directory, recalculating...");
                 }
             }
         }
@@ -359,6 +370,7 @@ pub async fn disk_usage(
     // Cache the result
     let cached = CachedDiskUsage {
         timestamp: chrono::Local::now().timestamp(),
+        screenpipe_dir: Some(screenpipe_dir.to_string_lossy().into_owned()),
         usage: disk_usage.clone(),
     };
 


### PR DESCRIPTION
Fixes #2458

### Description
The frontend's Disk Usage screen was reporting the storage of `~/.screenpipe` even when a custom data directory was configured in Settings.

### Root Cause
1. In `disk_usage.rs`, the cached result was saved to a static `disk_usage.json` path regardless of the selected directory. Thus, when querying the custom data directory, it would read the cache created by the background polling job (which was still tracking the old directory).
2. The UI hardcoded the text `Storage usage at ~/.screenpipe`.

### Changes
- Updated the cache file name to append a hash of the directory path: `disk_usage_<hash>.json`.
- Added the `screenpipe_dir` field to `CachedDiskUsage` and explicitly verify it matches the requested path.
- Exposed the resolved `dataDirPath` from `useDiskUsage` and displayed it instead of the hardcoded `~/.screenpipe` string in `DiskUsageSection`.

### Testing
- Tested running `cargo check` and validated logic. Verified it invalidates cache upon directory switch.