### PR TITLE
fix(connect): proxy forwards query params + Sheets OAuth includes drive.metadata.readonly

### DIFF
--- a/crates/screenpipe-connect/src/connections/google_sheets.rs
+++ b/crates/screenpipe-connect/src/connections/google_sheets.rs
@@ -29,7 +29,13 @@ static OAUTH: OAuthConfig = OAuthConfig {
     extra_auth_params: &[
         (
             "scope",
+            // drive.metadata.readonly is needed to list spreadsheets (e.g. the
+            // list-sheets pipe calling drive/v3/files?q=mimeType=spreadsheet).
+            // Without it, file listing fails with ACCESS_TOKEN_SCOPE_INSUFFICIENT
+            // and users have to re-authorize. Read/write of cells inside a
+            // *known* sheet still only needs the spreadsheets scope.
             "https://www.googleapis.com/auth/spreadsheets \
+             https://www.googleapis.com/auth/drive.metadata.readonly \
              https://www.googleapis.com/auth/userinfo.email",
         ),
         ("access_type", "offline"),

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -1086,6 +1086,7 @@ fn resolve_auth(
 async fn connection_proxy(
     State(state): State<ConnectionsState>,
     axum::extract::Path((id, api_path)): axum::extract::Path<(String, String)>,
+    axum::extract::RawQuery(raw_query): axum::extract::RawQuery,
     method: axum::http::Method,
     headers: axum::http::HeaderMap,
     body: axum::body::Bytes,
@@ -1168,8 +1169,19 @@ async fn connection_proxy(
 
     drop(mgr); // release lock before making external request
 
-    // Build the target URL
-    let target_url = format!("{}/{}", base_url, api_path.trim_start_matches('/'));
+    // Build the target URL. Query params from the caller (e.g.
+    // `?valueInputOption=USER_ENTERED` for Google Sheets appends) must be
+    // forwarded verbatim — without this, callers silently hit defaults and
+    // bad requests like 400s on `values:append`.
+    let target_url = match raw_query.as_deref() {
+        Some(q) if !q.is_empty() => format!(
+            "{}/{}?{}",
+            base_url,
+            api_path.trim_start_matches('/'),
+            q
+        ),
+        _ => format!("{}/{}", base_url, api_path.trim_start_matches('/')),
+    };
 
     // Audit log
     tracing::info!(


### PR DESCRIPTION
## Summary
- `connection_proxy` was dropping caller query strings — Sheets `values:append?valueInputOption=USER_ENTERED` and any similar call silently used upstream defaults and got 400s. Fix: add `RawQuery` extractor and append to target URL.
- Google Sheets OAuth scope was `spreadsheets + userinfo.email` — listing files needs `drive.metadata.readonly`. Added it so `list-sheets` and related pipes stop hard-failing with `ACCESS_TOKEN_SCOPE_INSUFFICIENT`.

## Why
Found via chat-log analysis — agents were burning 3-5 tool calls per Sheets write discovering the proxy drops query params, and pipe `list-sheets` had been dead for days.

## Test plan
- [x] `cargo check -p screenpipe-engine -p screenpipe-connect` clean
- [ ] After deploy: `POST /connections/google-sheets/proxy/$SHEET_ID/values/Sheet1!A1:append?valueInputOption=USER_ENTERED` should succeed 200 (was 400)
- [ ] `list-sheets` pipe completes without scope error (users with existing creds will still need to reconnect once to pick up the new scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)