### PR TITLE
fix chat ui (pi agent) not working

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -690,7 +690,7 @@ fn default_max_tokens() -> i32 {
 /// Returns a map of provider entries to merge into the existing models.json.
 /// We merge instead of rebuilding from scratch to avoid a race condition where
 /// concurrent pipes overwrite each other's providers.
-fn build_models_json(
+async fn build_models_json(
     user_token: Option<&str>,
     provider_config: Option<&PiProviderConfig>,
 ) -> serde_json::Value {
@@ -698,12 +698,13 @@ fn build_models_json(
 
     // Always add screenpipe cloud provider
     let api_key_value = user_token.unwrap_or("SCREENPIPE_API_KEY");
+    let models = screenpipe_cloud_models(SCREENPIPE_API_URL, user_token).await;
     let screenpipe_provider = json!({
         "baseUrl": SCREENPIPE_API_URL,
         "api": "openai-completions",
         "apiKey": api_key_value,
         "authHeader": true,
-        "models": screenpipe_cloud_models(SCREENPIPE_API_URL, user_token)
+        "models": models
     });
     providers_map.insert("screenpipe".to_string(), screenpipe_provider);
 
@@ -798,7 +799,7 @@ fn build_models_json(
 }
 
 /// Write pi's provider config (models.json + auth.json).
-fn ensure_pi_config(
+async fn ensure_pi_config(
     user_token: Option<&str>,
     provider_config: Option<&PiProviderConfig>,
 ) -> Result<(), String> {
@@ -806,7 +807,7 @@ fn ensure_pi_config(
     std::fs::create_dir_all(&config_dir)
         .map_err(|e| format!("Failed to create pi config dir: {}", e))?;
 
-    let new_providers = build_models_json(user_token, provider_config);
+    let new_providers = build_models_json(user_token, provider_config).await;
 
     // Merge into existing models.json to avoid race conditions with concurrent pipes
     let models_path = config_dir.join("models.json");
@@ -1038,7 +1039,7 @@ pub async fn pi_start_inner(
     ensure_web_search_extension(&project_dir, provider_config.as_ref())?;
 
     // Ensure Pi is configured with the user's provider
-    ensure_pi_config(user_token.as_deref(), provider_config.as_ref())?;
+    ensure_pi_config(user_token.as_deref(), provider_config.as_ref()).await?;
 
     // Determine which Pi provider and model to use
     let (pi_provider, pi_model) = match &provider_config {

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -22,8 +22,8 @@ pub const SCREENPIPE_API_URL: &str = "https://api.screenpi.pe/v1";
 /// The gateway (`/v1/models`) is the single source of truth. On failure
 /// (offline, timeout, gateway down) we fall back to a minimal hardcoded list
 /// so the app still works without network.
-pub fn screenpipe_cloud_models(api_url: &str, token: Option<&str>) -> serde_json::Value {
-    match fetch_models_from_gateway(api_url, token) {
+pub async fn screenpipe_cloud_models(api_url: &str, token: Option<&str>) -> serde_json::Value {
+    match fetch_models_from_gateway(api_url, token).await {
         Some(models) => models,
         None => {
             warn!("failed to fetch models from gateway, using fallback list");
@@ -33,9 +33,9 @@ pub fn screenpipe_cloud_models(api_url: &str, token: Option<&str>) -> serde_json
 }
 
 /// Fetch models from the gateway and transform into Pi's format.
-fn fetch_models_from_gateway(api_url: &str, token: Option<&str>) -> Option<serde_json::Value> {
+async fn fetch_models_from_gateway(api_url: &str, token: Option<&str>) -> Option<serde_json::Value> {
     let url = format!("{}/models", api_url.trim_end_matches('/'));
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()
         .ok()?;
@@ -45,13 +45,13 @@ fn fetch_models_from_gateway(api_url: &str, token: Option<&str>) -> Option<serde
         req = req.bearer_auth(t);
     }
 
-    let resp = req.send().ok()?;
+    let resp = req.send().await.ok()?;
     if !resp.status().is_success() {
         warn!("gateway /v1/models returned {}", resp.status());
         return None;
     }
 
-    let body: serde_json::Value = resp.json().ok()?;
+    let body: serde_json::Value = resp.json().await.ok()?;
     let data = body.get("data")?.as_array()?;
 
     let models: Vec<serde_json::Value> = data
@@ -328,7 +328,7 @@ impl PiExecutor {
     /// When a pipe uses a non-screenpipe provider (e.g. ollama, openai), pass
     /// the resolved `provider`, `model`, and optional `provider_url` so the
     /// corresponding entry is written to `models.json`.
-    pub fn ensure_pi_config(
+    pub async fn ensure_pi_config(
         user_token: Option<&str>,
         api_url: &str,
         provider: Option<&str>,
@@ -388,12 +388,13 @@ impl PiExecutor {
                 .or_else(|| std::env::var("SCREENPIPE_API_KEY").ok())
                 .unwrap_or_else(|| "SCREENPIPE_API_KEY".to_string());
             let api_key_value = api_key_value.as_str();
+            let models = screenpipe_cloud_models(api_url, user_token).await;
             let screenpipe_provider = json!({
                 "baseUrl": api_url,
                 "api": "openai-completions",
                 "apiKey": api_key_value,
                 "authHeader": true,
-                "models": screenpipe_cloud_models(api_url, user_token)
+                "models": models
             });
 
             if let Some(providers) = models_config
@@ -864,7 +865,7 @@ impl AgentExecutor for PiExecutor {
             provider,
             Some(model),
             provider_url,
-        )?;
+        ).await?;
         // Use filtered skills if permissions are configured, unfiltered otherwise
         Self::ensure_screenpipe_skill_auto(working_dir)?;
 
@@ -919,7 +920,7 @@ impl AgentExecutor for PiExecutor {
                 provider,
                 Some(&resolved_model),
                 provider_url,
-            )?;
+            ).await?;
             return self
                 .spawn_pi(
                     &pi_path,
@@ -960,7 +961,7 @@ impl AgentExecutor for PiExecutor {
             provider,
             Some(&resolved_model),
             provider_url,
-        )?;
+        ).await?;
         // Use filtered skills if permissions are configured, unfiltered otherwise
         Self::ensure_screenpipe_skill_auto(working_dir)?;
         Self::ensure_web_search_extension(working_dir, Some(&resolved_provider))?;
@@ -1008,7 +1009,7 @@ impl AgentExecutor for PiExecutor {
                 provider,
                 Some(&resolved_model),
                 provider_url,
-            )?;
+            ).await?;
             return self
                 .spawn_pi_streaming(
                     &pi_path,

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -1851,7 +1851,7 @@ impl PipeManager {
                 run_provider.as_deref(),
                 Some(&run_model),
                 run_provider_url.as_deref(),
-            ) {
+            ).await {
                 warn!("failed to pre-configure pi provider: {}", e);
             }
 
@@ -2325,7 +2325,7 @@ impl PipeManager {
                     run_provider.as_deref(),
                     Some(&run_model),
                     run_provider_url.as_deref(),
-                ) {
+                ).await {
                     warn!("failed to pre-configure pi provider: {}", e);
                 }
 
@@ -3302,7 +3302,7 @@ impl PipeManager {
                             provider.as_deref(),
                             Some(&model),
                             provider_url.as_deref(),
-                        ) {
+                        ).await {
                             warn!("scheduler: failed to pre-configure pi provider: {}", e);
                         }
 


### PR DESCRIPTION
``` 
 GET /chat 200 in 4848ms
 GET /home 200 in 7725ms
2026-04-16T19:12:14.371917Z  INFO sck_rs::stream_manager: persistent SCK stream started for display 1 (1470x956, 2fps, 30 excluded)
2026-04-16T19:12:14.420281Z  INFO screenpipe_audio::audio_manager::manager: transcription session created (will be reused across segments)
2026-04-16T19:12:14.426358Z  INFO screenpipe_audio::audio_manager::manager: seeded 1 known speakers from DB into embedding manager
2026-04-16T19:12:14.426442Z  INFO screenpipe_audio::audio_manager::manager: audio manager started
2026-04-16T19:12:14.426492Z  INFO screenpipe_audio::audio_manager::manager: calendar-assisted speaker diarization: listening for meeting events
2026-04-16T19:12:14.873757Z  INFO screenpipe_audio::device::device_manager: starting recording for device: System Audio (output)
2026-04-16T19:12:14.873979Z  INFO screenpipe_audio::core::run_record_and_transcribe: starting continuous recording for System Audio (output) (unknown / 30s segments)
2026-04-16T19:12:16.294565Z  INFO screenpipe_app::calendar: calendar events publisher: started
2026-04-16T19:12:16.481780Z  INFO screenpipe_app::commands: native shortcut action: close
2026-04-16T19:12:17.401774Z  INFO screenpipe_app::commands: [webview] [enterprise] isEnterpriseBuild = false
2026-04-16T19:12:17.610927Z  INFO screenpipe_app::commands: [webview] [enterprise] isEnterpriseBuild = false
2026-04-16T19:12:18.293850Z  INFO screenpipe_app::sync: cloud sync: not enabled, skipping auto-start
2026-04-16T19:12:21.295363Z  INFO screenpipe_app::ics_calendar: ics_calendar: poller started
PANIC: panicked at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
PANIC on thread 'tokio-rt-worker' at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:21: Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.

Backtrace:
   0: std::backtrace_rs::backtrace::libunwind::trace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1: std::backtrace_rs::backtrace::trace_unsynchronized
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
   2: std::backtrace::Backtrace::create
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/backtrace.rs:331:13
   3: screenpipe_app::main::{{closure}}::{{closure}}
             at ./src/main.rs:485:25
   4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/alloc/src/boxed.rs:2220:9
   5: std::panicking::panic_with_hook
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:833:13
   6: std::panicking::panic_handler::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:691:13
   7: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:176:18
   8: __rustc::rust_begin_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:689:5
   9: core::panicking::panic_fmt
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:80:14
  10: tokio::runtime::blocking::shutdown::Receiver::wait
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:21
  11: tokio::runtime::blocking::pool::BlockingPool::shutdown
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/pool.rs:263:29
  12: core::ptr::drop_in_place<tokio::runtime::blocking::pool::BlockingPool>
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ptr/mod.rs:805:1
  13: reqwest::blocking::wait::enter
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.12.12/src/blocking/wait.rs:76:21
  14: reqwest::blocking::wait::timeout
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.12.12/src/blocking/wait.rs:13:5
  15: reqwest::blocking::client::ClientHandle::new
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.12.12/src/blocking/client.rs:1245:15
  16: reqwest::blocking::client::ClientBuilder::build
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.12.12/src/blocking/client.rs:113:9
  17: screenpipe_core::agents::pi::fetch_models_from_gateway
             at /Users/ansh/screenpipe/crates/screenpipe-core/src/agents/pi.rs:40:10
  18: screenpipe_core::agents::pi::screenpipe_cloud_models
             at /Users/ansh/screenpipe/crates/screenpipe-core/src/agents/pi.rs:26:11
  19: screenpipe_app::pi::build_models_json
             at ./src/pi.rs:706:19
  20: screenpipe_app::pi::ensure_pi_config
             at ./src/pi.rs:809:25
  21: screenpipe_app::pi::pi_start_inner::{{closure}}
             at ./src/pi.rs:1041:5
  22: screenpipe_app::pi::pi_start::{{closure}}
             at ./src/pi.rs:916:81
  23: tauri::ipc::command::private::ResultFutureTag::future::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-2.10.1/src/ipc/command.rs:316:28
  24: screenpipe_app::main::{{closure}}::{{closure}}::{{closure}}::{{closure}}
             at ./src/pi.rs:905:1
  25: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/future/future.rs:133:9
  26: tauri::ipc::InvokeResolver<R>::respond_async_serialized_inner::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tauri-2.10.1/src/ipc/mod.rs:376:33
  27: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/core.rs:375:24
  28: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/loom/std/unsafe_cell.rs:16:9
  29: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/core.rs:364:30
  30: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:535:30
  31: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panic/unwind_safe.rs:274:9
  32: std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
  33: ___rust_try
  34: std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
  35: std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
  36: tokio::runtime::task::harness::poll_future
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:523:18
  37: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:210:27
  38: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:155:20
  39: tokio::runtime::task::raw::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/raw.rs:337:13
  40: tokio::runtime::task::raw::RawTask::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/raw.rs:267:18
  41: tokio::runtime::task::LocalNotified<S>::run
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/mod.rs:510:13
  42: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/worker.rs:647:18
  43: tokio::task::coop::with_budget
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/task/coop/mod.rs:167:5
  44: tokio::task::coop::budget
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/task/coop/mod.rs:133:5
  45: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/worker.rs:638:9
  46: tokio::runtime::scheduler::multi_thread::worker::Context::run
  47: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/worker.rs:536:24
  48: tokio::runtime::context::scoped::Scoped<T>::set
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context/scoped.rs:40:9
  49: tokio::runtime::context::set_scheduler::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context.rs:176:38
  50: std::thread::local::LocalKey<T>::try_with
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/thread/local.rs:513:12
  51: std::thread::local::LocalKey<T>::with
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/thread/local.rs:477:20
  52: tokio::runtime::context::set_scheduler
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context.rs:176:17
  53: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/worker.rs:531:9
  54: tokio::runtime::context::runtime::enter_runtime
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/context/runtime.rs:65:16
  55: tokio::runtime::scheduler::multi_thread::worker::run
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/worker.rs:523:5
  56: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/scheduler/multi_thread/worker.rs:489:45
  57: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/task.rs:42:21
  58: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/core.rs:375:24
  59: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/loom/std/unsafe_cell.rs:16:9
  60: tokio::runtime::task::core::Core<T,S>::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/core.rs:364:30
  61: tokio::runtime::task::harness::poll_future::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:535:30
  62: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panic/unwind_safe.rs:274:9
  63: std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
  64: std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
  65: std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
  66: tokio::runtime::task::harness::poll_future
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:523:18
  67: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:210:27
  68: tokio::runtime::task::harness::Harness<T,S>::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/harness.rs:155:20
  69: tokio::runtime::task::raw::RawTask::poll
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/raw.rs:267:18
  70: tokio::runtime::task::UnownedTask<S>::run
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/task/mod.rs:547:13
  71: tokio::runtime::blocking::pool::Task::run
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/pool.rs:161:19
  72: tokio::runtime::blocking::pool::Inner::run
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/pool.rs:518:22
  73: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/pool.rs:474:47
  74: std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:160:18
  75: std::thread::lifecycle::spawn_unchecked::{{closure}}::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/thread/lifecycle.rs:92:13
  76: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panic/unwind_safe.rs:274:9
  77: std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
  78: std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
  79: std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
  80: std::thread::lifecycle::spawn_unchecked::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/thread/lifecycle.rs:90:26
  81: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:250:5
  82: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/alloc/src/boxed.rs:2206:9
  83: std::sys::thread::unix::Thread::new::thread_start
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/thread/unix.rs:118:17
  84: __pthread_cond_wait


thread 'tokio-rt-worker' (14707126) panicked at /Users/ansh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.50.0/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```









### Before 
https://github.com/user-attachments/assets/4e08014f-2a59-4053-a7ad-62364697d28d





### After 

https://github.com/user-attachments/assets/482521e1-7181-465b-ba00-de7adf9e5719