### PR TITLE
chore: enforce .local/ for non-source files, scaffold gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,9 @@ crates/screenpipe-audio/openblas-0.3.31-x64.zip
 crates/screenpipe-audio/openblas-0.3.31-woa64-dll.zip
 apps/screenpipe-app-tauri/src-tauri/openblas/
 apps/screenpipe-app-tauri/src-tauri/mlx.metallib
+
+# Agent scratch
+.local/
+
+# Claude Code (broader than worktrees-only)
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,7 @@ Use `#` for Python, `//` for Rust/TS/JS/Swift. Keep it as the first comment in t
 
 ## git usage
 - make sure to understand there is always bunch of other agents working on the same codebase in parallel, never delete local code or use git reset or such
+
+## Local File Rules
+
+.local/ is local-only and must never be git added. Research logs, design notes, experiment code, and anything not required for build/run/test belong in .local/. .claude/ is also excluded from git.


### PR DESCRIPTION
## Summary
- Add `.local/` and `.claude/` to `.gitignore` so agent scratch files, research logs, and experiment code stay out of version control
- Append "Local File Rules" section to `CLAUDE.md` so contributors know where non-source files belong
- Existing `.github/` templates were already in place and left untouched

## Why
Non-source files (agent research findings, cloned reference repos) were accumulating in the repo root. This enforces a convention where scratch/research artifacts go to `.local/` which is gitignored.

## Test
- `git status` confirms `.local/` and `.claude/` are not tracked
- Only `.gitignore` and `CLAUDE.md` are modified