### PR TITLE
fix: audio stall false positives via transcription heartbeat

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -667,6 +667,9 @@ mod tests {
             verbose_instructions: None,
             device_status_details: None,
             monitors: None,
+            audio_pipeline: None,
+            vision_db_write_stalled: false,
+            audio_db_write_stalled: false,
         })
     }
 
@@ -684,6 +687,9 @@ mod tests {
             verbose_instructions: None,
             device_status_details: None,
             monitors: None,
+            audio_pipeline: None,
+            vision_db_write_stalled: false,
+            audio_db_write_stalled: false,
         })
     }
 

--- a/crates/screenpipe-audio/src/metrics.rs
+++ b/crates/screenpipe-audio/src/metrics.rs
@@ -71,6 +71,10 @@ pub struct AudioPipelineMetrics {
     pub started_at: Instant,
     /// Unix timestamp (secs) of most recent DB insert — used by health check to avoid DB queries
     pub last_db_write_ts: AtomicU64,
+    /// Unix timestamp (secs) of most recent transcription attempt (heartbeat for stall detection).
+    /// Advances even when VAD filters all audio as silence, so the health check can distinguish
+    /// "nothing to write" from "pipeline stalled".
+    pub last_transcription_attempt_ts: AtomicU64,
 }
 
 impl AudioPipelineMetrics {
@@ -99,6 +103,7 @@ impl AudioPipelineMetrics {
             per_device_rms_x10000: RwLock::new(HashMap::new()),
             started_at: Instant::now(),
             last_db_write_ts: AtomicU64::new(0),
+            last_transcription_attempt_ts: AtomicU64::new(0),
         }
     }
 
@@ -164,6 +169,18 @@ impl AudioPipelineMetrics {
             .unwrap()
             .as_secs();
         self.last_db_write_ts.store(now, Ordering::Relaxed);
+    }
+
+    /// Record that a transcription result was received and attempted to be processed.
+    /// This serves as a heartbeat for stall detection — even if VAD filters all audio
+    /// and nothing is written to DB, this timestamp advances.
+    pub fn record_transcription_attempt(&self) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        self.last_transcription_attempt_ts
+            .store(now, Ordering::Relaxed);
     }
 
     pub fn record_duplicate_blocked(&self) {
@@ -286,6 +303,9 @@ impl AudioPipelineMetrics {
             },
             audio_level_rms: self.audio_level_rms_x10000.load(Ordering::Relaxed) as f64 / 10000.0,
             last_db_write_ts: self.last_db_write_ts.load(Ordering::Relaxed),
+            last_transcription_attempt_ts: self
+                .last_transcription_attempt_ts
+                .load(Ordering::Relaxed),
         }
     }
 }
@@ -341,4 +361,6 @@ pub struct AudioMetricsSnapshot {
     pub audio_level_rms: f64,
     /// Unix timestamp (secs) of most recent DB insert (0 = none yet)
     pub last_db_write_ts: u64,
+    /// Unix timestamp (secs) of most recent transcription attempt (heartbeat)
+    pub last_transcription_attempt_ts: u64,
 }

--- a/crates/screenpipe-audio/src/transcription/handle_new_transcript.rs
+++ b/crates/screenpipe-audio/src/transcription/handle_new_transcript.rs
@@ -50,6 +50,11 @@ pub async fn handle_new_transcript(
     let mut prev_transcript_by_device: HashMap<String, String> = HashMap::new();
     let mut prev_id_by_device: HashMap<String, i64> = HashMap::new();
     while let Ok(mut transcription) = transcription_receiver.recv() {
+        // Heartbeat: record that the consumer is alive and processing, even when
+        // VAD filters everything. The health check uses this to distinguish
+        // "silence, nothing to write" from "pipeline stalled, writes blocked".
+        metrics.record_transcription_attempt();
+
         if transcription
             .transcription
             .clone()

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -214,8 +214,8 @@ pub async fn health_check(State(state): State<Arc<AppState>>) -> JsonResponse<He
         && vision_snap.last_capture_attempt_ts > 0
         && vision_snap.uptime_secs > 120.0
     {
-        let capture_fresh = now_ts.saturating_sub(vision_snap.last_capture_attempt_ts)
-            < threshold_secs;
+        let capture_fresh =
+            now_ts.saturating_sub(vision_snap.last_capture_attempt_ts) < threshold_secs;
         // Require at least one successful DB write before flagging a stall.
         // last_db_write_ts == 0 means "never written yet" (pipeline warming up),
         // not "writes stopped" — same fix as audio side.
@@ -237,16 +237,22 @@ pub async fn health_check(State(state): State<Arc<AppState>>) -> JsonResponse<He
     let audio_db_write_stalled = if !state.audio_disabled
         && global_audio_active
         && audio_snap.uptime_secs > 120.0
-        && audio_snap.last_db_write_ts > 0
     {
-        let db_stale = now_ts.saturating_sub(audio_snap.last_db_write_ts) > threshold_secs;
-        if db_stale {
+        // Only flag a stall when the transcription consumer is actively processing
+        // (heartbeat recent) but DB writes have stopped. This prevents false positives
+        // during silence when VAD filters everything and nothing is written to DB.
+        let transcription_fresh = audio_snap.last_transcription_attempt_ts > 0
+            && now_ts.saturating_sub(audio_snap.last_transcription_attempt_ts) < threshold_secs;
+        let db_stale = audio_snap.last_db_write_ts == 0
+            || now_ts.saturating_sub(audio_snap.last_db_write_ts) > threshold_secs;
+        let stalled = transcription_fresh && db_stale;
+        if stalled {
             warn!(
-                "health_check: audio DB writes stalled — devices active but last DB write {}s ago (pool exhaustion likely)",
-                now_ts.saturating_sub(audio_snap.last_db_write_ts),
+                "health_check: audio DB writes stalled — transcription active but last DB write {}s ago (pool exhaustion/lock contention likely)",
+                if audio_snap.last_db_write_ts > 0 { now_ts.saturating_sub(audio_snap.last_db_write_ts) } else { 0 },
             );
         }
-        db_stale
+        stalled
     } else {
         false
     };
@@ -266,9 +272,8 @@ pub async fn health_check(State(state): State<Arc<AppState>>) -> JsonResponse<He
     // Cross-check: if audio is enabled, uptime > 2 min, but zero chunks were ever
     // sent, the audio pipeline never started capturing (e.g. device retry loop).
     // The per-device timestamp fallback would mask this as "ok", so override here.
-    let audio_never_captured = !state.audio_disabled
-        && audio_snap.uptime_secs > 120.0
-        && audio_snap.chunks_sent == 0;
+    let audio_never_captured =
+        !state.audio_disabled && audio_snap.uptime_secs > 120.0 && audio_snap.chunks_sent == 0;
 
     let audio_status = if state.audio_disabled {
         "disabled".to_string()


### PR DESCRIPTION
## Summary

- Add transcription heartbeat (`last_transcription_attempt_ts`) to audio metrics — advances every time the consumer loop processes a result, even during silence
- Gate audio DB write stall detection on heartbeat freshness: only flag when transcription is actively processing but DB writes have stopped
- Eliminates ~3k/day false "audio DB writes stalled" warnings caused by VAD filtering all audio as silence (no DB writes → stale timestamp → false stall alarm)

**Files changed:** 4 files, +49/-11

| File | Change |
|------|--------|
| `crates/screenpipe-audio/src/metrics.rs` | Add `last_transcription_attempt_ts` field + `record_transcription_attempt()` method |
| `crates/screenpipe-audio/src/transcription/handle_new_transcript.rs` | Call heartbeat at top of receive loop |
| `crates/screenpipe-engine/src/routes/health.rs` | Use `transcription_fresh` to gate stall detection |
| `apps/screenpipe-app-tauri/src-tauri/src/health.rs` | Fix test helpers missing new struct fields |

## Test plan

- [x] `cargo check -p screenpipe-audio` — compiles
- [x] `cargo check -p screenpipe-engine` — compiles
- [x] 21/21 health tests pass
- [ ] CI green

Extracted from #2512 per review feedback.

Generated with [Claude Code](https://claude.com/claude-code)