### PR TITLE
fix: preserve original db error in write queue instead of masking with pool timed out

### DIFF
--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -1326,8 +1326,9 @@ async fn execute_single_write(
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
+    let err_str = error.to_string();
     for pw in batch.drain(..) {
-        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut));
+        let _ = pw.respond.send(Err(sqlx::Error::Protocol(err_str.clone().into())));
     }
     // Log the original error that caused the batch failure
     error!("write_queue: batch failed: {}", error);
@@ -1365,6 +1366,27 @@ fn is_busy_error(e: &sqlx::Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_send_error_to_all_propagates_actual_error() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        let mut batch = vec![PendingWrite {
+            op: WriteOp::InsertAudioChunk { file_path: "test".into(), timestamp: None },
+            respond: tx,
+        }];
+        
+        let err = sqlx::Error::RowNotFound;
+        send_error_to_all(&mut batch, err);
+        
+        assert!(batch.is_empty());
+        let received = rx.try_recv().unwrap();
+        match received {
+            Err(sqlx::Error::Protocol(msg)) => {
+                assert!(msg.to_string().contains("no rows returned by a query"));
+            }
+            _ => panic!("Expected Protocol error with original message"),
+        }
+    }
     use sqlx::sqlite::SqlitePoolOptions;
 
     async fn setup_test_db() -> (Pool<Sqlite>, Arc<Semaphore>) {


### PR DESCRIPTION
## Problem
When a database batch fails (e.g. due to database being locked or unable to open), the write queue hardcodes `sqlx::Error::PoolTimedOut` as the response to all pending writes. This masks the true root cause, causing Sentry to report `Failed to insert UI events batch: pool timed out while waiting for an open connection` (Issue 7331781144) instead of the actual SQLite error.

## Root cause
In `crates/screenpipe-db/src/write_queue.rs`, `send_error_to_all` hardcodes `Err(sqlx::Error::PoolTimedOut)` instead of propagating the actual error passed to the function.

## Fix
Propagate the actual error by mapping it to `sqlx::Error::Protocol` with the original error string. Added a unit test to verify the actual error propagates to pending writes.

## Confidence: 10/10

## Verification
```

running 1 test
test write_queue::tests::test_send_error_to_all_propagates_actual_error ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 66 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 31 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
```

---
auto-generated by issue-solver pipe