### PR TITLE
fix: reduce log noise from wired mic gap detection

### DIFF
--- a/crates/screenpipe-audio/src/core/source_buffer.rs
+++ b/crates/screenpipe-audio/src/core/source_buffer.rs
@@ -14,8 +14,8 @@
 //! This buffer:
 //! 1. Detects gaps by comparing elapsed wall-clock time vs. expected chunk duration.
 //! 2. Inserts digital silence (0.0 samples) proportional to the gap length.
-//! 3. Logs gaps at different levels depending on device type (debug for Bluetooth
-//!    where gaps are expected; warn for wired devices where they indicate a problem).
+//! 3. Logs gaps at `debug` (Bluetooth: expected jitter; wired: routine CPAL/Core Audio
+//!    jitter on built-in mics). `warn` only for unusually large gaps on wired hardware.
 //!
 //! # Design
 //!
@@ -38,9 +38,15 @@ use super::device_detection::InputDeviceKind;
 /// (the 30 s segment just has fewer real samples, which Whisper handles fine via VAD).
 const MAX_SILENCE_INSERT_MS: f64 = 500.0;
 
-/// Gap threshold multiplier: a gap must be > N × expected chunk duration to trigger insertion.
-/// Using 1.5× means we only fire on genuine packet drops, not on normal OS scheduler jitter.
-const GAP_THRESHOLD_MULTIPLIER: f64 = 1.5;
+/// Bluetooth / unknown: tight threshold — packet drops show up as large gaps vs chunk cadence.
+const GAP_THRESHOLD_MULTIPLIER_BLUETOOTH: f64 = 1.5;
+
+/// Wired (built-in, USB): CPAL on macOS often has 8–15 ms inter-chunk jitter vs a ~5 ms nominal
+/// chunk; 1.5× was far too tight and produced constant false positives and log spam.
+const GAP_THRESHOLD_MULTIPLIER_WIRED: f64 = 3.0;
+
+/// Wired-only: log at `warn` if wall-clock gap exceeds this (ms) — indicates driver/load issues.
+const WIRED_GAP_WARN_MIN_ELAPSED_MS: f64 = 80.0;
 
 /// Per-device buffer that detects Bluetooth packet gaps and inserts silence.
 pub struct SourceBuffer {
@@ -107,7 +113,12 @@ impl SourceBuffer {
             (self.last_chunk_time, self.expected_chunk_duration_ms)
         {
             let elapsed_ms = last_time.elapsed().as_secs_f64() * 1000.0;
-            let threshold_ms = expected_ms * GAP_THRESHOLD_MULTIPLIER;
+            let mult = if self.device_kind.is_bluetooth() {
+                GAP_THRESHOLD_MULTIPLIER_BLUETOOTH
+            } else {
+                GAP_THRESHOLD_MULTIPLIER_WIRED
+            };
+            let threshold_ms = expected_ms * mult;
 
             if elapsed_ms > threshold_ms {
                 // How many ms of audio are genuinely missing?
@@ -120,10 +131,19 @@ impl SourceBuffer {
                         "[{}] bluetooth gap: {:.1}ms elapsed (expected {:.1}ms) → inserting {:.1}ms silence ({} samples)",
                         self.device_name, elapsed_ms, expected_ms, gap_ms, silence_samples
                     );
-                } else {
+                } else if elapsed_ms >= WIRED_GAP_WARN_MIN_ELAPSED_MS {
                     warn!(
-                        "[{}] unexpected gap on wired device: {:.1}ms elapsed (expected {:.1}ms) → inserting silence",
-                        self.device_name, elapsed_ms, expected_ms
+                        "[{}] large gap on wired device: {:.1}ms elapsed (expected {:.1}ms) → inserting {:.1}ms silence ({} samples)",
+                        self.device_name,
+                        elapsed_ms,
+                        expected_ms,
+                        gap_ms,
+                        silence_samples
+                    );
+                } else {
+                    debug!(
+                        "[{}] wired gap: {:.1}ms elapsed (expected {:.1}ms) → inserting {:.1}ms silence ({} samples)",
+                        self.device_name, elapsed_ms, expected_ms, gap_ms, silence_samples
                     );
                 }
 


### PR DESCRIPTION
## What changed

The audio source buffer uses a gap threshold multiplier to decide when to insert silence for missing audio chunks. The old single value of 1.5x was calculated for Bluetooth, where packet drops show up as clear large gaps.

On wired and built-in mics, CPAL on macOS normally delivers chunks with 8–15ms of jitter against a ~5ms expected duration. The 1.5x threshold was too tight for this and fired constantly, producing warning-level log spam on every recording session even when nothing was wrong.

## Fix

- Added two separate threshold constants: `GAP_THRESHOLD_MULTIPLIER_BLUETOOTH` (1.5x, unchanged) and `GAP_THRESHOLD_MULTIPLIER_WIRED` (3.0x)
- For wired devices, gaps below 80ms are now logged at `debug` — this is routine CPAL jitter, not a problem
- `warn` is kept for wired gaps above 80ms, which indicate a real driver or system load issue
- Bluetooth behaviour is unchanged

## Testing

Run screenpipe with a built-in or USB mic and check that the log is no longer flooded with gap warnings during normal recording. A genuine large gap (e.g. system overload) should still produce a `warn` line.