### PR TITLE
fix: prevent permanent db pool starvation by not detaching on rollback failure

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -128,9 +128,9 @@ impl Drop for ImmediateTx {
                         }
                         Err(e) => {
                             // ROLLBACK failed — connection is likely broken.
-                            // Detach as last resort so it doesn't poison the pool.
-                            warn!("ImmediateTx rollback failed ({}), detaching connection", e);
-                            let _raw = conn.detach();
+                            // We do NOT detach because detaching permanently reduces the pool size.
+                            // Dropping returns it to the pool where it will be recovered on next use.
+                            warn!("ImmediateTx rollback failed ({}), returning broken connection to pool", e);
                         }
                     }
                     drop(permit); // Release the write permit so other writers can proceed
@@ -541,10 +541,9 @@ impl DatabaseManager {
                         }
                         Err(rb_err) => {
                             warn!(
-                                "ROLLBACK failed ({}), detaching connection as last resort",
+                                "ROLLBACK failed ({}), returning broken connection to pool",
                                 rb_err
                             );
-                            let _raw = conn.detach();
                         }
                     }
                     last_error = Some(e);

--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -481,8 +481,7 @@ async fn execute_batch(
                         drop(conn);
                     }
                     Err(rb_err) => {
-                        warn!("write_queue: ROLLBACK failed ({}), detaching connection as last resort", rb_err);
-                        let _raw = conn.detach();
+                        warn!("write_queue: ROLLBACK failed ({}), returning broken connection to pool", rb_err);
                     }
                 }
                 last_error = Some(e);
@@ -546,8 +545,7 @@ async fn execute_batch(
     // COMMIT or ROLLBACK
     if any_fatal {
         if let Err(e) = sqlx::query("ROLLBACK").execute(&mut *conn).await {
-            warn!("write_queue: ROLLBACK failed: {}, detaching connection", e);
-            let _raw = conn.detach();
+            warn!("write_queue: ROLLBACK failed: {}, returning connection to pool", e);
         }
         // All results become errors on rollback
         for result in results.iter_mut() {
@@ -559,8 +557,7 @@ async fn execute_batch(
         warn!("write_queue: COMMIT failed: {}", e);
         let msg = e.to_string().to_lowercase();
         if !msg.contains("no transaction is active") {
-            warn!("write_queue: detaching connection due to commit failure");
-            let _raw = conn.detach();
+            warn!("write_queue: commit failed, returning connection to pool");
         }
         // All results become the commit error
         for pw in batch.drain(..) {


### PR DESCRIPTION
## Problem
The app encounters frequent `pool timed out while waiting for an open connection` errors (Sentry 7331781144), causing it to fail to insert UI events or audio chunks. Concurrently, it experiences `(code: 14) unable to open database file` during batches (Sentry 7371922449).

## Root cause
When the database file is temporarily unavailable (e.g. out of FDs, locked), a write batch fails and attempts a `ROLLBACK`. Since the DB is locked, the `ROLLBACK` also fails. The fallback behavior previously called `conn.detach()`, which permanently removes the slot from the pool manager without replacing it correctly in all edge cases. After 3 such failures (since `max_connections=3`), the pool permanently drops to size 0, and all subsequent `write_pool.acquire()` calls fail with `PoolTimedOut`.

## Fix
Stop using `conn.detach()` when `ROLLBACK` fails. Instead, simply drop the connection so it returns to the pool. When the next requester acquires it, `sqlx` and our code's `is_nested_transaction_error` retry loop will safely execute another `ROLLBACK` once the database is available again, recovering the connection without destroying the pool permanently.

## Confidence: 9/10

## Verification
```
test tests::test_update_speaker_name ... ok
test tests::test_search_with_frame_name ... ok
test tests::test_search_with_time_range ... ok
test tests::test_search_accessibility_time_range ... ok

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.87s
```

---
auto-generated by issue-solver pipe