### PR TITLE
fix: prevent usage tab count inflation across refreshes

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/usage-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/usage-section.tsx
@@ -108,6 +108,20 @@ function aggregateEntries(entries: UsageEntry[], since?: number): ModelUsage[] {
   return Array.from(map.values()).sort((a, b) => b.count - a.count);
 }
 
+function dedupeEntries(entries: UsageEntry[]): UsageEntry[] {
+  const seen = new Set<string>();
+  const deduped: UsageEntry[] = [];
+
+  for (const entry of entries) {
+    const key = `${entry.timestamp}::${entry.source}::${entry.provider}::${entry.model}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(entry);
+  }
+
+  return deduped;
+}
+
 function getTimeSince(range: TimeRange): number | undefined {
   if (range === "all") return undefined;
   const now = Date.now();
@@ -144,7 +158,7 @@ export function UsageSection() {
 
     // Step 2: Incremental update
     try {
-      const newEntries = [...cache.entries];
+      const newEntries: UsageEntry[] = [];
       let totalChatsCount = 0;
       let chatMsgs = 0;
       let untracked = 0;
@@ -186,7 +200,6 @@ export function UsageSection() {
       }
 
       // Pipe executions - only fetch newer than cache watermark
-      let pipeNewCount = 0;
       try {
         const pipesRes = await fetch(`${SCREENPIPE_API}/pipes`);
         if (pipesRes.ok) {
@@ -218,7 +231,6 @@ export function UsageSection() {
                   const entryKey = `${ts}::${exec.provider || "pipe"}::${exec.model}`;
                   if (cachedPipeEntrySet.has(entryKey)) continue;
 
-                  pipeNewCount++;
                   newEntries.push({
                     model: exec.model,
                     provider: exec.provider || "pipe",
@@ -236,8 +248,8 @@ export function UsageSection() {
         // screenpipe not running
       }
 
-      // Merge new entries with cached entries (deduplicated by timestamp::model)
-      const allEntries = [...(cache.entries || []), ...newEntries];
+      // Merge new entries with cached entries and hard-dedupe to prevent inflation.
+      const allEntries = dedupeEntries([...(cache.entries || []), ...newEntries]);
 
       // Update cache
       const updatedCache: UsageCache = {


### PR DESCRIPTION
## Summary
Fixes Usage tab totals inflating each time settings is reopened or revisited.

## Root Cause
`UsageSection.loadData()` initialized `newEntries` with `cache.entries`, then merged again with `cache.entries`, effectively re-appending cached rows on each refresh cycle.

## Changes
- Start incremental collection with an empty `newEntries` array.
- Add `dedupeEntries()` and apply it during merge before persisting state/cache.
- Remove unused `pipeNewCount` bookkeeping.

## Impact
- Usage counters no longer grow artificially when switching tabs or reloading settings.
- Existing cache data remains compatible; duplicate inflation is prevented going forward.

## Validation
- `bunx tsc --noEmit --pretty false` (apps/screenpipe-app-tauri): PASS
- `bun run test` (apps/screenpipe-app-tauri): FAIL due to unrelated existing baseline test issues (multiple `bun:test` import resolution failures and unrelated failing suites like `text-overlay` and `use-frame-ocr-data`).

Closes #2730
