### PR TITLE
fix(app): prevent parakeet-mlx OOM crash on 8GB Macs

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -754,21 +754,23 @@ pub fn init_store(app: &AppHandle) -> Result<SettingsStore, String> {
             );
             if is_new_store || store.recording.device_tier.is_none() {
                 screenpipe_config::apply_tier_defaults(&mut store.recording, detected);
-            } else if stored_tier.is_some() {
-                // Tier boundary changed in update — only fix engine if it would OOM
-                // (user on parakeet/parakeet-mlx but now classified as Low)
-                if detected == screenpipe_config::DeviceTier::Low
-                    && (store.recording.audio_transcription_engine == "parakeet"
-                        || store.recording.audio_transcription_engine == "parakeet-mlx")
-                {
-                    tracing::warn!(
-                        "device reclassified as Low tier — switching from {} to whisper-tiny to prevent OOM",
-                        store.recording.audio_transcription_engine
-                    );
-                    store.recording.audio_transcription_engine = "whisper-tiny".to_string();
-                }
             }
             store.recording.device_tier = Some(detected.as_str().to_string());
+            should_save = true;
+        }
+
+        // Unconditional OOM guard: prevent parakeet/parakeet-mlx on Low tier devices
+        // regardless of whether the tier just changed. The 2.3GB MLX model crashes
+        // 8GB machines (macOS kills the process during Metal buffer allocation).
+        if detected == screenpipe_config::DeviceTier::Low
+            && (store.recording.audio_transcription_engine == "parakeet"
+                || store.recording.audio_transcription_engine == "parakeet-mlx")
+        {
+            tracing::warn!(
+                "Low tier device — switching from {} to whisper-tiny to prevent OOM crash (parakeet-mlx requires >8GB RAM)",
+                store.recording.audio_transcription_engine
+            );
+            store.recording.audio_transcription_engine = "whisper-tiny".to_string();
             should_save = true;
         }
     }


### PR DESCRIPTION
## Summary
- Parakeet-mlx (2.3GB MLX model) silently crashes the app on 8GB Macs — macOS kills the process during Metal buffer allocation
- The existing OOM guard only ran when the hardware tier *changed* between runs, so devices that were always Low tier never got switched to whisper-tiny
- Move the guard to run unconditionally on every startup: if device is Low tier and engine is parakeet/parakeet-mlx, switch to whisper-tiny

## Root cause
`store.rs` had the parakeet→whisper-tiny downgrade inside `if stored_tier != Some(detected)`, which only fires when the tier classification changes. On an 8GB M1 that was always Low tier, `stored_tier == detected == Low`, so the guard never triggered. The app kept loading parakeet-mlx, and macOS killed it every time during model loading (after "loaded vocabulary: 8192 tokens", before model weights finish loading).

## Verified on
- Apple M1, 8GB RAM, macOS 15.3
- store.bin had `deviceTier: low` + `audioTranscriptionEngine: parakeet`
- App crashed on every launch at the same point (parakeet-mlx model loading)
- Manually patching store.bin to `whisper-tiny` fixed the crash

## Test plan
- [ ] 8GB Mac with `audioTranscriptionEngine: parakeet` in store.bin → should auto-switch to whisper-tiny on startup
- [ ] 16GB+ Mac with parakeet → should keep parakeet (not Low tier)
- [ ] Fresh install on 8GB Mac → `apply_tier_defaults` sets whisper-tiny (existing behavior, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)