### PR TITLE
fix: --use-all-monitors CLI flag ignored on Mid/Low tier devices

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -666,7 +666,10 @@ async fn main() -> anyhow::Result<()> {
     let db_server = db.clone();
 
     let warning_audio_transcription_engine_clone = record_args.audio_transcription_engine.clone();
-    let monitor_ids: Vec<u32> = if config.monitor_ids.is_empty() {
+    let monitor_ids: Vec<u32> = if config.use_all_monitors || config.monitor_ids.is_empty() {
+        all_monitors.iter().map(|m| m.id()).collect::<Vec<_>>()
+    } else if config.monitor_ids == vec!["default"] {
+        // "default" means primary monitor only — show all for display, VisionManager filters
         all_monitors.iter().map(|m| m.id()).collect::<Vec<_>>()
     } else {
         config

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -419,6 +419,10 @@ impl RecordArgs {
         self,
         data_dir: PathBuf,
     ) -> crate::recording_config::RecordingConfig {
+        // Preserve explicit CLI monitor flags so tier defaults don't clobber them.
+        let cli_monitor_ids = self.monitor_id.clone();
+        let cli_use_all_monitors = self.use_all_monitors;
+
         let mut settings = self.to_recording_settings();
 
         // First-launch tier detection for CLI users
@@ -443,6 +447,22 @@ impl RecordArgs {
                 let is_fresh = !config_path.exists();
                 if is_fresh {
                     screenpipe_config::apply_tier_defaults(&mut settings, tier);
+
+                    // Restore CLI monitor flags — user's explicit --use-all-monitors or -m
+                    // must win over tier defaults (fixes #2897)
+                    if cli_use_all_monitors {
+                        settings.use_all_monitors = true;
+                        settings.monitor_ids = cli_monitor_ids
+                            .iter()
+                            .map(|id| id.to_string())
+                            .collect();
+                    } else if !cli_monitor_ids.is_empty() {
+                        settings.use_all_monitors = false;
+                        settings.monitor_ids = cli_monitor_ids
+                            .iter()
+                            .map(|id| id.to_string())
+                            .collect();
+                    }
                 }
                 settings.device_tier = Some(tier.as_str().to_string());
             }


### PR DESCRIPTION
## Summary

Fixes #2897

- On first launch, `apply_tier_defaults()` sets `use_all_monitors=false` and `monitor_ids=["default"]` for Mid/Low tier devices (like M2 MacBooks). This **overwrites** the user's explicit `--use-all-monitors` flag, causing secondary monitors to be skipped as "not in allowed list".
- After applying tier defaults, the CLI's monitor flags are now restored since user intent should take precedence over auto-detected defaults.
- Also fixes the startup config table showing "no monitors available" when `monitor_ids=["default"]` (the string "default" can't parse as u32).

## Test plan

- [ ] On a Mid-tier Mac with 2 monitors, run `screenpipe record --use-all-monitors` and verify both monitors are captured
- [ ] On a fresh install (no config.toml), verify tier defaults still apply when no monitor flags are passed
- [ ] Verify `-m 1 -m 2` also works correctly on Mid/Low tier devices
- [ ] Check startup config table shows monitor IDs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)