### PR TITLE
fix(audio): prevent underflow and zero-padding bug in speech segmentation

### DIFF
--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -44,26 +44,21 @@ fn create_speech_segment(
     let start_f64 = start * (sample_rate as f64);
     let end_f64 = end * (sample_rate as f64);
 
-    let start_idx = start_f64.min((samples.len() - 1600) as f64) as usize;
+    let start_idx = start_f64.min(samples.len().saturating_sub(1600) as f64) as usize;
     let mut end_idx = end_f64.min(samples.len() as f64) as usize;
 
-    // TODO: Why is this empty sometimes?
-    let mut samples = padded_samples[start_idx..end_idx].to_vec();
-    // // Ensure the segment has at least 1600 samples
     let min_length = 1600;
+    let mut padded_buf;
+
     let segment_samples = if end_idx - start_idx < min_length {
-        if end_idx + (min_length - (end_idx - start_idx)) <= samples.len() {
-            // Increase the end index if possible
-            end_idx += min_length - (end_idx - start_idx);
+        let needed = min_length - (end_idx - start_idx);
+        if end_idx + needed <= padded_samples.len() {
+            end_idx += needed;
             &padded_samples[start_idx..end_idx]
-        } else if start_idx >= min_length - (end_idx - start_idx) {
-            // Otherwise, pad the samples.
-
-            samples.resize(1600, 0.0);
-
-            samples.as_slice()
         } else {
-            &padded_samples[start_idx..end_idx]
+            padded_buf = padded_samples[start_idx..end_idx].to_vec();
+            padded_buf.resize(min_length, 0.0);
+            &padded_buf
         }
     } else {
         &padded_samples[start_idx..end_idx]


### PR DESCRIPTION
## Problem
High-frequency Sentry bug: `Failed to compute speaker embedding, skipping segment: compute_fbank failed`

## Root cause
In `create_speech_segment`:
1. When `samples.len() < 1600`, `samples.len() - 1600` panicked in debug mode or underflowed in release, bypassing the correct start index.
2. The logic for short segments incorrectly returned `padded_samples` (which could be shorter than the 1600 minimum) instead of correctly zero-padding it, because it checked `samples.len()` (the length of the already sliced buffer) instead of `padded_samples.len()`. This passed slices smaller than 1600 to `compute_fbank` causing it to fail.

## Fix
Used `saturating_sub(1600)` to prevent underflow, removed convoluted length checks, and ensured the returned buffer is actually resized to 1600 properly.

## Confidence: 9/10

## Verification
```
cargo check -p screenpipe-audio

```

---
auto-generated by issue-solver pipe