### PR TITLE
(Fix) Windows MS Team App Meeting detection trigger

### DIFF
--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -105,7 +105,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["microsoft teams", "teams"],
-                windows_process_names: &["ms-teams.exe", "teams.exe"],
+                windows_process_names: &["ms-teams.exe", "teams.exe", "msedgewebview2.exe"],
                 browser_url_patterns: &["teams.microsoft.com", "teams.live.com"],
             },
             call_signals: vec![


### PR DESCRIPTION
Fix windows teams App detection issue by adding msedgewebview2.exe to list of windows_process_names

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

just adds a correct MS Teams app windows process

related issue: #
Windows OS MS Teams App doesn't trigger meeting based on Accessibility Tree "Leave" button due to it living under the msedgewebview2.exe process
