### PR TITLE
fix: enforce recording schedule and reset stale pause flag on restart

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/embedded_server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/embedded_server.rs
@@ -425,6 +425,12 @@ pub async fn start_embedded_server(
     // Tracks system sleep/wake events and checks if recording degrades after wake
     start_sleep_monitor();
 
+    // Reset schedule pause flag — the embedded server runs inside the Tauri process,
+    // so static globals survive across stop/start cycles. Without this reset a flag
+    // set in a prior session (e.g. "outside work hours") would keep recording
+    // blocked even after the user disables the schedule and restarts.
+    screenpipe_engine::schedule_monitor::reset_schedule_paused();
+
     // Start work-hours schedule monitor if enabled
     if config.schedule_enabled {
         screenpipe_engine::schedule_monitor::start_schedule_monitor(

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -690,6 +690,10 @@ async fn main() -> anyhow::Result<()> {
 
     let (shutdown_tx, _) = broadcast::channel::<()>(1);
 
+    // Reset schedule pause flag before (optionally) starting the monitor.
+    // Ensures a clean state on every startup.
+    screenpipe_engine::schedule_monitor::reset_schedule_paused();
+
     // Start work-hours schedule monitor if enabled
     if config.schedule_enabled {
         screenpipe_engine::schedule_monitor::start_schedule_monitor(

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -292,8 +292,10 @@ pub async fn event_driven_capture_loop(
     // Also seeds the frame comparer so subsequent visual-change checks work.
     // Skip if screen is locked — avoids storing black frames from sleep/lock.
     // Pre-capture DRM gate: skip if DRM content is focused (AX-only, no SCK).
+    // Skip if outside work-hours schedule.
     if !crate::sleep_monitor::screen_is_locked()
         && !crate::drm_detector::pre_capture_drm_check(pause_on_drm_content, None)
+        && !crate::schedule_monitor::schedule_paused()
     {
         // Small delay to let the monitor settle after startup
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -387,8 +389,10 @@ pub async fn event_driven_capture_loop(
             }
         }
 
-        // Skip capture while DRM streaming content is focused
-        if crate::drm_detector::drm_content_paused() {
+        // Skip capture while DRM streaming content is focused or outside schedule
+        if crate::drm_detector::drm_content_paused()
+            || crate::schedule_monitor::schedule_paused()
+        {
             tokio::time::sleep(poll_interval).await;
             continue;
         }
@@ -453,6 +457,7 @@ pub async fn event_driven_capture_loop(
             && visual_check_enabled
             && state.can_capture()
             && !crate::drm_detector::drm_content_paused()
+            && !crate::schedule_monitor::schedule_paused()
             && last_visual_check.elapsed() >= visual_check_interval
         {
             last_visual_check = Instant::now();

--- a/crates/screenpipe-engine/src/schedule_monitor.rs
+++ b/crates/screenpipe-engine/src/schedule_monitor.rs
@@ -21,6 +21,15 @@ pub fn schedule_paused() -> bool {
     SCHEDULE_PAUSED.load(Ordering::SeqCst)
 }
 
+/// Reset the schedule pause flag to `false`.
+///
+/// Must be called at embedded-server startup so that a previously-set flag
+/// from a prior run (same process) does not carry over when the schedule is
+/// disabled or restarted with different rules.
+pub fn reset_schedule_paused() {
+    SCHEDULE_PAUSED.store(false, Ordering::SeqCst);
+}
+
 /// Check if the given time falls within any schedule rule for today.
 fn is_within_schedule(rules: &[ScheduleRule], now: &chrono::DateTime<chrono::Local>) -> bool {
     use chrono::Weekday::*;

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -38,6 +38,8 @@ pub async fn start_monitor_watcher(
         let mut permission_denied_logged = false;
         // Track whether we stopped monitors due to DRM
         let mut drm_stopped = false;
+        // Track whether we stopped recording due to work-hours schedule
+        let mut schedule_stopped = false;
 
         // Initialize with current monitors
         match list_monitors_detailed().await {
@@ -102,6 +104,45 @@ pub async fn start_monitor_watcher(
                 }
                 drm_stopped = false;
                 // Re-populate known_monitors after restart
+                if let Ok(monitors) = list_monitors_detailed().await {
+                    known_monitors = monitors.iter().map(|m| m.id()).collect();
+                }
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                continue;
+            }
+
+            // ── Schedule pause handling ─────────────────────────────────────
+            // When outside the work-hours schedule stop all capture so no data
+            // is recorded outside the user's defined window.
+            if crate::schedule_monitor::schedule_paused() {
+                if !schedule_stopped {
+                    info!("outside work-hours schedule — stopping all capture");
+                    if let Err(e) = vision_manager.stop().await {
+                        warn!("failed to stop vision manager for schedule pause: {:?}", e);
+                    }
+                    if let Some(ref am) = audio_manager {
+                        if let Err(e) = am.stop().await {
+                            warn!("failed to stop audio for schedule pause: {:?}", e);
+                        }
+                    }
+                    schedule_stopped = true;
+                }
+                // Check every 30 s — matches the schedule monitor's own cadence.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                continue;
+            }
+
+            if schedule_stopped {
+                info!("within work-hours schedule — resuming capture");
+                if let Err(e) = vision_manager.start().await {
+                    warn!("failed to restart vision manager after schedule resume: {:?}", e);
+                }
+                if let Some(ref am) = audio_manager {
+                    if let Err(e) = am.start().await {
+                        warn!("failed to restart audio after schedule resume: {:?}", e);
+                    }
+                }
+                schedule_stopped = false;
                 if let Ok(monitors) = list_monitors_detailed().await {
                     known_monitors = monitors.iter().map(|m| m.id()).collect();
                 }


### PR DESCRIPTION
### Description                                                                                                                                                   
  
  - Fix Recording Schedule (BETA) feature that was saving rules but never actually stopping audio/video capture outside the defined work hours, and fix a stale static flag bug that kept recording blocked after disabling the schedule.


https://github.com/user-attachments/assets/cb826718-4a5b-4d95-b067-f7705fd73265



### Files Changed

  - `crates/screenpipe-engine/src/schedule_monitor.rs` — added `reset_schedule_paused()` to explicitly clear the global `AtomicBool` on startup
  - `crates/screenpipe-engine/src/event_driven_capture.rs` — added `schedule_paused()` guards at startup capture, main loop, and visual-change check so frames are  
  skipped outside schedule
  - `crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs` — added schedule pause/resume block that stops and restarts `VisionManager` + `AudioManager`   
  when the schedule boundary is crossed
  - `apps/screenpipe-app-tauri/src-tauri/src/embedded_server.rs` — call `reset_schedule_paused()` unconditionally at embedded server startup to prevent stale flag  
  from a prior session (same process) blocking recording after schedule is disabled
  - `crates/screenpipe-engine/src/bin/screenpipe-engine.rs` — same reset call for the standalone CLI binary