### PR TITLE
fix(search): keyword flat mode no longer silently drops results without text positions

### DIFF
--- a/crates/screenpipe-engine/src/routes/search.rs
+++ b/crates/screenpipe-engine/src/routes/search.rs
@@ -549,9 +549,6 @@ pub(crate) async fn keyword_search_handler(
         let filtered: Vec<_> = matches
             .into_iter()
             .filter(|m| !m.app_name.to_lowercase().contains("screenpipe"))
-            // Drop results with no text_positions — the user can't see where
-            // the match is on the screenshot, so showing them is misleading
-            .filter(|m| !m.text_positions.is_empty() || query.query.is_empty())
             .collect();
 
         Ok(JsonResponse(json!(filtered)))


### PR DESCRIPTION
### Description:
When you searched using `/search/keyword?query=hello&group=false`, some results were invisibly missing from the response, no error, no warning, just fewer results than expected. The same query on `/search?q=hello` returned more results.

<img width="1918" height="1015" alt="image" src="https://github.com/user-attachments/assets/eda19d78-86e6-4690-aae2-6df6da5de4d3" />


Fixes #3024 

### What changed: 

- File: crates/screenpipe-engine/src/routes/search.rs