### PR TITLE
fix(db): prevent fatal panics on string truncation with multibyte characters

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1083,7 +1083,7 @@ impl DatabaseManager {
         {
             debug!(
                 "Skipping duplicate transcription (cross-device): {:?}",
-                &trimmed[..trimmed.len().min(50)]
+                trimmed.chars().take(50).collect::<String>()
             );
             return Ok(0);
         }
@@ -1142,7 +1142,7 @@ impl DatabaseManager {
         if is_duplicate {
             debug!(
                 "Skipping duplicate transcription (cross-device): {:?}",
-                &trimmed[..trimmed.len().min(50)]
+                trimmed.chars().take(50).collect::<String>()
             );
         }
 
@@ -6871,7 +6871,7 @@ LIMIT ? OFFSET ?
         }
 
         let display = if all_text.len() > 5000 {
-            format!("{}… (truncated)", &all_text[..5000])
+            format!("{}… (truncated)", all_text.chars().take(5000).collect::<String>())
         } else {
             all_text
         };
@@ -7849,5 +7849,17 @@ mod tests {
         assert_eq!(groups[0].representative.frame_id, 2); // highest confidence
         assert_eq!(groups[1].group_size, 2); // Gmail group
         assert_eq!(groups[2].group_size, 1); // Maps group 2 (separate visit)
+    }
+}
+
+#[cfg(test)]
+mod truncation_tests {
+    #[test]
+    fn test_multibyte_truncation_panic_fix() {
+        let trimmed = "восхитителен, то так бы прямо тебе и сказал. Но, по-моему, ты именно что великолепен. Ни больше, ни меньше.";
+        // Previous code: &trimmed[..trimmed.len().min(50)] would panic at byte 50
+        // New code works safely with char boundaries:
+        let safe = trimmed.chars().take(50).collect::<String>();
+        assert_eq!(safe.chars().count(), 50);
     }
 }


### PR DESCRIPTION
## Problem
Sentry reported a fatal panic: `panic: byte index 50 is not a char boundary; it is inside 'м' (bytes 49..51)`.
This occurs in the database layer when trying to debug-log transcriptions that contain multibyte characters (like Cyrillic, emojis, etc.).

## Root cause
The code in `DatabaseManager` used `&trimmed[..trimmed.len().min(50)]` to truncate strings for logging. Slicing a `&str` by byte indices panics if the index falls in the middle of a UTF-8 character. Slicing with `&all_text[..5000]` for long OCR texts suffers from the same issue.

## Fix
Replaced the byte-based slicing with safe character-based truncation: `trimmed.chars().take(50).collect::<String>()` and `all_text.chars().take(5000).collect::<String>()`. This guarantees valid UTF-8 boundaries and prevents panics.

## Confidence: 10/10

## Verification
\`\`\`
running 1 test
test db::truncation_tests::test_multibyte_truncation_panic_fix ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 65 filtered out; finished in 0.00s
\`\`\`

---
auto-generated by issue-solver pipe
