### PR TITLE
fix(ai-gateway): revert opening Opus 4.7 to logged_in (paid-only)

### DIFF
--- a/packages/ai-gateway/src/services/usage-tracker.ts
+++ b/packages/ai-gateway/src/services/usage-tracker.ts
@@ -184,9 +184,6 @@ const DEFAULT_TIER_CONFIG: Record<UserTier, TierLimits> = {
       'auto',
       'claude-haiku-4-5',
       'claude-sonnet-4-5',
-      // Opus 4.7 is cheap enough (~3× less than 4.6) that logged-in users
-      // can afford ~10 calls/day within the 50-query tier budget at weight=5.
-      'claude-opus-4-7',
       'gemini-3-flash',
       'gemini-3.1-flash-lite',
       'gemini-3-pro',


### PR DESCRIPTION
Reverts the tier-access part of #3026. Opus access is paid-only by policy — previous commit incorrectly opened Opus 4.7 to the logged_in tier.

Keeps the weight=5 reduction for Opus 4.7 since that remains correct (3× cheaper pricing → proportionally lower quota cost for subscribed users).

## Test plan
- [x] 36 pass, 1 pre-existing unrelated failure unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)