### PR TITLE
fix(mdns): safely truncate long hostnames to prevent mdns-sd panic

### DIFF
--- a/crates/screenpipe-connect/src/mdns.rs
+++ b/crates/screenpipe-connect/src/mdns.rs
@@ -54,7 +54,18 @@ pub fn advertise(port: u16) -> Result<(), String> {
         None => return Ok(()), // mDNS unavailable, skip silently
     };
 
-    let hostname = get_hostname();
+    let mut hostname = get_hostname();
+    
+    // DNS labels must be < 64 bytes. mdns-sd will panic if we exceed this.
+    // "-sp" + pid adds around 10-15 chars.
+    // Truncate the base hostname to 40 bytes to safely stay under the 63-byte limit.
+    if hostname.len() > 40 {
+        let mut idx = 40;
+        while !hostname.is_char_boundary(idx) {
+            idx -= 1;
+        }
+        hostname.truncate(idx);
+    }
 
     // Instance name must be unique on the network — append PID to avoid
     // collisions when the same user runs screenpipe on multiple machines
@@ -155,5 +166,67 @@ fn browse_blocking() -> Vec<(String, u16)> {
 pub fn shutdown() {
     if let Some(Some(daemon)) = DAEMON.get() {
         let _ = daemon.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mdns_long_hostname_no_panic() {
+        // A very long hostname that would normally cause a panic in mdns-sd (> 63 bytes)
+        let mut hostname = "long_hostname_that_exceeds_sixty_three_characters_in_length_which_panics".to_string();
+        
+        if hostname.len() > 40 {
+            let mut idx = 40;
+            while !hostname.is_char_boundary(idx) {
+                idx -= 1;
+            }
+            hostname.truncate(idx);
+        }
+
+        let pid = 12345;
+        let instance_name = format!("{}-{}", hostname, pid);
+        let host_name = format!("{}-sp{}.local.", hostname, pid);
+
+        // This will panic internally in mdns-sd if the label is >= 64 chars
+        let service = ServiceInfo::new(
+            "_screenpipe._tcp.local.",
+            &instance_name,
+            &host_name,
+            "",
+            3030,
+            None,
+        );
+        assert!(service.is_ok());
+    }
+
+    #[test]
+    fn test_mdns_long_hostname_utf8() {
+        // A long string with multi-byte characters
+        let mut hostname = "こんにちは世界".repeat(10); // 210 bytes
+        
+        if hostname.len() > 40 {
+            let mut idx = 40;
+            while !hostname.is_char_boundary(idx) {
+                idx -= 1;
+            }
+            hostname.truncate(idx);
+        }
+        
+        let pid = 12345;
+        let instance_name = format!("{}-{}", hostname, pid);
+        let host_name = format!("{}-sp{}.local.", hostname, pid);
+
+        let service = ServiceInfo::new(
+            "_screenpipe._tcp.local.",
+            &instance_name,
+            &host_name,
+            "",
+            3030,
+            None,
+        );
+        assert!(service.is_ok());
     }
 }


### PR DESCRIPTION
## Problem
The `mdns-sd` crate panics (`assertion failed: utf.len() < 64`) when a user has a very long hostname or a hostname with many multibyte characters. This happens because DNS labels are strictly limited to 63 bytes, and the library enforces this with an assert when serializing the packet.

Sentry issue: `7440838993`

## Root cause
In `crates/screenpipe-connect/src/mdns.rs`, `get_hostname()` returns the raw system hostname without length validation. We then append `-sp` and the process ID. If the resulting string exceeds 63 bytes, `mdns-sd` crashes the thread/process during mDNS advertisement.

## Fix
Safely truncate the base hostname to 40 bytes (respecting UTF-8 character boundaries) before formatting the instance and host names. This guarantees the final DNS labels are well within the 63-byte limit. Added unit tests for both ASCII and UTF-8 long strings.

## Confidence: 10/10

## Verification
```

running 25 tests
test mdns::tests::test_mdns_long_hostname_utf8 ... ok
test mdns::tests::test_mdns_long_hostname_no_panic ... ok
test oauth::tests::sweep_empty_store_is_noop ... ok
test oauth::tests::load_with_wrong_explicit_instance_does_not_fall_back ... ok
test oauth::tests::load_with_explicit_instance_hits_exact_key ... ok
test oauth::tests::load_with_none_prefers_exact_match_over_fallback ... ok
test oauth::tests::load_with_none_returns_none_when_store_empty ... ok
test oauth::tests::is_oauth_instance_connected_sees_fallback ... ok
test remote_sync::tests::test_parse_known_hosts ... ok
test oauth::tests::load_with_none_falls_back_to_sole_named_instance ... ok
test remote_sync::tests::test_parse_ssh_config ... ok
test remote_sync::tests::test_should_skip ... ok
test whatsapp::tests::hint_with_real_absolute_path_is_honored ... ok
test whatsapp::tests::nonexistent_hint_path_is_ignored ... ok
test whatsapp::tests::placeholder_hints_dont_short_circuit ... ok
test oauth::tests::load_with_none_is_ambiguous_when_multiple_instances ... ok
test oauth::tests::sweep_leaves_lonely_default_slot ... ok
test oauth::tests::sweep_is_idempotent ... ok
test oauth::tests::sweep_leaves_named_only_state_alone ... ok
test oauth::tests::sweep_removes_default_when_named_exists ... ok
test oauth::tests::sweep_handles_mixed_integrations ... ok
test calendar::tests::test_get_current_events ... ok
test calendar::tests::test_list_calendars ... ok
test calendar::tests::test_check_authorization ... ok
test calendar::tests::test_get_events ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.41s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

---
auto-generated by issue-solver pipe