### PR TITLE
fix: separate open app and settings tray menu actions

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -362,7 +362,7 @@ fn create_dynamic_menu(
 
     // --- Open screenpipe ---
     menu_builder = menu_builder
-        .item(&MenuItemBuilder::with_id("settings_top", "Open screenpipe").build(app)?)
+        .item(&MenuItemBuilder::with_id("open_app", "Open screenpipe").build(app)?)
         .item(&PredefinedMenuItem::separator(app)?);
 
     // --- Primary actions (most-used first) ---
@@ -715,7 +715,13 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                 }
             });
         }
-        "settings" | "settings_top" => {
+        "open_app" => {
+            let app = app_handle.clone();
+            let _ = app_handle.run_on_main_thread(move || {
+                let _ = ShowRewindWindow::Home { page: None }.show(&app);
+            });
+        }
+        "settings" => {
             let app = app_handle.clone();
             let page = Some("general".to_string());
             let _ = app_handle.run_on_main_thread(move || {


### PR DESCRIPTION
## Summary

- The **Open screenpipe** tray menu item previously shared the `settings_top` event identifier with the settings handler, causing it to open the settings page instead of the application home view.

- A dedicated `open_app` identifier has been introduced for the **Open screenpipe** item and wired to `ShowRewindWindow::Home`, ensuring it navigates the user to the home screen.

- The `settings` arm is unchanged and continues to route to the general settings page.

## Root Cause

In `handle_menu_event`, the match arm `"settings" | "settings_top"` treated both identifiers identically, always navigating to `page: Some("general")`. The **Open screenpipe** item, which carries `settings_top`, was therefore indistinguishable from a direct click on the Settings entry.


https://github.com/user-attachments/assets/64251da9-5298-4411-bf2f-7553f1df78c1


