### PR TITLE
fix: match numeric monitor IDs in is_monitor_allowed (-m flag)

### DIFF
--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -124,14 +124,14 @@ impl VisionManager {
             return monitor.is_primary();
         }
         let stable_id = monitor.stable_id();
+        let numeric_id = monitor.id().to_string();
         fn prefix(sid: &str) -> &str {
             sid.rsplitn(2, '_').last().unwrap_or(sid)
         }
         let monitor_prefix = prefix(&stable_id);
-        self.config
-            .monitor_ids
-            .iter()
-            .any(|allowed| *allowed == stable_id || prefix(allowed) == monitor_prefix)
+        self.config.monitor_ids.iter().any(|allowed| {
+            *allowed == stable_id || *allowed == numeric_id || prefix(allowed) == monitor_prefix
+        })
     }
 
     /// Start recording on all currently connected monitors


### PR DESCRIPTION
## Summary

PR #2902 (merged yesterday) fixed the `--use-all-monitors` CLI flag being clobbered by tier defaults on Mid/Low tier fresh installs. Thanks @louis030195 — my earlier version of this PR overlapped with that fix, so I've rebased and narrowed it down.

There's still one gap left: the documented `-m <id>` form is silently broken on multi-monitor setups.

## The remaining bug

`RecordArgs` stores `-m` values as `u32`, which get stringified to `"1"`, `"2"`, etc. in `settings.monitor_ids`. But `VisionManager::is_monitor_allowed()` only compares those entries against the monitor's **stable_id** (e.g. `"Display 2_3840x1080_-377,-1080"`) or its `name_resolution` prefix. Numeric IDs never match either form, so any secondary monitor selected with `-m 1 -m 2` is still silently dropped as "not in allowed list".

Repro on my M2 MacBook (built-in 1440x900 + external 3840x1080):

```
$ screenpipe --data-dir /tmp/sp -m 1 -m 2
Skipping monitor 1 (Built-in Retina Display_1440x900_0,0) — not in allowed list
Skipping monitor 2 (Display 2_3840x1080_-377,-1080) — not in allowed list
```

Both monitors are rejected despite being explicitly requested.

## Fix

One-line change in `is_monitor_allowed()`: also compare each allowed entry against `monitor.id().to_string()`. `--use-all-monitors` and stable-id-based matching keep working unchanged.

```rust
let stable_id = monitor.stable_id();
let numeric_id = monitor.id().to_string();
// ...
self.config.monitor_ids.iter().any(|allowed| {
    *allowed == stable_id || *allowed == numeric_id || prefix(allowed) == monitor_prefix
})
```

## Test plan

- [x] `cargo build --release -p screenpipe` on macOS arm64
- [x] Ran the patched binary on my hardware (M2, macOS 15.2, built-in + external ultrawide) with `-m 1 -m 2`. Both monitors record; data dir has `_m1` and `_m2` frames interleaved.
- [x] Also verified `--use-all-monitors` still works after rebasing onto main (covered by #2902).
- [ ] CI

Refs: #2897