### PR TITLE
fix: ensure event-driven columns exist & silence windows uiauto Sentry spam

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -317,12 +317,16 @@ impl DatabaseManager {
     /// and that frames_fts includes accessibility_text.
     /// An earlier version of migration 20260220000000 may have been applied
     /// without these columns.
-    async fn ensure_event_driven_columns(pool: &SqlitePool) -> Result<(), sqlx::Error> {
+    pub async fn ensure_event_driven_columns(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         // 1. Fix missing columns on frames table
         let missing_columns: &[(&str, &str)] = &[
+            ("snapshot_path", "TEXT DEFAULT NULL"),
+            ("accessibility_text", "TEXT DEFAULT NULL"),
             ("accessibility_tree_json", "TEXT DEFAULT NULL"),
             ("content_hash", "INTEGER DEFAULT NULL"),
             ("simhash", "INTEGER DEFAULT NULL"),
+            ("capture_trigger", "TEXT DEFAULT NULL"),
+            ("text_source", "TEXT DEFAULT NULL"),
         ];
 
         for (col_name, col_type) in missing_columns {

--- a/crates/screenpipe-db/tests/test_ensure_event_driven_columns.rs
+++ b/crates/screenpipe-db/tests/test_ensure_event_driven_columns.rs
@@ -1,0 +1,52 @@
+use screenpipe_db::DatabaseManager;
+use sqlx::{SqlitePool, Row};
+
+#[tokio::test]
+async fn test_ensure_event_driven_columns_adds_missing_columns() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    
+    // Create a barebones frames table without the new columns
+    sqlx::query(
+        "CREATE TABLE frames (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            video_chunk_id INTEGER DEFAULT NULL,
+            offset_index INTEGER NOT NULL DEFAULT 0,
+            timestamp TIMESTAMP NOT NULL,
+            name TEXT,
+            app_name TEXT DEFAULT NULL,
+            window_name TEXT DEFAULT NULL,
+            focused BOOLEAN DEFAULT NULL,
+            browser_url TEXT DEFAULT NULL,
+            device_name TEXT NOT NULL DEFAULT '',
+            sync_id TEXT,
+            machine_id TEXT,
+            synced_at DATETIME
+        )"
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    
+    // Call the fix function
+    DatabaseManager::ensure_event_driven_columns(&pool).await.unwrap();
+    
+    // Verify the columns were added
+    let rows = sqlx::query("PRAGMA table_info('frames')")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        
+    let mut columns = vec![];
+    for row in rows {
+        let name: String = row.get("name");
+        columns.push(name);
+    }
+    
+    assert!(columns.contains(&"snapshot_path".to_string()), "snapshot_path should be added");
+    assert!(columns.contains(&"accessibility_text".to_string()), "accessibility_text should be added");
+    assert!(columns.contains(&"accessibility_tree_json".to_string()), "accessibility_tree_json should be added");
+    assert!(columns.contains(&"content_hash".to_string()), "content_hash should be added");
+    assert!(columns.contains(&"simhash".to_string()), "simhash should be added");
+    assert!(columns.contains(&"capture_trigger".to_string()), "capture_trigger should be added");
+    assert!(columns.contains(&"text_source".to_string()), "text_source should be added");
+}

--- a/crates/screenpipe-screen/src/browser_utils/windows.rs
+++ b/crates/screenpipe-screen/src/browser_utils/windows.rs
@@ -77,8 +77,8 @@ impl WindowsUrlDetector {
                 }
             }
             Err(e) => {
-                error!("failed to find edit bar: {}", e);
-                return Err(anyhow!("failed to find edit bar: {}", e));
+                debug!("failed to find edit bar: {}", e);
+                return Ok(None);
             }
         }
         Ok(None)


### PR DESCRIPTION
Fixes #2503
Fixes #2496

This PR resolves two Sentry issues:
1. **snapshot compaction cycle fails with no such column snapshot_path**: Adds all missing event-driven capture columns (including `snapshot_path`, `accessibility_text`, `capture_trigger`, etc.) to the Rust-level `ensure_event_driven_columns` fallback migration. This ensures users who missed the primary DB migration will correctly have the columns added at runtime. Also includes a unit test.
2. **Windows URL detection spams Sentry with 'failed to find edit bar'**: Downgrades the `find_first` COM error from `error!` to `debug!` and returns `Ok(None)` instead of `Err`, which stops spamming Sentry for expected background app states on Windows where the edit bar doesn't exist.

### Test Output

```
running 1 test
test test_ensure_event_driven_columns_adds_missing_columns ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```