### PR TITLE
fix(pipes): block macOS protected paths in bash to prevent TCC popups

### DIFF
--- a/crates/screenpipe-core/assets/extensions/screenpipe-permissions.test.ts
+++ b/crates/screenpipe-core/assets/extensions/screenpipe-permissions.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import * as fs from "fs";
+
+// Must be initialized before importing the TS file so it picks up the mock!
+fs.writeFileSync(".screenpipe-permissions.json", JSON.stringify({
+  pipe_name: "test-pipe",
+  offline_mode: false,
+  pipe_dir: "/tmp"
+}));
+
+// Use dynamic import so it evaluates AFTER the file is created
+const plugin = (await import("./screenpipe-permissions.ts")).default;
+
+describe("macOS TCC Sandbox", () => {
+  let toolCallHandler: any = null;
+
+  beforeAll(() => {
+    const pi = {
+      on: (event: string, handler: any) => {
+        if (event === "tool_call") {
+          toolCallHandler = handler;
+        }
+      }
+    };
+    plugin(pi as any);
+  });
+
+  afterAll(() => {
+    fs.unlinkSync(".screenpipe-permissions.json");
+  });
+
+  test("initializes successfully", () => {
+    expect(toolCallHandler).not.toBeNull();
+  });
+
+  test("blocks access to ~/Documents", async () => {
+    const result = await toolCallHandler({ tool: "bash", input: { command: "ls ~/Documents" } });
+    expect(result.block).toBe(true);
+    expect(result.reason).toContain("Access to macOS protected folders");
+  });
+
+  test("blocks access to absolute /Users/.../Downloads", async () => {
+    const result = await toolCallHandler({ tool: "bash", input: { command: "cat /Users/louis/Downloads/test.txt" } });
+    expect(result.block).toBe(true);
+  });
+
+  test("allows access to unprotected folders like ~/Workspace", async () => {
+    const result = await toolCallHandler({ tool: "bash", input: { command: "ls ~/Workspace" } });
+    // Expect undefined or null since no block happened
+    expect(result).toBeUndefined();
+  });
+});

--- a/crates/screenpipe-core/assets/extensions/screenpipe-permissions.ts
+++ b/crates/screenpipe-core/assets/extensions/screenpipe-permissions.ts
@@ -272,6 +272,15 @@ function isInsidePipeDir(targetPath: string, pipeDir: string): boolean {
   );
 }
 
+function checkMacOSTccPaths(cmd: string): string | null {
+  const protectedPaths =
+    /(~\/|\/Users\/[^\/]+\/)(Documents|Desktop|Downloads|Library|Pictures|Movies|Music)(\/|\s|$|['"]|\\)/i;
+  if (protectedPaths.test(cmd)) {
+    return "Access to macOS protected folders (Documents, Desktop, Downloads, Library, Pictures, Movies, Music) is blocked to prevent recurring TCC permission popups. Please instruct the user to move required files to a non-protected directory or the pipe's workspace.";
+  }
+  return null;
+}
+
 function checkFilesystemWrite(cmd: string): string | null {
   if (!PERMS?.pipe_dir) return null;
   const pipeDir = PERMS.pipe_dir;
@@ -463,6 +472,12 @@ export default function (pi: ExtensionAPI) {
           "Only localhost and LAN addresses are allowed. " +
           "Disable offline mode in Settings → Privacy to restore external access.",
       };
+    }
+
+    // macOS TCC sandbox: block paths that trigger permission popups
+    const tccViolation = checkMacOSTccPaths(cmd);
+    if (tccViolation) {
+      return { block: true, reason: tccViolation };
     }
 
     // Filesystem sandbox: block writes outside pipe_dir


### PR DESCRIPTION
## Problem
Pipes running bash commands that touch `~/Documents` or read data from other protected apps trigger macOS TCC prompts. The current pipe permission system does not restrict these paths.

## Root cause
The `screenpipe-permissions.ts` extension used in the pi agent did not block protected macOS folders in `beforeToolCall` for the bash tool.

## Fix
Added `checkMacOSTccPaths` to block bash commands that contain protected macOS paths (Documents, Desktop, Downloads, Library, Pictures, Movies, Music). Also added a robust integration test using bun test to verify it correctly evaluates via the pi extension API.

## Confidence: 10/10

## Verification
```
bun test v1.3.10 (30e609e0)

screenpipe-permissions.test.ts:
(pass) macOS TCC Sandbox > initializes successfully
(pass) macOS TCC Sandbox > blocks access to ~/Documents [0.82ms]
(pass) macOS TCC Sandbox > blocks access to absolute /Users/.../Downloads [0.03ms]
(pass) macOS TCC Sandbox > allows access to unprotected folders like ~/Workspace [0.53ms]

 4 pass
 0 fail
 5 expect() calls
Ran 4 tests across 1 file. [14.00ms]
```

---
auto-generated by issue-solver pipe