### PR TITLE
Chat UI: input layout, image viewer, preset dropdown, and scrollbar

### DIFF
--- a/apps/screenpipe-app-tauri/app/globals.css
+++ b/apps/screenpipe-app-tauri/app/globals.css
@@ -325,6 +325,29 @@
     display: none;  /* Chrome, Safari and Opera */
   }
 
+  /* Minimal scrollbar: visible track + thumb, no up/down arrow buttons (like reference) */
+  .scrollbar-minimal {
+    scrollbar-width: thin;  /* Firefox: thin scrollbar, no arrows */
+    scrollbar-color: hsl(var(--muted-foreground) / 0.5) transparent;
+  }
+  .scrollbar-minimal::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  .scrollbar-minimal::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollbar-minimal::-webkit-scrollbar-thumb {
+    background: hsl(var(--muted-foreground) / 0.4);
+    border-radius: 4px;
+  }
+  .scrollbar-minimal::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--muted-foreground) / 0.6);
+  }
+  .scrollbar-minimal::-webkit-scrollbar-button {
+    display: none;  /* No arrow buttons */
+  }
+
   @keyframes shimmer {
     0% {
       background-position: -200% 0;

--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -1188,8 +1188,8 @@ export const AIPresetsSelector = ({
                   )}
                 >
                   {selectedPreset ? (
-                    <div className="flex w-full items-center justify-between gap-2 overflow-hidden">
-                      <div className="flex items-center gap-2 min-w-[80px] max-w-[30%]">
+                    <div className="flex w-full items-center justify-between gap-2 overflow-hidden min-w-0">
+                      <div className="flex items-center gap-2 min-w-0 flex-shrink overflow-hidden">
                         {selectedPresetRequiresLogin && (
                           <AlertTriangle className="h-4 w-4 text-amber-500 shrink-0" />
                         )}
@@ -1201,15 +1201,15 @@ export const AIPresetsSelector = ({
                           )}
                         </span>
                       </div>
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground overflow-hidden">
-                        <span className="rounded bg-muted px-1.5 py-0.5 whitespace-nowrap">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground min-w-0 flex-1 justify-end overflow-hidden">
+                        <span className="rounded bg-muted px-1.5 py-0.5 whitespace-nowrap shrink-0">
                           {
                             aiPresets.find(
                               (preset) => preset.id === selectedPreset,
                             )?.provider
                           }
                         </span>
-                        <span className="hidden sm:block truncate max-w-[30%]">
+                        <span className="hidden sm:block truncate min-w-0" title={aiPresets.find((p) => p.id === selectedPreset)?.model}>
                           {
                             aiPresets.find(
                               (preset) => preset.id === selectedPreset,
@@ -1243,7 +1243,7 @@ export const AIPresetsSelector = ({
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-          <PopoverContent className="min-w-[500px] w-[--radix-popover-trigger-width] p-0">
+          <PopoverContent side="top" sideOffset={6} className="min-w-[500px] w-[--radix-popover-trigger-width] p-0">
             <Command>
               <CommandInput placeholder="search presets..." />
               <CommandList>

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useSettings, ChatMessage, ChatConversation } from "@/lib/hooks/use-settings";
 import { cn } from "@/lib/utils";
-import { Loader2, Send, Square, User, Settings, ExternalLink, X, ImageIcon, Zap, History, Search, Trash2, ChevronLeft, ChevronDown, ChevronUp, Plus, Copy, Check, Clock, Paperclip, Filter } from "lucide-react";
+import { Loader2, Send, Square, User, Settings, ExternalLink, X, ImageIcon, Zap, History, Search, Trash2, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Plus, Copy, Check, Clock, Paperclip, Filter } from "lucide-react";
 import { SchedulePromptDialog } from "@/components/chat/schedule-prompt-dialog";
 import { toast } from "@/components/ui/use-toast";
 import { motion, AnimatePresence } from "framer-motion";
@@ -37,6 +37,7 @@ import { useSqlAutocomplete } from "@/lib/hooks/use-sql-autocomplete";
 import { homeDir, join } from "@tauri-apps/api/path";
 import { useTimelineStore } from "@/lib/hooks/use-timeline-store";
 import { UpgradeDialog } from "@/components/upgrade-dialog";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 import {
   parseMentions,
   buildAppMentionSuggestions,
@@ -723,7 +724,7 @@ function ToolCallGroup({ toolCalls }: { toolCalls: ToolCall[] }) {
 }
 
 // Renders message content with interleaved text and tool call blocks
-function MessageContent({ message }: { message: Message }) {
+function MessageContent({ message, onImageClick }: { message: Message; onImageClick?: (images: string[], index: number) => void }) {
   const isUser = message.role === "user";
 
   // If we have content blocks (Pi messages with tool calls), render them in order
@@ -748,12 +749,19 @@ function MessageContent({ message }: { message: Message }) {
     );
   }
 
-  // Render attached image thumbnails for user messages
+  // Render attached image thumbnails for user messages — larger, ChatGPT-style; click to open viewer
   const imageThumbs = isUser && message.images && message.images.length > 0 ? (
-    <div className="flex gap-1.5 flex-wrap">
+    <div className="flex gap-2 flex-wrap">
       {message.images.map((img, i) => (
-        // eslint-disable-next-line @next/next/no-img-element
-        <img key={i} src={img} alt={`Attached ${i + 1}`} className="max-w-[120px] max-h-[80px] rounded border border-background/20 object-cover" />
+        <button
+          key={i}
+          type="button"
+          onClick={() => onImageClick?.(message.images ?? [], i)}
+          className="rounded-lg border border-border/50 shadow-sm overflow-hidden p-0 block text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={img} alt={`Attached ${i + 1}`} className="max-w-[200px] max-h-[160px] min-h-[80px] w-full object-cover cursor-pointer" />
+        </button>
       ))}
     </div>
   ) : null;
@@ -862,6 +870,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
   const [prefillSource, setPrefillSource] = useState<string>("search");
   const [prefillFrameId, setPrefillFrameId] = useState<number | null>(null);
   const [pastedImages, setPastedImages] = useState<string[]>([]); // Base64 data URLs
+  const [imageViewer, setImageViewer] = useState<{ images: string[]; index: number } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const isEmbedded = !!className; // embedded in settings vs overlay panel
 
@@ -3086,7 +3095,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
                     : "bg-muted/30 border-border/50"
                 )}
               >
-                <MessageContent message={message} />
+                <MessageContent message={message} onImageClick={(images, index) => setImageViewer({ images, index })} />
                 {/* Upgrade button for daily limit errors */}
                 {message.role === "assistant" &&
                  (message.content.includes("used all your free queries") ||
@@ -3204,6 +3213,177 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
       {/* Input */}
       <div className="relative border-t border-border/50 bg-gradient-to-t from-muted/20 to-transparent">
         <div className="max-w-4xl mx-auto w-full">
+        {/* Prefill, filters, suggestions first; then attached images in gap; then agent bar; then form */}
+        {/* Prefill context indicator from search */}
+        {(prefillContext || prefillFrameId) && (
+          <div className="px-3 py-2 border-b border-border/30 bg-muted/30">
+            <div className="flex items-start justify-between gap-2">
+              {prefillFrameId && (
+                <div className="flex-shrink-0">
+                  <div className="relative group">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={`http://localhost:3030/frames/${prefillFrameId}`}
+                      alt="Attached frame"
+                      className="w-16 h-12 object-cover rounded border border-border/50"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setPrefillFrameId(null)}
+                      className="absolute -top-1 -right-1 p-0.5 bg-background rounded-full border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <X className="w-2.5 h-2.5 text-muted-foreground" />
+                    </button>
+                  </div>
+                </div>
+              )}
+              {prefillContext && (
+                <div className="flex-1 min-w-0">
+                  <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
+                    context from {prefillSource === "timeline" ? "timeline selection" : "search"}
+                  </div>
+                  <p className="text-xs text-foreground font-mono line-clamp-2">
+                    {prefillContext.slice(0, 150)}{prefillContext.length > 150 ? "..." : ""}
+                  </p>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => {
+                  setPrefillContext(null);
+                  setPrefillFrameId(null);
+                }}
+                className="p-1 hover:bg-muted rounded text-muted-foreground"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Active filters chips */}
+        {hasActiveFilters && (
+          <div className="px-3 py-2 border-b border-border/30 flex flex-wrap gap-1.5">
+            {activeFilters.timeRanges.map((range, idx) => (
+              <button
+                key={`time-${idx}`}
+                type="button"
+                onClick={() => removeFilter("time", range.label)}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 rounded-full hover:bg-blue-500/20 transition-colors"
+              >
+                <span>🕐</span>
+                <span>{range.label}</span>
+                <X className="w-2.5 h-2.5 ml-0.5" />
+              </button>
+            ))}
+            {activeFilters.contentType && (
+              <button
+                type="button"
+                onClick={() => removeFilter("content")}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20 rounded-full hover:bg-purple-500/20 transition-colors"
+              >
+                <span>{activeFilters.contentType === "audio" ? "🎤" : "🖥️"}</span>
+                <span>{activeFilters.contentType}</span>
+                <X className="w-2.5 h-2.5 ml-0.5" />
+              </button>
+            )}
+            {activeFilters.appName && (
+              <button
+                type="button"
+                onClick={() => removeFilter("app")}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20 rounded-full hover:bg-green-500/20 transition-colors"
+              >
+                <span>📱</span>
+                <span>{activeFilters.appName}</span>
+                <X className="w-2.5 h-2.5 ml-0.5" />
+              </button>
+            )}
+            {activeFilters.speakerName && (
+              <button
+                type="button"
+                onClick={() => removeFilter("speaker")}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-orange-500/10 text-orange-600 dark:text-orange-400 border border-orange-500/20 rounded-full hover:bg-orange-500/20 transition-colors"
+              >
+                <span>👤</span>
+                <span>{activeFilters.speakerName}</span>
+                <X className="w-2.5 h-2.5 ml-0.5" />
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Follow-up suggestions (TikTok-style) */}
+        <AnimatePresence>
+          {!isLoading && followUpSuggestions.length > 0 && messages.length > 0 && (
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 8 }}
+              transition={{ duration: 0.2 }}
+              className="px-3 pt-2 flex flex-col gap-1"
+            >
+              <span className="text-[10px] text-muted-foreground/60 uppercase tracking-wider font-medium">follow up</span>
+              <div className="flex flex-wrap gap-1.5">
+                {followUpSuggestions.map((q, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => sendMessage(q)}
+                    className="px-2.5 py-1 text-[11px] bg-primary/10 hover:bg-primary/20 rounded-full border border-primary/20 hover:border-primary/40 text-primary hover:text-primary transition-colors cursor-pointer"
+                  >
+                    {q}
+                  </button>
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Auto-suggestions above input */}
+        {messages.length > 0 && !isLoading && autoSuggestions.length > 0 && (
+          <div className="px-3 pt-2 flex flex-wrap gap-1.5">
+            {autoSuggestions.slice(0, 3).map((s, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => sendMessage(s.text)}
+                className="px-2.5 py-1 text-[11px] bg-muted/20 hover:bg-muted/50 rounded-full border border-border/20 hover:border-border/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+              >
+                {s.text}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Attached images in the gap (above agent bar, like reference); click to open full-screen viewer */}
+        {pastedImages.length > 0 && (
+          <div className="px-3 py-2 border-b border-border/30 flex flex-wrap items-center gap-2">
+            {pastedImages.map((img, i) => (
+              <div key={i} className="relative group shrink-0">
+                <button
+                  type="button"
+                  onClick={() => setImageViewer({ images: pastedImages, index: i })}
+                  className="block rounded-lg border border-border/50 shadow-sm overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={img}
+                    alt={`Attached ${i + 1}`}
+                    className="h-20 w-20 min-h-20 min-w-20 object-cover cursor-pointer"
+                  />
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setPastedImages(prev => prev.filter((_, idx) => idx !== i)); }}
+                  className="absolute -top-1.5 -right-1.5 w-6 h-6 bg-destructive text-destructive-foreground rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow-md hover:bg-destructive/90"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
         <div className="p-2 border-b border-border/30 flex items-center gap-2">
           <Popover open={appFilterOpen} onOpenChange={setAppFilterOpen}>
             <PopoverTrigger asChild>
@@ -3374,147 +3554,6 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           </div>
         </div>
 
-        {/* Prefill context indicator from search */}
-        {(prefillContext || prefillFrameId) && (
-          <div className="px-3 py-2 border-b border-border/30 bg-muted/30">
-            <div className="flex items-start justify-between gap-2">
-              {prefillFrameId && (
-                <div className="flex-shrink-0">
-                  <div className="relative group">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={`http://localhost:3030/frames/${prefillFrameId}`}
-                      alt="Attached frame"
-                      className="w-16 h-12 object-cover rounded border border-border/50"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setPrefillFrameId(null)}
-                      className="absolute -top-1 -right-1 p-0.5 bg-background rounded-full border border-border shadow-sm opacity-0 group-hover:opacity-100 transition-opacity"
-                    >
-                      <X className="w-2.5 h-2.5 text-muted-foreground" />
-                    </button>
-                  </div>
-                </div>
-              )}
-              {prefillContext && (
-                <div className="flex-1 min-w-0">
-                  <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider mb-1">
-                    context from {prefillSource === "timeline" ? "timeline selection" : "search"}
-                  </div>
-                  <p className="text-xs text-foreground font-mono line-clamp-2">
-                    {prefillContext.slice(0, 150)}{prefillContext.length > 150 ? "..." : ""}
-                  </p>
-                </div>
-              )}
-              <button
-                type="button"
-                onClick={() => {
-                  setPrefillContext(null);
-                  setPrefillFrameId(null);
-                }}
-                className="p-1 hover:bg-muted rounded text-muted-foreground"
-              >
-                <X className="w-3 h-3" />
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Active filters chips */}
-        {hasActiveFilters && (
-          <div className="px-3 py-2 border-b border-border/30 flex flex-wrap gap-1.5">
-            {activeFilters.timeRanges.map((range, idx) => (
-              <button
-                key={`time-${idx}`}
-                type="button"
-                onClick={() => removeFilter("time", range.label)}
-                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20 rounded-full hover:bg-blue-500/20 transition-colors"
-              >
-                <span>🕐</span>
-                <span>{range.label}</span>
-                <X className="w-2.5 h-2.5 ml-0.5" />
-              </button>
-            ))}
-            {activeFilters.contentType && (
-              <button
-                type="button"
-                onClick={() => removeFilter("content")}
-                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-purple-500/10 text-purple-600 dark:text-purple-400 border border-purple-500/20 rounded-full hover:bg-purple-500/20 transition-colors"
-              >
-                <span>{activeFilters.contentType === "audio" ? "🎤" : "🖥️"}</span>
-                <span>{activeFilters.contentType}</span>
-                <X className="w-2.5 h-2.5 ml-0.5" />
-              </button>
-            )}
-            {activeFilters.appName && (
-              <button
-                type="button"
-                onClick={() => removeFilter("app")}
-                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 border border-green-500/20 rounded-full hover:bg-green-500/20 transition-colors"
-              >
-                <span>📱</span>
-                <span>{activeFilters.appName}</span>
-                <X className="w-2.5 h-2.5 ml-0.5" />
-              </button>
-            )}
-            {activeFilters.speakerName && (
-              <button
-                type="button"
-                onClick={() => removeFilter("speaker")}
-                className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-orange-500/10 text-orange-600 dark:text-orange-400 border border-orange-500/20 rounded-full hover:bg-orange-500/20 transition-colors"
-              >
-                <span>👤</span>
-                <span>{activeFilters.speakerName}</span>
-                <X className="w-2.5 h-2.5 ml-0.5" />
-              </button>
-            )}
-          </div>
-        )}
-
-        {/* Follow-up suggestions (TikTok-style) */}
-        <AnimatePresence>
-          {!isLoading && followUpSuggestions.length > 0 && messages.length > 0 && (
-            <motion.div
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: 8 }}
-              transition={{ duration: 0.2 }}
-              className="px-3 pt-2 flex flex-col gap-1"
-            >
-              <span className="text-[10px] text-muted-foreground/60 uppercase tracking-wider font-medium">follow up</span>
-              <div className="flex flex-wrap gap-1.5">
-                {followUpSuggestions.map((q, i) => (
-                  <button
-                    key={i}
-                    type="button"
-                    onClick={() => sendMessage(q)}
-                    className="px-2.5 py-1 text-[11px] bg-primary/10 hover:bg-primary/20 rounded-full border border-primary/20 hover:border-primary/40 text-primary hover:text-primary transition-colors cursor-pointer"
-                  >
-                    {q}
-                  </button>
-                ))}
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        {/* Auto-suggestions above input */}
-        {messages.length > 0 && !isLoading && autoSuggestions.length > 0 && (
-          <div className="px-3 pt-2 flex flex-wrap gap-1.5">
-            {autoSuggestions.slice(0, 3).map((s, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => sendMessage(s.text)}
-                className="px-2.5 py-1 text-[11px] bg-muted/20 hover:bg-muted/50 rounded-full border border-border/20 hover:border-border/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
-              >
-                {s.text}
-              </button>
-            ))}
-          </div>
-        )}
-
         <form
           onSubmit={handleSubmit}
           className="p-3 relative"
@@ -3539,8 +3578,15 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
               )}
             </AnimatePresence>
           )}
-          <div className="flex gap-2 items-end">
-            <div className="relative flex-1">
+          <div
+            className={cn(
+              "flex flex-col rounded-lg border bg-input ring-offset-background transition-colors focus-within:border-foreground focus-within:ring-foreground/10 focus-within:ring-1",
+              "bg-background/50 border-border/50",
+              disabledReason && "border-muted-foreground/30"
+            )}
+          >
+            {/* Textarea row: full width so scrollbar is above the buttons and no dead zone */}
+            <div className="relative flex-1 min-w-0">
               <textarea
                 ref={inputRef}
                 value={input}
@@ -3553,37 +3599,9 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
                 }
                 disabled={!canChat}
                 rows={1}
-                className={cn(
-                  "flex w-full border border-border bg-input px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-foreground disabled:cursor-not-allowed disabled:opacity-50 caret-foreground resize-none overflow-y-auto",
-                  "flex-1 bg-background/50 border-border/50 focus:border-foreground/30 focus:ring-foreground/10 transition-colors",
-                  disabledReason && "border-muted-foreground/30",
-                  pastedImages.length > 0 && "pb-12" // Make room for image previews below
-                )}
+                className="w-full min-h-[44px] border-0 bg-transparent px-3 py-2.5 pr-3 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 caret-foreground resize-none overflow-y-auto scrollbar-minimal"
                 style={{ maxHeight: "150px" }}
               />
-
-              {/* Attached image previews below textarea */}
-              {pastedImages.length > 0 && (
-                <div className="absolute bottom-1 left-2 right-2 flex items-center gap-1.5 overflow-x-auto py-1">
-                  {pastedImages.map((img, i) => (
-                    <div key={i} className="relative group shrink-0">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={img}
-                        alt={`Attached ${i + 1}`}
-                        className="h-8 w-8 object-cover rounded border border-border/50"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => setPastedImages(prev => prev.filter((_, idx) => idx !== i))}
-                        className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-destructive text-destructive-foreground rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
-                      >
-                        <X className="w-2.5 h-2.5" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              )}
 
               <AnimatePresence>
                 {showMentionDropdown && filteredMentions.length > 0 && (
@@ -3635,35 +3653,38 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
                 )}
               </AnimatePresence>
             </div>
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              onClick={handleFilePicker}
-              disabled={isLoading || !canChat}
-              className="shrink-0 text-muted-foreground hover:text-foreground"
-              title="Attach image"
-            >
-              <Paperclip className="h-4 w-4" />
-            </Button>
-            <Button
-              type={isStreaming ? "button" : "submit"}
-              size="icon"
-              disabled={(!input.trim() && !isStreaming && pastedImages.length === 0) || !canChat}
-              onClick={isStreaming ? handleStop : undefined}
-              className={cn(
-                "shrink-0 transition-all duration-200",
-                isStreaming
-                  ? "bg-foreground text-background hover:bg-foreground/80"
-                  : "bg-foreground text-background hover:bg-background hover:text-foreground"
-              )}
-            >
-              {isStreaming ? (
-                <Square className="h-4 w-4" />
-              ) : (
-                <Send className="h-4 w-4" />
-              )}
-            </Button>
+            {/* Buttons row below textarea so scrollbar is above and full width is typeable */}
+            <div className="flex items-center justify-end gap-0.5 shrink-0 px-2 pb-2 pt-1">
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                onClick={handleFilePicker}
+                disabled={isLoading || !canChat}
+                className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                title="Attach image"
+              >
+                <Paperclip className="h-4 w-4" />
+              </Button>
+              <Button
+                type={isStreaming ? "button" : "submit"}
+                size="icon"
+                disabled={(!input.trim() && !isStreaming && pastedImages.length === 0) || !canChat}
+                onClick={isStreaming ? handleStop : undefined}
+                className={cn(
+                  "h-8 w-8 transition-all duration-200",
+                  isStreaming
+                    ? "bg-foreground text-background hover:bg-foreground/80"
+                    : "bg-foreground text-background hover:bg-background hover:text-foreground"
+                )}
+              >
+                {isStreaming ? (
+                  <Square className="h-4 w-4" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
           </div>
         </form>
       </div> {/* End of max-w-4xl input wrapper */}
@@ -3691,6 +3712,72 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           responsePreview={scheduleDialogMessage.response}
         />
       )}
+
+      {/* Full-screen image viewer (like reference): click any attached photo to open */}
+      <Dialog open={!!imageViewer} onOpenChange={(open) => !open && setImageViewer(null)}>
+        <DialogContent
+          hideCloseButton
+          className="fixed inset-0 z-50 max-w-none w-full h-full !left-0 !top-0 !translate-x-0 !translate-y-0 rounded-none border-0 bg-muted/95 p-0 flex flex-col gap-0"
+        >
+          {imageViewer && (
+            <>
+              <div className="flex items-center justify-between px-4 py-3 border-b border-border/50 shrink-0">
+                <span className="text-sm font-medium text-muted-foreground">
+                  {imageViewer.index + 1}/{imageViewer.images.length} Attached image {imageViewer.index + 1}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setImageViewer(null)}
+                  className="p-2 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                  aria-label="Close"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+              <div className="flex-1 flex items-center justify-center min-h-0 p-4 bg-background/50">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={imageViewer.images[imageViewer.index]}
+                  alt={`Attached image ${imageViewer.index + 1}`}
+                  className="max-w-full max-h-full object-contain rounded-lg"
+                />
+              </div>
+              <div className="flex items-center justify-center gap-4 py-3 border-t border-border/50 shrink-0">
+                <button
+                  type="button"
+                  onClick={() => setImageViewer((v) => v && v.index > 0 ? { ...v, index: v.index - 1 } : v)}
+                  disabled={imageViewer.index === 0}
+                  className="p-2 rounded-md hover:bg-muted disabled:opacity-40 disabled:pointer-events-none text-foreground"
+                  aria-label="Previous image"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setImageViewer((v) => v && v.index < v.images.length - 1 ? { ...v, index: v.index + 1 } : v)}
+                  disabled={imageViewer.index === imageViewer.images.length - 1}
+                  className="p-2 rounded-md hover:bg-muted disabled:opacity-40 disabled:pointer-events-none text-foreground"
+                  aria-label="Next image"
+                >
+                  <ChevronRight className="h-5 w-5" />
+                </button>
+              </div>
+              <div className="flex justify-center gap-1.5 pb-3">
+                {imageViewer.images.map((_, i) => (
+                  <div
+                    key={i}
+                    className={cn(
+                      "w-2 h-2 rounded-full transition-colors",
+                      i === imageViewer.index ? "bg-foreground" : "bg-muted-foreground/40"
+                    )}
+                    aria-hidden
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
**description**

- **Input:** Single chatbox with textarea full-width and paperclip/send on a row below so the scrollbar stays above the buttons and the whole width is typeable. Minimal scrollbar (thin, no arrows). Removed the line between textarea and buttons.
- **Attached images:** Shown in the gap above the agent bar; click a thumbnail to open a full-screen viewer with prev/next and close.
- **Messages:** In-chat image thumbnails are larger and clickable; same viewer opens from there.
- **Presets:** Model name no longer truncated; dropdown opens above so it doesn’t cover the input.
- **Scrollbar:** New `scrollbar-minimal` in `globals.css` (thin) used on the chat textarea.

- Before:

https://github.com/user-attachments/assets/0400f1c3-bd8b-465c-9540-36195c3012db

- After: 


https://github.com/user-attachments/assets/bb3c0e57-fdbe-41a2-923c-2f40620abe81


