### PR TITLE
fix: clean up unused imports and dead code warnings on Windows

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -11,14 +11,14 @@ use crate::{
 use tauri::{Emitter, Manager};
 use tracing::{debug, error, info, warn};
 
-use std::sync::OnceLock;
-
 /// Global app handle stored so the native notification action callback can emit events.
-static GLOBAL_APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
+#[cfg(target_os = "macos")]
+static GLOBAL_APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
 
 /// Callback invoked from Swift when user clicks a notification action.
 /// Handles "manage" directly in Rust (opens home window to notifications settings).
 /// Other actions are forwarded as Tauri events to JS.
+#[cfg(target_os = "macos")]
 extern "C" fn native_notif_action_callback(json_ptr: *const std::os::raw::c_char) {
     if json_ptr.is_null() {
         return;
@@ -57,6 +57,7 @@ extern "C" fn native_notif_action_callback(json_ptr: *const std::os::raw::c_char
 }
 
 /// Callback invoked from Swift when user clicks a shortcut reminder action.
+#[cfg(target_os = "macos")]
 extern "C" fn native_shortcut_action_callback(action_ptr: *const std::os::raw::c_char) {
     if action_ptr.is_null() {
         return;
@@ -746,14 +747,14 @@ pub async fn show_window(
 /// gestures (magnifyWithEvent:) reach the WKWebView for zoom handling.
 #[tauri::command]
 #[specta::specta]
-pub async fn ensure_webview_focus(app_handle: tauri::AppHandle) -> Result<(), String> {
+pub async fn ensure_webview_focus(_app_handle: tauri::AppHandle) -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         use crate::window::run_on_main_thread_safe;
         use tauri_nspanel::ManagerExt;
 
-        let app = app_handle.clone();
-        run_on_main_thread_safe(&app_handle, move || {
+        let app = _app_handle.clone();
+        run_on_main_thread_safe(&_app_handle, move || {
             for label in &["main", "main-window"] {
                 if let Ok(panel) = app.get_webview_panel(label) {
                     unsafe {

--- a/apps/screenpipe-app-tauri/src-tauri/src/livetext.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/livetext.rs
@@ -236,7 +236,7 @@ pub async fn livetext_analyze(
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (image_path, x, y, w, h);
+        let _ = (image_path, frame_id, x, y, w, h);
         Err("live text is only available on macOS".to_string())
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/native_notification.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/native_notification.rs
@@ -43,6 +43,7 @@ mod ffi {
 }
 
 #[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
 mod ffi {
     pub fn is_available() -> bool {
         false

--- a/apps/screenpipe-app-tauri/src-tauri/src/native_shortcut_reminder.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/native_shortcut_reminder.rs
@@ -48,6 +48,7 @@ mod ffi {
 }
 
 #[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
 mod ffi {
     pub fn is_available() -> bool {
         false

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -427,6 +427,7 @@ pub fn check_arc_installed() -> bool {
 }
 
 /// Returns the names of installed Chromium browsers that need Automation permission
+#[allow(dead_code)]
 #[tauri::command(async)]
 #[specta::specta]
 pub fn get_installed_browsers() -> Vec<String> {
@@ -447,6 +448,7 @@ pub fn get_installed_browsers() -> Vec<String> {
 
 /// Check if Automation permission is granted for all installed Chromium browsers.
 /// Returns true only if ALL installed browsers have automation granted.
+#[allow(dead_code)]
 #[tauri::command(async)]
 #[specta::specta]
 pub fn check_browsers_automation_permission(_app: tauri::AppHandle) -> bool {
@@ -480,6 +482,7 @@ pub fn check_browsers_automation_permission(_app: tauri::AppHandle) -> bool {
 /// Request Automation permission for installed Chromium browsers that are already running.
 /// Never force-launches browsers — only prompts for ones the user already has open.
 /// Opens System Settings > Automation as fallback for browsers not running.
+#[allow(dead_code)]
 #[tauri::command(async)]
 #[specta::specta]
 pub fn request_browsers_automation_permission(_app: tauri::AppHandle) -> bool {
@@ -543,6 +546,7 @@ pub fn request_browsers_automation_permission(_app: tauri::AppHandle) -> bool {
 
 /// Per-browser automation status: "granted", "denied", or "not_asked".
 /// Also includes whether the browser is currently running.
+#[allow(dead_code)]
 #[derive(Serialize, Deserialize, Type, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BrowserAutomationStatus {
@@ -552,6 +556,7 @@ pub struct BrowserAutomationStatus {
 }
 
 /// Returns per-browser automation permission status for all installed Chromium browsers.
+#[allow(dead_code)]
 #[tauri::command(async)]
 #[specta::specta]
 pub fn get_browsers_automation_status() -> Vec<BrowserAutomationStatus> {
@@ -596,6 +601,7 @@ pub fn get_browsers_automation_status() -> Vec<BrowserAutomationStatus> {
 
 /// Request automation permission for a single browser by name.
 /// Returns the new status: "granted", "denied", or "not_asked".
+#[allow(dead_code)]
 #[tauri::command(async)]
 #[specta::specta]
 pub fn request_single_browser_automation(browser_name: String) -> String {
@@ -639,6 +645,7 @@ pub fn request_single_browser_automation(browser_name: String) -> String {
 
     #[cfg(not(target_os = "macos"))]
     {
+        let _ = browser_name;
         "not_asked".to_string()
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server.rs
@@ -118,10 +118,9 @@ async fn handle_focus(
 }
 
 async fn kill_process_on_port(port: u16) {
-    let my_pid = std::process::id().to_string();
-
     #[cfg(unix)]
     {
+        let my_pid = std::process::id().to_string();
         // lsof can hang indefinitely on macOS — always enforce a timeout
         // and kill the child if it exceeds it, to avoid zombie lsof processes.
         let child = match tokio::process::Command::new("lsof")

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/gesture.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/gesture.rs
@@ -139,6 +139,7 @@ pub fn init_magnify_handler(app: tauri::AppHandle) {
 }
 
 #[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
 pub fn init_magnify_handler(_app: tauri::AppHandle) {}
 
 /// Attach an NSMagnificationGestureRecognizer to the given view.

--- a/crates/screenpipe-connect/src/remote_sync.rs
+++ b/crates/screenpipe-connect/src/remote_sync.rs
@@ -462,10 +462,7 @@ async fn sync_to_remote_inner(config: &SyncConfig, data_dir: &Path) -> Result<Sy
             .arg(&db_path)
             .arg("PRAGMA wal_checkpoint(TRUNCATE);");
         #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            wal_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-        }
+        wal_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
         match wal_cmd.output().await {
             Ok(out) if out.status.success() => {
                 debug!("WAL checkpoint completed before sync");
@@ -787,10 +784,7 @@ async fn discover_tailscale() -> Vec<DiscoveredHost> {
     let mut ts_cmd = tokio::process::Command::new("tailscale");
     ts_cmd.args(["status", "--json"]);
     #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        ts_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
+    ts_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     let out = match ts_cmd.output().await {
         Ok(o) if o.status.success() => o,
         _ => return vec![],

--- a/crates/screenpipe-connect/src/whatsapp/mod.rs
+++ b/crates/screenpipe-connect/src/whatsapp/mod.rs
@@ -138,10 +138,7 @@ impl WhatsAppGateway {
                 .stdout(Stdio::null())
                 .stderr(Stdio::piped());
             #[cfg(windows)]
-            {
-                use std::os::windows::process::CommandExt;
-                install_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-            }
+            install_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
             let install = install_cmd.spawn()?.wait().await?;
             if !install.success() {
                 anyhow::bail!("failed to install @whiskeysockets/baileys");
@@ -164,10 +161,7 @@ impl WhatsAppGateway {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            gateway_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-        }
+        gateway_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
         let mut child = gateway_cmd
             .spawn()
             .context("failed to spawn whatsapp gateway")?;
@@ -360,10 +354,7 @@ impl WhatsAppGateway {
                     .stderr(Stdio::piped())
                     .kill_on_drop(true);
                 #[cfg(windows)]
-                {
-                    use std::os::windows::process::CommandExt;
-                    respawn_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-                }
+                respawn_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
                 match respawn_cmd.spawn() {
                     Ok(mut new_child) => {
                         let stdin_handle = new_child.stdin.take().expect("stdin piped");

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1347,11 +1347,7 @@ fn build_async_command(path: &str) -> tokio::process::Command {
         }
 
         // Prevent console window flash on Windows
-        {
-            use std::os::windows::process::CommandExt;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            cmd.creation_flags(CREATE_NO_WINDOW);
-        }
+        cmd.creation_flags(0x08000000);
 
         cmd
     }

--- a/crates/screenpipe-core/src/ffmpeg.rs
+++ b/crates/screenpipe-core/src/ffmpeg.rs
@@ -38,10 +38,7 @@ pub fn ffmpeg_cmd_async(path: impl AsRef<std::ffi::OsStr>) -> tokio::process::Co
     #[allow(unused_mut)]
     let mut cmd = tokio::process::Command::new(path);
     #[cfg(windows)]
-    {
-        use std::os::windows::process::CommandExt;
-        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
-    }
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
     cmd
 }
 

--- a/crates/screenpipe-engine/src/drm_detector.rs
+++ b/crates/screenpipe-engine/src/drm_detector.rs
@@ -17,7 +17,9 @@
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use tracing::{debug, info, warn};
+#[cfg(target_os = "macos")]
+use tracing::warn;
+use tracing::{debug, info};
 
 /// Global flag — when `true`, all monitors skip screen capture.
 static DRM_CONTENT_PAUSED: AtomicBool = AtomicBool::new(false);
@@ -176,6 +178,7 @@ pub fn check_and_update_drm_state(
 }
 
 /// Known browser app names for URL-based DRM checking in poll_drm_clear.
+#[cfg(target_os = "macos")]
 const BROWSER_APPS: &[&str] = &[
     "arc",
     "google chrome",
@@ -194,6 +197,7 @@ const BROWSER_APPS: &[&str] = &[
     "comet",
 ];
 
+#[cfg(target_os = "macos")]
 fn is_browser(app_name: &str) -> bool {
     let lower = app_name.to_lowercase();
     BROWSER_APPS.iter().any(|&b| lower.contains(b))

--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -839,12 +839,14 @@ fn walk_for_signals(
 }
 
 /// A signal with pre-lowercased match strings to avoid per-node allocations.
+#[cfg(target_os = "macos")]
 struct PrecomputedSignal {
     signal: CallSignal,
     /// Pre-lowercased match string (the substring to search for).
     lower: String,
 }
 
+#[cfg(target_os = "macos")]
 impl PrecomputedSignal {
     fn from_signals(signals: &[CallSignal]) -> Vec<PrecomputedSignal> {
         signals
@@ -939,6 +941,7 @@ fn check_signal_match(
 
 /// Optimized signal match using pre-lowercased signal strings and pre-lowercased node fields.
 /// Avoids per-signal and per-node `.to_lowercase()` allocations on the hot path.
+#[cfg(target_os = "macos")]
 fn check_signal_match_precomputed(
     ps: &PrecomputedSignal,
     role: &str,
@@ -1898,12 +1901,7 @@ pub fn find_running_meeting_apps(
     profiles: &[MeetingDetectionProfile],
     currently_tracking: Option<&ActiveTracking>,
 ) -> Vec<RunningMeetingApp> {
-    use std::collections::{HashMap, HashSet};
-    use windows::Win32::Foundation::{BOOL, HWND, LPARAM};
-    use windows::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
-    use windows::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetWindowTextW, GetWindowThreadProcessId, IsWindowVisible,
-    };
+    use std::collections::HashSet;
 
     let mut results = Vec::new();
     let mut seen_pids = HashSet::new();
@@ -2085,6 +2083,7 @@ async fn db_find_browser_meetings(
 
     for (app_name, window_name, browser_url) in &rows {
         let window_lower = window_name.to_lowercase();
+        #[cfg(target_os = "macos")]
         let app_lower = app_name.to_lowercase();
         let url_lower = browser_url.as_deref().unwrap_or("").to_lowercase();
         for (idx, profile) in profiles.iter().enumerate() {

--- a/crates/screenpipe-engine/src/paired_capture.rs
+++ b/crates/screenpipe-engine/src/paired_capture.rs
@@ -18,14 +18,19 @@ use screenpipe_a11y::tree::{create_tree_walker, TreeSnapshot, TreeWalkerConfig};
 use screenpipe_core::pii_removal::remove_pii;
 use screenpipe_db::DatabaseManager;
 use screenpipe_screen::snapshot_writer::SnapshotWriter;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+#[cfg(not(target_os = "windows"))]
+use std::sync::OnceLock;
 use std::time::Instant;
+#[cfg(not(target_os = "windows"))]
 use tokio::sync::Semaphore;
 use tracing::{debug, warn};
 
 /// Limits concurrent OCR tasks to avoid CPU spikes when multiple monitors
 /// trigger capture simultaneously.
+#[cfg(not(target_os = "windows"))]
 static OCR_SEMAPHORE: OnceLock<Semaphore> = OnceLock::new();
+#[cfg(not(target_os = "windows"))]
 fn ocr_semaphore() -> &'static Semaphore {
     OCR_SEMAPHORE.get_or_init(|| Semaphore::new(1))
 }

--- a/crates/screenpipe-engine/src/power/monitor.rs
+++ b/crates/screenpipe-engine/src/power/monitor.rs
@@ -16,7 +16,9 @@
 
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use tracing::{debug, warn};
+#[cfg(target_os = "macos")]
+use tracing::warn;
+use tracing::debug;
 
 /// Thermal pressure level reported by the OS.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Eliminates all unused import and dead code warnings produced when building on Windows.



https://github.com/user-attachments/assets/f3a8175a-1fa8-45e8-b391-62d9d5cc083d





## What changed

- **Remove redundant `CommandExt` trait imports**: `tokio::process::Command::creation_flags` is an inherent method and does not require importing `std::os::windows::process::CommandExt`. Removed 6 such imports across `pi.rs`, `ffmpeg.rs`, `remote_sync.rs`, and `whatsapp/mod.rs`.

- **Gate macOS-only items behind `#[cfg(target_os = "macos")]`**:
  - `drm_detector.rs`: `BROWSER_APPS`, `is_browser`, and `warn` import (only used in macOS functions)
  - `meeting_detector.rs`: `PrecomputedSignal` struct + impl, `check_signal_match_precomputed`, and `app_lower` binding
  - `power/monitor.rs`: `warn` import (only used in macOS `macos_battery_state`)
  - `commands.rs`: `GLOBAL_APP_HANDLE`, `native_notif_action_callback`, `native_shortcut_action_callback`

- **Gate non-Windows items behind `#[cfg(not(target_os = "windows"))]`**:
  - `paired_capture.rs`: `OCR_SEMAPHORE`, `ocr_semaphore()`, and their `OnceLock`/`Semaphore` imports (only used in the non-Windows OCR path)

- **Fix unused parameter warnings**:
  - `commands.rs`: rename `app_handle` → `_app_handle` in `ensure_webview_focus`
  - `livetext.rs`: add `frame_id` to the non-macOS `let _ = (...)` discard
  - `permissions.rs`: add `let _ = browser_name` in non-macOS block of `request_single_browser_automation`
  - `server.rs`: move `my_pid` binding inside the `#[cfg(unix)]` block

- **Suppress false-positive dead_code lints with `#[allow(dead_code)]`**:
  - Browser automation Tauri commands/struct in `permissions.rs` (legitimately registered in `generate_handler!` but flagged on Windows)
  - Non-macOS FFI stub modules in `native_notification.rs` and `native_shortcut_reminder.rs`
  - Non-macOS `init_magnify_handler` stub in `window/gesture.rs`