### PR TITLE
fix(timeline): frames used before declaration

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -101,14 +101,6 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 	// Stable guardRefs object for Live Text click guards — refs are stable, so useMemo with empty deps is fine
 	const guardRefs = useMemo(() => ({ filters: filtersRef, scrubber: scrubberRef }), []);
 
-	// Force guard rect refresh when inner timeline mounts/unmounts
-	useEffect(() => {
-		// Slight delay to let DOM layout settle after inner timeline renders
-		const timer = setTimeout(() => {
-			window.dispatchEvent(new Event("resize"));
-		}, 500);
-		return () => clearTimeout(timer);
-	}, [frames.length]);
 	const [startAndEndDates, setStartAndEndDates] = useState<TimeRange>(() => {
 		// Lazy init to avoid SSR/client hydration mismatch from new Date()
 		const now = new Date();
@@ -189,6 +181,13 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 
 	const { meetings } = useMeetings(frames);
 
+	// Force guard rect refresh when inner timeline mounts/unmounts (e.g. when frames load)
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			window.dispatchEvent(new Event("resize"));
+		}, 500);
+		return () => clearTimeout(timer);
+	}, [frames.length]);
 
 	// --- Extracted hooks ---
 


### PR DESCRIPTION
### Description: 
A `useEffect` in `Timeline` had `frames.length` in its dependency array, but `frames` is only defined later in the component (from `useTimelineData()`). That violated block-scoping and broke the build.

- Removed the guard-rect refresh `useEffect` from its original position (above the `frames` declaration).
- Re-added the same effect immediately after `frames` is defined (after `useMeetings(frames)`), so it still runs when `frames.length` changes and triggers the resize for Live Text click guards.

No behavior change; `tauri dev` and type-check now succeed.
