### PR TITLE
fix(audio): downgrade transient SCK "callback never fired" to warn in device check loop

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -953,6 +953,13 @@ pub async fn start_device_monitor(
                                 {
                                     continue;
                                 }
+                                // SCK transiently fails during device switches ("callback never
+                                // fired") — downgrade to warn so it doesn't reach Sentry; the
+                                // monitor will retry on the next 2-second tick.
+                                if e_str.contains("callback never fired") {
+                                    warn!("device check transient error (will retry): {e}");
+                                    continue;
+                                }
                                 error!("device check error: {e}");
                             }
                         }


### PR DESCRIPTION
## Problem

Sentry issue 7323618416 fires 14+ times per day:

```
device check error: A backend-specific error has occurred: ScreenCaptureKit callback never fired (channel closed)
```

This is a false-alarm `error!` log that hits Sentry on every macOS system-default output device switch.

## Root cause

`device_monitor.rs` has a periodic 2-second loop that calls `start_device()` for every enabled device. When ScreenCaptureKit temporarily fails during a device switch (e.g. system audio routing changes), it returns `"callback never fired (channel closed)"`. The loop already silently ignores "already running" and "not found" errors but falls through to `error!()` for this SCK-specific transient, generating a Sentry event. The retry loop recovers on its own within 2 seconds.

## Fix

Add `"callback never fired"` to the transient-error guard, downgrading it from `error!` to `warn!` and continuing to the next cycle. This matches the same pattern used for the other known-transient errors.

```rust
// before
error!("device check error: {e}");

// after
if e_str.contains("callback never fired") {
    warn!("device check transient error (will retry): {e}");
    continue;
}
error!("device check error: {e}");
```

## Confidence: 8/10

- Clear Sentry → source mapping (14 events/24h → single `error!` macro at line 956)
- Consistent with existing transient-error handling pattern
- The DEVICE_RECOVERY swap path already uses `warn!` for the same error class (line 459)

## Verification

```
cargo check -p screenpipe-audio passed (28s, 0 errors)
warnings only from pre-existing objc/cfg issues unrelated to this change
```

---
auto-generated by issue-solver pipe