### PR TITLE
feat: make DRM full pipeline stop opt-in (default off)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -313,10 +313,6 @@ pub async fn start_health_check(app: tauri::AppHandle) -> Result<()> {
     let mut consecutive_failures: u32 = 0;
     let mut consecutive_unhealthy: u32 = 0;
 
-    // DRM pause state — tracked here because engine memory is lost on stop_screenpipe
-    let mut drm_stopped = false;
-    let mut drm_stop_time: Option<Instant> = None;
-
     // Capture stall detection state
     let mut consecutive_audio_stall: u32 = 0;
     let mut consecutive_vision_stall: u32 = 0;
@@ -473,60 +469,6 @@ pub async fn start_health_check(app: tauri::AppHandle) -> Result<()> {
                         consecutive_vision_stall = 0;
                     }
                     last_known_spawn_epoch = current_epoch;
-                }
-            }
-
-            // ── DRM content pause / resume ──
-            // When the engine detects DRM streaming content (Netflix, etc.),
-            // stop the entire recording pipeline — exactly like the "stop recording"
-            // button. This fully releases ScreenCaptureKit so DRM doesn't black out.
-            //
-            // IMPORTANT: Stop and start are serialized — we never emit start in the
-            // same iteration as stop, and we enforce a cooldown between DRM stop and
-            // DRM resume to prevent the rapid stop/start race that killed the server.
-            if let Ok(ref health) = health_result {
-                if health.drm_content_paused && !drm_stopped {
-                    info!("DRM content detected — calling stop_screenpipe to fully release screen recording");
-                    let _ = app.emit("shortcut-stop-recording", ());
-                    drm_stopped = true;
-                    drm_stop_time = Some(Instant::now());
-                    // Skip resume check this iteration — let the stop complete first
-                }
-            }
-            // Auto-resume: when server is down due to DRM, poll the focused app.
-            // Wait at least 5s after stop to let shutdown complete before attempting restart.
-            if drm_stopped {
-                let stop_elapsed = drm_stop_time.map(|t| t.elapsed()).unwrap_or_default();
-                if stop_elapsed < Duration::from_secs(5) {
-                    debug!(
-                        "DRM stop cooldown: {:.1}s elapsed, waiting for 5s before resume check",
-                        stop_elapsed.as_secs_f64()
-                    );
-                } else {
-                    let should_resume = tokio::task::spawn_blocking(|| {
-                        // poll_drm_clear returns true = still DRM, false = cleared
-                        !screenpipe_engine::drm_detector::poll_drm_clear()
-                    })
-                    .await
-                    .unwrap_or(false);
-                    if should_resume {
-                        info!("DRM content no longer focused — auto-restarting recording");
-                        let _ = app.emit("shortcut-start-recording", ());
-                        drm_stopped = false;
-                        drm_stop_time = None;
-                        // Give the server time to start before checking health again
-                        last_restart_triggered = Some(Instant::now());
-                    }
-                }
-            }
-            // Clear drm_stopped if server came back and DRM flag is no longer set
-            // (e.g. user manually started recording or toggled the setting off)
-            if drm_stopped && health_result.is_ok() {
-                if let Ok(ref health) = health_result {
-                    if !health.drm_content_paused {
-                        drm_stopped = false;
-                        drm_stop_time = None;
-                    }
                 }
             }
 

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -134,8 +134,9 @@ pub struct RecordingSettings {
     #[serde(rename = "ignoreIncognitoWindows")]
     pub ignore_incognito_windows: bool,
 
-    /// Pause all screen capture when a DRM streaming app (Netflix, etc.) is focused.
-    #[serde(rename = "pauseOnDrmContent", default = "default_true")]
+    /// Experimental: pause screen capture when a DRM streaming app or site is focused.
+    /// Off by default; engine-only pause (no full app shutdown).
+    #[serde(rename = "pauseOnDrmContent", default)]
     pub pause_on_drm_content: bool,
 
     /// Languages for transcription (ISO 639-1 codes).
@@ -292,7 +293,7 @@ impl Default for RecordingSettings {
             included_windows: vec![],
             ignored_urls: vec![],
             ignore_incognito_windows: true,
-            pause_on_drm_content: true,
+            pause_on_drm_content: false,
             languages: vec![],
             use_pii_removal: false,
             user_id: String::new(),
@@ -343,6 +344,7 @@ mod tests {
         assert_eq!(settings.video_quality, "balanced");
         assert!(settings.use_system_default_audio);
         assert!(settings.ignore_incognito_windows);
+        assert!(!settings.pause_on_drm_content);
     }
 
     #[test]


### PR DESCRIPTION
DRM detection previously triggered stop_screenpipe from the health loop, tearing down the embedded server and breaking timeline/API WebSockets. The engine already pauses capture without that.

- Add fullPipelineStopOnDrm to RecordingSettings (default false)
- Gate health.rs DRM stop on the setting
- Privacy UI: optional toggle under pause for streaming apps

# Before

<img width="1231" height="836" alt="2026-04-02_21-12-36" src="https://github.com/user-attachments/assets/0b20a8bd-fcc4-4798-a974-42c4fa1e1769" />


```
2026-04-02T15:41:58.490327Z  INFO screenpipe_engine::drm_detector: pre-capture DRM check: browser 'Safari' on DRM URL https://play.max.com — blocking
2026-04-02T15:41:58.490354Z  INFO screenpipe_engine::drm_detector: DRM content detected — pausing screen capture
2026-04-02T15:41:59.043134Z  INFO screenpipe_app::health: DRM content detected — calling stop_screenpipe to fully release screen recording
2026-04-02T15:41:59.043848Z  INFO screenpipe_app::recording: Stopping screenpipe server
2026-04-02T15:42:00.161762Z  INFO screenpipe_app::recording: Screenpipe server stopped
2026-04-02T15:42:00.162127Z  INFO screenpipe_app: Server handle removed from state, shutting down server thread
2026-04-02T15:42:02.292368Z  WARN screenpipe_app::commands: [webview] timeline WebSocket: server unreachable, retrying silently...
2026-04-02T15:42:02.292405Z  WARN screenpipe_app::commands: [webview] health WebSocket: server unreachable, retrying silently...
```




# After 
<img width="1236" height="831" alt="image" src="https://github.com/user-attachments/assets/5b194a6b-4409-4d1e-a8cd-e204bd7aafb9" />


