### PR TITLE
fix(db): resolve database is locked fallback issue in write_queue

### DIFF
--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error, warn};
 
 /// Maximum writes per batch. Caps transaction size to avoid holding
 /// the write lock too long and starving readers.
-const MAX_BATCH_SIZE: usize = 500;
+const MAX_BATCH_SIZE: usize = 100;
 
 /// How often the drain loop wakes up to flush buffered writes.
 const DRAIN_INTERVAL: Duration = Duration::from_millis(100);
@@ -424,7 +424,7 @@ async fn execute_batch(
     };
 
     // Acquire connection and BEGIN IMMEDIATE with retry logic
-    let max_retries = 3;
+    let max_retries = 5;
     let mut last_error = None;
     let mut conn_opt = None;
 
@@ -463,15 +463,20 @@ async fn execute_batch(
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 continue;
             }
-            Err(e) if attempt < max_retries && is_busy_error(&e) => {
-                warn!(
-                    "write_queue: BEGIN IMMEDIATE busy (attempt {}/{}), retrying...",
-                    attempt, max_retries
-                );
-                drop(conn);
-                last_error = Some(e);
-                tokio::time::sleep(Duration::from_millis(50 * attempt as u64)).await;
-                continue;
+            Err(e) if is_busy_error(&e) => {
+                if attempt < max_retries {
+                    warn!(
+                        "write_queue: BEGIN IMMEDIATE busy (attempt {}/{}), retrying...",
+                        attempt, max_retries
+                    );
+                    drop(conn);
+                    last_error = Some(e);
+                    tokio::time::sleep(Duration::from_millis(100 * attempt as u64)).await;
+                    continue;
+                } else {
+                    last_error = Some(e);
+                    break;
+                }
             }
             Err(e) => {
                 warn!("write_queue: BEGIN IMMEDIATE failed: {}", e);


### PR DESCRIPTION
## Problem
A high-frequency Sentry issue (`write_queue: batch failed: error returned from database: (code: 5) database is locked`) occurs because the retry logic for SQLite `BEGIN IMMEDIATE` incorrectly aborts instead of continuing through the retry exhaust path when a busy error occurs on the final attempt. Also, the lock is held for too long due to large batch sizes.

## Root cause
In `write_queue.rs`, the loop guard `Err(e) if attempt < max_retries && is_busy_error(&e)` fails to match on the final attempt (`attempt == max_retries`). As a result, the code falls through to the generic `Err(e)` block, which immediately calls `send_error_to_all` and returns, rather than populating `last_error` and hitting the intended "exhausted retries" log and return path. In addition, large batch sizes (500) increase the duration that a write lock is held.

## Fix
1. Refactored the `is_busy_error` match arm so it always matches busy errors. If `attempt < max_retries`, it sleeps and continues. Otherwise, it sets `last_error` and breaks, properly reaching the intended `exhausted retries` handling path.
2. Reduced `MAX_BATCH_SIZE` from 500 to 100 to drastically lower lock contention.
3. Increased `max_retries` from 3 to 5 and the sleep duration multiplier to give SQLite more time to recover from locked states.

## Confidence: 10/10

## Verification
```
test write_queue::tests::test_empty_transcription_skipped ... ok
test write_queue::tests::test_shutdown_flushes_pending ... ok
test write_queue::tests::test_snapshot_frame_insert ... ok
test write_queue::tests::test_duplicate_transcription_skipped ... ok
test write_queue::tests::test_video_chunk_insert ... ok
test write_queue::tests::test_single_write ... ok
test write_queue::tests::test_combined_chunk_and_transcription ... ok
test write_queue::tests::test_ordering_chunk_before_transcription ... ok
test write_queue::tests::test_concurrent_mixed_writes ... ok
test write_queue::tests::test_batch_coalescing ... ok\ntest result: ok. 10 passed; 0 failed
```

---
auto-generated by issue-solver pipe