### PR TITLE
fix: Windows Specific calendar connection

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/calendar-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/calendar-card.tsx
@@ -56,7 +56,7 @@ interface CalendarEventItem {
   isAllDay: boolean;
 }
 
-export function CalendarCard() {
+export function CalendarCard({ onConnectionChange }: { onConnectionChange?: () => void } = {}) {
   const [os, setOs] = useState<string>("");
   const [enabled, setEnabled] = useState(false);
   const [authorized, setAuthorized] = useState(false);
@@ -160,6 +160,7 @@ export function CalendarCard() {
         setEnabled(true);
         await setCalendarPref(ENABLED_KEY, true);
         posthog.capture("calendar_authorized", { result: "granted" });
+        onConnectionChange?.();
         checkStatus();
       } else {
         setAuthDenied(true);
@@ -310,6 +311,7 @@ export function CalendarCard() {
                       setCalendarPref(STORE_KEY, true),
                       setCalendarPref(ENABLED_KEY, false),
                     ]);
+                    onConnectionChange?.();
                     posthog.capture("calendar_disconnected");
                   }}
                   className="text-xs text-muted-foreground hover:text-destructive h-7 px-2"

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -12,7 +12,7 @@ import { Label } from "@/components/ui/label";
 import { Download, ExternalLink, Check, Loader2, Copy, Terminal, LogIn, LogOut, Send, X, HelpCircle, Search, Calendar as CalendarIcon, Eye, EyeOff } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { commands } from "@/lib/utils/tauri";
-import { useSettings } from "@/lib/hooks/use-settings";
+import { useSettings, getStore } from "@/lib/hooks/use-settings";
 import { ensureChatGptPreset } from "@/lib/utils/chatgpt-preset";
 import { showChatWithPrefill } from "@/lib/chat-utils";
 import { Command } from "@tauri-apps/plugin-shell";
@@ -1389,6 +1389,17 @@ export function ConnectionsSection() {
   const [cursorInstalled, setCursorInstalled] = useState(false);
   const [chatgptConnected, setChatgptConnected] = useState(false);
   const [browserExtConnected, setBrowserExtConnected] = useState(false);
+  const [calendarUserDisconnected, setCalendarUserDisconnected] = useState(false);
+
+  const refreshCalendarTile = useCallback(() => {
+    getStore()
+      .then((store) => store.get<boolean>("calendarUserDisconnected"))
+      .then((val) => setCalendarUserDisconnected(val ?? false))
+      .catch(() => {});
+  }, []);
+
+  // Re-read on panel open/close and on explicit connect/disconnect
+  useEffect(() => { refreshCalendarTile(); }, [selected, refreshCalendarTile]);
 
   const refreshStatus = useCallback(() => {
     getInstalledMcpVersion().then(v => {
@@ -1474,8 +1485,11 @@ export function ConnectionsSection() {
       const api = integrations.find(i => i.id === h.id);
       if (api) h.connected = api.connected;
     }
+    // If user explicitly disconnected calendar, suppress the dot regardless of OS state
+    const calTile = hardcoded.find(h => h.id === "apple-calendar");
+    if (calTile && calendarUserDisconnected) calTile.connected = false;
     return [...hardcoded, ...apiTiles];
-  }, [os, claudeInstalled, cursorInstalled, chatgptConnected, browserExtConnected, integrations]);
+  }, [os, claudeInstalled, cursorInstalled, chatgptConnected, browserExtConnected, integrations, calendarUserDisconnected]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return allTiles;
@@ -1496,7 +1510,7 @@ export function ConnectionsSection() {
       case "browser-url": return <BrowserUrlCard />;
       case "voice-memos": return <VoiceMemosCard />;
       case "apple-intelligence": return <AppleIntelligenceCard />;
-      case "apple-calendar": return <CalendarCard />;
+      case "apple-calendar": return <CalendarCard onConnectionChange={refreshCalendarTile} />;
       case "google-calendar": return <GoogleCalendarCard />;
       case "ics-calendar": return <IcsCalendarCard />;
       case "openclaw": return <OpenClawCard />;


### PR DESCRIPTION
### Description

Fixes the Apple/Windows Calendar connection so that disconnecting is properly persisted across app restarts, and renames the connection to "Windows Calendar" on Windows since it reads from the Windows Calendar app, not Apple Calendar.
<img width="1425" height="124" alt="Screenshot 2026-04-04 131936" src="https://github.com/user-attachments/assets/17af62a3-2ecf-4f4b-a5ed-106c879054b4" />

- Before:  Why there is a Apple calendar Showing on Windows ?


https://github.com/user-attachments/assets/e77ee1c9-8bbc-4562-ad81-c068acfb20d8




- After: 


https://github.com/user-attachments/assets/39d02b41-07ff-4190-9e2c-ab249a62f70e



###  What changed

1) components/settings/calendar-card.tsx
  - Replaced all localStorage usage with Tauri's native store (~/.screenpipe/store.bin)
  - Added calendarUserDisconnected flag — when user clicks Disconnect, this is saved so the app doesn't auto-reconnect
  on next load even though the OS permission is still granted
  - Auto-migrates existing calendar-enabled value from localStorage to the store on first load

2) components/settings/connections-section.tsx
  - On Windows: shows "Windows Calendar" with a calendar icon instead of "Apple Calendar" with the Apple logo
  - On macOS: unchanged — still shows "Apple Calendar" with Apple logo