### PR TITLE
fix: use tauriFetch for localhost custom AI preset diagnostics

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -106,6 +106,16 @@ const formatPresetName = (name: string): string => {
   return name;
 };
 
+const isLocalhostUrl = (url?: string): boolean => {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+};
+
 type DiagnosticStatus = "pass" | "fail" | "skip" | "pending" | "running";
 
 interface DiagnosticStepResult {
@@ -585,7 +595,11 @@ const AISection = ({
         chat: { status: "running", message: "Sending test message..." },
       }));
     } else {
-      const modelsFetchFn = fetch;
+      // Local custom providers often do not implement browser CORS preflight on /models.
+      const modelsFetchFn =
+        settingsPreset?.provider === "custom" && isLocalhostUrl(settingsPreset?.url)
+          ? tauriFetch
+          : fetch;
       try {
         modelsResponse = await modelsFetchFn(modelsUrl, {
           headers,
@@ -832,7 +846,8 @@ const AISection = ({
           break;
         case "custom":
           try {
-            const customResponse = await fetch(
+            const customFetchFn = isLocalhostUrl(settingsPreset?.url) ? tauriFetch : fetch;
+            const customResponse = await customFetchFn(
               `${settingsPreset?.url}/models`,
               {
                 headers: settingsPreset.apiKey


### PR DESCRIPTION
## Summary
Fixes Custom AI preset Connection Test failures for local OpenAI-compatible servers (for example LM Studio on `localhost`) caused by browser CORS preflight.

## Root Cause
`runDiagnostics()` used browser `fetch` for `GET /models`. For local custom providers with auth headers, browser `fetch` can trigger an `OPTIONS` preflight, and many local servers do not implement that route.

## Changes
- Added `isLocalhostUrl(url)` helper.
- In `runDiagnostics()`, use `tauriFetch` for `/models` when provider is `custom` and URL host is loopback (`localhost`, `127.0.0.1`, `::1`).
- Applied the same localhost-aware `tauriFetch` behavior in custom model loading (`fetchModels` custom provider path).

## Impact
- Local custom Connection Test now uses native HTTP and avoids false negatives from CORS preflight.
- Non-local custom endpoints keep existing browser `fetch` behavior.

## Validation
- PASS: `bunx tsc --noEmit --pretty false` (in `apps/screenpipe-app-tauri`)
- NOTE: `bun run test` fails in current repo baseline for unrelated existing tests (including `bun:test` resolution and unrelated assertions in `clean-pipe-stdout`, `text-overlay`, `use-frame-ocr-data`).

Closes #2667
