### PR TITLE
fix(chat): avoid false daily usage limit message on 429

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1835,28 +1835,17 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           console.error("[Pi] Auto-retry failed:", errorStr);
 
           // Detect rate limit or daily limit from the error
-          if (errorStr.includes("daily_limit_exceeded") || errorStr.includes("daily_cost_limit_exceeded") || errorStr.includes("429") || errorStr.includes("rate limit")) {
-            // Distinguish between daily limit and per-minute rate limit
-            const isDailyLimit = errorStr.includes("daily_limit_exceeded") || errorStr.includes("daily_cost_limit_exceeded");
-            const isPerMinuteRate = errorStr.includes("rate limit exceeded") || errorStr.includes("requests per minute");
-
-            if (isDailyLimit) {
+          const quotaErrorType = classifyQuotaError(errorStr);
+          if (quotaErrorType === "daily" || quotaErrorType === "rate") {
+            if (quotaErrorType === "daily") {
               posthog.capture("wall_hit", { reason: "daily_limit", source: "chat" });
             }
 
             if (piMessageIdRef.current) {
               const msgId = piMessageIdRef.current;
-              let content: string;
-              if (isDailyLimit) {
-                content = buildDailyLimitMessage(errorStr);
-              } else if (isPerMinuteRate) {
-                // Extract wait time from error
-                const waitMatch = errorStr.match(/wait (\d+) seconds/i);
-                const waitTime = waitMatch ? waitMatch[1] : "a moment";
-                content = `Rate limited — please wait ${waitTime} seconds and try again.`;
-              } else {
-                content = "Rate limited — try again in a moment or switch to a different model.";
-              }
+              const content = quotaErrorType === "daily"
+                ? buildDailyLimitMessage(errorStr)
+                : buildRateLimitMessage(errorStr);
               setMessages((prev) =>
                 prev.map((m) => m.id === msgId ? { ...m, content } : m)
               );
@@ -1880,10 +1869,9 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
             const msgId = piMessageIdRef.current;
             const fullError = `${reason} ${errorDetail}`.trim();
 
-            if (fullError.includes("daily_limit_exceeded") || fullError.includes("daily_cost_limit_exceeded") || fullError.includes("429") || fullError.includes("rate limit")) {
-              const isDailyLimit = fullError.includes("daily_limit_exceeded") || fullError.includes("daily_cost_limit_exceeded");
-              const isPerMinuteRate = fullError.includes("rate limit exceeded") || fullError.includes("requests per minute");
-              if (isDailyLimit) {
+            const quotaErrorType = classifyQuotaError(fullError);
+            if (quotaErrorType === "daily" || quotaErrorType === "rate") {
+              if (quotaErrorType === "daily") {
                 try {
                   const match = fullError.match(/"resets_at":\s*"([^"]+)"/);
                 } catch {}
@@ -1891,11 +1879,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
                   prev.map((m) => m.id === msgId ? { ...m, content: buildDailyLimitMessage(fullError) } : m)
                 );
               } else {
-                  const waitMatch = fullError.match(/wait (\d+) seconds/i);
-                const waitTime = waitMatch ? waitMatch[1] : "a moment";
-                const content = isPerMinuteRate
-                  ? `Rate limited — please wait ${waitTime} seconds and try again.`
-                  : "Rate limited — try again in a moment or switch to a different model.";
+                const content = buildRateLimitMessage(fullError);
                 setMessages((prev) =>
                   prev.map((m) => m.id === msgId ? { ...m, content } : m)
                 );
@@ -2074,10 +2058,9 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           if (piMessageIdRef.current) {
             const msgId = piMessageIdRef.current;
 
-            if (errorStr.includes("daily_limit_exceeded") || errorStr.includes("daily_cost_limit_exceeded") || errorStr.includes("429") || errorStr.includes("rate limit")) {
-              const isDailyLimit = errorStr.includes("daily_limit_exceeded") || errorStr.includes("daily_cost_limit_exceeded");
-              const isPerMinuteRate = errorStr.includes("rate limit exceeded") || errorStr.includes("requests per minute");
-              if (isDailyLimit) {
+            const quotaErrorType = classifyQuotaError(errorStr);
+            if (quotaErrorType === "daily" || quotaErrorType === "rate") {
+              if (quotaErrorType === "daily") {
                 try {
                   const match = errorStr.match(/"resets_at":\s*"([^"]+)"/);
                 } catch {}
@@ -2085,11 +2068,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
                   prev.map((m) => m.id === msgId ? { ...m, content: buildDailyLimitMessage(errorStr) } : m)
                 );
               } else {
-                  const waitMatch = errorStr.match(/wait (\d+) seconds/i);
-                const waitTime = waitMatch ? waitMatch[1] : "a moment";
-                const content = isPerMinuteRate
-                  ? `Rate limited — please wait ${waitTime} seconds and try again.`
-                  : "Rate limited — try again in a moment or switch to a different model.";
+                const content = buildRateLimitMessage(errorStr);
                 setMessages((prev) =>
                   prev.map((m) => m.id === msgId ? { ...m, content } : m)
                 );
@@ -2122,8 +2101,9 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
               );
             }
           }
-          const errorCategory = errorStr.includes("daily_limit") ? "daily_limit"
-            : errorStr.includes("rate limit") || errorStr.includes("429") ? "rate_limit"
+          const quotaErrorType = classifyQuotaError(errorStr);
+          const errorCategory = quotaErrorType === "daily" ? "daily_limit"
+            : quotaErrorType === "rate" ? "rate_limit"
             : errorStr.includes("model_not_allowed") ? "model_not_allowed"
             : "other";
           posthog.capture("chat_response_error", {

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -112,6 +112,34 @@ function buildDailyLimitMessage(errorStr: string): string {
   }
 }
 
+function classifyQuotaError(errorStr: string): "daily" | "rate" | "none" {
+  const normalized = errorStr.toLowerCase();
+  const isDailyLimit =
+    normalized.includes("credits_exhausted") ||
+    normalized.includes("daily_limit_exceeded") ||
+    normalized.includes("daily_cost_limit_exceeded");
+  if (isDailyLimit) {
+    return "daily";
+  }
+
+  const isRateLimit =
+    normalized.includes("429") ||
+    normalized.includes("rate limit") ||
+    normalized.includes("rate_limit") ||
+    normalized.includes("requests per minute") ||
+    normalized.includes("too many requests");
+  return isRateLimit ? "rate" : "none";
+}
+
+function buildRateLimitMessage(errorStr: string): string {
+  const waitMatch = errorStr.match(/wait (\d+) seconds/i);
+  const waitTime = waitMatch ? waitMatch[1] : "a moment";
+  const isPerMinuteRate = /rate limit exceeded|requests per minute/i.test(errorStr);
+  return isPerMinuteRate
+    ? `Rate limited — please wait ${waitTime} seconds and try again.`
+    : "Rate limited — try again in a moment or switch to a different model.";
+}
+
 /** Extract the gateway-reported tier from an error string, if present. */
 // Helper to get timezone offset string (e.g., "+1" or "-5")
 function getTimezoneOffsetString(): string {
@@ -1895,7 +1923,8 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           if (piMessageIdRef.current) {
             const msgId = piMessageIdRef.current;
 
-            if (errMsg.includes("credits_exhausted") || errMsg.includes("daily_limit_exceeded") || errMsg.includes("daily_cost_limit_exceeded") || errMsg.includes("429")) {
+            const quotaErrorType = classifyQuotaError(errMsg);
+            if (quotaErrorType === "daily") {
               try {
                 const resetsAtMatch = errMsg.match(/"resets_at":\s*"([^"]+)"/);
                 } catch {}
@@ -1903,9 +1932,9 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
               setMessages((prev) =>
                 prev.map((m) => m.id === msgId ? { ...m, content: buildDailyLimitMessage(errMsg) } : m)
               );
-            } else if (errMsg.includes("rate limit") || errMsg.includes("rate_limit")) {
+            } else if (quotaErrorType === "rate") {
               setMessages((prev) =>
-                prev.map((m) => m.id === msgId ? { ...m, content: "Rate limited — try again in a moment." } : m)
+                prev.map((m) => m.id === msgId ? { ...m, content: buildRateLimitMessage(errMsg) } : m)
               );
             } else {
               setMessages((prev) =>
@@ -1950,13 +1979,14 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
             // Surface credits_exhausted / rate limit errors from agent_end
             if (agentEndError && !content) {
               const errStr = agentEndError;
-              if (errStr.includes("credits_exhausted") || errStr.includes("daily_limit_exceeded") || errStr.includes("daily_cost_limit_exceeded") || errStr.includes("429")) {
+              const quotaErrorType = classifyQuotaError(errStr);
+              if (quotaErrorType === "daily") {
                 try {
                   const resetsAtMatch = errStr.match(/"resets_at":\s*"([^"]+)"/);
                     } catch {}
                                   content = buildDailyLimitMessage(errStr);
-              } else if (errStr.includes("rate limit")) {
-                  content = "Rate limited — try again in a moment.";
+              } else if (quotaErrorType === "rate") {
+                  content = buildRateLimitMessage(errStr);
               } else {
                 content = `Error: ${errStr}`;
               }


### PR DESCRIPTION
## Summary
Fixes a false-positive daily limit wall in Pi chat error handling.

## Root Cause
Two error paths in `standalone-chat.tsx` (`message_start/message_end` and `agent_end`) treated generic HTTP 429 as a daily-limit condition. This mislabeled transient or model rate-limit responses as "daily usage limit reached" for paid-model users.

## Changes
- Added `classifyQuotaError(errorStr)` helper to separate:
  - `daily`: `credits_exhausted`, `daily_limit_exceeded`, `daily_cost_limit_exceeded`
  - `rate`: generic `429` and rate-limit markers
- Added `buildRateLimitMessage(errorStr)` helper to keep rate-limit messaging consistent.
- Updated `message_start/message_end` and `agent_end` error branches to use the classifier.

## Impact
- Generic `429` now shows a rate-limit message instead of the daily-limit wall.
- True daily-limit signals still show the daily-limit message and analytics event.
- Scope is UI error classification only (no network or request-path changes).

## Validation
- PASS: `bunx tsc --noEmit --pretty false` (in `apps/screenpipe-app-tauri`)
- NOTE: `bun run test` still has existing baseline failures unrelated to this patch (multiple `bun:test` import-resolution suites and pre-existing assertion failures in `text-overlay` and `use-frame-ocr-data`).

Closes #2941