### PR TITLE
fix: avoid panics on ffmpeg spawn and unwrap in audio encoding

### DIFF
--- a/crates/screenpipe-audio/src/utils/ffmpeg.rs
+++ b/crates/screenpipe-audio/src/utils/ffmpeg.rs
@@ -20,7 +20,8 @@ fn encode_single_audio(
 ) -> anyhow::Result<()> {
     debug!("Starting FFmpeg process");
 
-    let mut command = screenpipe_core::ffmpeg_cmd(find_ffmpeg_path().unwrap());
+    let ffmpeg_path = find_ffmpeg_path().ok_or_else(|| anyhow::anyhow!("FFmpeg not found"))?;
+    let mut command = screenpipe_core::ffmpeg_cmd(ffmpeg_path);
     command
         .args([
             "-f",
@@ -57,16 +58,18 @@ fn encode_single_audio(
     debug!("FFmpeg command: {:?}", command);
 
     #[allow(clippy::zombie_processes)]
-    let mut ffmpeg = command.spawn().expect("Failed to spawn FFmpeg process");
+    let mut ffmpeg = command
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn FFmpeg process: {}", e))?;
     debug!("FFmpeg process spawned");
-    let mut stdin = ffmpeg.stdin.take().expect("Failed to open stdin");
+    let mut stdin = ffmpeg.stdin.take().ok_or_else(|| anyhow::anyhow!("Failed to open stdin"))?;
 
     stdin.write_all(data)?;
 
     debug!("Dropping stdin");
     drop(stdin);
     debug!("Waiting for FFmpeg process to exit");
-    let output = ffmpeg.wait_with_output().unwrap();
+    let output = ffmpeg.wait_with_output()?;
     let status = output.status;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -107,7 +110,8 @@ pub fn get_new_file_path_with_timestamp(
 pub fn read_audio_from_file(path: &Path) -> Result<(Vec<f32>, u32)> {
     let sample_rate: u32 = 16000;
 
-    let mut command = screenpipe_core::ffmpeg_cmd(find_ffmpeg_path().unwrap());
+    let ffmpeg_path = find_ffmpeg_path().ok_or_else(|| anyhow::anyhow!("FFmpeg not found"))?;
+    let mut command = screenpipe_core::ffmpeg_cmd(ffmpeg_path);
     command
         .args([
             "-i",


### PR DESCRIPTION
## Problem
Under heavy load, spawning the `ffmpeg` process can fail due to OS limits, resulting in a panic from `.expect("Failed to spawn FFmpeg process")`. Specifically, Sentry reports: `panic: Failed to spawn FFmpeg process: Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }`.

## Root cause
In `crates/screenpipe-audio/src/utils/ffmpeg.rs`, there were unwraps on `command.spawn()`, `find_ffmpeg_path()`, `ffmpeg.stdin.take()`, and `ffmpeg.wait_with_output()` within `encode_single_audio`. These cause unrecoverable crashes when process/file descriptor limits are reached.

## Fix
Changed `encode_single_audio` and `read_audio_from_file` to return `anyhow::Result` using `?` and `.map_err(...)` instead of panicking. The callers (`write_audio_to_file`) already gracefully log the error without panicking, making this change safe.

## Confidence: 10/10

## Verification
```
test core::engine::tests::from_str_unknown_returns_error ... ok
test core::engine::tests::from_str_whisper_large ... ok
test core::engine::tests::from_str_whisper_large_quantized ... ok
test core::engine::tests::from_str_whisper_large_v3_turbo ... ok
test core::engine::tests::from_str_whisper_large_v3_turbo_quantized ... ok
test core::engine::tests::from_str_whisper_tiny ... ok
test core::engine::tests::from_str_whisper_tiny_quantized ... ok
test core::source_buffer::tests::bluetooth_gap_is_debug_not_warn ... ok
test core::source_buffer::tests::gap_samples_are_exactly_zero ... ok
test core::source_buffer::tests::no_gap_no_silence ... ok
test core::source_buffer::tests::wired_large_gap_inserts_silence ... ok
test idle_detector::tests::test_idle_after_stable_period ... ok
test idle_detector::tests::test_idle_with_high_threshold ... ok
test meeting_detector::tests::test_default_not_in_meeting ... ok
test idle_detector::tests::test_not_idle_with_zero_threshold ... ok
test meeting_detector::tests::test_v2_override ... ok
test core::source_buffer::tests::silence_duration_proportional_to_gap ... ok
test speaker::embedding_manager::tests::test_basic_speaker_creation ... ok
test speaker::embedding_manager::tests::test_max_speakers_force_merge ... ok
test speaker::embedding_manager::tests::test_seed_speaker ... ok
test speaker::embedding_manager::tests::test_clear_speakers ... ok
test core::source_buffer::tests::silence_capped_at_max ... ok
test speaker::embedding_manager::tests::test_seed_then_clear_then_reseed ... ok
test idle_detector::tests::test_paused_reason_when_not_idle ... ok
test speaker::embedding_manager::tests::test_set_and_reset_max_speakers ... ok
test speaker::models::tests::empty_cache_returns_none ... ok
test transcription::openai_compatible::batch::tests::test_create_wav_data ... ok
strange error flushing buffer ... 
test transcription::openai_compatible::batch::tests::test_create_mp3_data ... ok
test speaker::models::tests::cached_path_returned_when_file_exists_on_disk ... ok
test speaker::models::tests::stale_cached_path_is_dropped_when_file_missing ... ok
test utils::audio::music_detection::tests::test_short_audio_unchanged ... ok
test utils::audio::music_detection::tests::test_energy_variance_ratio_sine_is_low ... ok
test utils::audio::music_detection::tests::test_silence_left_untouched ... ok
test transcription::openai_compatible::batch::tests::test_create_mp3_data_downsampling ... ok
test utils::audio::music_detection::tests::test_zcr_variance_sine_is_low ... ok
test transcription::transcription_result::tests::test_pii_removal_no_false_positives ... ok
test transcription::transcription_result::tests::test_pii_removal_preserves_non_pii ... ok
test transcription::transcription_result::tests::test_pii_removal_multiple_types ... ok
test transcription::transcription_result::tests::test_pii_removal_edge_cases ... ok
test transcription::transcription_result::tests::test_pii_removal_realistic_transcriptions ... ok
test transcription::transcription_result::tests::test_pii_removal_on_transcription ... ok
test transcription::transcription_result::tests::test_pii_removal_performance ... ok
test utils::audio::music_detection::tests::test_sine_wave_detected_as_music ... ok
test utils::audio::music_detection::tests::test_white_noise_not_detected_as_music ... ok
test audio_manager::reconciliation::tests::backfill_skips_when_segmentation_models_missing ... ok
test transcription::transcription_result::tests::test_empty_speaker_embedding_stores_no_speaker ... ok

test result: ok. 77 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.06s
```

---
auto-generated by issue-solver pipe