### PR TITLE
chore(ci): fix pre-existing code-quality failures on main

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -5493,8 +5493,6 @@ dependencies = [
  "dbus-secret-service",
  "linux-keyutils",
  "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
  "windows-sys 0.60.2",
  "zeroize",
 ]
@@ -6532,7 +6530,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -9445,7 +9443,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -9491,7 +9489,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.10",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.52.0",
@@ -9727,7 +9725,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.3.107"
+version = "2.3.109"
 dependencies = [
  "anyhow",
  "arboard",
@@ -9752,7 +9750,6 @@ dependencies = [
  "icalendar",
  "image 0.25.10",
  "ini",
- "keyring",
  "lazy_static",
  "log",
  "nokhwa-bindings-macos",
@@ -10202,19 +10199,6 @@ dependencies = [
  "pkcs8 0.10.2",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "core-foundation-sys 0.8.7",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -38,7 +38,6 @@ tauri-plugin-http = "=2.5.7"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native-sync-persistent"] }
 base64 = "0.22"
 
 tower-http = { version = "0.4.0", features = ["cors", "trace"] }

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -956,9 +956,10 @@ async fn do_capture(
         config.walk_timeout_override = Some(decision.timeout);
     }
 
-    let tree_walk_result =
-        tokio::task::spawn_blocking(move || crate::paired_capture::walk_accessibility_tree(&config))
-            .await?;
+    let tree_walk_result = tokio::task::spawn_blocking(move || {
+        crate::paired_capture::walk_accessibility_tree(&config)
+    })
+    .await?;
 
     // If the window was skipped (incognito/private browsing or user filter),
     // bail out entirely — don't OCR the screenshot.


### PR DESCRIPTION
## Summary

Two pre-existing Code Quality failures on `main` (broken since at least the v2.3.109 release commit, also failed on #2994). Both are housekeeping, no behavior change.

- **rustfmt**: reformat `tokio::task::spawn_blocking` closure in `crates/screenpipe-engine/src/event_driven_capture.rs:956` to satisfy `cargo fmt --check`.
- **cargo-machete**: remove unused `keyring` dep from `apps/screenpipe-app-tauri/src-tauri/Cargo.toml`. The actual keychain access was moved into `screenpipe-secrets` (already declared as a path dep at line 123), and on macOS that crate shells out to the `security` CLI rather than using the `keyring` crate anyway (`crates/screenpipe-secrets/src/keychain.rs:40`). Verified no remaining `keyring` usage in `src-tauri/src/` — `secrets.rs` only re-exports from `screenpipe_secrets::keychain`.

Cargo.lock changes:
- Drops transitive `security-framework 2.11.1` (only pulled by the removed `keyring` apple-native feature).
- Syncs `screenpipe-app` entry to v2.3.109 (lock was stale at 2.3.107 — the release-bump commit didn't touch it).

## Test plan

- [x] `cargo fmt --all -- --check` clean locally
- [x] `cargo machete` clean locally (no unused deps detected)
- [x] `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml` builds successfully
- [ ] CI Code Quality & Optimization passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)