### PR TITLE
fix(audio): compute_fbank failing with insufficient samples length

### DIFF
--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -44,26 +44,23 @@ fn create_speech_segment(
     let start_f64 = start * (sample_rate as f64);
     let end_f64 = end * (sample_rate as f64);
 
-    let start_idx = start_f64.min((samples.len() - 1600) as f64) as usize;
+    let start_idx = start_f64.min(samples.len().saturating_sub(1600) as f64) as usize;
     let mut end_idx = end_f64.min(samples.len() as f64) as usize;
 
-    // TODO: Why is this empty sometimes?
-    let mut samples = padded_samples[start_idx..end_idx].to_vec();
-    // // Ensure the segment has at least 1600 samples
     let min_length = 1600;
+    let mut samples_vec = padded_samples[start_idx..end_idx].to_vec();
+    
     let segment_samples = if end_idx - start_idx < min_length {
-        if end_idx + (min_length - (end_idx - start_idx)) <= samples.len() {
-            // Increase the end index if possible
-            end_idx += min_length - (end_idx - start_idx);
+        let needed = min_length - (end_idx - start_idx);
+        if end_idx + needed <= padded_samples.len() {
+            end_idx += needed;
             &padded_samples[start_idx..end_idx]
-        } else if start_idx >= min_length - (end_idx - start_idx) {
-            // Otherwise, pad the samples.
-
-            samples.resize(1600, 0.0);
-
-            samples.as_slice()
+        } else if start_idx >= needed {
+            let new_start = start_idx - needed;
+            &padded_samples[new_start..end_idx]
         } else {
-            &padded_samples[start_idx..end_idx]
+            samples_vec.resize(min_length, 0.0);
+            samples_vec.as_slice()
         }
     } else {
         &padded_samples[start_idx..end_idx]


### PR DESCRIPTION
## Problem
`compute_fbank` fails when extracting speaker embeddings because the audio segment is shorter than 1600 samples (100ms). This causes frequent segment drop errors (Sentry #7340577177).

## Root cause
In `crates/screenpipe-audio/src/speaker/segment.rs`, if an audio chunk is smaller than 1600 samples, the fallback logic that is supposed to pad the samples with zeros uses the wrong `samples.len()` value to compute the bounds, leading to an underflow, or it hits the `else` branch which completely forgets to perform the actual padding and returns an unpadded slice anyway. Also, it uses a dangerous usize underflow `samples.len() - 1600` that can wrap around.

## Fix
Refactored `create_speech_segment` to safely use `saturating_sub(1600)` to prevent usize underflow panics, and properly fixed the fallback logic to actually `resize(1600, 0.0)` the vector if `padded_samples` itself doesn't contain enough surrounding audio to expand the window to 1600 samples.

## Confidence: 10/10

## Verification
```
$ cargo test -p screenpipe-audio
test result: ok. 82 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.07s
```

---
auto-generated by issue-solver pipe
