### PR TITLE
feat(ai-gateway): open Opus 4.7 to logged_in tier + lower quota weight

### DIFF
--- a/packages/ai-gateway/src/handlers/models.ts
+++ b/packages/ai-gateway/src/handlers/models.ts
@@ -261,9 +261,8 @@ const CURATED_MODELS: ModelEntry[] = [
     best_for: ['complex tasks', 'analysis', 'agentic coding'],
     speed: 'slow',
     intelligence: 'highest',
-    cost_tier: 'high',
-    recommended_for: ['chat', 'analysis'],
-    warning: 'expensive — will use your daily limit fast. use haiku or a free model for pipes',
+    cost_tier: 'medium',
+    recommended_for: ['chat', 'analysis', 'coding'],
   },
   {
     id: 'claude-opus-4-6',

--- a/packages/ai-gateway/src/services/usage-tracker.ts
+++ b/packages/ai-gateway/src/services/usage-tracker.ts
@@ -118,6 +118,10 @@ const MODEL_WEIGHTS: Record<string, number> = {
   'glm-4.7': 0,
   'glm-5': 0,
   'kimi-k2.5': 0,
+  // Opus 4.7 is ~3× cheaper per token than 4.5/4.6 ($5/$25 vs $15/$75 per 1M),
+  // so it consumes proportionally less daily quota. Longest-prefix match in
+  // getModelWeight ensures this override beats the generic 'claude-opus' entry.
+  'claude-opus-4-7': 5,
   'claude-opus': 15,
   'claude-sonnet': 3,
   'claude-haiku': 1,
@@ -180,6 +184,9 @@ const DEFAULT_TIER_CONFIG: Record<UserTier, TierLimits> = {
       'auto',
       'claude-haiku-4-5',
       'claude-sonnet-4-5',
+      // Opus 4.7 is cheap enough (~3× less than 4.6) that logged-in users
+      // can afford ~10 calls/day within the 50-query tier budget at weight=5.
+      'claude-opus-4-7',
       'gemini-3-flash',
       'gemini-3.1-flash-lite',
       'gemini-3-pro',


### PR DESCRIPTION
## Summary
- Opus 4.7 now available to `logged_in` users (was subscribed-only).
- Quota weight dropped 15 → 5 to reflect the ~3× lower pricing ($5/$25 per 1M vs Opus 4.6's $15/$75).
- Curated models catalog re-tiered: `cost_tier` high → medium, stale "expensive" warning removed.

## Effect per tier
| Tier | Before | After |
|---|---|---|
| `anonymous` (25/day) | no opus | no opus |
| `logged_in` (50/day) | no opus | **~10 Opus 4.7 calls/day** |
| `subscribed` (1500/day) | ~100 Opus 4.6/day | ~300 Opus 4.7/day (or mix) |

## Test plan
- [x] `bun test src/test/anthropic-proxy.unit.test.ts` — 36 pass (1 pre-existing unrelated failure on `gemini-2.5-flash`/anonymous)
- [ ] Smoke test via curl after deploy: `claude-opus-4-7` accepted for a logged-in device id
- [ ] Confirm D1 usage rows increment by 5 per opus-4-7 call (not 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)