### PR TITLE
fix: hardcode server port to 3030, remove dynamic port setting

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/hooks/use-voice-training.ts
+++ b/apps/screenpipe-app-tauri/components/settings/hooks/use-voice-training.ts
@@ -26,14 +26,14 @@ export function useVoiceTraining(opts: {
     const timer = setTimeout(async () => {
       try {
         const res = await fetch(
-          `http://localhost:${settings.port}/speakers/search?name=${encodeURIComponent(name)}`,
+          `http://localhost:3030/speakers/search?name=${encodeURIComponent(name)}`,
           { signal: controller.signal }
         );
         if (res.ok) setSpeakerSuggestions(await res.json());
       } catch { /* ignore */ }
     }, 300);
     return () => { clearTimeout(timer); controller.abort(); };
-  }, [settings.userName, settings.port]);
+  }, [settings.userName]);
 
   const handleStartTraining = useCallback(() => {
     const name = (settings.userName || "").trim();

--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -582,13 +582,6 @@ export function RecordingSettings() {
       const errors: Record<string, string> = {};
       
       // Validate numeric fields
-      if (newSettings.port !== undefined) {
-        const portValidation = validateField("port", newSettings.port);
-        if (!portValidation.isValid && portValidation.error) {
-          errors.port = portValidation.error;
-        }
-      }
-      
       if (newSettings.dataDir !== undefined) {
         const dataDirValidation = validateField("dataDir", newSettings.dataDir);
         if (!dataDirValidation.isValid && dataDirValidation.error) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -298,9 +298,9 @@ async fn upload_file_to_s3(file_path: &str, signed_url: &str) -> Result<bool, St
 #[tauri::command]
 #[specta::specta]
 #[allow(dead_code)]
-async fn is_server_running(app: AppHandle) -> Result<bool, String> {
-    let store = app.state::<store::SettingsStore>();
-    let port = store.recording.port;
+async fn is_server_running(_app: AppHandle) -> Result<bool, String> {
+    // always check port 3030 — the desktop app hardcodes this port everywhere
+    let port: u16 = 3030;
     let client = reqwest::Client::new();
     let response = client
         .get(format!("http://localhost:{}", port))
@@ -1406,7 +1406,9 @@ async fn main() {
                             }
 
                             info!("Starting embedded screenpipe server on dedicated runtime...");
-                            let config = store_clone.to_recording_config(data_dir_clone);
+                            let mut config = store_clone.to_recording_config(data_dir_clone);
+                            // always bind to port 3030 — the desktop app hardcodes this port everywhere
+                            config.port = 3030;
 
                             match embedded_server::start_embedded_server(config, on_pipe_output).await {
                                 Ok(handle) => {

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -164,8 +164,9 @@ pub async fn spawn_screenpipe(
         return Ok(());
     }
 
-    let store = SettingsStore::get(&app).ok().flatten().unwrap_or_default();
-    let port = store.recording.port;
+    // always use the default port — the desktop app hardcodes 3030 everywhere,
+    // so letting users change it via settings just breaks all API calls.
+    let port: u16 = 3030;
     let health_url = format!("http://localhost:{}/health", port);
 
     // Check if another start is already in progress (race between main.rs boot and frontend)

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -308,8 +308,10 @@ pub async fn spawn_screenpipe(
         );
     }
 
-    // Build config from store
-    let config = store.to_recording_config(data_dir);
+    // Build config from store, but always bind to port 3030 in the desktop app —
+    // the frontend hardcodes localhost:3030 for all API calls.
+    let mut config = store.to_recording_config(data_dir);
+    config.port = 3030;
     let recording_state_inner = state.handle.clone();
 
     // Create pipe output callback that emits Tauri events to the frontend

--- a/apps/screenpipe-app-tauri/src-tauri/src/voice_training.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/voice_training.rs
@@ -35,7 +35,7 @@ pub async fn train_voice(
             "voice training requires audio recording, but audio is disabled in settings".into(),
         );
     }
-    let port = store.recording.port;
+    let port: u16 = 3030;
 
     if TRAINING_IN_PROGRESS.swap(true, Ordering::SeqCst) {
         return Err("voice training already in progress".into());


### PR DESCRIPTION
## description

Hardcode the server port to 3030 in all desktop app paths instead of reading it from settings. When users changed the port in Settings, the app restarted on the new port but all frontend API calls still hit localhost:3030 (hardcoded in ~180 places), breaking Timeline, Chat, Pipes, and most features.

Rather than propagating the configured port to all ~180 hardcoded locations, this removes the footgun entirely:

- **recording.rs**: `let port: u16 = 3030` instead of reading `store.recording.port`
- **main.rs**: override `config.port = 3030` after building config from store
- **voice_training.rs**: hardcode port 3030 in the training polling loop
- **use-voice-training.ts**: use `localhost:3030` instead of `localhost:${settings.port}`
- **recording-settings.tsx**: remove dead port validation code

The `port` field stays in settings structs for serialization backward compat.

related issue: #2533

## how to test

1. `cargo check` / `npx tsc --noEmit` — verify compilation
2. start the desktop app, confirm server starts on port 3030
3. verify Timeline, Chat, and Pipes all work
4. if a user previously changed port in their config, the app now ignores it and uses 3030 — this is the intended fix