### PR TITLE
fix: remove unused base64 dependency from screenpipe-connect

### DIFF
--- a/crates/screenpipe-connect/Cargo.toml
+++ b/crates/screenpipe-connect/Cargo.toml
@@ -22,7 +22,6 @@ russh-sftp = "2.1"
 dirs = "6"
 chrono = "0.4"
 async-trait = "0.1"
-base64 = "0.22"
 once_cell = "1"
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"] }
 mdns-sd = "0.13"


### PR DESCRIPTION
## Summary
- remove unused `base64` dependency from `crates/screenpipe-connect/Cargo.toml`
- fix `cargo-machete` failure in CI for `screenpipe-connect`

## Root Cause
`base64` was declared as a direct dependency in `screenpipe-connect`, but there is no code usage of the crate in that package.

## Why this approach
Instead of suppressing the warning via `package.metadata.cargo-machete.ignored`, this removes the dead dependency directly and keeps dependency hygiene strict.

## Security / Maintenance Impact
- reduces dependency surface area
- avoids carrying an unnecessary direct crate in the supply chain

## Validation
- `cargo machete`
  - result: no unused dependencies reported
