### PR TITLE
fix(secrets): keep legacy OAuth files after migration

### DIFF
--- a/crates/screenpipe-secrets/src/migration.rs
+++ b/crates/screenpipe-secrets/src/migration.rs
@@ -94,14 +94,14 @@ pub async fn migrate_legacy_secrets(
                         if let Err(e) = store.set(&store_key, &contents).await {
                             report.errors.push(format!("{}: {}", filename, e));
                         } else {
-                            // Delete the legacy file — SecretStore handles refresh now
-                            if let Err(e) = std::fs::remove_file(&path) {
-                                warn!("migrated {} but failed to delete: {}", filename, e);
-                            }
+                            // Keep the legacy file — Phase 1 per module doc. Readers
+                            // (e.g. chatgpt_oauth::read_tokens) still consult the file;
+                            // deleting it here breaks OAuth restore across restarts.
+                            // Phase 2 (reader migration to SecretStore) can delete later.
                             report
                                 .migrated
                                 .push(format!("{} -> {}", filename, store_key));
-                            info!("migrated {} -> {} (file deleted)", filename, store_key);
+                            info!("migrated {} -> {} (file kept for legacy readers)", filename, store_key);
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
## Summary

Migration was deleting `*-oauth.json` files after importing them into the `SecretStore`, but readers (e.g. `chatgpt_oauth::read_tokens`) still consult the file directly. As a result, every app restart invalidated OAuth sessions and users were forced to re-authenticate repeatedly.

The module-level doc comment already states:

> Old files are NOT deleted (Phase 2 will handle that after a grace period)

`crates/screenpipe-secrets/src/migration.rs` L23

The deletion call added in `14262dc722` contradicted that documented intent. This PR restores Phase 1 behavior: import into `SecretStore`, keep the legacy file, let Phase 2 (reader migration) handle deletion later.

## Repro (before this PR)

1. Launch app, sign into ChatGPT via OAuth — chat works.
2. Quit the app (Cmd-Q) and relaunch.
3. ChatGPT "not logged in to ChatGPT. Please sign in again" toast appears in chat. `~/.screenpipe/chatgpt-oauth.json` no longer exists.
4. Re-auth → same cycle on next restart.

## Fix

Remove the `std::fs::remove_file(&path)` call in the migration loop. `SecretStore` still receives the content (the "re-import if file is newer" logic in the same function keeps the store in sync), but the legacy file is preserved so current file-based readers continue working.

Diff: 5 insertions, 5 deletions, single file.

## Verification

- Built locally, installed, signed into ChatGPT, quit and relaunched three times — OAuth persists across every restart.
- `~/.screenpipe/chatgpt-oauth.json` retains `0600` permissions after migration.
- Existing reader (`chatgpt_oauth::read_tokens`) behavior unchanged.

## Follow-up (not in this PR)

Migrate `chatgpt_oauth.rs` readers to consult `SecretStore` directly (Phase 2). Once all readers are migrated, the file can safely be deleted again.

## Test plan

- [ ] CI green on Linux/macOS/Windows
- [ ] Manual: fresh OAuth login → restart app → session persists
- [ ] Existing migration tests (`test_migrate_oauth_files`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)