### PR TITLE
fix: gate parakeet-mlx on macOS 26+ and device tier

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -9616,7 +9616,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.2.275"
+version = "2.2.273"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9718,7 +9718,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -9773,7 +9773,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -9785,7 +9785,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9811,7 +9811,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -9855,7 +9855,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9880,7 +9880,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9943,7 +9943,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9959,7 +9959,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -9995,7 +9995,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.3.235"
+version = "0.3.234"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -754,18 +754,18 @@ pub fn init_store(app: &AppHandle) -> Result<SettingsStore, String> {
             should_save = true;
         }
 
-        // Unconditional OOM guard: prevent parakeet/parakeet-mlx on Low tier devices
-        // regardless of whether the tier just changed. The 2.3GB MLX model crashes
-        // 8GB machines (macOS kills the process during Metal buffer allocation).
-        if detected == screenpipe_config::DeviceTier::Low
-            && (store.recording.audio_transcription_engine == "parakeet"
-                || store.recording.audio_transcription_engine == "parakeet-mlx")
-        {
+        // Unconditional safety guard: prevent parakeet/parakeet-mlx on platforms
+        // where it will crash (Low tier = OOM, macOS < 26 = MLX segfault).
+        if screenpipe_config::is_engine_unsafe(&store.recording.audio_transcription_engine, detected) {
+            let safe = screenpipe_config::best_engine_for_platform(detected);
             tracing::warn!(
-                "Low tier device — switching from {} to whisper-tiny to prevent OOM crash (parakeet-mlx requires >8GB RAM)",
-                store.recording.audio_transcription_engine
+                "engine {} is unsafe on this platform (tier={:?}, macOS={:?}) — switching to {}",
+                store.recording.audio_transcription_engine,
+                detected,
+                screenpipe_config::macos_major_version(),
+                safe,
             );
-            store.recording.audio_transcription_engine = "whisper-tiny".to_string();
+            store.recording.audio_transcription_engine = safe.to_string();
             should_save = true;
         }
     }

--- a/crates/screenpipe-config/src/defaults.rs
+++ b/crates/screenpipe-config/src/defaults.rs
@@ -7,6 +7,11 @@
 use crate::RecordingSettings;
 use sysinfo::{System, SystemExt};
 
+/// Minimum macOS major version required for parakeet-mlx (Metal GPU).
+/// macOS 26 (Tahoe) is required for the MLX framework APIs used by parakeet.
+/// On older macOS versions, the model loading segfaults during Metal buffer allocation.
+const PARAKEET_MIN_MACOS_MAJOR: u32 = 26;
+
 /// Device performance tier, determined by hardware detection.
 /// Used to select conservative or aggressive default settings on first launch.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -173,6 +178,74 @@ impl Default for ChannelConfig {
     }
 }
 
+/// Detect the macOS major version, or `None` on other platforms.
+#[cfg(target_os = "macos")]
+pub fn macos_major_version() -> Option<u32> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    version_str.trim().split('.').next()?.parse().ok()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn macos_major_version() -> Option<u32> {
+    None
+}
+
+/// Pick the best audio transcription engine for the current platform.
+///
+/// Decision matrix:
+///
+/// | Tier | macOS ≥ 26  | macOS < 26 / other OS |
+/// |------|-------------|-----------------------|
+/// | High | parakeet    | whisper-large-v3-turbo-quantized |
+/// | Mid  | parakeet    | whisper-large-v3-turbo-quantized |
+/// | Low  | whisper-tiny| whisper-tiny           |
+///
+/// Parakeet requires macOS 26+ for MLX Metal GPU support. On older macOS
+/// or non-Mac platforms, it crashes during model loading. Low-tier devices
+/// (≤8 GB) can't fit the 2.3 GB model regardless of OS version.
+pub fn best_engine_for_platform(tier: DeviceTier) -> &'static str {
+    if tier == DeviceTier::Low {
+        return "whisper-tiny";
+    }
+
+    let macos_ok = macos_major_version()
+        .map(|v| v >= PARAKEET_MIN_MACOS_MAJOR)
+        .unwrap_or(false);
+
+    if macos_ok {
+        "parakeet"
+    } else {
+        "whisper-large-v3-turbo-quantized"
+    }
+}
+
+/// Returns true if the given engine string is unsafe for the current platform.
+///
+/// An engine is unsafe if:
+/// - It's parakeet/parakeet-mlx on a Low-tier device (OOM crash)
+/// - It's parakeet/parakeet-mlx on macOS < 26 (segfault during Metal init)
+/// - It's parakeet/parakeet-mlx on a non-macOS platform (no MLX support)
+pub fn is_engine_unsafe(engine: &str, tier: DeviceTier) -> bool {
+    let is_parakeet = engine == "parakeet" || engine == "parakeet-mlx";
+    if !is_parakeet {
+        return false;
+    }
+
+    if tier == DeviceTier::Low {
+        return true;
+    }
+
+    let macos_ok = macos_major_version()
+        .map(|v| v >= PARAKEET_MIN_MACOS_MAJOR)
+        .unwrap_or(false);
+
+    !macos_ok
+}
+
 /// Apply platform-specific defaults to a `RecordingSettings`.
 ///
 /// Called once when creating default settings. Sets values that differ
@@ -209,7 +282,10 @@ pub fn apply_platform_defaults(settings: &mut RecordingSettings) {
 ///
 /// Called once on first launch after hardware detection. Adjusts capture
 /// aggressiveness based on what the hardware can handle comfortably.
+/// Also picks the best audio engine for the device tier and macOS version.
 pub fn apply_tier_defaults(settings: &mut RecordingSettings, tier: DeviceTier) {
+    settings.audio_transcription_engine = best_engine_for_platform(tier).to_string();
+
     match tier {
         DeviceTier::High => {
             settings.video_quality = "balanced".to_string();
@@ -222,7 +298,6 @@ pub fn apply_tier_defaults(settings: &mut RecordingSettings, tier: DeviceTier) {
         DeviceTier::Low => {
             settings.video_quality = "low".to_string();
             settings.power_mode = Some("battery_saver".to_string());
-            settings.audio_transcription_engine = "whisper-tiny".to_string();
         }
     }
 }
@@ -244,6 +319,7 @@ mod tests {
         apply_tier_defaults(&mut settings, DeviceTier::Low);
         assert_eq!(settings.video_quality, "low");
         assert_eq!(settings.power_mode.as_deref(), Some("battery_saver"));
+        assert_eq!(settings.audio_transcription_engine, "whisper-tiny");
     }
 
     #[test]
@@ -252,6 +328,19 @@ mod tests {
         let default_quality = settings.video_quality.clone();
         apply_tier_defaults(&mut settings, DeviceTier::High);
         assert_eq!(settings.video_quality, default_quality);
+    }
+
+    #[test]
+    fn best_engine_low_tier_always_whisper_tiny() {
+        assert_eq!(best_engine_for_platform(DeviceTier::Low), "whisper-tiny");
+    }
+
+    #[test]
+    fn parakeet_unsafe_on_low_tier() {
+        assert!(is_engine_unsafe("parakeet", DeviceTier::Low));
+        assert!(is_engine_unsafe("parakeet-mlx", DeviceTier::Low));
+        assert!(!is_engine_unsafe("whisper-tiny", DeviceTier::Low));
+        assert!(!is_engine_unsafe("whisper-large-v3-turbo-quantized", DeviceTier::High));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -441,6 +441,22 @@ impl RecordArgs {
             }
         }
 
+        // Safety guard: downgrade engine if unsafe for this platform
+        // (Low tier = OOM, macOS < 26 = parakeet-mlx segfault)
+        let tier = settings
+            .device_tier
+            .as_deref()
+            .and_then(screenpipe_config::DeviceTier::from_str_loose)
+            .unwrap_or_else(screenpipe_config::detect_tier);
+        if screenpipe_config::is_engine_unsafe(&settings.audio_transcription_engine, tier) {
+            let safe = screenpipe_config::best_engine_for_platform(tier);
+            eprintln!(
+                "warning: {} is not supported on this platform, using {} instead",
+                settings.audio_transcription_engine, safe
+            );
+            settings.audio_transcription_engine = safe.to_string();
+        }
+
         crate::recording_config::RecordingConfig::from_settings(&settings, data_dir, None)
     }
 }


### PR DESCRIPTION
## Summary
- Parakeet-mlx requires **macOS 26+** (Tahoe) for MLX Metal GPU support — crashes on older macOS (segfault during model loading)
- Also OOM-kills **8GB machines** regardless of OS (2.3GB model too large)
- Adds centralized engine safety logic that picks the right engine based on both tier and macOS version

Supersedes #2607 which only handled the Low tier case.

## Changes
**`screenpipe-config/src/defaults.rs`** — new functions:
- `best_engine_for_platform(tier)` — picks the best safe engine
- `is_engine_unsafe(engine, tier)` — checks if an engine would crash
- `macos_major_version()` — detects OS version via `sw_vers`
- `apply_tier_defaults()` now uses `best_engine_for_platform()`

**Decision matrix:**
| Tier | macOS ≥ 26 | macOS < 26 / other OS |
|------|------------|----------------------|
| High | parakeet | whisper-large-v3-turbo-quantized |
| Mid | parakeet | whisper-large-v3-turbo-quantized |
| Low | whisper-tiny | whisper-tiny |

**`store.rs`** (Tauri app) — unconditional startup guard replaces the old tier-change-only check. Runs every launch.

**`cli/mod.rs`** — safety check before starting recording. Prints warning if engine is downgraded.

## Test plan
- [ ] 8GB Mac, any macOS → engine forced to whisper-tiny
- [ ] 16GB+ Mac, macOS 26+ → parakeet works
- [ ] 16GB+ Mac, macOS 15.x → engine forced to whisper-large-v3-turbo-quantized
- [ ] Linux/Windows → whisper-large-v3-turbo-quantized (no MLX support)
- [ ] `cargo test -p screenpipe-config` — all 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)