### PR TITLE
fix(audio): invalidate corrupt segmentation model on protobuf parsing error

### DIFF
--- a/crates/screenpipe-audio/src/speaker/prepare_segments.rs
+++ b/crates/screenpipe-audio/src/speaker/prepare_segments.rs
@@ -126,13 +126,29 @@ pub async fn prepare_segments(
             .as_ref()
             .expect("embedding extractor checked above")
             .clone();
-        let segments = get_segments(
+        let segments = match get_segments(
             &audio_data,
             16000,
             segmentation_model_path,
             embedding_extractor,
             embedding_manager,
-        )?;
+        ) {
+            Ok(segments) => segments,
+            Err(e) => {
+                let err_str = e.to_string();
+                if err_str.contains("Protobuf") || err_str.contains("Load model from") {
+                    error!("segmentation model corrupt, invalidating cache: {:?}", e);
+                    if let Err(err) = crate::speaker::models::invalidate_cached_model(
+                        &crate::speaker::models::PyannoteModel::Segmentation,
+                    )
+                    .await
+                    {
+                        error!("failed to invalidate corrupt segmentation model: {:?}", err);
+                    }
+                }
+                return Err(e);
+            }
+        };
 
         for segment in segments {
             match segment {


### PR DESCRIPTION
## Problem
Sentry reports numerous errors: `Error processing audio: Load model from ~/Library/Caches/screenpipe/models/segmentation-3.0.onnx failed:Protobuf parsing failed.`
This happens when the downloaded ONNX model is corrupted (e.g. from an interrupted download). The system fails permanently because the corrupt file is never cleared from the cache.

## Root cause
The embedding model is loaded eagerly at startup (and handles cache invalidation), but the segmentation model is lazily loaded per-chunk in `SegmentIterator::new` -> `ort::create_session`. If `ort` throws a Protobuf parsing error, it propagates through `prepare_segments` to `process_audio_input`, but no logic clears the corrupt cached model file.

## Fix
In `prepare_segments`, intercept errors from `get_segments`. If the error message mentions 'Protobuf' or 'Load model from', trigger `invalidate_cached_model(&PyannoteModel::Segmentation)` so the file is deleted. The next iteration will automatically re-download it.

## Confidence: 9/10

## Verification
```
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `screenpipe-core` (lib) generated 7 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.68s
```

---
auto-generated by issue-solver pipe