### PR TITLE
fix: prevent launch crash on macOS 14 with parakeet-mlx

### DIFF
--- a/crates/screenpipe-apple-intelligence/build.rs
+++ b/crates/screenpipe-apple-intelligence/build.rs
@@ -123,7 +123,7 @@ char* fm_supported_languages(void) { return make_string("[]"); }
             "-sdk",
             &sdk_path,
             "-target",
-            "arm64-apple-macos26.0",
+            "arm64-apple-macos14.0",
             "-O",
             "-whole-module-optimization",
             "-o",

--- a/crates/screenpipe-apple-intelligence/swift/bridge.swift
+++ b/crates/screenpipe-apple-intelligence/swift/bridge.swift
@@ -4,9 +4,12 @@
 // screenpipe-apple-intelligence Swift bridge
 // Provides C-callable functions that wrap Apple's Foundation Models framework.
 // Compiled by build.rs → linked into the Rust crate.
+//
+// NOTE: compiled with -target arm64-apple-macos14.0 so the binary can launch
+// on macOS 14+. All FoundationModels usage is gated behind @available(macOS 26, *).
 
 import Foundation
-import FoundationModels
+@preconcurrency import FoundationModels
 
 // MARK: - Memory helpers
 
@@ -25,57 +28,204 @@ private func makeCString(_ str: String) -> UnsafeMutablePointer<CChar> {
     return strdup(str)!
 }
 
-// MARK: - Exported C functions
+// MARK: - macOS 26+ implementation
 
-/// Check if Foundation Models is available.
-/// Returns status code: 0=available, 1=not enabled, 2=not eligible, 3=not ready, 4=unknown
-/// Writes reason string to `out_reason` (caller must free with fm_free_string).
+@available(macOS 26, *)
+private enum FM {
+    static func checkAvailability(
+        _ out_reason: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
+    ) -> Int32 {
+        let model = SystemLanguageModel.default
+
+        switch model.availability {
+        case .available:
+            out_reason.pointee = makeCString("available")
+            return 0
+        case .unavailable(let reason):
+            switch reason {
+            case .appleIntelligenceNotEnabled:
+                out_reason.pointee = makeCString("Apple Intelligence is not enabled")
+                return 1
+            case .deviceNotEligible:
+                out_reason.pointee = makeCString("Device not eligible for Apple Intelligence")
+                return 2
+            case .modelNotReady:
+                out_reason.pointee = makeCString("Model not ready (still downloading or configuring)")
+                return 3
+            @unknown default:
+                out_reason.pointee = makeCString("Unknown unavailability reason")
+                return 4
+            }
+        }
+    }
+
+    static func generateText(
+        _ instructions: UnsafePointer<CChar>?,
+        _ prompt: UnsafePointer<CChar>?,
+        _ out_text: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+        _ out_error: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+        _ out_total_time_ms: UnsafeMutablePointer<Double>,
+        _ out_mem_before: UnsafeMutablePointer<UInt64>,
+        _ out_mem_after: UnsafeMutablePointer<UInt64>
+    ) -> Int32 {
+        guard let prompt = prompt else {
+            out_error.pointee = makeCString("prompt is null")
+            return -1
+        }
+
+        let promptStr = String(cString: prompt)
+        let instructionsStr = instructions.map { String(cString: $0) }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var status: Int32 = 0
+
+        Task {
+            let memBefore = getResidentMemory()
+            out_mem_before.pointee = memBefore
+            let startTime = ContinuousClock.now
+
+            do {
+                let session: LanguageModelSession
+                if let inst = instructionsStr {
+                    session = LanguageModelSession(instructions: inst)
+                } else {
+                    session = LanguageModelSession()
+                }
+
+                let response = try await session.respond(to: promptStr)
+                let totalDuration = ContinuousClock.now - startTime
+                let memAfter = getResidentMemory()
+
+                out_text.pointee = makeCString(response.content)
+                out_total_time_ms.pointee = Double(totalDuration.components.seconds) * 1000.0
+                    + Double(totalDuration.components.attoseconds) / 1_000_000_000_000_000.0
+                out_mem_after.pointee = memAfter
+                status = 0
+            } catch {
+                out_error.pointee = makeCString(error.localizedDescription)
+                status = -1
+            }
+
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return status
+    }
+
+    static func generateJson(
+        _ instructions: UnsafePointer<CChar>?,
+        _ prompt: UnsafePointer<CChar>?,
+        _ jsonSchema: UnsafePointer<CChar>?,
+        _ out_text: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+        _ out_error: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>,
+        _ out_total_time_ms: UnsafeMutablePointer<Double>,
+        _ out_mem_before: UnsafeMutablePointer<UInt64>,
+        _ out_mem_after: UnsafeMutablePointer<UInt64>
+    ) -> Int32 {
+        guard let prompt = prompt else {
+            out_error.pointee = makeCString("prompt is null")
+            return -1
+        }
+        guard let jsonSchema = jsonSchema else {
+            out_error.pointee = makeCString("jsonSchema is null")
+            return -1
+        }
+
+        let promptStr = String(cString: prompt)
+        let instructionsStr = instructions.map { String(cString: $0) }
+        let schemaStr = String(cString: jsonSchema)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var status: Int32 = 0
+
+        Task {
+            let memBefore = getResidentMemory()
+            out_mem_before.pointee = memBefore
+            let startTime = ContinuousClock.now
+
+            do {
+                guard let schemaData = Data(schemaStr.utf8) as Data? else {
+                    out_error.pointee = makeCString("Failed to encode schema as UTF-8")
+                    status = -1
+                    semaphore.signal()
+                    return
+                }
+
+                let schemaObj = try JSONDecoder().decode(GenerationSchema.self, from: schemaData)
+
+                let session: LanguageModelSession
+                if let inst = instructionsStr {
+                    session = LanguageModelSession(instructions: inst)
+                } else {
+                    session = LanguageModelSession()
+                }
+
+                let response = try await session.respond(
+                    to: promptStr,
+                    schema: schemaObj
+                )
+
+                let totalDuration = ContinuousClock.now - startTime
+                let memAfter = getResidentMemory()
+
+                let jsonStr = response.content.jsonString
+
+                out_text.pointee = makeCString(jsonStr)
+                out_total_time_ms.pointee = Double(totalDuration.components.seconds) * 1000.0
+                    + Double(totalDuration.components.attoseconds) / 1_000_000_000_000_000.0
+                out_mem_after.pointee = memAfter
+                status = 0
+            } catch {
+                out_error.pointee = makeCString(error.localizedDescription)
+                status = -1
+            }
+
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        return status
+    }
+
+    static func prewarm() -> Int32 {
+        let model = SystemLanguageModel.default
+        guard model.availability == .available else { return -1 }
+
+        let session = LanguageModelSession()
+        session.prewarm()
+        return 0
+    }
+
+    static func supportedLanguages() -> UnsafeMutablePointer<CChar> {
+        let model = SystemLanguageModel.default
+        let langs = model.supportedLanguages.map { $0.languageCode?.identifier ?? "unknown" }
+        guard let data = try? JSONEncoder().encode(langs) else {
+            return makeCString("[]")
+        }
+        let str = String(decoding: data, as: UTF8.self)
+        return makeCString(str)
+    }
+}
+
+// MARK: - Exported C functions (available on all macOS versions)
+
 @_cdecl("fm_check_availability")
 public func fmCheckAvailability(
     _ out_reason: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>
 ) -> Int32 {
-    let model = SystemLanguageModel.default
-
-    switch model.availability {
-    case .available:
-        out_reason.pointee = makeCString("available")
-        return 0
-    case .unavailable(let reason):
-        switch reason {
-        case .appleIntelligenceNotEnabled:
-            out_reason.pointee = makeCString("Apple Intelligence is not enabled")
-            return 1
-        case .deviceNotEligible:
-            out_reason.pointee = makeCString("Device not eligible for Apple Intelligence")
-            return 2
-        case .modelNotReady:
-            out_reason.pointee = makeCString("Model not ready (still downloading or configuring)")
-            return 3
-        @unknown default:
-            out_reason.pointee = makeCString("Unknown unavailability reason")
-            return 4
-        }
+    if #available(macOS 26, *) {
+        return FM.checkAvailability(out_reason)
     }
+    out_reason.pointee = makeCString("macOS 26 or later required for Apple Intelligence")
+    return 4
 }
 
-/// Free a string allocated by the Swift side.
 @_cdecl("fm_free_string")
 public func fmFreeString(_ ptr: UnsafeMutablePointer<CChar>?) {
     if let ptr = ptr { free(ptr) }
 }
 
-/// Generate a plain text response from a prompt.
-///
-/// Parameters:
-///   - instructions: system instructions (nullable)
-///   - prompt: user prompt (required)
-///   - out_text: receives response text (caller frees)
-///   - out_error: receives error message on failure (caller frees)
-///   - out_total_time_ms: receives total generation time
-///   - out_mem_before: receives resident memory before (bytes)
-///   - out_mem_after: receives resident memory after (bytes)
-///
-/// Returns 0 on success, -1 on error.
 @_cdecl("fm_generate_text")
 public func fmGenerateText(
     _ instructions: UnsafePointer<CChar>?,
@@ -86,58 +236,13 @@ public func fmGenerateText(
     _ out_mem_before: UnsafeMutablePointer<UInt64>,
     _ out_mem_after: UnsafeMutablePointer<UInt64>
 ) -> Int32 {
-    guard let prompt = prompt else {
-        out_error.pointee = makeCString("prompt is null")
-        return -1
+    if #available(macOS 26, *) {
+        return FM.generateText(instructions, prompt, out_text, out_error, out_total_time_ms, out_mem_before, out_mem_after)
     }
-
-    let promptStr = String(cString: prompt)
-    let instructionsStr = instructions.map { String(cString: $0) }
-
-    let semaphore = DispatchSemaphore(value: 0)
-    var status: Int32 = 0
-
-    Task {
-        let memBefore = getResidentMemory()
-        out_mem_before.pointee = memBefore
-        let startTime = ContinuousClock.now
-
-        do {
-            let session: LanguageModelSession
-            if let inst = instructionsStr {
-                session = LanguageModelSession(instructions: inst)
-            } else {
-                session = LanguageModelSession()
-            }
-
-            let response = try await session.respond(to: promptStr)
-            let totalDuration = ContinuousClock.now - startTime
-            let memAfter = getResidentMemory()
-
-            out_text.pointee = makeCString(response.content)
-            out_total_time_ms.pointee = Double(totalDuration.components.seconds) * 1000.0
-                + Double(totalDuration.components.attoseconds) / 1_000_000_000_000_000.0
-            out_mem_after.pointee = memAfter
-            status = 0
-        } catch {
-            out_error.pointee = makeCString(error.localizedDescription)
-            status = -1
-        }
-
-        semaphore.signal()
-    }
-
-    semaphore.wait()
-    return status
+    out_error.pointee = makeCString("macOS 26 or later required for Apple Intelligence")
+    return -1
 }
 
-/// Generate a structured JSON response using a JSON schema string.
-///
-/// The schema constrains the model output. The response is a JSON string
-/// derived from GeneratedContent's debug description (since GeneratedContent
-/// is not directly Encodable).
-///
-/// Returns 0 on success, -1 on error.
 @_cdecl("fm_generate_json")
 public func fmGenerateJson(
     _ instructions: UnsafePointer<CChar>?,
@@ -149,94 +254,25 @@ public func fmGenerateJson(
     _ out_mem_before: UnsafeMutablePointer<UInt64>,
     _ out_mem_after: UnsafeMutablePointer<UInt64>
 ) -> Int32 {
-    guard let prompt = prompt else {
-        out_error.pointee = makeCString("prompt is null")
-        return -1
+    if #available(macOS 26, *) {
+        return FM.generateJson(instructions, prompt, jsonSchema, out_text, out_error, out_total_time_ms, out_mem_before, out_mem_after)
     }
-    guard let jsonSchema = jsonSchema else {
-        out_error.pointee = makeCString("jsonSchema is null")
-        return -1
-    }
-
-    let promptStr = String(cString: prompt)
-    let instructionsStr = instructions.map { String(cString: $0) }
-    let schemaStr = String(cString: jsonSchema)
-
-    let semaphore = DispatchSemaphore(value: 0)
-    var status: Int32 = 0
-
-    Task {
-        let memBefore = getResidentMemory()
-        out_mem_before.pointee = memBefore
-        let startTime = ContinuousClock.now
-
-        do {
-            guard let schemaData = schemaStr.data(using: .utf8) else {
-                out_error.pointee = makeCString("Failed to encode schema as UTF-8")
-                status = -1
-                semaphore.signal()
-                return
-            }
-
-            let schemaObj = try JSONDecoder().decode(GenerationSchema.self, from: schemaData)
-
-            let session: LanguageModelSession
-            if let inst = instructionsStr {
-                session = LanguageModelSession(instructions: inst)
-            } else {
-                session = LanguageModelSession()
-            }
-
-            let response = try await session.respond(
-                to: promptStr,
-                schema: schemaObj
-            )
-
-            let totalDuration = ContinuousClock.now - startTime
-            let memAfter = getResidentMemory()
-
-            // GeneratedContent has a built-in .jsonString property
-            let jsonStr = response.content.jsonString
-
-            out_text.pointee = makeCString(jsonStr)
-            out_total_time_ms.pointee = Double(totalDuration.components.seconds) * 1000.0
-                + Double(totalDuration.components.attoseconds) / 1_000_000_000_000_000.0
-            out_mem_after.pointee = memAfter
-            status = 0
-        } catch {
-            out_error.pointee = makeCString(error.localizedDescription)
-            status = -1
-        }
-
-        semaphore.signal()
-    }
-
-    semaphore.wait()
-    return status
+    out_error.pointee = makeCString("macOS 26 or later required for Apple Intelligence")
+    return -1
 }
 
-// No manual JSON conversion needed — GeneratedContent has .jsonString built-in
-
-/// Prewarm the model (loads assets into memory). Blocking call.
-/// Returns 0 on success, non-zero on error.
 @_cdecl("fm_prewarm")
 public func fmPrewarm() -> Int32 {
-    let model = SystemLanguageModel.default
-    guard model.availability == .available else { return -1 }
-
-    let session = LanguageModelSession()
-    session.prewarm()
-    return 0
+    if #available(macOS 26, *) {
+        return FM.prewarm()
+    }
+    return -1
 }
 
-/// Get supported languages as a JSON array string. Caller must free.
 @_cdecl("fm_supported_languages")
 public func fmSupportedLanguages() -> UnsafeMutablePointer<CChar> {
-    let model = SystemLanguageModel.default
-    let langs = model.supportedLanguages.map { $0.languageCode?.identifier ?? "unknown" }
-    guard let data = try? JSONEncoder().encode(langs),
-          let str = String(data: data, encoding: .utf8) else {
-        return makeCString("[]")
+    if #available(macOS 26, *) {
+        return FM.supportedLanguages()
     }
-    return makeCString(str)
+    return makeCString("[]")
 }


### PR DESCRIPTION
## Summary
- App crashes at launch on macOS 14 (Sonoma) with `Symbol not found: String.data(using:allowLossyConversion:)` in Foundation
- Root cause: apple-intelligence Swift bridge compiled with `-target arm64-apple-macos26.0` emits Foundation symbols that don't exist on macOS 14
- This only started happening when `parakeet-mlx` feature was added to CI builds, changing linker symbol resolution

## Changes
- Compile Swift bridge with `-target arm64-apple-macos14.0` instead of `arm64-apple-macos26.0`
- Gate all FoundationModels usage behind `@available(macOS 26, *)` runtime checks
- Replace `String.data(using:)` / `String(data:encoding:)` with `Data(str.utf8)` / `String(decoding:as:)` to avoid macOS 15+ only Foundation symbols

## Test plan
- [ ] Verify app launches on macOS 14 (Sonoma)
- [ ] Verify Apple Intelligence still works on macOS 26
- [ ] Verify `nm` shows no `sSS10FoundationE4data` undefined symbols in the static lib

🤖 Generated with [Claude Code](https://claude.com/claude-code)