### PR TITLE
fix: resolve windows url detection spam (#2496) and disk usage data dir (#2458)

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-disk-usage.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-disk-usage.tsx
@@ -34,7 +34,7 @@ export interface DiskUsage {
 }
 
 export function useDiskUsage() {
-  const { getDataDir } = useSettings();
+  const { getDataDir, isSettingsLoaded, settings } = useSettings();
   const [diskUsage, setDiskUsage] = useState<DiskUsage | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -81,8 +81,10 @@ export function useDiskUsage() {
   };
 
   useEffect(() => {
-    fetchDiskUsage();
-  }, []);
+    if (isSettingsLoaded) {
+      fetchDiskUsage();
+    }
+  }, [isSettingsLoaded, settings.dataDir]);
 
   return {
     diskUsage,

--- a/crates/screenpipe-screen/src/browser_utils/windows.rs
+++ b/crates/screenpipe-screen/src/browser_utils/windows.rs
@@ -77,8 +77,8 @@ impl WindowsUrlDetector {
                 }
             }
             Err(e) => {
-                error!("failed to find edit bar: {}", e);
-                return Err(anyhow!("failed to find edit bar: {}", e));
+                debug!("failed to find window/edit bar: {}", e);
+                return Ok(None);
             }
         }
         Ok(None)


### PR DESCRIPTION
This PR resolves two bug issues:

### 1. #2496: Windows URL detection spams Sentry with 'failed to find edit bar'
In `crates/screenpipe-screen/src/browser_utils/windows.rs`, the UIAutomation `find_first` call fails gracefully when trying to locate a browser window edit bar but logs it as an `error!` and returns an `Err`, which spams Sentry.
**Fix:** Changed it to log at `debug!` and return `Ok(None)`, aligning with the expected behavior when a UI element isn't found.

### 2. #2458: Screenpipe Disk Usage does not detect custom Data Directory
In the desktop app, the `useDiskUsage` hook was eagerly dispatching the `get_disk_usage` Tauri command immediately on mount. Because settings were not fully loaded from the store, it retrieved the default `~/.screenpipe` directory instead of the custom Data Directory the user configured.
**Fix:** Updated the hook to await `isSettingsLoaded` and properly include `settings.dataDir` in its dependency array. The UI will now calculate disk usage for the correct custom data directory.