### PR TITLE
fix(chat): extend @mention regex to include hyphens

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/global-chat-mentions.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/global-chat-mentions.test.ts
@@ -40,4 +40,19 @@ describe("global chat mentions", () => {
     expect(mentions.appName).toBe("Google Chrome");
     expect(mentions.cleanedInput).toBe("find notes");
   });
+
+  it("handles @mention trigger with hyphens", () => {
+    const regex = /@([\w-]*)$/;
+    const match1 = "@last".match(regex);
+    expect(match1).not.toBeNull();
+    expect(match1![1]).toBe("last");
+
+    const match2 = "@last-".match(regex);
+    expect(match2).not.toBeNull();
+    expect(match2![1]).toBe("last-");
+
+    const match3 = "@last-week".match(regex);
+    expect(match3).not.toBeNull();
+    expect(match3![1]).toBe("last-week");
+  });
 });

--- a/apps/screenpipe-app-tauri/components/hooks/use-mention-system.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-mention-system.ts
@@ -135,7 +135,7 @@ export function useMentionSystem(opts: {
 
     const cursorPos = e.target.selectionStart || 0;
     const textBeforeCursor = value.slice(0, cursorPos);
-    const atMatch = textBeforeCursor.match(/@(\w*)$/);
+    const atMatch = textBeforeCursor.match(/@([\w-]*)$/);
 
     if (atMatch) {
       setShowMentionDropdown(true);

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1401,7 +1401,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
 
     const cursorPos = e.target.selectionStart || 0;
     const textBeforeCursor = value.slice(0, cursorPos);
-    const atMatch = textBeforeCursor.match(/@(\w*)$/);
+    const atMatch = textBeforeCursor.match(/@([\w-]*)$/);
 
     if (atMatch) {
       setShowMentionDropdown(true);


### PR DESCRIPTION

* **Title:** `@mention` dropdown disappears when typing hyphenated tags like `@last-week`


* **Observed Behavior:** The mention trigger regex `/@(\w*)$/` stops matching when the user types a `-` character. The dropdown closes mid-suggestion for `@last-week`, `@last-hour`, `@this-morning`.

* **Expected Behavior:** Dropdown stays open throughout `@last-week` and correctly filters to that suggestion.

# Before


https://github.com/user-attachments/assets/a11116f1-4438-4c07-86ea-6b3ad41a521c



#  After 


https://github.com/user-attachments/assets/8e4d0d38-2762-49be-942e-0e34c920e24f



