### PR TITLE
fix: preserve chat state across navigation

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -263,20 +263,7 @@ function SettingsPageContent() {
     }
   }, [activeSection, setActiveSection]);
 
-  const renderMainSection = () => {
-    switch (activeSection) {
-      case "home":
-        return <StandaloneChat className="h-full" />;
-      case "timeline":
-        return <Timeline embedded />;
-      case "pipes":
-        return <PipeStoreView />;
-      case "help":
-        return <FeedbackSection />;
-      default:
-        return <StandaloneChat className="h-full" />;
-    }
-  };
+
 
   const renderModalSection = () => {
     switch (modalSection) {
@@ -650,14 +637,24 @@ function SettingsPageContent() {
 
           {/* Content */}
           <div className="flex-1 flex flex-col h-full bg-background min-h-0 rounded-tr-lg relative">
-            {isFullHeight ? (
+            {/* StandaloneChat — always mounted to preserve in-progress conversation */}
+            <div className={cn("flex-1 min-h-0 overflow-hidden", activeSection !== "home" && "hidden")}>
+              <StandaloneChat className="h-full" />
+            </div>
+
+            {/* Timeline — full height like chat */}
+            {activeSection === "timeline" && (
               <div className="flex-1 min-h-0 overflow-hidden">
-                {renderMainSection()}
+                <Timeline embedded />
               </div>
-            ) : (
+            )}
+
+            {/* Scrollable sections */}
+            {(activeSection === "pipes" || activeSection === "help") && (
               <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
                 <div className="p-6 pb-12 max-w-4xl mx-auto">
-                  {renderMainSection()}
+                  {activeSection === "pipes" && <PipeStoreView />}
+                  {activeSection === "help" && <FeedbackSection />}
                 </div>
               </div>
             )}


### PR DESCRIPTION
### Summary: 

Chat conversations were being wiped whenever a user navigated from Home to Timeline, Pipes, or any other section. and back.

  What changed:
  - StandaloneChat is now always mounted in the DOM, hidden via CSS (hidden class) when not active
  - Timeline, Pipes, and Help sections continue to mount/unmount normally — no state worth preserving there
  - Removed the renderMainSection() switch function; sections are now rendered inline with explicit conditions

  No behavior changes outside of chat persistence. Layout and scroll behavior for all sections remain intact.
  
  - Before:
  

https://github.com/user-attachments/assets/1586ce3d-4f70-461b-914a-bd1a3402ccfe

- After :


https://github.com/user-attachments/assets/282f9a35-cae2-4fa4-b459-eb0ce656009e



