### PR TITLE
Fix onMouseDown event to ensure `history` and `new chat` button is clickable

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -2863,6 +2863,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
         <Button
           variant={showHistory ? "secondary" : "ghost"}
           size="sm"
+          onMouseDown={(e) => e.stopPropagation()}
           onClick={async (e) => {
             e.stopPropagation();
             if (!showHistory) {
@@ -2871,7 +2872,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
             }
             setShowHistory(!showHistory);
           }}
-          className="h-7 px-2 gap-1 text-xs"
+          className="relative z-10 h-7 px-2 gap-1 text-xs"
           title="Chat history"
         >
           <History size={14} />
@@ -2880,13 +2881,14 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
         <Button
           variant="default"
           size="sm"
+          onMouseDown={(e) => e.stopPropagation()}
           onClick={async (e) => {
             e.stopPropagation();
             piStoppedIntentionallyRef.current = true;
             await startNewConversation();
             // Pi will auto-restart on the next message via the sendPiMessage flow
           }}
-          className="h-7 px-3 gap-1.5 text-xs bg-foreground text-background hover:bg-background hover:text-foreground transition-colors duration-150"
+          className="relative z-10 h-7 px-3 gap-1.5 text-xs bg-foreground text-background hover:bg-background hover:text-foreground transition-colors duration-150"
           title="New chat"
         >
           <Plus size={14} />


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/57e7eb7c-de5e-4fc0-95af-390daaad0edb




# After 
https://github.com/user-attachments/assets/e2f8003d-8b83-484e-9e81-f0943c4165b1

