### PR TITLE
fix(chat): prevent IME Enter from submitting during composition

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1072,6 +1072,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
   const [deletingConvId, setDeletingConvId] = useState<string | null>(null);
   const [activePreset, setActivePreset] = useState<AIPreset | undefined>();
   const [showMentionDropdown, setShowMentionDropdown] = useState(false);
+  const [isComposing, setIsComposing] = useState(false);
   const [mentionFilter, setMentionFilter] = useState("");
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
   const [speakerSuggestions, setSpeakerSuggestions] = useState<MentionSuggestion[]>([]);
@@ -1605,6 +1606,14 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
     // Prevent '/' from triggering app shortcuts while typing
     if (e.key === '/') {
       e.stopPropagation();
+    }
+
+    const nativeEvent = e.nativeEvent as KeyboardEvent & { isComposing?: boolean; keyCode?: number };
+    const nativeIsComposing = nativeEvent.isComposing || nativeEvent.keyCode === 229;
+
+    // Ignore Enter while an IME composition is active so confirmation does not submit the message.
+    if (isComposing || nativeIsComposing) {
+      return;
     }
 
     // Enter without shift submits the form
@@ -3950,6 +3959,8 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
                 ref={inputRef}
                 value={input}
                 onChange={handleInputChange}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
                 onKeyDown={handleKeyDown}
                 placeholder={
                   disabledReason


### PR DESCRIPTION
## Problem

In `standalone-chat.tsx`, pressing **Enter to confirm an IME composition** (e.g. Japanese, Chinese, Korean input) unintentionally submits the message. The user expects Enter to only confirm the candidate, then a second Enter to submit — but the message is sent the moment the candidate is confirmed.

### Reproduction

1. Enable a Japanese IME (e.g. macOS Japanese — Romaji)
2. Type `こんにちは` and confirm with Enter
3. **Expected:** the candidate is confirmed in the textarea, no submission
4. **Actual:** the message `こんにちは` is submitted immediately on the confirmation Enter

This is a long-standing pain point for users of any IME-driven language.

## Root cause

`handleKeyDown` on the chat textarea checks `e.key === "Enter"` without consulting the IME composition state. Modern browsers fire the IME confirmation Enter through the same KeyboardEvent path as a regular Enter, so the submit guard fires unconditionally.

## Fix

Two-layer composition guard, applied early in `handleKeyDown`:

1. **React-level state** via `onCompositionStart` / `onCompositionEnd` (`isComposing` boolean)
2. **Native event fallback** via `nativeEvent.isComposing || nativeEvent.keyCode === 229`

Both are checked because:

- React's `compositionend` can fire **after** the keydown that confirms the composition in some Safari / older Chromium builds, leaving the React state stale at the critical moment
- `nativeEvent.isComposing` is synchronous and authoritative when available
- `keyCode === 229` is the legacy IME marker (IE / older Chromium) and is still emitted by current engines during composition — kept as a defensive fallback

If either guard says \"composition active\", the handler returns early without touching the existing Enter / Shift+Enter branches.

## Files changed

- `apps/screenpipe-app-tauri/components/standalone-chat.tsx` (+11 lines)

## Testing

Verified manually in Tauri WKWebView (dev build of v2.3.82):

| # | Scenario | Result |
|---|----------|--------|
| 1 | IME ON, type 'こんにちは', confirm with Enter | ✅ Not submitted |
| 2 | After confirmation, press Enter again | ✅ Submitted (backend response received) |
| 3 | Shift+Enter | ✅ Inserts newline |
| 4 | `@` triggers mention dropdown | ✅ Dropdown shown |

No regressions to non-IME Enter behavior. No changes to mention dropdown logic.

## Notes

- No new dependencies
- No changes to backend / Rust side
- Header comment per repo convention is already present in the file