### PR TITLE
fix: meeting detector v2 native apps keepalive

### DIFF
--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -1638,11 +1638,15 @@ pub fn advance_state(
             since,
             is_browser,
         } => {
-            let timeout = if is_browser {
+            // Process-alive keep-alive: if the meeting app process is still running,
+            // we use a longer timeout (5min). Controls disappear during minification/multitasking.
+            let app_is_alive = scan_results.iter().any(|r| r.app_name == app);
+            let timeout = if is_browser || app_is_alive {
                 ENDING_TIMEOUT_BROWSER
             } else {
                 ENDING_TIMEOUT
             };
+
             if let Some(result) = best_active {
                 info!(
                     "meeting v2: Ending -> Active (controls reappeared, app={}, id={})",
@@ -1658,7 +1662,7 @@ pub fn advance_state(
                     },
                     None,
                 )
-            } else if is_browser && has_output_audio {
+            } else if has_output_audio && (is_browser || app_is_alive) {
                 // Audio output is still active — the user likely just switched
                 // tabs/apps while the meeting continues. Keep alive.
                 info!(
@@ -3129,8 +3133,8 @@ mod tests {
     }
 
     #[test]
-    fn test_native_ending_ignores_output_audio() {
-        // Native app: output audio should NOT prevent ending (controls are reliable)
+    fn test_native_ending_ignores_output_audio_if_process_dead() {
+        // Native app process dead (not in results): output audio should NOT prevent ending
         let state = MeetingState::Ending {
             meeting_id: 42,
             app: "Zoom".to_string(),
@@ -3148,6 +3152,33 @@ mod tests {
             action,
             Some(StateAction::EndMeeting { meeting_id: 42 })
         ));
+    }
+
+    #[test]
+    fn test_native_ending_stays_active_with_output_audio_if_alive() {
+        // Native app alive but no call controls: output audio prevents ending
+        let state = MeetingState::Ending {
+            meeting_id: 42,
+            app: "Zoom".to_string(),
+            started_at: Utc::now(),
+            since: Instant::now(),
+            is_browser: false,
+        };
+        let results = vec![make_scan_result("Zoom", false, 0)];
+        let (new_state, action) = advance_state(state, &results, true);
+
+        assert!(
+            matches!(
+                new_state,
+                MeetingState::Active {
+                    meeting_id: 42,
+                    is_browser: false,
+                    ..
+                }
+            ),
+            "native meeting should stay Active when output audio is flowing and process is alive"
+        );
+        assert!(action.is_none());
     }
 
     // ── Edge case tests ────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
Meeting detector v2 ends meetings prematurely (after 30s) when call control UI elements disappear from the active window. This happens when native apps (like Zoom) lose focus or are minimized, causing them to drop from the active macOS Accessibility tree.

## Root cause
The `advance_state` function only checked `has_output_audio` to keep browser meetings alive, but ignored it for native apps. Furthermore, it didn't check if the native application process was still running to apply the longer graduated timeout (5 min) used for browsers.

## Fix
Modified `advance_state` to use process liveness tracking for native apps as well. If the native meeting app process is still alive:
- We apply the 5-minute timeout instead of immediately timing out after 30s.
- We allow `has_output_audio` to keep the meeting alive indefinitely while audio is flowing (exactly as it does for browser meetings).

## Confidence: 10/10

## Verification
```
warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:171:33
    |
171 |         let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:171:43
    |
171 |         let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `class` crate for guidance on how handle this unexpected cfg
    = help: the macro `class` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `class` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:176:29
    |
176 |                 let _: () = msg_send![pool, drain];
    |                             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:183:13
    |
183 |             msg_send![class!(NSString), stringWithUTF8String: c"soun".as_ptr()];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
```

---
auto-generated by issue-solver pipe