### PR TITLE
fix(audio): log speaker distance on miss for tuning

### DIFF
--- a/crates/screenpipe-audio/src/speaker/embedding_manager.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding_manager.rs
@@ -35,14 +35,24 @@ impl EmbeddingManager {
     pub fn search_speaker(&mut self, embedding: Vec<f32>, threshold: f32) -> Option<usize> {
         let embedding_array = Array1::from_vec(embedding);
         let mut best_speaker_id = None;
-        let mut best_similarity = threshold;
+        let mut max_similarity = f32::MIN;
 
         for (&speaker_id, speaker_embedding) in &self.speakers {
             let similarity = Self::cosine_similarity(&embedding_array, speaker_embedding);
-            if similarity > best_similarity {
+            if similarity > max_similarity {
+                max_similarity = similarity;
                 best_speaker_id = Some(speaker_id);
-                best_similarity = similarity;
             }
+        }
+
+        if max_similarity <= threshold {
+            tracing::debug!(
+                "best local speaker similarity: {:.2} (threshold: {:.2}, distance: {:.2})", 
+                max_similarity, 
+                threshold,
+                1.0 - max_similarity
+            );
+            best_speaker_id = None;
         }
 
         match best_speaker_id {

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1393,45 +1393,50 @@ impl DatabaseManager {
         &self,
         embedding: &[f32],
     ) -> Result<Option<Speaker>, SqlxError> {
-        let speaker_threshold = 0.55;
+        let speaker_threshold = 0.55_f32;
         let bytes: &[u8] = embedding.as_bytes();
 
         // First try matching against stored embeddings (up to 10 per speaker)
-        let speaker: Option<Speaker> = sqlx::query_as(
-            "SELECT id, name, metadata
-             FROM speakers
-             WHERE id = (
-                 SELECT speaker_id
-                 FROM speaker_embeddings
-                 WHERE vec_distance_cosine(embedding, vec_f32(?1)) < ?2
-                 ORDER BY vec_distance_cosine(embedding, vec_f32(?1))
-                 LIMIT 1
-             )",
+        let closest_stored: Option<(i64, String, String, f32)> = sqlx::query_as(
+            "SELECT s.id, s.name, s.metadata, vec_distance_cosine(se.embedding, vec_f32(?1)) as distance
+             FROM speaker_embeddings se
+             JOIN speakers s ON s.id = se.speaker_id
+             ORDER BY distance ASC
+             LIMIT 1"
         )
         .bind(bytes)
-        .bind(speaker_threshold)
         .fetch_optional(&self.pool)
         .await?;
 
-        if speaker.is_some() {
-            return Ok(speaker);
+        if let Some((id, name, metadata, distance)) = closest_stored {
+            if distance < speaker_threshold {
+                return Ok(Some(Speaker { id, name, metadata }));
+            } else {
+                tracing::debug!("closest stored speaker embedding distance: {:.2} (threshold: {:.2})", distance, speaker_threshold);
+            }
         }
 
         // Fallback: match against speaker centroids (running average embeddings)
-        let speaker = sqlx::query_as(
-            "SELECT id, name, metadata
+        let closest_centroid: Option<(i64, String, String, f32)> = sqlx::query_as(
+            "SELECT id, name, metadata, vec_distance_cosine(centroid, vec_f32(?1)) as distance
              FROM speakers
              WHERE centroid IS NOT NULL
-               AND vec_distance_cosine(centroid, vec_f32(?1)) < ?2
-             ORDER BY vec_distance_cosine(centroid, vec_f32(?1))
+             ORDER BY distance ASC
              LIMIT 1",
         )
         .bind(bytes)
-        .bind(speaker_threshold)
         .fetch_optional(&self.pool)
         .await?;
 
-        Ok(speaker)
+        if let Some((id, name, metadata, distance)) = closest_centroid {
+            if distance < speaker_threshold {
+                return Ok(Some(Speaker { id, name, metadata }));
+            } else {
+                tracing::debug!("closest speaker centroid distance: {:.2} (threshold: {:.2})", distance, speaker_threshold);
+            }
+        }
+
+        Ok(None)
     }
 
     /// Add an embedding to a speaker's stored embeddings (up to max_stored).


### PR DESCRIPTION
## Problem
It is difficult to tune the speaker diarization threshold because the closest distance is not logged when a match fails.

## Root cause
The previous queries in `get_speaker_from_embedding` filtered directly using `< threshold`, which masked the actual distance for missed embeddings. Similarly, the local `EmbeddingManager` didn't log distances when below threshold.

## Fix
Refactored the SQL queries and `EmbeddingManager` search loop to first find the absolute closest match, log its distance if it misses the threshold, and fall back correctly.

## Confidence: 9/10

## Verification
```
cargo test -p screenpipe-audio --lib passed (82 passed, 0 failed)
```

---
auto-generated by issue-solver pipe