### PR TITLE
fix(db): resolve database is locked errors by protecting direct DB writes

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1345,13 +1345,15 @@ impl DatabaseManager {
 
         if (count as usize) < max_stored {
             // Under capacity — just insert
+            let mut tx = self.begin_immediate_with_retry().await?;
             sqlx::query(
                 "INSERT INTO speaker_embeddings (embedding, speaker_id) VALUES (vec_f32(?1), ?2)",
             )
             .bind(bytes)
             .bind(speaker_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+            tx.commit().await?;
         } else {
             // At capacity — replace the most redundant embedding (closest to centroid)
             // to keep the collection diverse and adapting to voice drift.
@@ -1378,13 +1380,15 @@ impl DatabaseManager {
 
                 if let Some((redundant_id,)) = most_redundant {
                     // Replace it with the new embedding
+                    let mut tx = self.begin_immediate_with_retry().await?;
                     sqlx::query(
                         "UPDATE speaker_embeddings SET embedding = vec_f32(?1) WHERE id = ?2",
                     )
                     .bind(bytes)
                     .bind(redundant_id)
-                    .execute(&self.pool)
+                    .execute(&mut **tx.conn())
                     .await?;
+                    tx.commit().await?;
                     debug!(
                         "speaker {}: rotated embedding {} (closest to centroid) with new sample",
                         speaker_id, redundant_id
@@ -1438,14 +1442,16 @@ impl DatabaseManager {
         };
 
         let bytes: &[u8] = new_centroid.as_bytes();
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query(
             "UPDATE speakers SET centroid = vec_f32(?1), embedding_count = ?2 WHERE id = ?3",
         )
         .bind(bytes)
         .bind(new_count)
         .bind(speaker_id)
-        .execute(&self.pool)
+        .execute(&mut **tx.conn())
         .await?;
+        tx.commit().await?;
 
         Ok(())
     }
@@ -2222,11 +2228,13 @@ impl DatabaseManager {
         frame_id: i64,
         text_source: &str,
     ) -> Result<(), anyhow::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET text_source = ?1 WHERE id = ?2")
             .bind(text_source)
             .bind(frame_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5182,11 +5190,13 @@ impl DatabaseManager {
         chunk_id: i64,
         blob_id: &str,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE video_chunks SET cloud_blob_id = ?1 WHERE id = ?2")
             .bind(blob_id)
             .bind(chunk_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5196,11 +5206,13 @@ impl DatabaseManager {
         frame_id: i64,
         blob_id: &str,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET cloud_blob_id = ?1 WHERE id = ?2")
             .bind(blob_id)
             .bind(frame_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5277,10 +5289,12 @@ impl DatabaseManager {
     }
 
     pub async fn mark_speaker_as_hallucination(&self, id: i64) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE speakers SET hallucination = TRUE WHERE id = ?")
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
 
         Ok(())
     }
@@ -5345,11 +5359,13 @@ impl DatabaseManager {
 
     // Add method to update frame names
     pub async fn update_frame_name(&self, frame_id: i64, name: &str) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET name = ?1 WHERE id = ?2")
             .bind(name)
             .bind(frame_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5359,11 +5375,13 @@ impl DatabaseManager {
         video_chunk_id: i64,
         name: &str,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET name = ?1 WHERE video_chunk_id = ?2")
             .bind(name)
             .bind(video_chunk_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -6068,11 +6086,13 @@ LIMIT ? OFFSET ?
         embedding_id: i64,
         to_speaker_id: i64,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE speaker_embeddings SET speaker_id = ? WHERE id = ?")
             .bind(to_speaker_id)
             .bind(embedding_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -6082,22 +6102,26 @@ LIMIT ? OFFSET ?
         audio_chunk_id: i64,
         new_speaker_id: i64,
     ) -> Result<u64, sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         let result =
             sqlx::query("UPDATE audio_transcriptions SET speaker_id = ? WHERE audio_chunk_id = ?")
                 .bind(new_speaker_id)
                 .bind(audio_chunk_id)
-                .execute(&self.pool)
+                .execute(&mut **tx.conn())
                 .await?;
+        tx.commit().await?;
         Ok(result.rows_affected())
     }
 
     /// Create a new speaker with a name (no embedding)
     pub async fn create_speaker_with_name(&self, name: &str) -> Result<Speaker, sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         let id = sqlx::query("INSERT INTO speakers (name) VALUES (?)")
             .bind(name)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?
             .last_insert_rowid();
+        tx.commit().await?;
 
         Ok(Speaker {
             id,

--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -1335,8 +1335,10 @@ async fn execute_single_write(
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
+    let msg = error.to_string();
     for pw in batch.drain(..) {
-        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut));
+        let e = sqlx::Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg.clone()));
+        let _ = pw.respond.send(Err(e));
     }
     // Log the original error that caused the batch failure
     error!("write_queue: batch failed: {}", error);


### PR DESCRIPTION
## Problem
App and CLI frequently experienced "pool timed out while waiting for an open connection" or "database is locked" errors, causing audio handlers to restart and events to be dropped.

## Root cause
1. Multiple database methods bypassed the `write_semaphore` by using `.execute(&self.pool)` directly on the read pool. Because SQLite uses a single write lock, these direct writes fought with `write_queue` and other transaction mechanisms, causing `SQLITE_BUSY` (database is locked) inside `write_queue.rs`.
2. When `write_queue` failed its retries due to this lock contention, `send_error_to_all` broadcasted `sqlx::Error::PoolTimedOut` regardless of the actual error, masking the "database is locked" failure as a pool timeout.

## Fix
- Refactored all direct `.execute(&self.pool)` writes in `db.rs` to use `begin_immediate_with_retry()` so they queue correctly via the `write_semaphore`.
- Updated `send_error_to_all` in `write_queue.rs` to correctly propagate the actual error message inside a new `sqlx::Error::Io` wrapper, allowing accurate logs and handling upstream.

## Confidence: 10/10

## Verification
```
test result: ok. 65 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests/audio_duplicate_test.rs (target/debug/deps/audio_duplicate_test-8b7508aafaac27fc)

running 12 tests
test tests::test_cross_device_whisper_variations ... ok
test tests::test_unique_constraint_exists ... ok
test tests::test_different_transcriptions_same_chunk_allowed ... ok
test tests::test_full_deduplication_behavior ... ok
test tests::test_empty_transcription_skipped ... ok
test tests::test_cross_device_short_contained_in_long ... ok
--
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.77s

     Running tests/db.rs (target/debug/deps/db-4192dd653f8fd0d5)

running 31 tests
[2m2026-04-16T04:28:17.606952Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
test tests::test_get_speaker_by_id ... ok
[2m2026-04-16T04:28:17.607294Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
[2m2026-04-16T04:28:17.612104Z[0m [33m WARN[0m [2mscreenpipe_db::db[0m[2m:[0m ImmediateTx dropped without commit — rolling back
[2m2026-04-16T04:28:17.612404Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
[2m2026-04-16T04:28:17.612425Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=2 (no existing match within threshold)
--
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.96s

     Running tests/db_config_test.rs (target/debug/deps/db_config_test-532e4ea1ca926981)

running 4 tests
test low_tier_db_initializes_successfully ... ok
test mid_tier_db_initializes_successfully ... ok
test low_tier_db_can_insert_and_query ... ok
test high_tier_db_initializes_successfully ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.24s

     Running tests/frame_offset_sync_test.rs (target/debug/deps/frame_offset_sync_test-25964bb94dcb6abb)

running 6 tests
test tests::test_offset_resets_per_chunk ... ok
test tests::test_desync_when_video_drops_frame ... ok
test tests::test_multiple_windows_same_offset ... ok
test tests::test_frame_number_as_offset_prevents_desync ... ok
test tests::test_none_offset_uses_db_fallback ... ok
test tests::test_get_next_frame_offset_uses_db_count ... ok
--
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s

     Running tests/fts_contention_test.rs (target/debug/deps/fts_contention_test-2744dc7edbaf3fe1)

running 4 tests
test fts_contention_tests::test_fts_microbatch_transactions_commit ... ok
test fts_contention_tests::test_microbatch_indexes_all_rows ... ok
test fts_contention_tests::test_microbatch_fts_lock_time_bounded ... ok
test fts_contention_tests::test_frame_inserts_not_starved_during_microbatch_fts ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.30s

     Running tests/fts_dots_test.rs (target/debug/deps/fts_dots_test-a643fc3ac14ce87d)

running 13 tests
test tests::test_sanitize_fts5_query_special_chars ... ok
test tests::test_sanitize_fts5_query_dots ... ok
test tests::test_value_to_fts5_column_query ... ok
test tests::test_search_accessibility_window_name_with_dots ... ok
test tests::test_search_ocr_browser_url_with_dots ... ok
test tests::test_search_all_types_dotted_app_name ... ok
--
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.61s

     Running tests/heavy_read_test.rs (target/debug/deps/heavy_read_test-7f5de12edfa7179d)

running 2 tests
test test_search_completes_within_timeout ... ok
test test_concurrent_ocr_searches_dont_starve_pool ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s

     Running tests/keyword_search_accessibility_test.rs (target/debug/deps/keyword_search_accessibility_test-0754b0c9971e5039)

running 5 tests
test tests::test_keyword_search_grouping_finds_accessibility_text ... ok
test tests::test_keyword_search_finds_accessibility_text ... ok
test tests::test_keyword_search_finds_app_name_in_frames_fts ... ok
test tests::test_keyword_search_finds_ocr_text ... ok
test tests::test_keyword_search_finds_both_ocr_and_accessibility ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.42s

     Running tests/keyword_search_order_test.rs (target/debug/deps/keyword_search_order_test-7de93a2de93b8756)

running 3 tests
test tests::test_keyword_search_sorted_by_timestamp_ascending ... ok
test tests::test_keyword_search_same_timestamp_uses_relevance_tiebreak ... ok
test tests::test_keyword_search_sorted_by_timestamp_descending ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s

     Running tests/query_plan_test.rs (target/debug/deps/query_plan_test-21265320f1266107)

running 15 tests
test query_plan_tests::test_timeline_audio_query_uses_index ... ok
test query_plan_tests::test_search_accessibility_with_time_range_uses_index ... ok
test query_plan_tests::test_search_audio_with_time_range_uses_index ... ok
test query_plan_tests::test_audio_dedup_query_uses_index ... ok
test query_plan_tests::test_count_audio_with_time_range_uses_index ... ok
test query_plan_tests::test_batch_insert_write_lock_minimized ... ok
--
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.99s

     Running tests/search_ocr_snapshot_test.rs (target/debug/deps/search_ocr_snapshot_test-7a25b6bf98e4c271)

running 4 tests
test tests::test_search_ocr_returns_snapshot_frames ... ok
test tests::test_search_pagination_returns_page_two ... ok
test tests::test_search_all_limit_exceeded ... ok
test tests::test_search_all_pagination_wrong_page_two ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.27s

     Running tests/speaker_benchmark.rs (target/debug/deps/speaker_benchmark-39860f08f582fe26)

running 1 test
test speaker_benchmark::benchmark_speaker_clustering ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/speaker_reassignment_test.rs (target/debug/deps/speaker_reassignment_test-56917601aa660df0)

running 13 tests
[2m2026-04-16T04:28:27.184517Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
[2m2026-04-16T04:28:27.184842Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
test speaker_reassignment_tests::test_count_embeddings_for_speaker ... ok
[2m2026-04-16T04:28:27.187653Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=2 (no existing match within threshold)
[2m2026-04-16T04:28:27.188663Z[0m [32m INFO[0m [2mscreenpipe_db::db[0m[2m:[0m created new speaker id=1 (no existing match within threshold)
test speaker_reassignment_tests::test_create_speaker_with_name ... ok
--
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.75s

     Running tests/timeline_performance_test.rs (target/debug/deps/timeline_performance_test-f671a9f0e1fda6b1)

running 12 tests
test timeline_performance_tests::test_stress_find_breaking_point ... ignored
test timeline_performance_tests::test_audio_fallback_to_closest_frame ... ok
test timeline_performance_tests::test_audio_assigned_to_multiple_frames ... ok
test timeline_performance_tests::test_find_video_chunks_performance_small ... ok
test timeline_performance_tests::test_estimate_full_day_performance ... ok
test timeline_performance_tests::test_find_video_chunks_performance_medium ... ok
--
test result: ok. 11 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 10.13s

     Running tests/untranscribed_chunks_test.rs (target/debug/deps/untranscribed_chunks_test-d346b7dafd2c79fd)

running 7 tests
test tests::test_respects_since_filter ... ok
test tests::test_returns_empty_on_empty_db ... ok
test tests::test_ordered_by_timestamp_descending ... ok
test tests::test_respects_limit ... ok
test tests::test_returns_transcriptions_without_speaker ... ok
test tests::test_returns_empty_when_all_transcribed ... ok
--
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s

   Doc-tests screenpipe_db

running 2 tests
test crates/screenpipe-db/src/text_normalizer.rs - text_normalizer::sanitize_fts5_query (line 41) ... ok
test crates/screenpipe-db/src/text_normalizer.rs - text_normalizer::expand_search_query (line 74) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s
```

---
auto-generated by issue-solver pipe