### PR TITLE
fix(audio): implement global heartbeat stall detection for macOS reliability #1626

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -633,15 +633,15 @@ pub async fn start_device_monitor(
                         .unwrap()
                         .as_secs();
                     
-                    let is_stalled = !enabled_devices.is_empty() 
+                    let is_stalled = !enabled_devices.is_empty()
                         && metrics_snapshot.last_transcription_attempt_ts > 0
-                        && now_ts - metrics_snapshot.last_transcription_attempt_ts > 120; // 2 minutes
+                        && now_ts.saturating_sub(metrics_snapshot.last_transcription_attempt_ts) > 120; // 2 minutes
 
                     let result = if is_stalled {
                         warn!("[DEVICE_RECOVERY] audio pipeline stalled (no heartbeat for 120s), forcing restart");
-                        audio_manager.check_and_restart_central_handlers().await
+                        audio_manager.check_and_restart_central_handlers(true).await
                     } else {
-                        audio_manager.check_and_restart_central_handlers().await
+                        audio_manager.check_and_restart_central_handlers(false).await
                     };
 
                     if is_stalled || result.recording_restarted || result.transcription_restarted {

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -811,7 +811,7 @@ impl AudioManager {
     ///
     /// The crossbeam channels are `Arc`-wrapped and survive handler restarts,
     /// so per-device recording tasks keep sending without interruption.
-    pub async fn check_and_restart_central_handlers(&self) -> CentralHandlerRestartResult {
+    pub async fn check_and_restart_central_handlers(&self, force: bool) -> CentralHandlerRestartResult {
         let mut result = CentralHandlerRestartResult::default();
 
         // --- fast path: read-lock to check liveness ---
@@ -830,19 +830,24 @@ impl AudioManager {
             }
         };
 
-        if !recording_dead && !transcription_dead {
+        if !force && !recording_dead && !transcription_dead {
             return result; // both alive, nothing to do
         }
 
-        // --- slow path: write-lock and restart dead handlers ---
-        if recording_dead {
+        // --- slow path: write-lock and restart dead (or force-abort live) handlers ---
+        if recording_dead || force {
             let mut guard = self.recording_receiver_handle.write().await;
-            // double-check under write lock (another task may have restarted it)
             let still_dead = match guard.as_ref() {
                 Some(h) => h.is_finished(),
                 None => true,
             };
-            if still_dead {
+            if still_dead || force {
+                if force && !still_dead {
+                    if let Some(h) = guard.take() {
+                        warn!("force-aborting audio-receiver handler");
+                        h.abort();
+                    }
+                }
                 warn!("central audio-receiver handler is dead, restarting");
                 match self.start_audio_receiver_handler().await {
                     Ok(handle) => {
@@ -858,13 +863,19 @@ impl AudioManager {
             }
         }
 
-        if transcription_dead {
+        if transcription_dead || force {
             let mut guard = self.transcription_receiver_handle.write().await;
             let still_dead = match guard.as_ref() {
                 Some(h) => h.is_finished(),
                 None => true,
             };
-            if still_dead {
+            if still_dead || force {
+                if force && !still_dead {
+                    if let Some(h) = guard.take() {
+                        warn!("force-aborting transcription-receiver handler");
+                        h.abort();
+                    }
+                }
                 warn!("central transcription-receiver handler is dead, restarting");
                 match self.start_transcription_receiver_handler().await {
                     Ok(handle) => {


### PR DESCRIPTION
This PR addresses #1626 by implementing a global heartbeat-based stall detection in the device monitor. It monitors the 'last_transcription_attempt_ts' metric and forces a restart of the central audio handlers if no data is processed for 120 seconds while devices are enabled. This ensures reliability against silent macOS audio stream failures (SCK/CPAL) after long runtimes. /claim #1626