### PR TITLE
fix: prevent mid-response exit for screenpipe-cloud models

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -866,6 +866,7 @@ export function AIProviderConfig({
 
         {showAdvanced && (
           <div className="space-y-1.5">
+            {selectedProvider !== "screenpipe-cloud" && (
             <div className="space-y-1">
               <Label htmlFor="maxTokens" className="text-xs">max output tokens</Label>
               <Input
@@ -881,6 +882,7 @@ export function AIProviderConfig({
                 className="h-6 text-[10px]"
               />
             </div>
+            )}
             <div className="space-y-1">
               <Label htmlFor="prompt" className="text-xs">prompt</Label>
               <Textarea
@@ -956,9 +958,14 @@ export const AIPresetDialog = ({
       model: providerData.model,  // Fixed: was providerData.modelName
       id: providerData.id,
       maxContextChars: providerData.maxContextChars,
-      maxTokens: (providerData as any).maxTokens ?? 4096,
       prompt: providerData.prompt,
     };
+
+    // Screenpipe Cloud: max output is defined per model in the gateway catalog (see screenpipe_cloud_models in Rust).
+    // Do not persist or override maxTokens from this dialog — avoids defaulting to 4096 and matches Settings.
+    if (providerData.provider !== "screenpipe-cloud") {
+      (newPreset as any).maxTokens = (providerData as any).maxTokens ?? 4096;
+    }
 
     // Add apiKey for providers that require it
     if (
@@ -979,7 +986,9 @@ export const AIPresetDialog = ({
         url: preset.url,
         model: preset.model,
         maxContextChars: preset.maxContextChars,
-        maxTokens: (preset as any).maxTokens ?? 4096,
+        ...(preset.provider !== "screenpipe-cloud"
+          ? { maxTokens: (preset as any).maxTokens ?? 4096 }
+          : {}),
         prompt: preset.prompt,
         defaultPreset: preset.defaultPreset,
         apiKey: preset.apiKey || null,

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -445,11 +445,13 @@ const AISection = ({
   useEffect(() => {
     const model = settingsPreset?.model;
     if (!model) return;
+    // Screenpipe Cloud uses per-model max output from the gateway catalog — do not infer from model name.
+    if (settingsPreset?.provider === "screenpipe-cloud") return;
     const tokens = getDefaultMaxTokens(model);
     if (tokens && (settingsPreset as any)?.maxTokens !== tokens) {
       updateSettingsPreset({ maxTokens: tokens } as any);
     }
-  }, [settingsPreset?.model]);
+  }, [settingsPreset?.model, settingsPreset?.provider, getDefaultMaxTokens, updateSettingsPreset]);
 
   const handleCustomPromptChange = useCallback((value: string, isValid: boolean) => {
     updateSettingsPreset({ prompt: value });


### PR DESCRIPTION
## Summary
Fixes an issue where responses would terminate prematurely when using Screenpipe Cloud models.

## Why
Screenpipe Cloud models define their own `maxTokens` in the backend catalog.

Previously:
- The UI and preset flow defaulted `maxTokens` to `4096`
- This overrode higher model limits (e.g. 32k / 65k)
- Responses were cut off early, causing mid-response exits





# Before

<img width="728" height="812" alt="image" src="https://github.com/user-attachments/assets/511afb9f-96db-41ba-ba87-d2cb6d6102b8" />


# After 


https://github.com/user-attachments/assets/549ce5c8-dba7-43fc-8f2c-cfdf8447cbce


