### PR TITLE
fix: respect user port setting in background tasks

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -331,7 +331,12 @@ pub async fn start_health_check(app: tauri::AppHandle) -> Result<()> {
             interval.tick().await;
 
             let theme = dark_light::detect().unwrap_or(Mode::Dark);
-            let health_result = check_health(&client).await;
+            let port = crate::store::SettingsStore::get(&app)
+                .ok()
+                .flatten()
+                .map(|s| s.recording.port)
+                .unwrap_or(3030);
+            let health_result = check_health(&client, port).await;
 
             // Track consecutive failures (connection errors) and unhealthy responses separately.
             // Connection errors = server unreachable (crash, restart, port conflict).
@@ -642,9 +647,9 @@ async fn show_capture_stall_notification(app: &tauri::AppHandle, system: &str) -
 
 /// Checks the health of the sidecar by making a request to its health endpoint.
 /// Returns an error if the sidecar is not running or not responding.
-async fn check_health(client: &reqwest::Client) -> Result<HealthCheckResponse> {
+async fn check_health(client: &reqwest::Client, port: u16) -> Result<HealthCheckResponse> {
     match client
-        .get("http://localhost:3030/health")
+        .get(format!("http://localhost:{}/health", port))
         .header("Cache-Control", "no-cache")
         .header("Pragma", "no-cache")
         .timeout(Duration::from_secs(5)) // on windows it never times out

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1636,8 +1636,9 @@ async fn main() {
                 scheduler_handle: suggestions_state.scheduler_handle.clone(),
                 enhanced_ai: suggestions_state.enhanced_ai.clone(),
             };
+            let app_handle_sugg = app_handle.clone();
             tauri::async_runtime::spawn(async move {
-                suggestions::auto_start_scheduler(&suggestions_state_clone).await;
+                suggestions::auto_start_scheduler(app_handle_sugg, &suggestions_state_clone).await;
             });
 
             // Auto-start pipe suggestions scheduler if enabled

--- a/apps/screenpipe-app-tauri/src-tauri/src/suggestions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/suggestions.rs
@@ -78,8 +78,10 @@ impl SuggestionsState {
 #[tauri::command]
 #[specta::specta]
 pub async fn get_cached_suggestions(
+    app: tauri::AppHandle,
     state: tauri::State<'_, SuggestionsState>,
 ) -> Result<CachedSuggestions, String> {
+    let port = crate::store::SettingsStore::get(&app).ok().flatten().map(|s| s.recording.port).unwrap_or(3030);
     let guard = state.cache.lock().await;
     if let Some(cached) = guard.clone() {
         return Ok(cached);
@@ -88,7 +90,7 @@ pub async fn get_cached_suggestions(
 
     // Cache is empty (app just started) — do a quick template generation
     // using current data so the UI shows personalized suggestions immediately.
-    let (apps, windows) = tokio::join!(fetch_app_activity(), fetch_window_activity());
+    let (apps, windows) = tokio::join!(fetch_app_activity(port), fetch_window_activity(port));
     let apps = apps.unwrap_or_default();
     let windows = windows.unwrap_or_default();
     let mode = detect_mode(&apps, &windows);
@@ -118,10 +120,12 @@ pub async fn get_cached_suggestions(
 #[tauri::command]
 #[specta::specta]
 pub async fn force_regenerate_suggestions(
+    app: tauri::AppHandle,
     state: tauri::State<'_, SuggestionsState>,
 ) -> Result<CachedSuggestions, String> {
+    let port = crate::store::SettingsStore::get(&app).ok().flatten().map(|s| s.recording.port).unwrap_or(3030);
     let enhanced = state.enhanced_ai.lock().await.clone();
-    let cached = generate_suggestions(enhanced.as_ref()).await?;
+    let cached = generate_suggestions(enhanced.as_ref(), port).await?;
     let mut guard = state.cache.lock().await;
     *guard = Some(cached.clone());
     Ok(cached)
@@ -148,10 +152,11 @@ pub async fn set_enhanced_ai_suggestions(
 
 /// Auto-start the suggestions scheduler on app launch.
 /// Regenerates on a 10-min timer AND reactively on meeting start/end events.
-pub async fn auto_start_scheduler(state: &SuggestionsState) {
+pub async fn auto_start_scheduler(app: tauri::AppHandle, state: &SuggestionsState) {
     let cache = state.cache.clone();
     let handle_arc = state.scheduler_handle.clone();
     let enhanced_ai = state.enhanced_ai.clone();
+    let app_clone = app.clone();
 
     let handle = tokio::spawn(async move {
         info!("suggestions scheduler: started (10-min interval + event triggers)");
@@ -200,9 +205,10 @@ pub async fn auto_start_scheduler(state: &SuggestionsState) {
 
             // Read current enhanced AI config (picks up setting changes each cycle)
             let enhanced = enhanced_ai.lock().await.clone();
+            let port = crate::store::SettingsStore::get(&app_clone).ok().flatten().map(|s| s.recording.port).unwrap_or(3030);
 
             // Fetch activity & generate suggestions
-            match generate_suggestions(enhanced.as_ref()).await {
+            match generate_suggestions(enhanced.as_ref(), port).await {
                 Ok(cached) => {
                     debug!(
                         "suggestions scheduler: generated {} suggestions (mode={}, ai={}, trigger={})",
@@ -1158,12 +1164,11 @@ fn template_suggestions(
 
 // ─── Suggestion generation ──────────────────────────────────────────────────
 
-const API: &str = "http://localhost:3030";
 
-async fn fetch_app_activity() -> Result<Vec<AppActivity>, String> {
+async fn fetch_app_activity(port: u16) -> Result<Vec<AppActivity>, String> {
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT app_name, COUNT(*) as cnt FROM frames WHERE datetime(timestamp) > datetime('now', '-30 minutes') AND app_name != '' AND app_name != 'screenpipe' AND app_name != 'screenpipe-app' GROUP BY app_name ORDER BY cnt DESC LIMIT 15"
         }))
@@ -1180,10 +1185,10 @@ async fn fetch_app_activity() -> Result<Vec<AppActivity>, String> {
         .map_err(|e| format!("parse app activity: {}", e))
 }
 
-async fn fetch_window_activity() -> Result<Vec<WindowActivity>, String> {
+async fn fetch_window_activity(port: u16) -> Result<Vec<WindowActivity>, String> {
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT app_name, window_name, COUNT(*) as cnt FROM frames WHERE datetime(timestamp) > datetime('now', '-30 minutes') AND app_name != '' AND app_name != 'screenpipe' AND app_name != 'screenpipe-app' AND window_name != '' GROUP BY app_name, window_name ORDER BY cnt DESC LIMIT 20"
         }))
@@ -1200,9 +1205,9 @@ async fn fetch_window_activity() -> Result<Vec<WindowActivity>, String> {
         .map_err(|e| format!("parse window activity: {}", e))
 }
 
-async fn check_ai_available() -> bool {
+async fn check_ai_available(port: u16) -> bool {
     let resp = reqwest::Client::new()
-        .get(format!("{}/ai/status", API))
+        .get(format!("http://localhost:{}/ai/status", port))
         .timeout(std::time::Duration::from_secs(3))
         .send()
         .await;
@@ -1235,10 +1240,10 @@ struct AudioSnippet {
     speaker_name: Option<String>,
 }
 
-async fn fetch_accessibility_snippets() -> Vec<AccessibilitySnippet> {
+async fn fetch_accessibility_snippets(port: u16) -> Vec<AccessibilitySnippet> {
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT app_name, window_name, SUBSTR(text_content, 1, 200) as snippet FROM accessibility WHERE datetime(timestamp) > datetime('now', '-15 minutes') AND LENGTH(text_content) > 30 AND app_name != 'screenpipe' ORDER BY timestamp DESC LIMIT 8"
         }))
@@ -1252,10 +1257,10 @@ async fn fetch_accessibility_snippets() -> Vec<AccessibilitySnippet> {
     }
 }
 
-async fn fetch_audio_snippets() -> Vec<AudioSnippet> {
+async fn fetch_audio_snippets(port: u16) -> Vec<AudioSnippet> {
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT SUBSTR(at.transcription, 1, 200) as transcription, at.device, s.name as speaker_name FROM audio_transcriptions at LEFT JOIN speakers s ON at.speaker_id = s.id WHERE datetime(at.timestamp) > datetime('now', '-30 minutes') AND LENGTH(at.transcription) > 10 ORDER BY at.timestamp DESC LIMIT 6"
         }))
@@ -1269,10 +1274,10 @@ async fn fetch_audio_snippets() -> Vec<AudioSnippet> {
     }
 }
 
-async fn fetch_ocr_snippets() -> Vec<String> {
+async fn fetch_ocr_snippets(port: u16) -> Vec<String> {
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT SUBSTR(ot.text, 1, 150) as snippet FROM ocr_text ot JOIN frames f ON ot.frame_id = f.id WHERE datetime(f.timestamp) > datetime('now', '-15 minutes') AND LENGTH(ot.text) > 20 ORDER BY RANDOM() LIMIT 5"
         }))
@@ -1297,10 +1302,10 @@ async fn fetch_ocr_snippets() -> Vec<String> {
     }
 }
 
-async fn count_accessibility_rows() -> i64 {
+async fn count_accessibility_rows(port: u16) -> i64 {
     let client = reqwest::Client::new();
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT COUNT(*) as cnt FROM accessibility WHERE datetime(timestamp) > datetime('now', '-30 minutes')"
         }))
@@ -1327,7 +1332,7 @@ async fn count_accessibility_rows() -> i64 {
 
 /// Build a context string that fits within ~4500 chars (~1100 tokens) using
 /// the best available data sources. Priority: accessibility > OCR, always audio.
-async fn build_activity_context(apps: &[AppActivity], windows: &[WindowActivity]) -> String {
+async fn build_activity_context(port: u16, apps: &[AppActivity], windows: &[WindowActivity]) -> String {
     const MAX_CHARS: usize = 4500;
     let mut parts = Vec::new();
     let mut char_budget = MAX_CHARS;
@@ -1358,7 +1363,7 @@ async fn build_activity_context(apps: &[AppActivity], windows: &[WindowActivity]
 
     // 3. Audio transcriptions — always include if available (~1500 chars budget)
     let audio_budget = char_budget / 3;
-    let audio = fetch_audio_snippets().await;
+    let audio = fetch_audio_snippets(port).await;
     if !audio.is_empty() {
         parts.push("Recent audio/speech:".to_string());
         let mut used = 0;
@@ -1376,10 +1381,10 @@ async fn build_activity_context(apps: &[AppActivity], windows: &[WindowActivity]
     }
 
     // 4. Screen content: prefer accessibility (structured) over OCR (noisy)
-    let has_accessibility = count_accessibility_rows().await > 5;
+    let has_accessibility = count_accessibility_rows(port).await > 5;
 
     if has_accessibility {
-        let snippets = fetch_accessibility_snippets().await;
+        let snippets = fetch_accessibility_snippets(port).await;
         if !snippets.is_empty() {
             parts.push("Screen content (accessibility):".to_string());
             let mut used = 0;
@@ -1399,7 +1404,7 @@ async fn build_activity_context(apps: &[AppActivity], windows: &[WindowActivity]
             );
         }
     } else {
-        let snippets = fetch_ocr_snippets().await;
+        let snippets = fetch_ocr_snippets(port).await;
         if !snippets.is_empty() {
             parts.push("Screen text (OCR):".to_string());
             let mut used = 0;
@@ -1451,6 +1456,7 @@ struct AiResult {
 const SCREENPIPE_CLOUD_API: &str = "https://api.screenpi.pe/v1";
 
 async fn generate_ai_suggestions(
+    port: u16,
     mode: &str,
     apps: &[AppActivity],
     windows: &[WindowActivity],
@@ -1461,12 +1467,12 @@ async fn generate_ai_suggestions(
         .as_ref()
         .map_or(false, |c| c.enabled && !c.token.is_empty());
 
-    if !use_cloud && !check_ai_available().await {
+    if !use_cloud && !check_ai_available(port).await {
         info!("suggestions: Apple Intelligence not available and enhanced AI not enabled, using templates");
         return None;
     }
 
-    let context = build_activity_context(apps, windows).await;
+    let context = build_activity_context(port, apps, windows).await;
 
     debug!(
         "suggestions: AI prompt ~{} tokens, backend={}",
@@ -1501,7 +1507,7 @@ async fn generate_ai_suggestions(
         // Apple Intelligence (on-device)
         let prompt = format!("{}Activity mode: {}\n\n{}", AI_SYSTEM_PROMPT, mode, context);
         client
-            .post(format!("{}/ai/chat/completions", API))
+            .post(format!("http://localhost:{}/ai/chat/completions", port))
             .json(&serde_json::json!({
                 "messages": [
                     {"role": "user", "content": prompt}
@@ -1645,8 +1651,9 @@ fn extract_json_object(content: &str) -> Option<String> {
 
 async fn generate_suggestions(
     enhanced_ai: Option<&EnhancedAIConfig>,
+    port: u16,
 ) -> Result<CachedSuggestions, String> {
-    let (apps, windows) = tokio::join!(fetch_app_activity(), fetch_window_activity());
+    let (apps, windows) = tokio::join!(fetch_app_activity(port), fetch_window_activity(port));
     let apps = apps.unwrap_or_default();
     let windows = windows.unwrap_or_default();
 
@@ -1662,7 +1669,7 @@ async fn generate_suggestions(
 
     // Try AI-powered suggestions + tags in one call
     let (suggestions, tags, ai_generated) =
-        match generate_ai_suggestions(mode, &apps, &windows, enhanced_ai).await {
+        match generate_ai_suggestions(port, mode, &apps, &windows, enhanced_ai).await {
             Some(result) => {
                 info!(
                     "suggestions: AI generated {} suggestions + {} tags",
@@ -1693,7 +1700,7 @@ async fn generate_suggestions(
     if !tags.is_empty() {
         let tags_clone = tags.clone();
         tokio::spawn(async move {
-            if let Err(e) = store_tags(&tags_clone).await {
+            if let Err(e) = store_tags(port, &tags_clone).await {
                 warn!("suggestions: failed to store tags: {}", e);
             }
         });
@@ -1718,12 +1725,12 @@ fn generate_heuristic_tags(mode: &str, top_apps: &[String]) -> Vec<String> {
 }
 
 /// Store AI-generated tags on recent frames using the existing tags + vision_tags tables.
-async fn store_tags(tags: &[String]) -> Result<(), String> {
+async fn store_tags(port: u16, tags: &[String]) -> Result<(), String> {
     let client = reqwest::Client::new();
 
     // Get recent frame IDs (last 10 minutes, sample up to 10)
     let resp = client
-        .post(format!("{}/raw_sql", API))
+        .post(format!("http://localhost:{}/raw_sql", port))
         .json(&serde_json::json!({
             "query": "SELECT id FROM frames WHERE timestamp >= datetime('now', '-10 minutes') ORDER BY timestamp DESC LIMIT 10"
         }))
@@ -1754,7 +1761,7 @@ async fn store_tags(tags: &[String]) -> Result<(), String> {
     let mut tagged = 0;
     for frame in &frames {
         let resp = client
-            .post(format!("{}/tags/vision/{}", API, frame.id))
+            .post(format!("http://localhost:{}/tags/vision/{}", port, frame.id))
             .json(&tag_body)
             .timeout(std::time::Duration::from_secs(5))
             .send()
@@ -1972,12 +1979,12 @@ mod tests {
     #[ignore] // requires screenpipe running locally
     async fn benchmark_data_sources() {
         // Verify all data sources return data
-        let apps = fetch_app_activity().await.unwrap_or_default();
-        let windows = fetch_window_activity().await.unwrap_or_default();
-        let accessibility = fetch_accessibility_snippets().await;
-        let audio = fetch_audio_snippets().await;
-        let ocr = fetch_ocr_snippets().await;
-        let acc_count = count_accessibility_rows().await;
+        let apps = fetch_app_activity(port).await.unwrap_or_default();
+        let windows = fetch_window_activity(port).await.unwrap_or_default();
+        let accessibility = fetch_accessibility_snippets(port).await;
+        let audio = fetch_audio_snippets(port).await;
+        let ocr = fetch_ocr_snippets(port).await;
+        let acc_count = count_accessibility_rows(port).await;
 
         println!("\n=== Data Source Availability ===");
         println!("  apps:          {} entries", apps.len());
@@ -2024,7 +2031,7 @@ mod tests {
         }
 
         // Verify context builder respects budget
-        let context = build_activity_context(&apps, &windows).await;
+        let context = build_activity_context(port, &apps, &windows).await;
         let est_tokens = context.len() / 4;
         println!("\n=== Context Builder ===");
         println!(
@@ -2043,14 +2050,14 @@ mod tests {
     #[tokio::test]
     #[ignore] // requires screenpipe + Apple Intelligence
     async fn benchmark_ai_suggestion_quality() {
-        let ai_available = check_ai_available().await;
+        let ai_available = check_ai_available(port).await;
         if !ai_available {
             println!("\n=== SKIP: Apple Intelligence not available ===");
             return;
         }
 
-        let apps = fetch_app_activity().await.unwrap_or_default();
-        let windows = fetch_window_activity().await.unwrap_or_default();
+        let apps = fetch_app_activity(port).await.unwrap_or_default();
+        let windows = fetch_window_activity(port).await.unwrap_or_default();
         if apps.is_empty() {
             println!("\n=== SKIP: no activity data ===");
             return;
@@ -2060,7 +2067,7 @@ mod tests {
         let top_apps: Vec<String> = apps.iter().take(6).map(|a| a.app_name.clone()).collect();
 
         // Collect speaker names from audio
-        let audio = fetch_audio_snippets().await;
+        let audio = fetch_audio_snippets(port).await;
         let speakers: Vec<String> = audio
             .iter()
             .filter_map(|a| a.speaker_name.clone())
@@ -2182,16 +2189,16 @@ mod tests {
     #[ignore] // requires screenpipe running locally
     async fn benchmark_context_builder_coverage() {
         // Test that the context builder uses the right data source
-        let acc_count = count_accessibility_rows().await;
-        let apps = fetch_app_activity().await.unwrap_or_default();
-        let windows = fetch_window_activity().await.unwrap_or_default();
+        let acc_count = count_accessibility_rows(port).await;
+        let apps = fetch_app_activity(port).await.unwrap_or_default();
+        let windows = fetch_window_activity(port).await.unwrap_or_default();
 
         if apps.is_empty() {
             println!("\n=== SKIP: no activity data ===");
             return;
         }
 
-        let context = build_activity_context(&apps, &windows).await;
+        let context = build_activity_context(port, &apps, &windows).await;
 
         println!("\n=== Context Coverage ===");
         println!("  accessibility rows (30min): {}", acc_count);

--- a/apps/screenpipe-app-tauri/src-tauri/src/sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/sync.rs
@@ -172,7 +172,13 @@ pub async fn set_sync_enabled(state: State<'_, SyncState>, enabled: bool) -> Res
 /// Trigger an immediate sync via the screenpipe server.
 #[tauri::command]
 #[specta::specta]
-pub async fn trigger_sync(state: State<'_, SyncState>) -> Result<(), String> {
+pub async fn trigger_sync(app: AppHandle, state: State<'_, SyncState>) -> Result<(), String> {
+    let port = crate::store::SettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .map(|s| s.recording.port)
+        .unwrap_or(3030);
+
     let enabled = *state.enabled.read().await;
     if !enabled {
         return Err("sync is not enabled".to_string());
@@ -199,7 +205,7 @@ pub async fn trigger_sync(state: State<'_, SyncState>) -> Result<(), String> {
     tokio::spawn(async move {
         let client = reqwest::Client::new();
         let result = client
-            .post("http://localhost:3030/sync/trigger")
+            .post(&format!("http://localhost:{}/sync/trigger", port))
             .send()
             .await;
 
@@ -307,16 +313,22 @@ pub async fn remove_sync_device(
 #[tauri::command]
 #[specta::specta]
 pub async fn delete_device_local_data(
+    app: AppHandle,
     state: State<'_, SyncState>,
     machine_id: String,
 ) -> Result<String, String> {
+    let port = crate::store::SettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .map(|s| s.recording.port)
+        .unwrap_or(3030);
     if machine_id == state.machine_id {
         return Err("cannot delete your own device's local data".to_string());
     }
 
     let client = reqwest::Client::new();
     let resp = client
-        .post("http://localhost:3030/data/delete-device")
+        .post(&format!("http://localhost:{}/data/delete-device", port))
         .json(&serde_json::json!({ "machine_id": machine_id }))
         .send()
         .await
@@ -342,6 +354,11 @@ pub async fn init_sync(
     _settings: State<'_, SettingsStore>,
     password: String,
 ) -> Result<bool, String> {
+    let port = crate::store::SettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .map(|s| s.recording.port)
+        .unwrap_or(3030);
     // Get auth token from FRESH settings (not managed state which may be stale)
     // The managed SettingsStore is loaded once at startup and doesn't update when user logs in
     let fresh_settings = SettingsStore::get(&app)
@@ -407,7 +424,7 @@ pub async fn init_sync(
     });
 
     match client
-        .post("http://localhost:3030/sync/init")
+        .post(&format!("http://localhost:{}/sync/init", port))
         .json(&init_request)
         .send()
         .await
@@ -442,6 +459,12 @@ pub async fn init_sync(
 #[tauri::command]
 #[specta::specta]
 pub async fn lock_sync(app: AppHandle, state: State<'_, SyncState>) -> Result<(), String> {
+    let port = crate::store::SettingsStore::get(&app)
+        .ok()
+        .flatten()
+        .map(|s| s.recording.port)
+        .unwrap_or(3030);
+
     // Lock local manager
     let manager_guard = state.manager.read().await;
     if let Some(manager) = manager_guard.as_ref() {
@@ -458,7 +481,7 @@ pub async fn lock_sync(app: AppHandle, state: State<'_, SyncState>) -> Result<()
 
     // Lock server sync service
     let client = reqwest::Client::new();
-    match client.post("http://localhost:3030/sync/lock").send().await {
+    match client.post(&format!("http://localhost:{}/sync/lock", port)).send().await {
         Ok(response) if response.status().is_success() => {
             info!("server sync service locked");
         }
@@ -473,6 +496,12 @@ pub async fn lock_sync(app: AppHandle, state: State<'_, SyncState>) -> Result<()
 /// Auto-start cloud sync on app launch if previously enabled.
 /// Called from main.rs during startup.
 pub async fn auto_start_sync(app: &AppHandle, state: &SyncState) {
+    let port = crate::store::SettingsStore::get(app)
+        .ok()
+        .flatten()
+        .map(|s| s.recording.port)
+        .unwrap_or(3030);
+
     // Only auto-start if user previously enabled sync and saved a password
     let password = match CloudSyncSettingsStore::get(app) {
         Ok(Some(s)) if s.enabled && !s.encrypted_password.is_empty() => {
@@ -558,7 +587,7 @@ pub async fn auto_start_sync(app: &AppHandle, state: &SyncState) {
     });
 
     match client
-        .post("http://localhost:3030/sync/init")
+        .post(&format!("http://localhost:{}/sync/init", port))
         .json(&init_request)
         .send()
         .await
@@ -587,6 +616,12 @@ pub async fn auto_start_sync(app: &AppHandle, state: &SyncState) {
 /// Called from main.rs during startup (after sync auto-start so archive can
 /// reuse the sync manager if available).
 pub async fn auto_start_archive(app: &AppHandle) {
+    let port = crate::store::SettingsStore::get(app)
+        .ok()
+        .flatten()
+        .map(|s| s.recording.port)
+        .unwrap_or(3030);
+
     // Check dedicated cloud_archive store key first, then fall back to
     // reading cloudArchiveEnabled from the main settings extra fields
     // (for users who enabled archive before this auto-start was added).
@@ -654,7 +689,7 @@ pub async fn auto_start_archive(app: &AppHandle) {
         }
 
         match client
-            .post("http://localhost:3030/archive/init")
+            .post(&format!("http://localhost:{}/archive/init", port))
             .json(&init_request)
             .send()
             .await
@@ -671,7 +706,7 @@ pub async fn auto_start_archive(app: &AppHandle) {
                 // Already initialized — make sure it's enabled
                 let enable_req = serde_json::json!({ "enabled": true });
                 if let Err(e) = client
-                    .post("http://localhost:3030/archive/configure")
+                    .post(&format!("http://localhost:{}/archive/configure", port))
                     .json(&enable_req)
                     .send()
                     .await
@@ -717,6 +752,7 @@ pub async fn auto_start_retention(app: &AppHandle) {
         Ok(Some(s)) => s,
         _ => return,
     };
+    let port = settings.recording.port;
 
     let enabled = settings
         .extra
@@ -741,7 +777,7 @@ pub async fn auto_start_retention(app: &AppHandle) {
     });
 
     match client
-        .post("http://localhost:3030/retention/configure")
+        .post(&format!("http://localhost:{}/retention/configure", port))
         .json(&configure_req)
         .send()
         .await


### PR DESCRIPTION
## Problem
Sync, health checks, and AI suggestions background tasks break when a user changes the screenpipe server port from the default 3030 because the port was hardcoded in internal requests.

## Root cause
`health.rs`, `sync.rs`, and `suggestions.rs` had hardcoded `http://localhost:3030` URLs.

## Fix
Fetched the dynamic port from `SettingsStore` (using `AppHandle`) and injected it into the API endpoints across sync, health checks, and background suggestion generators.

## Confidence: 9/10

## Verification
```
warning: unexpected `cfg` condition value: `cargo-clippy`
   --> /Users/louis/screenpipe/crates/screenpipe-core/src/permissions.rs:171:33
    |
171 |         let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> /Users/louis/screenpipe/crates/screenpipe-core/src/permissions.rs:171:43
    |
171 |         let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `class` crate for guidance on how handle this unexpected cfg
    = help: the macro `class` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `class` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> /Users/louis/screenpipe/crates/screenpipe-core/src/permissions.rs:176:29
    |
176 |                 let _: () = msg_send![pool, drain];
    |                             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> /Users/louis/screenpipe/crates/screenpipe-core/src/permissions.rs:183:13
    |
183 |             msg_send![class!(NSString), stringWithUTF8String: c"soun".as_ptr()];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
```

---
auto-generated by issue-solver pipe