### PR TITLE
fix(db): resolve database is locked errors by protecting direct DB writes

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1404,13 +1404,15 @@ impl DatabaseManager {
 
         if (count as usize) < max_stored {
             // Under capacity — just insert
+            let mut tx = self.begin_immediate_with_retry().await?;
             sqlx::query(
                 "INSERT INTO speaker_embeddings (embedding, speaker_id) VALUES (vec_f32(?1), ?2)",
             )
             .bind(bytes)
             .bind(speaker_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+            tx.commit().await?;
         } else {
             // At capacity — replace the most redundant embedding (closest to centroid)
             // to keep the collection diverse and adapting to voice drift.
@@ -1437,13 +1439,15 @@ impl DatabaseManager {
 
                 if let Some((redundant_id,)) = most_redundant {
                     // Replace it with the new embedding
+                    let mut tx = self.begin_immediate_with_retry().await?;
                     sqlx::query(
                         "UPDATE speaker_embeddings SET embedding = vec_f32(?1) WHERE id = ?2",
                     )
                     .bind(bytes)
                     .bind(redundant_id)
-                    .execute(&self.pool)
+                    .execute(&mut **tx.conn())
                     .await?;
+                    tx.commit().await?;
                     debug!(
                         "speaker {}: rotated embedding {} (closest to centroid) with new sample",
                         speaker_id, redundant_id
@@ -1497,14 +1501,16 @@ impl DatabaseManager {
         };
 
         let bytes: &[u8] = new_centroid.as_bytes();
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query(
             "UPDATE speakers SET centroid = vec_f32(?1), embedding_count = ?2 WHERE id = ?3",
         )
         .bind(bytes)
         .bind(new_count)
         .bind(speaker_id)
-        .execute(&self.pool)
+        .execute(&mut **tx.conn())
         .await?;
+        tx.commit().await?;
 
         Ok(())
     }
@@ -2281,11 +2287,13 @@ impl DatabaseManager {
         frame_id: i64,
         text_source: &str,
     ) -> Result<(), anyhow::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET text_source = ?1 WHERE id = ?2")
             .bind(text_source)
             .bind(frame_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5241,11 +5249,13 @@ impl DatabaseManager {
         chunk_id: i64,
         blob_id: &str,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE video_chunks SET cloud_blob_id = ?1 WHERE id = ?2")
             .bind(blob_id)
             .bind(chunk_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5255,11 +5265,13 @@ impl DatabaseManager {
         frame_id: i64,
         blob_id: &str,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET cloud_blob_id = ?1 WHERE id = ?2")
             .bind(blob_id)
             .bind(frame_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5336,10 +5348,12 @@ impl DatabaseManager {
     }
 
     pub async fn mark_speaker_as_hallucination(&self, id: i64) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE speakers SET hallucination = TRUE WHERE id = ?")
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
 
         Ok(())
     }
@@ -5404,11 +5418,13 @@ impl DatabaseManager {
 
     // Add method to update frame names
     pub async fn update_frame_name(&self, frame_id: i64, name: &str) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET name = ?1 WHERE id = ?2")
             .bind(name)
             .bind(frame_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -5418,11 +5434,13 @@ impl DatabaseManager {
         video_chunk_id: i64,
         name: &str,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE frames SET name = ?1 WHERE video_chunk_id = ?2")
             .bind(name)
             .bind(video_chunk_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -6127,11 +6145,13 @@ LIMIT ? OFFSET ?
         embedding_id: i64,
         to_speaker_id: i64,
     ) -> Result<(), sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         sqlx::query("UPDATE speaker_embeddings SET speaker_id = ? WHERE id = ?")
             .bind(to_speaker_id)
             .bind(embedding_id)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -6141,22 +6161,26 @@ LIMIT ? OFFSET ?
         audio_chunk_id: i64,
         new_speaker_id: i64,
     ) -> Result<u64, sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         let result =
             sqlx::query("UPDATE audio_transcriptions SET speaker_id = ? WHERE audio_chunk_id = ?")
                 .bind(new_speaker_id)
                 .bind(audio_chunk_id)
-                .execute(&self.pool)
+                .execute(&mut **tx.conn())
                 .await?;
+        tx.commit().await?;
         Ok(result.rows_affected())
     }
 
     /// Create a new speaker with a name (no embedding)
     pub async fn create_speaker_with_name(&self, name: &str) -> Result<Speaker, sqlx::Error> {
+        let mut tx = self.begin_immediate_with_retry().await?;
         let id = sqlx::query("INSERT INTO speakers (name) VALUES (?)")
             .bind(name)
-            .execute(&self.pool)
+            .execute(&mut **tx.conn())
             .await?
             .last_insert_rowid();
+        tx.commit().await?;
 
         Ok(Speaker {
             id,

--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -1338,8 +1338,10 @@ async fn execute_single_write(
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
+    let msg = error.to_string();
     for pw in batch.drain(..) {
-        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut));
+        let e = sqlx::Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg.clone()));
+        let _ = pw.respond.send(Err(e));
     }
     // Log the original error that caused the batch failure
     error!("write_queue: batch failed: {}", error);


### PR DESCRIPTION
## Problem
App and CLI frequently experienced 'pool timed out while waiting for an open connection' or 'database is locked' errors, causing audio handlers to restart and events to be dropped. This is reported frequently in Sentry.

## Root cause
1. Multiple database methods bypassed the `write_semaphore` by using `.execute(&self.pool)` directly on the read pool. Because SQLite uses a single write lock, these direct writes fought with `write_queue` and other transaction mechanisms, causing `SQLITE_BUSY` (database is locked) inside `write_queue.rs`.
2. When `write_queue` failed its retries due to this lock contention, `send_error_to_all` broadcasted `sqlx::Error::PoolTimedOut` regardless of the actual error, masking the 'database is locked' failure as a pool timeout.

## Fix
- Refactored all direct `.execute(&self.pool)` writes in `db.rs` to use `begin_immediate_with_retry()` so they queue correctly via the `write_semaphore`.
- Updated `send_error_to_all` in `write_queue.rs` to correctly propagate the actual error message inside a new `sqlx::Error::Io` wrapper, allowing accurate logs and handling upstream.

Note: This is a properly tested cherry-pick of PR 2985. The tests demonstrate `test_concurrent_mixed_writes` passes cleanly.

## Confidence: 9/10

## Verification
```
test text_normalizer::tests::test_split_compound_numbers ... ok
test text_normalizer::tests::test_expand_number_boundary ... ok
test text_normalizer::tests::test_split_compound_camel_case ... ok
test text_normalizer::tests::test_expand_compound_query ... ok
test text_normalizer::tests::test_expand_dots_in_query ... ok
test text_similarity::tests::test_minimum_meaningful_length ... ok
test text_similarity::tests::test_production_case_bicycle_for_mind ... ok
test text_similarity::tests::test_short_phrases_different_not_deduplicated ... ok
test text_similarity::tests::test_production_case_single_course_college ... ok
test types::tests::parse_flexible_timestamp_all_formats_agree ... ok
test types::tests::parse_flexible_timestamp_garbage_returns_epoch ... ok
test text_similarity::tests::test_threshold_boundary ... ok
test text_similarity::tests::test_production_case_beautiful_typography ... ok
test types::tests::test_content_type_deserialization ... ok
test text_similarity::tests::test_short_phrases_exact_match_deduplicated ... ok
test text_similarity::tests::test_whisper_transcription_variations ... ok
test text_similarity::tests::test_production_case_dots_looking_forward ... ok
test write_queue::tests::test_shutdown_flushes_pending ... ok
test write_queue::tests::test_duplicate_transcription_skipped ... ok
test write_queue::tests::test_ordering_chunk_before_transcription ... ok
test write_queue::tests::test_empty_transcription_skipped ... ok
test write_queue::tests::test_combined_chunk_and_transcription ... ok
test write_queue::tests::test_single_write ... ok
test write_queue::tests::test_video_chunk_insert ... ok
test write_queue::tests::test_snapshot_frame_insert ... ok
test write_queue::tests::test_concurrent_mixed_writes ... ok
test write_queue::tests::test_batch_coalescing ... ok

test result: ok. 65 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

---
auto-generated by issue-solver pipe