### PR TITLE
Fix: Timeline colors inverted on Windows

### DIFF
--- a/crates/screenpipe-screen/src/wgc_capture.rs
+++ b/crates/screenpipe-screen/src/wgc_capture.rs
@@ -128,19 +128,14 @@ impl PersistentCapture {
         }
     }
 
-    /// Convert an xcap Frame (BGRA raw bytes) to DynamicImage (RGBA).
+    /// Convert an xcap Frame to DynamicImage.
+    /// Note: xcap 0.9.1's `texture_to_frame` already converts BGRA→RGBA via `bgra_to_rgba()`,
+    /// so Frame.raw is already in RGBA order — no channel swap needed here.
     fn frame_to_image(frame: &Frame) -> Result<DynamicImage> {
         let width = frame.width;
         let height = frame.height;
-        let mut rgba = frame.raw.clone();
 
-        // BGRA → RGBA: swap B and R channels
-        for pixel in rgba.chunks_exact_mut(4) {
-            let pixel: &mut [u8] = pixel;
-            pixel.swap(0, 2);
-        }
-
-        let img = RgbaImage::from_raw(width, height, rgba)
+        let img = RgbaImage::from_raw(width, height, frame.raw.clone())
             .ok_or_else(|| anyhow!("failed to create RgbaImage from frame {}x{}", width, height))?;
 
         Ok(DynamicImage::ImageRgba8(img))


### PR DESCRIPTION
 ### Summary

 - Screen captures on Windows had red/blue channels swapped (inverted colors)
 - xcap 0.9.1 already converts BGRA→RGBA internally, but our wgc_capture.rs was doing a second swap, turning it back
  to BGRA
- Removed the redundant channel swap


###  Before:
<img width="1454" height="398" alt="image" src="https://github.com/user-attachments/assets/7731a0ca-fe66-4761-92b3-559aeb193f04" />


### After: 
<img width="926" height="265" alt="image" src="https://github.com/user-attachments/assets/69fb9b1e-8ecf-453b-b817-6aff37286a9c" />




