### PR TITLE
fix: bypass daily cost limit for paid models if user has positive credit balance

### DIFF
--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -12,7 +12,7 @@ import { handleVertexProxy, handleVertexModels } from './handlers/vertex-proxy';
 import { handleWebSearch } from './handlers/web-search';
 import { logCost, getModelCost, inferProvider, getSpendSummary, getDailyUserCost, getMaxDailyCostPerUser, getTierDailyCostCap, isZeroCostModel } from './services/cost-tracker';
 import { trackResponseUsage } from './utils/stream-usage-tracker';
-import { getModelWeight } from './services/usage-tracker';
+import { getModelWeight, getCreditBalance } from './services/usage-tracker';
 import { pruneModelHealth } from './services/model-health';
 // import { handleTTSWebSocketUpgrade } from './handlers/voice-ws';
 
@@ -104,11 +104,15 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
 				const dailyCost = await getDailyUserCost(env, authResult.deviceId);
 				const maxCost = getTierDailyCostCap(authResult.tier, env);
 				if (dailyCost >= maxCost) {
-					return addCorsHeaders(createErrorResponse(429, JSON.stringify({
-						error: 'daily_cost_limit_exceeded',
-						message: `You've reached your daily AI usage limit. Try a free model or wait until tomorrow.`,
-						free_models: ['gemini-3-flash'],
-					})));
+					// Bypass cost limit if user has credits available
+					const hasCredits = authResult.userId ? await getCreditBalance(env, authResult.userId).then(b => b > 0).catch(() => false) : false;
+					if (!hasCredits) {
+						return addCorsHeaders(createErrorResponse(429, JSON.stringify({
+							error: 'daily_cost_limit_exceeded',
+							message: `You've reached your daily AI usage limit. Try a free model or wait until tomorrow.`,
+							free_models: ['gemini-3-flash'],
+						})));
+					}
 				}
 			}
 
@@ -339,11 +343,15 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
 				const dailyCost = await getDailyUserCost(env, authResult.deviceId);
 				const maxCost = getTierDailyCostCap(authResult.tier, env);
 				if (dailyCost >= maxCost) {
-					return addCorsHeaders(createErrorResponse(429, JSON.stringify({
-						error: 'daily_cost_limit_exceeded',
-						message: `You've reached your daily AI usage limit. Try a free model or wait until tomorrow.`,
-						free_models: ['gemini-3-flash'],
-					})));
+					// Bypass cost limit if user has credits available
+					const hasCredits = authResult.userId ? await getCreditBalance(env, authResult.userId).then(b => b > 0).catch(() => false) : false;
+					if (!hasCredits) {
+						return addCorsHeaders(createErrorResponse(429, JSON.stringify({
+							error: 'daily_cost_limit_exceeded',
+							message: `You've reached your daily AI usage limit. Try a free model or wait until tomorrow.`,
+							free_models: ['gemini-3-flash'],
+						})));
+					}
 				}
 			}
 
@@ -438,11 +446,15 @@ async function handleRequest(request: Request, env: Env, ctx: ExecutionContext):
 				const dailyCost = await getDailyUserCost(env, authResult.deviceId);
 				const maxCost = getTierDailyCostCap(authResult.tier, env);
 				if (dailyCost >= maxCost) {
-					return addCorsHeaders(createErrorResponse(429, JSON.stringify({
-						error: 'daily_cost_limit_exceeded',
-						message: `You've reached your daily AI usage limit. Try a free model or wait until tomorrow.`,
-						free_models: ['gemini-3-flash'],
-					})));
+					// Bypass cost limit if user has credits available
+					const hasCredits = authResult.userId ? await getCreditBalance(env, authResult.userId).then(b => b > 0).catch(() => false) : false;
+					if (!hasCredits) {
+						return addCorsHeaders(createErrorResponse(429, JSON.stringify({
+							error: 'daily_cost_limit_exceeded',
+							message: `You've reached your daily AI usage limit. Try a free model or wait until tomorrow.`,
+							free_models: ['gemini-3-flash'],
+						})));
+					}
 				}
 			}
 

--- a/packages/ai-gateway/src/services/usage-tracker.ts
+++ b/packages/ai-gateway/src/services/usage-tracker.ts
@@ -87,7 +87,7 @@ async function tryDeductCredit(env: Env, userId: string, reason: string): Promis
 /**
  * Get user's current credit balance without deducting.
  */
-async function getCreditBalance(env: Env, userId: string): Promise<number> {
+export async function getCreditBalance(env: Env, userId: string): Promise<number> {
   const clerkId = await resolveClerkId(env, userId);
   if (!clerkId) return 0;
 


### PR DESCRIPTION
## Problem
The API proxy blocks users from accessing expensive models (like Sonnet) if their daily cost exceeds the tier's `maxCost`, even if the user has a positive credit balance (credits they bought themselves). This leads to the false 'daily usage limit reached' error on Pi agent for paid models.

## Root cause
In `packages/ai-gateway/src/index.ts`, the check `dailyCost >= maxCost` immediately returned a 429 error for models with weight >= 3, without first checking if the user has credits available.

## Fix
Exported `getCreditBalance` from `usage-tracker.ts` and updated `index.ts` to bypass the daily cost limit if `getCreditBalance() > 0`. `trackUsage` handles the actual credit deduction on the next line.

## Confidence: 10/10

## Verification
```
I verified no typescript syntax or type errors in the modified files. The logic cleanly intercepts the daily cost limit check and only bypasses it if getCreditBalance(env, userId) > 0. The subsequent trackUsage call will correctly handle credit deduction.
```

---
auto-generated by issue-solver pipe