### PR TITLE
fix: resolve empty accessibility tree and missing app name for electron apps

### DIFF
--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -202,7 +202,18 @@ impl MacosTreeWalker {
             Ok(pid) => pid,
             Err(_) => return Ok(TreeWalkResult::NotFound),
         };
-        let Some(app) = ns::RunningApp::with_pid(pid) else {
+        let app = ns::RunningApp::with_pid(pid).or_else(|| {
+            let workspace = ns::Workspace::shared();
+            let apps = workspace.running_apps();
+            for i in 0..apps.len() {
+                let app = &apps[i];
+                if app.is_active() {
+                    return Some(app.retained());
+                }
+            }
+            None
+        });
+        let Some(app) = app else {
             return Ok(TreeWalkResult::NotFound);
         };
 
@@ -245,6 +256,11 @@ impl MacosTreeWalker {
         // and causes the renderer to materialize the full AX tree.
         // Ref: https://codereview.chromium.org/6909013
         // Ref: https://github.com/electron/electron/issues/7206
+        // Set AXManualAccessibility to force the accessibility tree on Electron apps (e.g. Obsidian)
+        let ma_attr_name = cf::String::from_str("AXManualAccessibility");
+        let ma_attr = ax::Attr::with_string(&ma_attr_name);
+        let _ = ax_app.set_attr(ma_attr, cf::Boolean::value_true());
+
         let eui_attr_name = cf::String::from_str("AXEnhancedUserInterface");
         let eui_attr = ax::Attr::with_string(&eui_attr_name);
         let _ = ax_app.set_attr(eui_attr, cf::Boolean::value_true());

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1180,6 +1180,17 @@ fn get_focused_app_name_lightweight() -> Option<String> {
     let app = sys.focused_app().ok()?;
     let pid = app.pid().ok()?;
     ns::RunningApp::with_pid(pid)
+        .or_else(|| {
+            let workspace = ns::Workspace::shared();
+            let apps = workspace.running_apps();
+            for i in 0..apps.len() {
+                let app = &apps[i];
+                if app.is_active() {
+                    return Some(app.retained());
+                }
+            }
+            None
+        })
         .and_then(|app| app.localized_name())
         .map(|s| s.to_string())
 }


### PR DESCRIPTION
## Problem
Obsidian and other Electron apps capture as empty accessibility tree, leading to expensive OCR fallback and missing app metadata. Additionally, the focused UI element's PID belongs to a helper process, meaning the app name resolves to empty.

## Root cause
- Electron apps build their DOM accessibility tree asynchronously and require `AXManualAccessibility` to be enabled.
- `ns::RunningApp::with_pid(pid)` fails when given a helper/renderer PID, resulting in an empty `app_name`.

## Fix
- Added `AXManualAccessibility = true` to `macos.rs` accessibility tree walking.
- Added a fallback to `ns::Workspace::shared().running_apps()` to fetch the active app when `RunningApp::with_pid` returns `None`.

## Confidence: 9/10

## Verification
```
cargo check -p screenpipe-a11y -p screenpipe-engine
```

---
auto-generated by issue-solver pipe