### PR TITLE
perf(db): dynamic WHERE in count_search_results + docs: ops section (health probe, .env hygiene)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,112 @@ then ask claude `what did i see in the last 5 mins?` or `summarize today convers
     <a href="https://www.reddit.com/r/screen_pipe">reddit</a>
 </p>
 
+## operations
+
+self-hosted tips for keeping the local CLI daemon healthy and the on-disk API key locked down. all paths are under `~/.screenpipe`, so they work for any user.
+
+### daemon health monitoring
+
+screenpipe exposes `GET http://localhost:3030/health`. a healthy response is http 200 with `"status":"healthy"`. a scheduled probe against this endpoint catches silent daemon stops (e.g. after a crash or macOS sleep/wake cycle) that the menubar indicator may not surface.
+
+save the probe as `~/.screenpipe/bin/health-probe.sh` and `chmod +x` it:
+
+```bash
+#!/usr/bin/env bash
+set -u
+SP_HOME="${HOME}/.screenpipe"
+ENV_FILE="${SP_HOME}/.env"
+LOG_DIR="${SP_HOME}/logs"
+LOG_FILE="${LOG_DIR}/health-probe.log"
+ENDPOINT="http://localhost:3030/health"
+mkdir -p "${LOG_DIR}"
+
+# Pick up the API key defensively in case /health is gated in a future release.
+AUTH=""
+if [[ -r "${ENV_FILE}" ]]; then
+  KEY="$(grep -E '^SCREENPIPE_API_KEY=' "${ENV_FILE}" | cut -d= -f2- | tr -d '\r\n"'"'")"
+  [[ -n "${KEY}" ]] && AUTH="Authorization: Bearer ${KEY}"
+fi
+
+BODY="$(mktemp -t sp_health.XXXXXX)"; trap 'rm -f "${BODY}"' EXIT
+if [[ -n "${AUTH}" ]]; then
+  CODE="$(curl -sS --max-time 5 -H "${AUTH}" -o "${BODY}" -w '%{http_code}' "${ENDPOINT}" 2>/dev/null || echo 000)"
+else
+  CODE="$(curl -sS --max-time 5 -o "${BODY}" -w '%{http_code}' "${ENDPOINT}" 2>/dev/null || echo 000)"
+fi
+
+STATUS="$(grep -o '"status":"[^"]*"' "${BODY}" | head -n1 | cut -d'"' -f4)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+OUTCOME=ok
+[[ "${CODE}" != 200 ]] && OUTCOME="http_${CODE}"
+[[ "${STATUS}" != healthy && "${OUTCOME}" == ok ]] && OUTCOME=unhealthy
+printf '{"ts":"%s","outcome":"%s","http":"%s","status":"%s"}\n' \
+  "${TS}" "${OUTCOME}" "${CODE}" "${STATUS:-unknown}" >> "${LOG_FILE}"
+
+# Rotate at ~1 MB.
+if [[ "$(stat -f%z "${LOG_FILE}" 2>/dev/null || stat -c%s "${LOG_FILE}" 2>/dev/null || echo 0)" -gt 1048576 ]]; then
+  mv "${LOG_FILE}" "${LOG_FILE}.1"
+fi
+
+# Notify once per failure streak (don't spam while daemon stays down).
+if [[ "${OUTCOME}" != ok ]]; then
+  PREV="$(tail -n 2 "${LOG_FILE}" 2>/dev/null | head -n 1 | grep -o '"outcome":"[^"]*"' | cut -d'"' -f4)"
+  if [[ "${PREV}" == ok || -z "${PREV}" ]]; then
+    /usr/bin/osascript -e "display notification \"screenpipe /health: ${OUTCOME}\" with title \"screenpipe\" sound name \"Basso\"" 2>/dev/null || true
+  fi
+  exit 1
+fi
+```
+
+schedule it every 5 minutes on macOS with a LaunchAgent at `~/Library/LaunchAgents/com.screenpipe.healthprobe.plist` (replace `/Users/YOU` with your `$HOME` — `launchd` does not expand `~`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.screenpipe.healthprobe</string>
+  <key>ProgramArguments</key>
+  <array><string>/Users/YOU/.screenpipe/bin/health-probe.sh</string></array>
+  <key>StartInterval</key><integer>300</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>/Users/YOU/.screenpipe/logs/health-probe.stdout.log</string>
+  <key>StandardErrorPath</key><string>/Users/YOU/.screenpipe/logs/health-probe.stderr.log</string>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>
+```
+
+load, verify, tail, and force-run:
+
+```bash
+launchctl load -w ~/Library/LaunchAgents/com.screenpipe.healthprobe.plist
+launchctl list | grep com.screenpipe.healthprobe         # PID | last_exit | label
+tail -n 5 ~/.screenpipe/logs/health-probe.log             # most recent JSON events
+launchctl kickstart -k gui/$(id -u)/com.screenpipe.healthprobe   # trigger on demand
+launchctl unload -w ~/Library/LaunchAgents/com.screenpipe.healthprobe.plist  # disable
+```
+
+on linux, swap the LaunchAgent for a systemd user timer or a `*/5 * * * *` cron entry that runs the same script.
+
+the log is json lines so it's easy to alert on:
+
+```bash
+# anything unhealthy in the last hour?
+grep -v '"outcome":"ok"' ~/.screenpipe/logs/health-probe.log | tail
+```
+
+### api key hygiene
+
+`~/.screenpipe/.env` holds `SCREENPIPE_API_KEY` (the bearer token the desktop app and MCP server use against the local REST API). keep it readable only by your user:
+
+```bash
+chmod 600 ~/.screenpipe/.env
+ls -la ~/.screenpipe/.env   # expect -rw-------
+```
+
+the probe above loads the key from this file, so tightening the perms doesn't break the scheduled job (it runs as you under `launchd`, so it can still read `0600` files).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs. AI/vibe-coded PRs welcome!

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -3444,36 +3444,92 @@ impl DatabaseManager {
         let fts_query = fts_parts.join(" ");
         let has_fts = !fts_query.trim().is_empty();
 
-        let sql = match content_type {
-            ContentType::OCR | ContentType::Accessibility => format!(
+        // OCR / Accessibility: build the WHERE clause dynamically so SQLite can
+        // use idx_frames_timestamp for range bounds. The previous
+        // `(?x IS NULL OR col OP ?x)` pattern forced a full table scan because
+        // statement-level planning in SQLite cannot see parameter values and
+        // therefore assumed every branch of the OR could be active.
+        // See tests/query_plan_test.rs::test_is_null_or_defeats_timestamp_index.
+        if matches!(content_type, ContentType::OCR | ContentType::Accessibility) {
+            let mut conditions: Vec<&'static str> = Vec::new();
+            if start_time.is_some() {
+                conditions.push("frames.timestamp >= ?");
+            }
+            if end_time.is_some() {
+                conditions.push("frames.timestamp <= ?");
+            }
+            if min_length.is_some() {
+                conditions.push("LENGTH(COALESCE(frames.full_text, '')) >= ?");
+            }
+            if max_length.is_some() {
+                conditions.push("LENGTH(COALESCE(frames.full_text, '')) <= ?");
+            }
+            if frame_name.is_some() {
+                conditions.push("frames.name LIKE '%' || ? || '%'");
+            }
+            if focused.is_some() {
+                conditions.push("frames.focused = ?");
+            }
+            if content_type == ContentType::Accessibility {
+                conditions.push(
+                    "frames.accessibility_text IS NOT NULL AND frames.accessibility_text != ''",
+                );
+            }
+
+            let extra_where = if conditions.is_empty() {
+                String::new()
+            } else {
+                format!(" AND {}", conditions.join(" AND "))
+            };
+
+            let sql = format!(
                 r#"SELECT COUNT(DISTINCT frames.id)
                    FROM frames
                    {fts_join}
                    WHERE 1=1
                        {fts_condition}
-                       AND (?2 IS NULL OR frames.timestamp >= ?2)
-                       AND (?3 IS NULL OR frames.timestamp <= ?3)
-                       AND (?4 IS NULL OR LENGTH(COALESCE(frames.full_text, '')) >= ?4)
-                       AND (?5 IS NULL OR LENGTH(COALESCE(frames.full_text, '')) <= ?5)
-                       AND (?6 IS NULL OR frames.name LIKE '%' || ?6 || '%')
-                       AND (?7 IS NULL OR frames.focused = ?7)
-                       {a11y_filter}"#,
+                       {extra_where}"#,
                 fts_join = if has_fts {
                     "JOIN frames_fts ON frames.id = frames_fts.rowid"
                 } else {
                     ""
                 },
                 fts_condition = if has_fts {
-                    "AND frames_fts MATCH ?1"
+                    "AND frames_fts MATCH ?"
                 } else {
                     ""
                 },
-                a11y_filter = if content_type == ContentType::Accessibility {
-                    "AND frames.accessibility_text IS NOT NULL AND frames.accessibility_text != ''"
-                } else {
-                    ""
-                }
-            ),
+                extra_where = extra_where,
+            );
+
+            let mut q = sqlx::query_scalar::<_, i64>(&sql);
+            if has_fts {
+                q = q.bind(fts_query);
+            }
+            if let Some(t) = start_time {
+                q = q.bind(t);
+            }
+            if let Some(t) = end_time {
+                q = q.bind(t);
+            }
+            if let Some(l) = min_length {
+                q = q.bind(l as i64);
+            }
+            if let Some(l) = max_length {
+                q = q.bind(l as i64);
+            }
+            if let Some(n) = frame_name {
+                q = q.bind(n.to_owned());
+            }
+            if let Some(f) = focused {
+                q = q.bind(f);
+            }
+
+            let count: i64 = q.fetch_one(&self.pool).await?;
+            return Ok(count as usize);
+        }
+
+        let sql = match content_type {
             ContentType::Audio => format!(
                 r#"SELECT COUNT(DISTINCT audio_transcriptions.id)
                    FROM {table}
@@ -3575,18 +3631,6 @@ impl DatabaseManager {
         };
 
         let count: i64 = match content_type {
-            ContentType::OCR | ContentType::Accessibility => {
-                sqlx::query_scalar(&sql)
-                    .bind(if has_fts { fts_query } else { "*".to_owned() })
-                    .bind(start_time)
-                    .bind(end_time)
-                    .bind(min_length.map(|l| l as i64))
-                    .bind(max_length.map(|l| l as i64))
-                    .bind(frame_name)
-                    .bind(focused)
-                    .fetch_one(&self.pool)
-                    .await?
-            }
             ContentType::Audio => {
                 let sanitized_audio = if query.is_empty() {
                     "*".to_owned()

--- a/crates/screenpipe-db/tests/query_plan_test.rs
+++ b/crates/screenpipe-db/tests/query_plan_test.rs
@@ -557,6 +557,58 @@ mod query_plan_tests {
         );
     }
 
+    /// Regression test: the refactored count_search_results OCR branch must
+    /// emit SQL with direct `frames.timestamp >= ?` predicates (not the old
+    /// `(?x IS NULL OR frames.timestamp >= ?x)` anti-pattern) so SQLite can
+    /// use idx_frames_timestamp for range bounds.
+    #[tokio::test]
+    async fn test_count_search_results_ocr_refactored_uses_range_bounds() {
+        let db = setup_test_db().await;
+        seed_data(&db, 200).await;
+
+        // Shape of the SQL produced by count_search_results when only
+        // start_time and end_time are bound (the common pipe call path).
+        let plan = explain(
+            &db,
+            r#"SELECT COUNT(DISTINCT frames.id)
+               FROM frames
+               WHERE 1=1
+                   AND frames.timestamp >= '2020-01-01'
+                   AND frames.timestamp <= '2030-01-01'"#,
+        )
+        .await;
+
+        assert_no_table_scan(&plan, "count_search_results_ocr_refactored");
+        let has_range_bounds = plan
+            .iter()
+            .any(|l| l.contains("timestamp>") || l.contains("timestamp<"));
+        assert!(
+            has_range_bounds,
+            "Refactored count query must use range bounds on timestamp.\nPlan:\n{}",
+            plan.join("\n")
+        );
+    }
+
+    /// Regression test: zero-filter variant (no optional predicates bound)
+    /// must not regress into a full table scan. With dynamic WHERE this
+    /// becomes essentially `SELECT COUNT(DISTINCT id) FROM frames` which
+    /// SQLite can resolve with a covering index scan rather than a heap walk.
+    #[tokio::test]
+    async fn test_count_search_results_ocr_no_filters_no_table_scan() {
+        let db = setup_test_db().await;
+        seed_data(&db, 200).await;
+
+        let plan = explain(
+            &db,
+            r#"SELECT COUNT(DISTINCT frames.id)
+               FROM frames
+               WHERE 1=1"#,
+        )
+        .await;
+
+        assert_no_table_scan(&plan, "count_search_results_ocr_no_filters");
+    }
+
     #[tokio::test]
     async fn test_count_audio_with_time_range_uses_index() {
         let db = setup_test_db().await;


### PR DESCRIPTION
## Summary

This branch contains **two commits** ahead of `main`. Reviewers: if you'd prefer these as separate PRs, happy to split.

### 1. `perf(db): avoid IS NULL OR anti-pattern in count_search_results OCR path`
Pre-existing perf work on the branch. Rewrites the count query on the OCR path to drop the `IS NULL OR` predicate pattern in favor of a dynamic `WHERE` clause, letting SQLite pick better plans. Test coverage lives in `crates/screenpipe-db/tests/query_plan_test.rs`.

### 2. `docs(readme): add operations section for health probe and api key hygiene`
Adds an `## operations` section to `README.md` covering:
- **Daemon health monitoring** — polling `GET /health` to catch silent daemon stops (after crash or macOS sleep/wake). Includes a full bash probe script with JSONL logging, size-based log rotation, and debounced macOS user notifications on failure.
- **macOS LaunchAgent** — example `com.screenpipe.healthprobe.plist` that runs the probe every 5 minutes, plus `launchctl` load/verify/kickstart/unload cheatsheet.
- **Linux fallback** — systemd user timer or `*/5 * * * *` cron.
- **API key hygiene** — `chmod 600 ~/.screenpipe/.env` since it holds `SCREENPIPE_API_KEY`, with a note that the probe script reads the key defensively in case `/health` is gated behind auth later.

All paths are generic (`~/.screenpipe/...`) so the instructions work for any user, not only the author.

## Testing
- `perf`: covered by `crates/screenpipe-db/tests/query_plan_test.rs` (unchanged from prior WIP — see `git log -p e620c92`).
- `docs`: README-only change, no runtime impact. Probe script + LaunchAgent were dogfooded locally against the live daemon (`/health` returned 200 with `status=healthy`; two `outcome=ok` events were logged before commit).

## Scope note
The branch name reflects only the perf work. The docs commit was added later. Splitting into two PRs is straightforward if preferred — say the word.

---

Generated with assistance from [Warp](https://app.warp.dev/conversation/6c19d161-e1e8-47bd-8d7c-f438a162457f).