### PR TITLE
fix: memories pipeline silently stopped updating

### DIFF
--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -333,27 +333,25 @@ export function PipeStoreView() {
       .catch(() => setInstalledCount(0));
   }, []);
 
-  // Read initial tab from URL param (e.g. ?section=pipes&tab=discover)
-  // Default to "discover" when user has no pipes installed
-  const [activeTab, setActiveTab] = useState<"discover" | "my-pipes">(() => {
-    if (typeof window !== "undefined") {
-      const params = new URLSearchParams(window.location.search);
-      if (params.get("tab") === "discover") return "discover";
-      if (params.get("tab") === "my-pipes") return "my-pipes";
+  const [activeTab, setActiveTab] = useState<"discover" | "my-pipes">("my-pipes");
+
+  // Read ?tab= from URL after mount, then strip it so it doesn't persist
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tab = params.get("tab");
+    if (tab === "discover") setActiveTab("discover");
+    else if (tab === "my-pipes") setActiveTab("my-pipes");
+    if (tab) {
+      params.delete("tab");
+      window.history.replaceState({}, "", `${window.location.pathname}?${params}`);
     }
-    return "my-pipes";
-  });
+  }, []);
 
   // Once we know installed count, switch new users to discover
   useEffect(() => {
     if (installedCount !== null && installedCount === 0) {
-      // Only auto-switch if no explicit tab param was set
-      if (typeof window !== "undefined") {
-        const params = new URLSearchParams(window.location.search);
-        if (!params.get("tab")) {
-          setActiveTab("discover");
-        }
-      }
+      const params = new URLSearchParams(window.location.search);
+      if (!params.get("tab")) setActiveTab("discover");
     }
   }, [installedCount]);
 
@@ -388,14 +386,7 @@ export function PipeStoreView() {
 
       {/* Tab content */}
       {activeTab === "discover" ? (
-        <DiscoverView
-          onInstalled={() => setActiveTab("my-pipes")}
-          initialQuery={
-            typeof window !== "undefined"
-              ? new URLSearchParams(window.location.search).get("q") ?? ""
-              : ""
-          }
-        />
+        <DiscoverView onInstalled={() => setActiveTab("my-pipes")} />
       ) : (
         <PipesSection />
       )}
@@ -405,7 +396,7 @@ export function PipeStoreView() {
 
 // --- Discover View ---
 
-function DiscoverView({ onInstalled, initialQuery = "" }: { onInstalled?: () => void; initialQuery?: string }) {
+function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
   const { settings } = useSettings();
   const { toast } = useToast();
   const token = settings.user?.token;
@@ -413,8 +404,20 @@ function DiscoverView({ onInstalled, initialQuery = "" }: { onInstalled?: () => 
   // Browse state
   const [pipes, setPipes] = useState<StorePipe[]>([]);
   const [loading, setLoading] = useState(true);
-  const [searchQuery, setSearchQuery] = useState(initialQuery);
-  const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  // Prefill search from ?q= URL param after mount, then strip it so it doesn't persist
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get("q") ?? "";
+    if (q) {
+      setSearchQuery(q);
+      setDebouncedQuery(q);
+      params.delete("q");
+      window.history.replaceState({}, "", `${window.location.pathname}?${params}`);
+    }
+  }, []);
   const [category, setCategory] = useState("All");
   const [sort, setSort] = useState("popular");
 
@@ -743,12 +746,13 @@ function DiscoverView({ onInstalled, initialQuery = "" }: { onInstalled?: () => 
   }
 
   // First-visit banner — show once, dismiss permanently
-  const [showWelcome, setShowWelcome] = useState(() => {
-    if (typeof window !== "undefined") {
-      return !localStorage.getItem("screenpipe:pipes-welcome-dismissed");
+  // Initialize false to match server render, set true after mount if not dismissed
+  const [showWelcome, setShowWelcome] = useState(false);
+  useEffect(() => {
+    if (!localStorage.getItem("screenpipe:pipes-welcome-dismissed")) {
+      setShowWelcome(true);
     }
-    return true;
-  });
+  }, []);
 
   const dismissWelcome = () => {
     setShowWelcome(false);

--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -388,7 +388,14 @@ export function PipeStoreView() {
 
       {/* Tab content */}
       {activeTab === "discover" ? (
-        <DiscoverView onInstalled={() => setActiveTab("my-pipes")} />
+        <DiscoverView
+          onInstalled={() => setActiveTab("my-pipes")}
+          initialQuery={
+            typeof window !== "undefined"
+              ? new URLSearchParams(window.location.search).get("q") ?? ""
+              : ""
+          }
+        />
       ) : (
         <PipesSection />
       )}
@@ -398,7 +405,7 @@ export function PipeStoreView() {
 
 // --- Discover View ---
 
-function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
+function DiscoverView({ onInstalled, initialQuery = "" }: { onInstalled?: () => void; initialQuery?: string }) {
   const { settings } = useSettings();
   const { toast } = useToast();
   const token = settings.user?.token;
@@ -406,8 +413,8 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
   // Browse state
   const [pipes, setPipes] = useState<StorePipe[]>([]);
   const [loading, setLoading] = useState(true);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const [debouncedQuery, setDebouncedQuery] = useState(initialQuery);
   const [category, setCategory] = useState("All");
   const [sort, setSort] = useState("popular");
 

--- a/apps/screenpipe-app-tauri/components/settings/memories-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/memories-section.tsx
@@ -268,6 +268,28 @@ export function MemoriesSection() {
     fetchPage(0, false);
   }, [sortField, sortDir]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Separate state for the newest memory timestamp — used only for the stale warning.
+  // Kept outside fetchPage so the background poll can update it without resetting the list.
+  const [newestCreatedAt, setNewestCreatedAt] = useState<string | null>(null);
+  const [bgTotal, setBgTotal] = useState<number | null>(null);
+
+  // Silent background check every 30s — fetches only 1 record to detect new memories.
+  // Updates the stale-warning state without touching the displayed list or showing a spinner.
+  useEffect(() => {
+    const check = async () => {
+      try {
+        const res = await localFetch("/memories?limit=1&order_by=created_at&order_dir=desc");
+        if (!res.ok) return;
+        const data: MemoryListResponse = await res.json();
+        setBgTotal(data.pagination.total);
+        if (data.data[0]) setNewestCreatedAt(data.data[0].created_at);
+      } catch {}
+    };
+    check();
+    const id = setInterval(check, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
   // infinite scroll via IntersectionObserver
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -420,19 +442,12 @@ export function MemoriesSection() {
     }
   };
 
-  // Show a stale warning when no filter is active and the newest memory is >24h old
-  const newestMemory =
-    !loading &&
-    memories.length > 0 &&
-    !debouncedQuery &&
-    !activeTag &&
-    sortField === "created_at" &&
-    sortDir === "desc"
-      ? memories[0]
-      : null;
-  const staleDays = newestMemory
-    ? Math.floor((Date.now() - new Date(newestMemory.created_at).getTime()) / 86400000)
-    : 0;
+  // Stale warning: use the background-polled newest timestamp so it auto-clears
+  // without disrupting the displayed list.
+  const staleDays =
+    newestCreatedAt && (bgTotal ?? total) > 0
+      ? Math.floor((Date.now() - new Date(newestCreatedAt).getTime()) / 86400000)
+      : 0;
   const isStale = staleDays >= 1;
 
   return (

--- a/apps/screenpipe-app-tauri/components/settings/memories-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/memories-section.tsx
@@ -27,6 +27,7 @@ import {
   Pencil,
   ChevronDown,
   ChevronUp,
+  AlertCircle,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { MemoizedReactMarkdown } from "@/components/markdown";
@@ -419,11 +420,44 @@ export function MemoriesSection() {
     }
   };
 
+  // Show a stale warning when no filter is active and the newest memory is >24h old
+  const newestMemory =
+    !loading &&
+    memories.length > 0 &&
+    !debouncedQuery &&
+    !activeTag &&
+    sortField === "created_at" &&
+    sortDir === "desc"
+      ? memories[0]
+      : null;
+  const staleDays = newestMemory
+    ? Math.floor((Date.now() - new Date(newestMemory.created_at).getTime()) / 86400000)
+    : 0;
+  const isStale = staleDays >= 1;
+
   return (
     <div className="space-y-4 h-full flex flex-col">
       <p className="text-muted-foreground text-sm mb-4">
         facts and preferences the AI has learned from your activity
       </p>
+
+      {/* stale memories warning */}
+      {isStale && (
+        <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-600 dark:text-yellow-400">
+          <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>
+            memories haven&apos;t updated in {staleDays} day{staleDays !== 1 ? "s" : ""}.
+            check that a memory-writing pipe is installed and enabled —{" "}
+            <a
+              href="?section=pipes&tab=discover&q=memory"
+              className="underline hover:opacity-80 transition-opacity"
+            >
+              browse memory pipes
+            </a>
+            .
+          </span>
+        </div>
+      )}
 
       {/* search bar + add button */}
       <div className="flex items-center gap-2">

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -3295,13 +3295,31 @@ impl PipeManager {
                             ),
                         }
                     } else {
-                        (
-                            config.model.clone(),
-                            config.provider.clone(),
-                            None,
-                            None,
-                            None,
-                        )
+                        // No preset in pipe config — use the user's default preset
+                        // so scheduled pipes respect the user's AI settings instead
+                        // of silently falling through to screenpipe cloud.
+                        match resolve_preset(&pipes_dir, "default") {
+                            Some(resolved) => {
+                                info!(
+                                    "scheduler: pipe '{}' has no preset configured, using user's default preset → model={}, provider={:?}",
+                                    name, resolved.model, resolved.provider
+                                );
+                                (
+                                    resolved.model,
+                                    resolved.provider,
+                                    resolved.url,
+                                    resolved.api_key,
+                                    resolved.prompt,
+                                )
+                            }
+                            None => (
+                                config.model.clone(),
+                                config.provider.clone(),
+                                None,
+                                None,
+                                None,
+                            ),
+                        }
                     };
 
                     // Pre-configure pi with the pipe's provider

--- a/crates/screenpipe-core/src/pipes/preset_fallback.rs
+++ b/crates/screenpipe-core/src/pipes/preset_fallback.rs
@@ -325,8 +325,17 @@ impl PresetFallbackRegistry {
 
         for (id, breaker) in state.presets.iter_mut() {
             if breaker.state == BreakerState::Open && now >= breaker.cooldown_until {
-                breaker.state = BreakerState::HalfOpen;
-                info!("startup recovery: preset '{}' moved to half-open", id);
+                // Cooldown expired >24h ago — fully reset so a prolonged outage
+                // (e.g. auth drift) doesn't leave the breaker stuck indefinitely.
+                if now.saturating_sub(breaker.cooldown_until) > 86400 {
+                    breaker.state = BreakerState::Closed;
+                    breaker.failure_count = 0;
+                    breaker.success_streak = 0;
+                    info!("startup recovery: preset '{}' reset to closed (stale open >24h)", id);
+                } else {
+                    breaker.state = BreakerState::HalfOpen;
+                    info!("startup recovery: preset '{}' moved to half-open", id);
+                }
                 changed = true;
             }
             // Sanity: if cooldown_until is more than 24h in the future, reset it


### PR DESCRIPTION
### Description: 

Fixes a chain of bugs that caused memory-writing pipes to stop creating memories and adds a UI warning when memories go stale. 

### Bug:

<img width="1284" height="74" alt="Screenshot 2026-04-20 141445" src="https://github.com/user-attachments/assets/fd587229-77c1-4799-bc03-a4d9efba739f" />


- before:

<img width="1916" height="1020" alt="Screenshot 2026-04-20 132848" src="https://github.com/user-attachments/assets/e020742c-f25a-4429-8cdd-c78804a2af6f" />

- After:


https://github.com/user-attachments/assets/aee435d4-09ac-405d-9a12-0f0eb53c7d5d

- Updated Memories.

<img width="1919" height="1079" alt="Screenshot 2026-04-20 165853" src="https://github.com/user-attachments/assets/5fbbb08e-96bd-497e-b0ca-8bd262c41229" />
  
   
### File changed: 
  - Scheduler preset fix (pipes/mod.rs) — scheduled pipes now use the user's configured AI preset instead of falling back to screenpipe-cloud  
  when no preset is set
  - Circuit breaker recovery (preset_fallback.rs) — breakers stuck open for >24h are fully reset on app startup instead of staying half-open
  indefinitely
  - Stale memories banner (memories-section.tsx) — yellow warning appears when memories haven't updated in 1+ days, so the failure is no longer
   silent
  - Clickable pipe link (pipe-store.tsx) — banner links directly to Pipes → Discover with "memory" pre-filled in search so users can fix it in one click.

