### PR TITLE
fix: ignore send error when stopping stream on disconnected device

### DIFF
--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, oneshot};
 use tokio::task::LocalSet;
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
 use crate::utils::audio::audio_to_mono;
@@ -230,9 +230,9 @@ fn create_error_callback(
                 "audio device {} disconnected. stopping recording.",
                 device_name
             );
-            stream_control_tx
-                .send(StreamControl::Stop(oneshot::channel().0))
-                .unwrap();
+            if let Err(e) = stream_control_tx.send(StreamControl::Stop(oneshot::channel().0)) {
+                debug!("failed to send stop signal on device disconnect: {}", e);
+            }
             is_disconnected.store(true, Ordering::Relaxed);
         } else {
             error!("an error occurred on the audio stream: {}", err);


### PR DESCRIPTION
## Problem
App crashes with panic: `called Result::unwrap() on an Err value: SendError` when a USB audio device is unplugged or disconnected abruptly.

## Root cause
In `crates/screenpipe-audio/src/core/stream.rs`, the stream error callback tries to send a stop signal over `stream_control_tx`, but unwraps the result. If the device was abruptly disconnected and the receiver was already dropped, this causes an immediate panic.

## Fix
Replaced `.unwrap()` with a graceful `if let Err(e) = stream_control_tx.send(...)` check that logs a debug message instead of panicking.

## Confidence: 9/10

## Verification
```

```

---
auto-generated by issue-solver pipe