### PR TITLE
fix: pass OCR languages to Apple Vision in event-driven capture

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -214,6 +214,7 @@ pub async fn event_driven_capture_loop(
     vision_metrics: Arc<screenpipe_screen::PipelineMetrics>,
     hot_frame_cache: Option<Arc<HotFrameCache>>,
     use_pii_removal: bool,
+    languages: Vec<screenpipe_core::Language>,
     power_profile_rx: Option<watch::Receiver<PowerProfile>>,
 ) -> Result<()> {
     info!(
@@ -263,6 +264,7 @@ pub async fn event_driven_capture_loop(
             &tree_walker_config,
             &CaptureTrigger::Manual,
             use_pii_removal,
+            &languages,
             None, // first capture — no previous hash
             last_db_write,
         )
@@ -408,6 +410,7 @@ pub async fn event_driven_capture_loop(
                         &tree_walker_config,
                         &trigger,
                         use_pii_removal,
+                        &languages,
                         last_content_hash,
                         last_db_write,
                     ),
@@ -607,6 +610,7 @@ async fn do_capture(
     tree_walker_config: &TreeWalkerConfig,
     trigger: &CaptureTrigger,
     use_pii_removal: bool,
+    languages: &[screenpipe_core::Language],
     previous_content_hash: Option<i64>,
     last_db_write: Instant,
 ) -> Result<CaptureOutput> {
@@ -730,6 +734,7 @@ async fn do_capture(
         focused: true, // event-driven captures are always for the focused window
         capture_trigger: trigger.as_str(),
         use_pii_removal,
+        languages: languages.to_vec(),
     };
 
     let result = paired_capture(&ctx, tree_snapshot.as_ref()).await?;

--- a/crates/screenpipe-engine/src/paired_capture.rs
+++ b/crates/screenpipe-engine/src/paired_capture.rs
@@ -44,6 +44,7 @@ pub struct CaptureContext<'a> {
     pub focused: bool,
     pub capture_trigger: &'a str,
     pub use_pii_removal: bool,
+    pub languages: Vec<screenpipe_core::Language>,
 }
 
 /// Result of a paired capture operation.
@@ -151,17 +152,18 @@ pub async fn paired_capture(
         {
             let _permit = ocr_semaphore().acquire().await.unwrap();
             let image_for_ocr = ctx.image.clone();
+            let languages = ctx.languages.clone();
             let ocr_result = tokio::task::spawn_blocking(move || {
                 #[cfg(target_os = "macos")]
                 {
                     let (text, json, _confidence) =
-                        screenpipe_screen::perform_ocr_apple(&image_for_ocr, &[]);
+                        screenpipe_screen::perform_ocr_apple(&image_for_ocr, &languages);
                     (text, json)
                 }
                 #[cfg(not(target_os = "macos"))]
                 {
                     let (text, json, _confidence) =
-                        screenpipe_screen::perform_ocr_tesseract(&image_for_ocr, vec![]);
+                        screenpipe_screen::perform_ocr_tesseract(&image_for_ocr, languages);
                     (text, json)
                 }
             })
@@ -550,6 +552,7 @@ mod tests {
             focused: true,
             capture_trigger: "click",
             use_pii_removal: false,
+            languages: vec![],
         };
 
         let result = paired_capture(&ctx, None).await.unwrap();
@@ -583,6 +586,7 @@ mod tests {
             focused: true,
             capture_trigger: "app_switch",
             use_pii_removal: false,
+            languages: vec![],
         };
 
         let snap = TreeSnapshot {
@@ -639,6 +643,7 @@ mod tests {
             focused: true,
             capture_trigger: "idle",
             use_pii_removal: false,
+            languages: vec![],
         };
 
         // Empty accessibility text should be treated as no text

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -210,6 +210,7 @@ impl RecordingConfig {
             monitor_ids: self.monitor_ids.clone(),
             use_all_monitors: self.use_all_monitors,
             ignore_incognito_windows: self.ignore_incognito_windows,
+            languages: self.languages.clone(),
         }
     }
 }

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -35,6 +35,7 @@ pub struct VisionManagerConfig {
     pub use_all_monitors: bool,
     /// Automatically detect and skip incognito / private browsing windows.
     pub ignore_incognito_windows: bool,
+    pub languages: Vec<screenpipe_core::Language>,
 }
 
 /// Status of the VisionManager
@@ -274,6 +275,7 @@ impl VisionManager {
         let vision_metrics = self.config.vision_metrics.clone();
         let hot_frame_cache = self.hot_frame_cache.clone();
         let use_pii_removal = self.config.use_pii_removal;
+        let languages = self.config.languages.clone();
         let power_profile_rx = self.power_profile_rx.clone();
 
         info!(
@@ -298,6 +300,7 @@ impl VisionManager {
                 vision_metrics,
                 hot_frame_cache,
                 use_pii_removal,
+                languages,
                 power_profile_rx,
             )
             .await

--- a/crates/screenpipe-screen/src/apple.rs
+++ b/crates/screenpipe-screen/src/apple.rs
@@ -34,10 +34,15 @@ pub fn get_apple_languages(languages: &[Language]) -> Vec<String> {
         m
     });
 
-    languages
+    let mut result: Vec<String> = languages
         .iter()
         .filter_map(|lang| map.get(lang).map(|&s| s.to_string()))
-        .collect()
+        .collect();
+    // Chinese: include both Simplified and Traditional
+    if languages.contains(&Language::Chinese) && !result.contains(&"zh-Hant".to_string()) {
+        result.push("zh-Hant".to_string());
+    }
+    result
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## description

`paired_capture()` always calls `perform_ocr_apple()` with an empty language list, ignoring `--language` CLI flags. this makes non-English OCR completely broken in event-driven mode (the default since v0.3.x).

the language config is correctly parsed into `RecordingConfig.languages`, but never reaches the OCR call:

```
CLI: --language chinese --language english
  ↓ ✅ RecordingConfig.languages = [Chinese, English]
  ↓ ✅ event_driven_capture_loop() has config
  ↓ ❌ do_capture() — no languages param
  ↓ ❌ paired_capture() — no languages param
  ↓ ❌ perform_ocr_apple(&image, &[]) — always empty
```

this PR threads languages through the full chain: `VisionManagerConfig` → `event_driven_capture_loop` → `do_capture` → `CaptureContext` → `perform_ocr_apple`.

also adds `zh-Hant` (Traditional Chinese) alongside `zh-Hans` when `Language::Chinese` is selected, since Apple Vision supports both and they share the same recognition model.

related issue: #2549, #2550

## how to test

1. build and run with `--language chinese --language english`
2. open a page with Chinese text (simplified or traditional)
3. search OCR results via `/search?content_type=ocr` API

**before this fix:** `zh=0` — zero Chinese characters recognized, regardless of `--language` setting
**after this fix:** `zh=23` — both simplified and traditional Chinese recognized correctly

test content used:
```
It's Simplified Chinese 这是简体中文
It's Traditional Chinese 這是繁體中文
```

i will attach before/after screenshots in a comment below.