### PR TITLE
fix: handle closed channel in audio stream error callback

### DIFF
--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -230,9 +230,15 @@ fn create_error_callback(
                 "audio device {} disconnected. stopping recording.",
                 device_name
             );
-            stream_control_tx
+            if stream_control_tx
                 .send(StreamControl::Stop(oneshot::channel().0))
-                .unwrap();
+                .is_err()
+            {
+                warn!(
+                    "stream control channel closed for {}, stream already stopping",
+                    device_name
+                );
+            }
             is_disconnected.store(true, Ordering::Relaxed);
         } else {
             error!("an error occurred on the audio stream: {}", err);


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` with graceful `.is_err()` check + `warn!` log in the audio device-disconnected error callback (`create_error_callback` in `crates/screenpipe-audio/src/core/stream.rs`)
- The `mpsc::Sender::send()` can fail with `SendError` when the receiver is already dropped (stream stopping concurrently), which caused a panic on an unnamed thread

## Root Cause
When an audio device disconnects, `cpal` fires the error callback which tries to send `StreamControl::Stop` over the `stream_control_tx` channel.  If the `AudioStream` is already being dropped or the receiving thread has exited, the channel receiver is gone and `.unwrap()` panics.

Closes #2621

## Test plan
- [x] Verify no other `.unwrap()` on channel sends exist in `screenpipe-audio`
- [ ] CI passes
- [ ] Disconnect an audio device while screenpipe is recording; confirm graceful shutdown instead of panic