### PR TITLE
fix: Meetings summarize with AI flow

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/meetings-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/meetings-section.tsx
@@ -328,7 +328,7 @@ export function MeetingsSection() {
     }
   };
 
-  const summarizeMeeting = (meeting: MeetingRecord) => {
+  const summarizeMeeting = async (meeting: MeetingRecord) => {
     const start = new Date(meeting.meeting_start);
     const end = meeting.meeting_end ? new Date(meeting.meeting_end) : null;
     const duration = end
@@ -345,13 +345,22 @@ export function MeetingsSection() {
 
     const prompt = `search screenpipe for what happened during this meeting and summarize it: key topics, decisions, action items. then suggest which of my connected integrations would be useful to share this with and draft a message for each.\n\nmeeting:\n${parts.join("\n")}`;
 
-    showChatWithPrefill({
-      context: "",
-      prompt,
-      autoSend: true,
-      source: "meeting-summarize",
-      useHomeChat: true,
-    });
+    try {
+      await showChatWithPrefill({
+        context: "",
+        prompt,
+        autoSend: true,
+        source: "meeting-summarize",
+        useHomeChat: true,
+      });
+    } catch (err) {
+      console.error("failed to launch meeting summary chat", err);
+      toast({
+        title: "failed to summarize meeting",
+        description: "could not open home chat. please try again.",
+        variant: "destructive",
+      });
+    }
   };
 
   const cancelEdit = () => {

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1195,6 +1195,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
   const [prefillContext, setPrefillContext] = useState<string | null>(null);
   const [prefillSource, setPrefillSource] = useState<string>("search");
   const [prefillFrameId, setPrefillFrameId] = useState<number | null>(null);
+  const [isPreparingPrefill, setIsPreparingPrefill] = useState(false);
   const [pastedImages, setPastedImages] = useState<string[]>([]); // Base64 data URLs
   const [imageViewer, setImageViewer] = useState<{ images: string[]; index: number } | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -1431,20 +1432,26 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
   // Other windows wait for "chat-ready" before emitting "chat-prefill"
   // to avoid the event being lost when the chat webview is freshly created.
   useEffect(() => {
-    emit("chat-ready", {});
+    const windowLabel = getCurrentWindow().label;
+    emit("chat-ready", { windowLabel });
     // Also respond to "chat-ping" for when the chat is already open
-    const unlisten = listen("chat-ping", () => {
-      emit("chat-ready", {});
+    const unlisten = listen<{ targetWindow?: string }>("chat-ping", (event) => {
+      const targetWindow = event.payload?.targetWindow;
+      if (targetWindow && targetWindow !== windowLabel) return;
+      emit("chat-ready", { windowLabel });
     });
     // Check for pending prefill from same-window navigation (e.g. pipes → home)
     const pending = sessionStorage.getItem("pendingChatPrefill");
     if (pending) {
+      setIsPreparingPrefill(true);
       sessionStorage.removeItem("pendingChatPrefill");
       try {
         const data = JSON.parse(pending);
-        // Small delay to let the chat fully initialize
-        setTimeout(() => emit("chat-prefill", data), 500);
-      } catch {}
+        // Small delay to let the chat fully initialize without showing setup flashes.
+        setTimeout(() => emit("chat-prefill", data), 120);
+      } catch {
+        setIsPreparingPrefill(false);
+      }
     }
     // Clean up stale pipe-generation markers (>30 min old) so they don't
     // leak into a future unrelated chat session.
@@ -1532,13 +1539,15 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
       // Only process if this window is the intended target (or no target for backwards compat)
       if (targetWindow && getCurrentWindow().label !== targetWindow) return;
 
-      if (autoSend && prompt && context) {
+      if (autoSend && prompt) {
         // Deduplicate: skip if another listener instance is already handling this
         if (prefillInFlightRef.current) return;
         prefillInFlightRef.current = true;
+        setIsPreparingPrefill(true);
 
         // Auto-send: compose full message (context above, user text below) and send immediately
-        const fullMessage = `${context}\n\n${prompt}`;
+        const trimmedContext = context?.trim();
+        const fullMessage = trimmedContext ? `${trimmedContext}\n\n${prompt}` : prompt;
         // Start a new conversation then send
         (async () => {
           try {
@@ -1572,11 +1581,13 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           } finally {
             autoSendBypassRef.current = false;
             prefillInFlightRef.current = false;
+            setIsPreparingPrefill(false);
           }
         })();
         return;
       }
 
+      setIsPreparingPrefill(false);
       setPrefillContext(context);
       setPrefillSource(source || "search");
       if (frameId) {
@@ -3611,7 +3622,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
           }}
         >
         <div className="max-w-4xl mx-auto w-full p-4 space-y-4">
-        {messages.length === 0 && disabledReason && (!hasPresets || !hasValidModel || needsLogin) && (
+        {messages.length === 0 && !isPreparingPrefill && disabledReason && (!hasPresets || !hasValidModel || needsLogin) && (
           <div className="relative flex flex-col items-center justify-center py-12 space-y-4">
             <div className="relative p-6 rounded-2xl border bg-muted/50 border-border/50">
               {needsLogin ? (
@@ -3652,7 +3663,7 @@ export function StandaloneChat({ className }: { className?: string } = {}) {
             )}
           </div>
         )}
-        {messages.length === 0 && hasPresets && hasValidModel && !needsLogin && (
+        {messages.length === 0 && !isPreparingPrefill && hasPresets && hasValidModel && !needsLogin && (
           <SummaryCards
             onSendMessage={sendMessage}
             autoSuggestions={autoSuggestions}

--- a/apps/screenpipe-app-tauri/lib/chat-utils.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-utils.ts
@@ -7,6 +7,7 @@
 // ============================================================================
 
 import { emit, listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { commands } from "@/lib/utils/tauri";
 
 // ============================================================================
@@ -23,6 +24,9 @@ export interface ChatPrefillData {
   useHomeChat?: boolean;
 }
 
+const CHAT_READY_TIMEOUT_MS = 2500;
+const CHAT_READY_MAX_ATTEMPTS = 3;
+
 /**
  * Show a chat window and reliably deliver a chat-prefill event.
  *
@@ -36,29 +40,72 @@ export interface ChatPrefillData {
  */
 export async function showChatWithPrefill(data: ChatPrefillData): Promise<void> {
   const targetWindow = data.useHomeChat ? "home" : "chat";
+  const currentWindowLabel = getCurrentWindow().label;
+
+  // If we're already in the Home window but on another route (e.g. /settings),
+  // route locally and pass prefill through sessionStorage so the embedded chat
+  // can consume it after /home mounts.
+  if (data.useHomeChat && currentWindowLabel === "home") {
+    const url = new URL(window.location.href);
+    const isHomeRoute = url.pathname === "/home";
+    const isHomeSection = url.searchParams.get("section") === "home";
+
+    if (!isHomeRoute || !isHomeSection) {
+      sessionStorage.setItem(
+        "pendingChatPrefill",
+        JSON.stringify({ ...data, targetWindow }),
+      );
+      window.location.assign("/home?section=home");
+      return;
+    }
+  }
 
   if (data.useHomeChat) {
-    await commands.showWindow({ Home: { page: null } });
+    // Home chat only mounts when section=home; focusing a non-home section can
+    // drop prefill events because no chat listener exists yet.
+    await commands.showWindow({ Home: { page: "home" } });
   } else {
     await commands.showWindow("Chat");
   }
 
-  // Wait for the chat component to signal readiness.
-  await new Promise<void>((resolve) => {
-    let resolved = false;
-    const done = () => {
-      if (resolved) return;
-      resolved = true;
-      clearTimeout(timeout);
-      unlistenPromise.then((fn) => fn());
-      resolve();
-    };
-    const timeout = setTimeout(done, 5000);
-    const unlistenPromise = listen("chat-ready", done);
-    // Ping in case chat is already mounted (won't re-emit "chat-ready" on its own).
-    // Small delay to ensure the listen call above has registered first.
-    setTimeout(() => emit("chat-ping", {}), 50);
-  });
+  let chatReady = false;
+  for (let attempt = 1; attempt <= CHAT_READY_MAX_ATTEMPTS; attempt++) {
+    // Wait for the chat component to signal readiness in the intended window.
+    chatReady = await new Promise<boolean>((resolve) => {
+      let resolved = false;
+      const done = (ready: boolean) => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(timeout);
+        unlistenPromise.then((fn) => fn());
+        resolve(ready);
+      };
+
+      const timeout = setTimeout(() => done(false), CHAT_READY_TIMEOUT_MS);
+      const unlistenPromise = listen<{ windowLabel?: string }>(
+        "chat-ready",
+        (event) => {
+          const readyWindow = event.payload?.windowLabel;
+          if (readyWindow && readyWindow !== targetWindow) return;
+          done(true);
+        },
+      );
+
+      // Ping in case chat is already mounted and won't re-emit on its own.
+      setTimeout(() => {
+        emit("chat-ping", { targetWindow });
+      }, 50);
+    });
+
+    if (chatReady) {
+      break;
+    }
+  }
+
+  if (!chatReady) {
+    throw new Error(`chat did not become ready in ${targetWindow} window`);
+  }
+
   await emit("chat-prefill", { ...data, targetWindow });
 }
 


### PR DESCRIPTION
### Description: 
Fix Meetings “summarize with AI” flow to reliably open Home chat and auto-send without dropped prefill events, while improving failure handling.

https://github.com/user-attachments/assets/0560ef48-a3b0-4e98-b4d1-ba402051603d

### Files changed

- `apps/screenpipe-app-tauri/lib/chat-utils.ts`
  - Made Home summarize routing deterministic (`Home.page = "home"`).
  - Scoped `chat-ready` handshake to target window and added retry/timeout handling.
  - Added same-window fallback: persist `pendingChatPrefill` and navigate to `/home?section=home` when launched from Home window on non-home route.
  - Removed added debug/warn logs after review.

- `apps/screenpipe-app-tauri/components/standalone-chat.tsx`
  - Updated `chat-ready` emit payload to include `windowLabel`.
  - Updated `chat-ping` listener to respect `targetWindow`.
  - Fixed auto-send gate from `autoSend && prompt && context` to `autoSend && prompt`.
  - Built auto-send message safely when context is empty.
  - Added/used `isPreparingPrefill` to suppress transient setup empty-state rendering during pending prefill handoff.
  - Reverted hydration-unsafe `typeof window` state initializer.

- `apps/screenpipe-app-tauri/components/settings/meetings-section.tsx`
  - Made `summarizeMeeting` async and `await`ed `showChatWithPrefill`.
  - Added user-visible error toast (and error catch path) when launch/prefill bridge fails.