### PR TITLE
fix(audio): reduce speaker fragmentation and adapt output device threshold

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -1252,11 +1252,11 @@ impl AudioManager {
     }
 }
 
-/// Seed the embedding manager with named speakers from the DB.
+/// Seed the embedding manager with speakers from the DB.
 /// This allows returning voices to be recognized immediately instead of
 /// starting anonymous for the first 30+ seconds.
 async fn seed_speakers_from_db(db: &Arc<DatabaseManager>, seg_mgr: &Arc<SegmentationManager>) {
-    match db.get_named_speakers_with_centroids().await {
+    match db.get_speakers_with_centroids().await {
         Ok(speakers) if !speakers.is_empty() => {
             for (_db_id, name, centroid) in &speakers {
                 let emb = ndarray::Array1::from_vec(centroid.clone());
@@ -1269,10 +1269,10 @@ async fn seed_speakers_from_db(db: &Arc<DatabaseManager>, seg_mgr: &Arc<Segmenta
             );
         }
         Ok(_) => {
-            debug!("no named speakers with centroids found in DB to seed");
+            debug!("no speakers with centroids found in DB to seed");
         }
         Err(e) => {
-            warn!("failed to query named speakers for seeding: {}", e);
+            warn!("failed to query speakers for seeding: {}", e);
         }
     }
 }

--- a/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
+++ b/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
@@ -662,7 +662,7 @@ async fn extract_speaker_id(
 
     let embedding = best_embedding?;
 
-    match get_or_create_speaker_from_embedding(db, &embedding).await {
+    match get_or_create_speaker_from_embedding(db, &embedding, false).await {
         Ok(speaker) => {
             debug!(
                 "reconciliation: matched speaker id={} for batch",

--- a/crates/screenpipe-audio/src/transcription/transcription_result.rs
+++ b/crates/screenpipe-audio/src/transcription/transcription_result.rs
@@ -81,7 +81,8 @@ pub async fn process_transcription_result(
         debug!("empty speaker embedding; storing transcript without speaker");
         None
     } else {
-        let speaker = get_or_create_speaker_from_embedding(db, &result.speaker_embedding).await?;
+        let is_output = matches!(result.input.device.device_type, crate::core::device::DeviceType::Output);
+        let speaker = get_or_create_speaker_from_embedding(db, &result.speaker_embedding, is_output).await?;
         debug!("detected speaker id={}", speaker.id);
         Some(speaker.id)
     };
@@ -183,8 +184,10 @@ pub async fn process_transcription_result(
 pub async fn get_or_create_speaker_from_embedding(
     db: &DatabaseManager,
     embedding: &[f32],
+    is_output: bool,
 ) -> Result<Speaker, anyhow::Error> {
-    let speaker = db.get_speaker_from_embedding(embedding).await?;
+    let threshold = if is_output { 0.65 } else { 0.55 };
+    let speaker = db.get_speaker_from_embedding(embedding, threshold).await?;
     if let Some(speaker) = speaker {
         debug!(
             "matched speaker id={} name={:?}",

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1283,8 +1283,8 @@ impl DatabaseManager {
     pub async fn get_speaker_from_embedding(
         &self,
         embedding: &[f32],
+        speaker_threshold: f32,
     ) -> Result<Option<Speaker>, SqlxError> {
-        let speaker_threshold = 0.55;
         let bytes: &[u8] = embedding.as_bytes();
 
         // First try matching against stored embeddings (up to 10 per speaker)
@@ -1321,6 +1321,21 @@ impl DatabaseManager {
         .bind(speaker_threshold)
         .fetch_optional(&self.pool)
         .await?;
+
+        if speaker.is_none() {
+            // Log closest distance if we didn't match anything
+            let closest: Option<(Option<f64>,)> = sqlx::query_as(
+                "SELECT MIN(vec_distance_cosine(embedding, vec_f32(?1))) as dist
+                 FROM speaker_embeddings"
+            )
+            .bind(bytes)
+            .fetch_optional(&self.pool)
+            .await?;
+
+            if let Some((Some(dist),)) = closest {
+                tracing::debug!("no speaker match. closest distance: {:.3} (threshold: {:.3})", dist, speaker_threshold);
+            }
+        }
 
         Ok(speaker)
     }
@@ -1450,15 +1465,14 @@ impl DatabaseManager {
         Ok(())
     }
 
-    /// Get named speakers with non-null centroids for seeding the embedding manager.
+    /// Get speakers with non-null centroids for seeding the embedding manager.
     /// Returns (speaker_id, name, centroid as Vec<f32>).
-    pub async fn get_named_speakers_with_centroids(
+    pub async fn get_speakers_with_centroids(
         &self,
     ) -> Result<Vec<(i64, String, Vec<f32>)>, SqlxError> {
         let rows: Vec<(i64, String, Vec<u8>)> = sqlx::query_as(
-            "SELECT id, name, centroid FROM speakers \
-             WHERE name IS NOT NULL AND name != '' \
-             AND centroid IS NOT NULL \
+            "SELECT id, COALESCE(name, 'Speaker ' || id) as name, centroid FROM speakers \
+             WHERE centroid IS NOT NULL \
              AND (hallucination IS NULL OR hallucination = 0)",
         )
         .fetch_all(&self.pool)

--- a/crates/screenpipe-db/tests/db.rs
+++ b/crates/screenpipe-db/tests/db.rs
@@ -840,7 +840,7 @@ mod tests {
 
         let sample_embedding = vec![0.1; 512];
         let speaker = db
-            .get_speaker_from_embedding(&sample_embedding)
+            .get_speaker_from_embedding(&sample_embedding, 0.55)
             .await
             .unwrap();
         assert_eq!(speaker.unwrap().id, 1);


### PR DESCRIPTION
## Problem
Speaker fragmentation creates 190+ speakers instead of recognizing the correct ones (see #2969). Output device audio is noisier, which causes embeddings to drift and exceed the default `0.55` distance threshold. Additionally, the fast-matching embedding manager only seeded named speakers on restart, forcing the system to start 'blind' for anonymous but established speakers.

## Root cause
1. The global distance threshold was hardcoded to `0.55`, which is too low for system audio from output devices.
2. `get_named_speakers_with_centroids` arbitrarily filtered out unnamed speakers, restricting the local embedding manager from doing fast matching for a huge portion of speakers.
3. No closest-distance logging was present to inform users or devs about proper threshold adjustments.

## Fix
1. Passed `is_output` flag to `get_or_create_speaker_from_embedding`, increasing the threshold to `0.65` for `DeviceType::Output`.
2. Renamed `get_named_speakers_with_centroids` to `get_speakers_with_centroids` and removed the `name IS NOT NULL` filter to seed all active speakers with centroids.
3. Added a closest-distance query and `tracing::debug` log when no speaker is matched to help adjust thresholds dynamically.

## Confidence: 9/10

## Verification
```
[2m2026-04-14T19:29:05.332719Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=3 (no existing match within threshold)
[2m2026-04-14T19:29:05.333134Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=4 (no existing match within threshold)
[2m2026-04-14T19:29:05.333357Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=5 (no existing match within threshold)
test tests::test_insert_and_search_speaker ... ok
test tests::test_insert_and_search_ocr ... ok
test tests::test_search_accessibility_fts ... ok
[2m2026-04-14T19:29:05.342833Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
[2m2026-04-14T19:29:05.343950Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=2 (no existing match within threshold)
test tests::test_merge_speakers ... ok
test tests::test_search_accessibility_window_filter ... ok
test tests::test_search_accessibility_no_matches ... ok
[2m2026-04-14T19:29:05.819758Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
[2m2026-04-14T19:29:05.820481Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
test tests::test_update_speaker_metadata ... ok
test tests::test_update_speaker_name ... ok
[2m2026-04-14T19:29:05.821958Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
test tests::test_search_speakers ... ok
test tests::test_search_all ... ok
test tests::test_update_and_search_audio ... ok
test tests::test_search_with_frame_name ... ok
test tests::test_search_with_time_range ... ok
test tests::test_search_accessibility_time_range ... ok

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.81s
```

---
auto-generated by issue-solver pipe