### PR TITLE
fix: stuck openai/ prefix in ai presets selector for custom models

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -482,10 +482,17 @@ export function AIProviderConfig({
             className="flex h-8 items-center justify-center gap-1.5 text-xs px-3"
             onClick={() => {
               setSelectedProvider("custom");
+              
+              let newModel = formData.model || "";
+              if (newModel.startsWith("openai/")) {
+                newModel = newModel.replace("openai/", "");
+              }
+              
               setFormData({
                 ...formData,
                 provider: "custom",
                 url: "http://localhost:11434/v1",
+                model: newModel,
               });
             }}
           >
@@ -586,33 +593,26 @@ export function AIProviderConfig({
             </div>
             <div className="space-y-1">
               <Label htmlFor="model" className="text-xs">model</Label>
-              <Select
-                value={formData.model}
-                onValueChange={(value) =>
-                  setFormData({ ...formData, model: value })
-                }
-              >
-                <SelectTrigger className="h-8 text-sm">
-                  <SelectValue
-                    placeholder={
-                      isLoadingModels ? "loading models..." : "select model"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {openaiModels.length > 0 ? (
-                    openaiModels.map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        {model.id}
-                      </SelectItem>
-                    ))
-                  ) : (
-                    <SelectItem value="no-models" disabled>
-                      {isLoadingModels ? "loading..." : "no models found"}
-                    </SelectItem>
-                  )}
-                </SelectContent>
-              </Select>
+              <div className="relative">
+                <Input
+                  id="model"
+                  type="text"
+                  list="custom-models"
+                  placeholder={isLoadingModels ? "loading..." : "e.g. gpt-4o or qwen2"}
+                  value={formData.model || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, model: e.target.value })
+                  }
+                  className="h-8 text-sm"
+                />
+                {openaiModels.length > 0 && (
+                  <datalist id="custom-models">
+                    {openaiModels.map((model) => (
+                      <option key={model.id} value={model.id} />
+                    ))}
+                  </datalist>
+                )}
+              </div>
             </div>
           </div>
         )}

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -490,6 +490,9 @@ const AISection = ({
         break;
       case "custom":
         newUrl = settingsPreset?.url || "";
+        if (newModel && newModel.startsWith("openai/")) {
+          newModel = newModel.replace("openai/", "");
+        }
         break;
       case "openai-chatgpt":
         newUrl = "https://api.openai.com/v1";


### PR DESCRIPTION
## Problem
In the pipe configuration UI, if a user selects a model from OpenRouter or another API that returns models prefixed with `openai/`, and then switches to the `custom` provider, the `openai/` prefix becomes stuck. Furthermore, because the custom model field was a `Select` dropdown instead of an `<Input>`, users were completely unable to type their own model name if the `/models` endpoint failed for their custom URL.

## Root cause
1. `selectedProvider === "custom"` rendered a `<Select>` instead of an `<Input list="...">`, preventing free text entry for models.
2. Switching the provider to `custom` did not clear any existing `openai/` prefix from the `model` state.

## Fix
- Replaced the `<Select>` for custom models with an `<Input list="custom-models">`, allowing users to type custom model names.
- Added logic to automatically strip `openai/` prefixes from the model name when switching the provider back to `custom`.

## Confidence: 10/10

## Verification
```
Changes made to React frontend components. Replaced restricted select inputs with editable inputs that support datalists. Verified state transitions for 'custom' provider.
```

---
auto-generated by issue-solver pipe