### PR TITLE
fix: prevent mac audio timeouts from deadlocking watchdog

### DIFF
--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -190,20 +190,22 @@ impl AudioStream {
         #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
         {
             let (tx, rx) = oneshot::channel();
-            self.stream_control.send(StreamControl::Stop(tx))?;
-            rx.await?;
+            if self.stream_control.send(StreamControl::Stop(tx)).is_ok() {
+                let _ = tokio::time::timeout(std::time::Duration::from_secs(2), rx).await;
+            }
         }
 
         if let Some(thread_arc) = self.stream_thread.as_ref() {
             let thread_arc_clone = thread_arc.clone();
             let thread_handle = tokio::task::spawn_blocking(move || {
-                let mut thread_guard = thread_arc_clone.blocking_lock();
-                if let Some(join_handle) = thread_guard.take() {
-                    join_handle.abort();
+                if let Ok(mut thread_guard) = thread_arc_clone.try_lock() {
+                    if let Some(join_handle) = thread_guard.take() {
+                        join_handle.abort();
+                    }
                 }
             });
 
-            thread_handle.await?;
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), thread_handle).await;
         }
 
         Ok(())

--- a/crates/screenpipe-audio/src/device/device_manager.rs
+++ b/crates/screenpipe-audio/src/device/device_manager.rs
@@ -88,7 +88,7 @@ impl DeviceManager {
         }
 
         if let Some(p) = self.streams.get(device) {
-            let _ = p.value().stop().await;
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), p.value().stop()).await;
         }
 
         self.streams.remove(device);


### PR DESCRIPTION
This addresses the issue where the mac display audio and microphone randomly stop and require a restart after extended periods.

The cause was a deadlock during cpal stream teardown: when CoreAudio drops the device or enters an invalid sleep state, the native stream callback hangs. When the screenpipe `DeviceMonitor` attempts to recover the device and calls `stop_device()`, the `StreamControl::Stop` channel blocks forever waiting for the crashed native thread to reply. This totally deadlocks the monitor loop, disabling all future auto-reconnections.

Fix: Added explicit asynchronous timeouts around oneshot receivers and blocking teardown routines in both `manager.rs` and `stream.rs`. This ensures that if CoreAudio crashes, the main auto-reconnection loop will successfully abandon and restart the stream without getting stuck.

/claim #1626