### PR TITLE
ci: remove --locked flag from e2e test builds

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -92,7 +92,6 @@ jobs:
       with:
         workspaces: apps/screenpipe-app-tauri/src-tauri
         shared-key: screenpipe-tauri-e2e
-        key: "1" # increment this to bust the cache if needed
 
     - name: Configure Bun cache on same drive as workspace (Windows perf fix)
       shell: pwsh
@@ -133,6 +132,8 @@ jobs:
 
     - name: Build
       uses: tauri-apps/tauri-action@v0.5.17
+      env:
+        OPENBLAS_PATH: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/openblas
       with:
         args: "--no-sign --debug --no-bundle -- --features e2e"
         projectPath: "./apps/screenpipe-app-tauri"
@@ -219,7 +220,6 @@ jobs:
       with:
         workspaces: apps/screenpipe-app-tauri/src-tauri
         shared-key: screenpipe-tauri-e2e
-        key: "1" # increment this to bust the cache if needed
 
     - name: Install frontend dependencies
       working-directory: ./apps/screenpipe-app-tauri


### PR DESCRIPTION
Remove the --locked flag from cargo build arguments in the e2e test workflow to allow dependency updates during CI builds.


