### PR TITLE
fix: resolve speaker embedding fbank crash for short audio segments

### DIFF
--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -44,26 +44,24 @@ fn create_speech_segment(
     let start_f64 = start * (sample_rate as f64);
     let end_f64 = end * (sample_rate as f64);
 
-    let start_idx = start_f64.min((samples.len() - 1600) as f64) as usize;
+    let start_idx = start_f64.min((samples.len().saturating_sub(1600)) as f64) as usize;
     let mut end_idx = end_f64.min(samples.len() as f64) as usize;
 
-    // TODO: Why is this empty sometimes?
-    let mut samples = padded_samples[start_idx..end_idx].to_vec();
-    // // Ensure the segment has at least 1600 samples
     let min_length = 1600;
-    let segment_samples = if end_idx - start_idx < min_length {
-        if end_idx + (min_length - (end_idx - start_idx)) <= samples.len() {
-            // Increase the end index if possible
-            end_idx += min_length - (end_idx - start_idx);
+    let mut segment_vec;
+    
+    let segment_samples = if end_idx.saturating_sub(start_idx) < min_length {
+        let diff = min_length - end_idx.saturating_sub(start_idx);
+        if end_idx + diff <= padded_samples.len() {
+            end_idx += diff;
             &padded_samples[start_idx..end_idx]
-        } else if start_idx >= min_length - (end_idx - start_idx) {
-            // Otherwise, pad the samples.
-
-            samples.resize(1600, 0.0);
-
-            samples.as_slice()
+        } else if start_idx >= diff {
+            let start_idx_new = start_idx - diff;
+            &padded_samples[start_idx_new..end_idx]
         } else {
-            &padded_samples[start_idx..end_idx]
+            segment_vec = padded_samples[start_idx..end_idx].to_vec();
+            segment_vec.resize(min_length, 0.0);
+            segment_vec.as_slice()
         }
     } else {
         &padded_samples[start_idx..end_idx]


### PR DESCRIPTION
## Problem
Sentry issue 7340577177 (Failed to compute speaker embedding, skipping segment: compute_fbank failed)
The candle `compute_fbank` operation was failing because audio segments shorter than 1600 samples were being incorrectly passed into it without proper padding.

## Root cause
In `create_speech_segment` (in `crates/screenpipe-audio/src/speaker/segment.rs`), there were several bugs in handling short audio segments:
1. `(samples.len() - 1600)` underflowed if `samples.len()` was < 1600.
2. The logic to extend the slice if it was too short shadowed the `samples` variable and incorrectly compared bounds against `samples.len()` instead of `padded_samples.len()`. This led to the code silently skipping the extension.
3. The fallback padding branch incorrectly returned the original un-padded slice if bounds couldn't be extended, leading to a `< 1600` slice being passed to `compute_fbank`.

## Fix
- Replaced `(samples.len() - 1600)` with `samples.len().saturating_sub(1600)`.
- Fixed the bounds checks to use `padded_samples.len()` instead of `samples.len()`.
- Ensured the slice correctly falls back to zero-padding if the segment bounds cannot be safely extended, guaranteeing a minimum size of 1600 samples before `compute_fbank`.

## Confidence: 10/10

## Verification
```
Verified via compilation (cargo check -p screenpipe-audio).
The bug is a clear edge case in indexing and underflow when audio samples are fewer than 1600 or the slice length is exactly right to trigger the shadow slice logic bug.
It's logically fixed by safe slicing + saturating_sub + allocating only when necessary.
```

---
auto-generated by issue-solver pipe