### PR TITLE
fix(analytics): downgrade backend-unavailable health check errors to warn to suppress Sentry noise

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -244,13 +244,23 @@ impl AnalyticsManager {
                 let health_status = match self.check_recording_health().await {
                     Ok(status) => status,
                     Err(e) => {
-                        error!("failed to check recording health: {}", e);
+                        // Connection errors are expected when the backend hasn't started yet;
+                        // downgrade to warn so Sentry doesn't treat startup races as errors.
+                        let e_str = e.to_string();
+                        if e_str.contains("error sending request")
+                            || e_str.contains("Connection refused")
+                            || e_str.contains("os error")
+                        {
+                            warn!("backend not yet available for health check: {}", e_str);
+                        } else {
+                            error!("failed to check recording health: {}", e_str);
+                        }
                         json!({
                             "is_healthy": false,
                             "frame_status": "error",
                             "audio_status": "error",
                             "ui_status": "error",
-                            "error": e.to_string()
+                            "error": e_str
                         })
                     }
                 };
@@ -339,7 +349,12 @@ impl AnalyticsManager {
         &self,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
         let health_url = format!("{}/health", self.local_api_base_url);
-        let response = self.client.get(&health_url).send().await?;
+        let response = self
+            .client
+            .get(&health_url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await?;
 
         if !response.status().is_success() {
             return Ok(json!({


### PR DESCRIPTION
### Description:
When the screenpipe backend on port 3030 hasn't started yet (common at app startup), check_recording_health() propagates the connection error via ?, which hits error!() at line 247 — and Sentry captures every error! log.

<img width="1551" height="149" alt="image" src="https://github.com/user-attachments/assets/05155450-9c00-444c-99cc-53fa42b8e78e" />


  What changed:

  1. analytics.rs:244-257 — Connection/OS errors (expected during startup) are now logged at warn! level instead of
  error!, so Sentry stops treating them as issues. Genuine unexpected errors still use error!.
  2. analytics.rs:351-355 — Added a 5-second timeout to the health check request so it doesn't hang if the backend is
  slow to respond.

  The breadcrumbs confirm this is a startup race: the health check fires right after the recording data directory is
  set, before the backend has had time to bind to port 3030.