### PR TITLE
fix: Windows URL detection spams Sentry with 'failed to find edit bar'

### DIFF
--- a/crates/screenpipe-screen/src/browser_utils/windows.rs
+++ b/crates/screenpipe-screen/src/browser_utils/windows.rs
@@ -77,8 +77,8 @@ impl WindowsUrlDetector {
                 }
             }
             Err(e) => {
-                error!("failed to find edit bar: {}", e);
-                return Err(anyhow!("failed to find edit bar: {}", e));
+                debug!("failed to find edit bar: {}", e);
+                return Ok(None);
             }
         }
         Ok(None)
@@ -93,5 +93,17 @@ impl BrowserUrlDetector for WindowsUrlDetector {
         _window_title: &str,
     ) -> Result<Option<String>> {
         Self::get_active_url_from_window(process_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detector_instantiation() {
+        let detector = WindowsUrlDetector::new();
+        // Just verify it doesn't panic on creation
+        let _ = detector;
     }
 }


### PR DESCRIPTION
Fixes #2496

Changes the log level from `error!` to `debug!` and returns `Ok(None)` instead of an `Err` when UIAutomation fails to find the edit bar in a window. This prevents normal background processes or uninitialized UI states from spamming Sentry with 'Operation completed successfully' errors.

Tested locally by instantiating the detector.