### PR TITLE
fix: panic when spawning server without tokio reactor

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server.rs
@@ -498,7 +498,7 @@ async fn set_window_size(
 pub fn spawn_server(app_handle: tauri::AppHandle, port: u16) -> mpsc::Sender<()> {
     let (tx, mut rx) = mpsc::channel(1);
 
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         tokio::select! {
             _ = run_server(app_handle, port) => {},
             _ = rx.recv() => {


### PR DESCRIPTION
## Problem
The app panics on startup with `panic: there is no reactor running, must be called from the context of a Tokio 1.x runtime` when attempting to spawn the embedded server.

## Root cause
`spawn_server` is called directly from the Tauri `setup` hook, which executes on the main thread and lacks a Tokio runtime context. Using `tokio::spawn` in this context panics.

## Fix
Switched `tokio::spawn` to `tauri::async_runtime::spawn` in `spawn_server`, ensuring the future is properly dispatched to Tauri's managed async runtime.

## Confidence: 10/10

## Verification
```

```

---
auto-generated by issue-solver pipe