### PR TITLE
fix: power profile jpeg_quality never applied to SnapshotWriter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6737,7 +6737,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -6797,7 +6797,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6980,7 +6980,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.3.255"
+version = "0.3.256"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -117,6 +117,12 @@ pub struct RecordingSettings {
     #[serde(rename = "videoQuality")]
     pub video_quality: String,
 
+    /// Maximum width for stored snapshots. Images wider than this are downscaled
+    /// (preserving aspect ratio) before JPEG encoding. 0 = no limit (store at
+    /// native resolution). Default: 1920.
+    #[serde(rename = "maxSnapshotWidth", default = "default_max_snapshot_width")]
+    pub max_snapshot_width: u32,
+
     // ── Filters ────────────────────────────────────────────────────────
     /// Window titles to exclude from capture.
     #[serde(rename = "ignoredWindows")]
@@ -288,6 +294,7 @@ impl Default for RecordingSettings {
             monitor_ids: vec![],
             use_all_monitors: true,
             video_quality: "balanced".to_string(),
+            max_snapshot_width: default_max_snapshot_width(),
             ignored_windows: vec![],
             included_windows: vec![],
             ignored_urls: vec![],
@@ -321,6 +328,10 @@ impl Default for RecordingSettings {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_max_snapshot_width() -> u32 {
+    1920
 }
 
 #[cfg(test)]

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -378,6 +378,7 @@ pub async fn event_driven_capture_loop(
                 state.config.min_capture_interval_ms = profile.min_capture_interval_ms;
                 state.config.idle_capture_interval_ms = profile.idle_capture_interval_ms;
                 state.config.jpeg_quality = profile.jpeg_quality;
+                snapshot_writer.set_quality(profile.jpeg_quality);
                 visual_check_interval = Duration::from_millis(profile.visual_check_interval_ms);
                 visual_change_threshold = profile.visual_change_threshold;
                 visual_check_enabled = profile.visual_check_interval_ms > 0;

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -106,6 +106,9 @@ pub struct RecordingConfig {
 
     /// Per-day schedule rules (only used when schedule_enabled is true).
     pub schedule_rules: Vec<screenpipe_config::ScheduleRule>,
+
+    /// Maximum width for stored snapshots (0 = no limit). Default: 1920.
+    pub max_snapshot_width: u32,
 }
 
 impl RecordingConfig {
@@ -192,6 +195,7 @@ impl RecordingConfig {
                 .unwrap_or_default(),
             schedule_enabled: settings.schedule_enabled,
             schedule_rules: settings.schedule_rules.clone(),
+            max_snapshot_width: settings.max_snapshot_width,
         }
     }
 
@@ -250,6 +254,7 @@ impl RecordingConfig {
             ignore_incognito_windows: self.ignore_incognito_windows,
             pause_on_drm_content: self.pause_on_drm_content,
             languages: self.languages.clone(),
+            max_snapshot_width: self.max_snapshot_width,
         }
     }
 }

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -39,6 +39,8 @@ pub struct VisionManagerConfig {
     pub pause_on_drm_content: bool,
     /// Languages for OCR recognition.
     pub languages: Vec<screenpipe_core::Language>,
+    /// Maximum width for stored snapshots (0 = no limit, store at native res).
+    pub max_snapshot_width: u32,
 }
 
 /// Status of the VisionManager
@@ -242,10 +244,17 @@ impl VisionManager {
         let output_path = self.config.output_path.clone();
         let device_name = format!("monitor_{}", monitor_id);
 
-        // Create snapshot writer for this monitor's data directory
+        // Create snapshot writer for this monitor's data directory.
+        // Use current power profile's JPEG quality instead of hardcoded 80.
+        let initial_jpeg_quality = self
+            .power_profile_rx
+            .as_ref()
+            .map(|rx| rx.borrow().jpeg_quality)
+            .unwrap_or(80);
         let snapshot_writer = Arc::new(SnapshotWriter::new(
             format!("{}/data", output_path),
-            80, // JPEG quality
+            initial_jpeg_quality,
+            self.config.max_snapshot_width,
         ));
 
         // Create activity feed for this monitor

--- a/crates/screenpipe-screen/src/snapshot_writer.rs
+++ b/crates/screenpipe-screen/src/snapshot_writer.rs
@@ -10,28 +10,44 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use image::codecs::jpeg::JpegEncoder;
+use image::imageops::FilterType;
 use image::DynamicImage;
 use std::fs;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU8, AtomicU32, Ordering};
 use tracing::{debug, error};
 
 /// Writes JPEG snapshots to disk for event-driven capture.
 pub struct SnapshotWriter {
     base_dir: PathBuf,
-    quality: u8,
+    quality: AtomicU8,
+    /// Maximum width for stored snapshots (0 = no limit).
+    max_width: AtomicU32,
 }
 
 impl SnapshotWriter {
     /// Create a new SnapshotWriter.
     ///
     /// - `base_dir`: root data directory (e.g., `~/.screenpipe/data`)
-    /// - `quality`: JPEG quality 1-100 (default 80)
-    pub fn new(base_dir: impl Into<PathBuf>, quality: u8) -> Self {
+    /// - `quality`: JPEG quality 1-100
+    /// - `max_width`: max snapshot width in pixels (0 = no limit)
+    pub fn new(base_dir: impl Into<PathBuf>, quality: u8, max_width: u32) -> Self {
         Self {
             base_dir: base_dir.into(),
-            quality: quality.clamp(1, 100),
+            quality: AtomicU8::new(quality.clamp(1, 100)),
+            max_width: AtomicU32::new(max_width),
         }
+    }
+
+    /// Update JPEG quality at runtime (called by power manager).
+    pub fn set_quality(&self, quality: u8) {
+        self.quality.store(quality.clamp(1, 100), Ordering::Relaxed);
+    }
+
+    /// Update maximum snapshot width at runtime (0 = no limit).
+    pub fn set_max_width(&self, width: u32) {
+        self.max_width.store(width, Ordering::Relaxed);
     }
 
     /// Write a screenshot as JPEG. Returns the absolute path to the written file.
@@ -52,19 +68,34 @@ impl SnapshotWriter {
         let filename = format!("{}_m{}.jpg", timestamp_ms, monitor_id);
         let path = date_dir.join(&filename);
 
+        let quality = self.quality.load(Ordering::Relaxed);
+        let max_w = self.max_width.load(Ordering::Relaxed);
+
+        // Downscale if image exceeds max_width (preserving aspect ratio).
+        // Use a reference to avoid cloning the full image buffer when no resize is needed.
+        let resized;
+        let img: &DynamicImage = if max_w > 0 && image.width() > max_w {
+            resized = image.resize(max_w, u32::MAX, FilterType::Triangle);
+            &resized
+        } else {
+            image
+        };
+
         let file = fs::File::create(&path)?;
         let mut writer = BufWriter::new(file);
-        let mut encoder = JpegEncoder::new_with_quality(&mut writer, self.quality);
-        encoder.encode_image(image)?;
+        let mut encoder = JpegEncoder::new_with_quality(&mut writer, quality);
+        encoder.encode_image(img)?;
         writer.flush()?;
         writer.get_ref().sync_all()?;
 
         debug!(
-            "snapshot written: {} ({}x{}, q={})",
+            "snapshot written: {} ({}x{} -> {}x{}, q={})",
             path.display(),
             image.width(),
             image.height(),
-            self.quality
+            img.width(),
+            img.height(),
+            quality
         );
 
         Ok(path)
@@ -126,7 +157,7 @@ mod tests {
     #[test]
     fn test_write_creates_jpeg() {
         let tmp = TempDir::new().unwrap();
-        let writer = SnapshotWriter::new(tmp.path(), 80);
+        let writer = SnapshotWriter::new(tmp.path(), 80, 0);
         let img = test_image(1920, 1080);
         let now = Utc::now();
 
@@ -145,7 +176,7 @@ mod tests {
     #[test]
     fn test_write_creates_date_directory() {
         let tmp = TempDir::new().unwrap();
-        let writer = SnapshotWriter::new(tmp.path(), 80);
+        let writer = SnapshotWriter::new(tmp.path(), 80, 0);
         let img = test_image(100, 100);
         let now = Utc::now();
 
@@ -158,7 +189,7 @@ mod tests {
     #[test]
     fn test_write_includes_monitor_id() {
         let tmp = TempDir::new().unwrap();
-        let writer = SnapshotWriter::new(tmp.path(), 80);
+        let writer = SnapshotWriter::new(tmp.path(), 80, 0);
         let img = test_image(100, 100);
         let now = Utc::now();
 
@@ -169,10 +200,10 @@ mod tests {
 
     #[test]
     fn test_quality_clamped() {
-        let writer = SnapshotWriter::new("/tmp", 150);
-        assert_eq!(writer.quality, 100);
+        let writer = SnapshotWriter::new("/tmp", 150, 0);
+        assert_eq!(writer.quality.load(Ordering::Relaxed), 100);
 
-        let writer = SnapshotWriter::new("/tmp", 0);
-        assert_eq!(writer.quality, 1);
+        let writer = SnapshotWriter::new("/tmp", 0, 0);
+        assert_eq!(writer.quality.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `SnapshotWriter` was constructed with hardcoded JPEG quality `80`, ignoring the power profile's `jpeg_quality` field entirely. Saver mode (quality=40) and Balanced mode (quality=60) had zero effect on actual screenshot file size — every frame was always written at q=80.
- **Same class of bug** as #2198 (video quality preset defined but not applied to the encoder).
- **New config**: adds `maxSnapshotWidth` setting (default 1920) that downscales wider screenshots before JPEG encoding, saving ~40% storage for 2560px+ monitors. Set to 0 for native resolution.

## Changes

| File | What |
|---|---|
| `screenpipe-screen/src/snapshot_writer.rs` | `quality` → `AtomicU8` with `set_quality()`; configurable `max_width` with aspect-ratio-preserving downscale; avoid full image clone on no-resize path |
| `screenpipe-engine/src/event_driven_capture.rs` | Call `snapshot_writer.set_quality()` when power profile changes |
| `screenpipe-engine/src/vision_manager/manager.rs` | Use power profile's initial quality instead of hardcoded 80; pass `max_snapshot_width` from config |
| `screenpipe-config/src/recording.rs` | Add `maxSnapshotWidth` field (default 1920) |
| `screenpipe-engine/src/recording_config.rs` | Wire `max_snapshot_width` through `RecordingConfig` → `VisionManagerConfig` |

## Test plan

- [ ] Verify Saver mode (battery_saver) writes JPEGs at quality 40 (check file sizes — should be ~50% smaller than before)
- [ ] Verify Balanced mode writes at quality 60
- [ ] Verify `maxSnapshotWidth=1920` downscales 2560px monitors correctly (check output resolution with `sips -g pixelWidth`)
- [ ] Verify `maxSnapshotWidth=0` stores at native resolution
- [ ] Existing `snapshot_writer` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)