### PR TITLE
fix(audio): prevent usize underflow panic in create_speech_segment

### DIFF
--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -44,7 +44,7 @@ fn create_speech_segment(
     let start_f64 = start * (sample_rate as f64);
     let end_f64 = end * (sample_rate as f64);
 
-    let start_idx = start_f64.min((samples.len() - 1600) as f64) as usize;
+    let start_idx = start_f64.min(samples.len().saturating_sub(1600) as f64) as usize;
     let mut end_idx = end_f64.min(samples.len() as f64) as usize;
 
     // TODO: Why is this empty sometimes?


### PR DESCRIPTION
## Problem
App panics due to usize underflow when extracting speaker embeddings if the audio segment is shorter than 1600 samples.

## Root cause
In `create_speech_segment`, `(samples.len() - 1600) as f64` panics if `samples.len() < 1600` because `samples.len()` is `usize`.

## Fix
Replaced `-` with `.saturating_sub(1600)` to safely return 0 when the sample length is too small. This is part 1 of PR 3014 as requested.

## Confidence: 10/10

## Verification
```
test result: ok. 82 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.07s
```

---
auto-generated by issue-solver pipe