### PR TITLE
feat(mcp): structured output format for AI consumption

### DIFF
--- a/packages/screenpipe-mcp/bun.lock
+++ b/packages/screenpipe-mcp/bun.lock
@@ -133,13 +133,13 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g=="],
 
-    "@screenpipe/cli-darwin-arm64": ["@screenpipe/cli-darwin-arm64@0.3.302", "", { "os": "darwin", "cpu": "arm64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-WlPu/vT20xbKCACQjoTvK2D7jOxdDpMjP1X093/f0GbjUxwXjSeHkqxgWES1jWlv6+rsVS181yF9/II3UOy5NA=="],
+    "@screenpipe/cli-darwin-arm64": ["@screenpipe/cli-darwin-arm64@0.3.289", "", { "os": "darwin", "cpu": "arm64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-7HIeg7MZVHpYrSNiD2ico8ihr1WQsx7SABKR0WCZWwwPZVxxfBIYa4nMLUEjnvpbkmqYLEvUShUnHBgh/AN1Hg=="],
 
-    "@screenpipe/cli-darwin-x64": ["@screenpipe/cli-darwin-x64@0.3.302", "", { "os": "darwin", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-KrMeC4+MHTl8la1EQmVV2LcmK2ifuOe2AXb5BWoZ748HDUwR+pPSalNIvIt2GS6GuJVnpudB1HH0fIZqox9afQ=="],
+    "@screenpipe/cli-darwin-x64": ["@screenpipe/cli-darwin-x64@0.3.289", "", { "os": "darwin", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-h5lqSiNucVpQN0fmjuK+a6wLvEiX3RX20KDc9AWEgnPoh3u0/APFfLI7GBzSlNC+ITAtbjOIFgvgQOa04gY1ag=="],
 
-    "@screenpipe/cli-linux-x64": ["@screenpipe/cli-linux-x64@0.3.302", "", { "os": "linux", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-/aY+YaOqnroPDGPa0j9hZhv97ePMlNpReaigIMs9H7/vjLsFkgzSBZE/goFYxFCks7MjTm18SN7BcvUmJA8x6Q=="],
+    "@screenpipe/cli-linux-x64": ["@screenpipe/cli-linux-x64@0.3.289", "", { "os": "linux", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-0W63DPaf3CRMekeBd7LPKKIT9bSkH3xVBA+4j6wZGL7IO5vz7PSn3jyjgPU0CQScECP/lpoIcFvXGpZaV6RXpg=="],
 
-    "@screenpipe/cli-win32-x64": ["@screenpipe/cli-win32-x64@0.3.302", "", { "os": "win32", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe.exe" } }, "sha512-gq7WF1pV6CtPk9ozPDzmC9OiuAEgi6x9YVj3iyEOO3M+IsHOZ1V7sBBX4txRObHHSF5v2FWVaGfkLEA4N3N2rQ=="],
+    "@screenpipe/cli-win32-x64": ["@screenpipe/cli-win32-x64@0.3.289", "", { "os": "win32", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe.exe" } }, "sha512-OiVrwngLLbc6C4I5TIMbhQoDJtVWp1UW2h7ceVaUa3gB/xJGnhu0kIwMXMYPPFaN9SjszIagGTMm48ZzGhRHAw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -361,7 +361,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "screenpipe": ["screenpipe@0.3.302", "", { "optionalDependencies": { "@screenpipe/cli-darwin-arm64": "0.3.302", "@screenpipe/cli-darwin-x64": "0.3.302", "@screenpipe/cli-linux-x64": "0.3.302", "@screenpipe/cli-win32-x64": "0.3.302" }, "bin": { "screenpipe": "bin/screenpipe.js" } }, "sha512-S/rSOBqeQ7IqRFyDLCtEJlvQTZdbcEz/LOgQ5HBqnMf095kDzyorzmN+UsB+9ZEpZKC8gUotuqpbYD4v5tkV6A=="],
+    "screenpipe": ["screenpipe@0.3.289", "", { "optionalDependencies": { "@screenpipe/cli-darwin-arm64": "0.3.289", "@screenpipe/cli-darwin-x64": "0.3.289", "@screenpipe/cli-linux-x64": "0.3.289", "@screenpipe/cli-win32-x64": "0.3.289" }, "bin": { "screenpipe": "bin/screenpipe.js" } }, "sha512-xTvec6Vif0p1RFjjrLTqTvdH3132T+YYtnjA/qZcyqYylVxaCsn3NMW8vz09H+i/7rdQWLccKwHVYfpOUa+RVQ=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 

--- a/packages/screenpipe-mcp/bun.lock
+++ b/packages/screenpipe-mcp/bun.lock
@@ -5,16 +5,15 @@
     "": {
       "name": "screenpipe-mcp",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
-        "screenpipe": "latest",
-        "ws": "^8.19.0",
+        "@modelcontextprotocol/sdk": "latest",
+        "ws": "latest",
       },
       "devDependencies": {
-        "@types/node": "^25.3.5",
-        "@types/ws": "^8.18.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.3",
-        "vitest": "^4.0.18",
+        "@types/node": "latest",
+        "@types/ws": "latest",
+        "ts-node": "latest",
+        "typescript": "latest",
+        "vitest": "latest",
       },
     },
   },
@@ -132,14 +131,6 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g=="],
-
-    "@screenpipe/cli-darwin-arm64": ["@screenpipe/cli-darwin-arm64@0.3.289", "", { "os": "darwin", "cpu": "arm64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-7HIeg7MZVHpYrSNiD2ico8ihr1WQsx7SABKR0WCZWwwPZVxxfBIYa4nMLUEjnvpbkmqYLEvUShUnHBgh/AN1Hg=="],
-
-    "@screenpipe/cli-darwin-x64": ["@screenpipe/cli-darwin-x64@0.3.289", "", { "os": "darwin", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-h5lqSiNucVpQN0fmjuK+a6wLvEiX3RX20KDc9AWEgnPoh3u0/APFfLI7GBzSlNC+ITAtbjOIFgvgQOa04gY1ag=="],
-
-    "@screenpipe/cli-linux-x64": ["@screenpipe/cli-linux-x64@0.3.289", "", { "os": "linux", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-0W63DPaf3CRMekeBd7LPKKIT9bSkH3xVBA+4j6wZGL7IO5vz7PSn3jyjgPU0CQScECP/lpoIcFvXGpZaV6RXpg=="],
-
-    "@screenpipe/cli-win32-x64": ["@screenpipe/cli-win32-x64@0.3.289", "", { "os": "win32", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe.exe" } }, "sha512-OiVrwngLLbc6C4I5TIMbhQoDJtVWp1UW2h7ceVaUa3gB/xJGnhu0kIwMXMYPPFaN9SjszIagGTMm48ZzGhRHAw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -360,8 +351,6 @@
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "screenpipe": ["screenpipe@0.3.289", "", { "optionalDependencies": { "@screenpipe/cli-darwin-arm64": "0.3.289", "@screenpipe/cli-darwin-x64": "0.3.289", "@screenpipe/cli-linux-x64": "0.3.289", "@screenpipe/cli-win32-x64": "0.3.289" }, "bin": { "screenpipe": "bin/screenpipe.js" } }, "sha512-xTvec6Vif0p1RFjjrLTqTvdH3132T+YYtnjA/qZcyqYylVxaCsn3NMW8vz09H+i/7rdQWLccKwHVYfpOUa+RVQ=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 

--- a/packages/screenpipe-mcp/bun.lock
+++ b/packages/screenpipe-mcp/bun.lock
@@ -5,15 +5,16 @@
     "": {
       "name": "screenpipe-mcp",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "latest",
-        "ws": "latest",
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "screenpipe": "latest",
+        "ws": "^8.19.0",
       },
       "devDependencies": {
-        "@types/node": "latest",
-        "@types/ws": "latest",
-        "ts-node": "latest",
-        "typescript": "latest",
-        "vitest": "latest",
+        "@types/node": "^25.3.5",
+        "@types/ws": "^8.18.1",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18",
       },
     },
   },
@@ -131,6 +132,14 @@
     "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ=="],
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g=="],
+
+    "@screenpipe/cli-darwin-arm64": ["@screenpipe/cli-darwin-arm64@0.3.303", "", { "os": "darwin", "cpu": "arm64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-tQek93gxiteh6zgw55E9VK/xtG6bbC48ZPKz4sTF2xkrbvE3N++Z6F7Cnfc70ceQXmCRYK6zuTTK8Vx5QPG0QA=="],
+
+    "@screenpipe/cli-darwin-x64": ["@screenpipe/cli-darwin-x64@0.3.303", "", { "os": "darwin", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-jW0Dy+gXqIfVNkuwXGcE78Lmd01hdrFY/6jvptAHR837sw176WBxGaE0DVnP52fDkb04yxf9zTZRVwW5e1Ltxw=="],
+
+    "@screenpipe/cli-linux-x64": ["@screenpipe/cli-linux-x64@0.3.303", "", { "os": "linux", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe" } }, "sha512-gkGhbB0kiR/DiAKB1w4h6iOWfQOinanjuvVsI1YFyS6rUsrdcd6FAmq2BIxCEl606Iz8LXL4FixmFgdpNMFMNA=="],
+
+    "@screenpipe/cli-win32-x64": ["@screenpipe/cli-win32-x64@0.3.303", "", { "os": "win32", "cpu": "x64", "bin": { "screenpipe": "bin/screenpipe.exe" } }, "sha512-Ut3HN/pIDZR1NgA+m/RgS1I+9Ji8czclkxERjRnGzQ8JIi3OoWrrsSk+G6r3CkIpHAJ5gIqumI160qD90bL1hA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -351,6 +360,8 @@
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "screenpipe": ["screenpipe@0.3.303", "", { "optionalDependencies": { "@screenpipe/cli-darwin-arm64": "0.3.303", "@screenpipe/cli-darwin-x64": "0.3.303", "@screenpipe/cli-linux-x64": "0.3.303", "@screenpipe/cli-win32-x64": "0.3.303" }, "bin": { "screenpipe": "bin/screenpipe.js" } }, "sha512-UJJzDcEfdHZqlDWsyjvlcDihIU761pscjoM17e3RF4ogAJJPj4eBvZYZ3vP0Ri6T/22TTwmslGshF2/8gfBJhw=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 

--- a/packages/screenpipe-mcp/src/helpers.test.ts
+++ b/packages/screenpipe-mcp/src/helpers.test.ts
@@ -1,0 +1,173 @@
+// screenpipe — AI that knows everything you've seen, said, or heard
+// https://screenpi.pe
+
+import { describe, it, expect } from "vitest";
+import {
+  formatSection,
+  formatOptionalSection,
+  formatPagination,
+  formatQuery,
+  formatDeepLink,
+  flattenObject,
+  formatToolError,
+} from "./helpers";
+
+describe("formatSection", () => {
+  it("returns empty string for empty lines", () => {
+    expect(formatSection("Title", [])).toBe("");
+  });
+
+  it("renders ### header with lines", () => {
+    expect(formatSection("Status", ["ok", "running"])).toBe("### Status\nok\nrunning");
+  });
+});
+
+describe("formatOptionalSection", () => {
+  it("renders section when condition is true", () => {
+    expect(formatOptionalSection("Warnings", ["w1"], true)).toBe("### Warnings\nw1");
+  });
+
+  it("returns empty string when condition is false", () => {
+    expect(formatOptionalSection("Warnings", ["w1"], false)).toBe("");
+  });
+});
+
+describe("formatPagination", () => {
+  it("returns empty string when all results fit", () => {
+    expect(formatPagination(10, 10, 0, "search-content")).toBe("");
+  });
+
+  it("shows correct next offset on first page", () => {
+    const hint = formatPagination(20, 100, 0, "search-content");
+    expect(hint).toContain("offset=20");
+    expect(hint).toContain("1–20 of 100");
+  });
+
+  it("shows correct next offset on a later page (offset=80)", () => {
+    const hint = formatPagination(20, 100, 80, "search-content");
+    // offset+count = 100 which equals total, so no more pages
+    expect(hint).toBe("");
+  });
+
+  it("shows correct next offset mid-page (offset=60, count=20, total=100)", () => {
+    const hint = formatPagination(20, 100, 60, "search-content");
+    expect(hint).toContain("offset=80");
+    expect(hint).toContain("61–80 of 100");
+  });
+
+  it("shows soft hint when total is unknown", () => {
+    const hint = formatPagination(15, null, 0, "search-content");
+    expect(hint).toContain("15 results shown");
+    expect(hint).toContain("offset");
+  });
+
+  it("returns empty when count is 0 and total is unknown", () => {
+    expect(formatPagination(0, null, 0, "search-content")).toBe("");
+  });
+});
+
+describe("formatQuery", () => {
+  it("skips null and undefined values", () => {
+    const result = formatQuery({ q: "hello", limit: undefined, offset: null });
+    expect(result).toContain("- q: hello");
+    expect(result).not.toContain("limit");
+    expect(result).not.toContain("offset");
+  });
+
+  it("skips empty string values", () => {
+    const result = formatQuery({ q: "", app_name: "Chrome" });
+    expect(result).not.toContain("q:");
+    expect(result).toContain("app_name: Chrome");
+  });
+
+  it("skips non-primitive values safely (no cast needed)", () => {
+    const result = formatQuery({ q: "test", nested: { foo: "bar" }, arr: [1, 2] });
+    expect(result).toContain("- q: test");
+    expect(result).not.toContain("nested");
+    expect(result).not.toContain("arr");
+  });
+
+  it("returns empty string when no valid params", () => {
+    expect(formatQuery({ a: null, b: undefined })).toBe("");
+  });
+
+  it("includes boolean and number params", () => {
+    const result = formatQuery({ include_frames: true, limit: 50 });
+    expect(result).toContain("- include_frames: true");
+    expect(result).toContain("- limit: 50");
+  });
+});
+
+describe("formatDeepLink", () => {
+  it("returns frame link when frameId is provided", () => {
+    expect(formatDeepLink(42)).toBe("  → [frame 42](screenpipe://frame/42)");
+  });
+
+  it("handles frameId === 0 correctly (not falsy)", () => {
+    expect(formatDeepLink(0)).toBe("  → [frame 0](screenpipe://frame/0)");
+  });
+
+  it("falls back to timeline link when frameId is null", () => {
+    const link = formatDeepLink(null, "2024-01-15T10:00:00Z");
+    expect(link).toContain("screenpipe://timeline");
+    expect(link).toContain("2024-01-15T10%3A00%3A00Z");
+  });
+
+  it("returns empty string when both are absent", () => {
+    expect(formatDeepLink(null)).toBe("");
+    expect(formatDeepLink(undefined)).toBe("");
+  });
+});
+
+describe("flattenObject", () => {
+  it("flattens scalar values to key: value lines", () => {
+    const lines = flattenObject({ workers: 4, queue: "ready" });
+    expect(lines).toContain("  workers: 4");
+    expect(lines).toContain("  queue: ready");
+  });
+
+  it("JSON-stringifies nested objects inline", () => {
+    const lines = flattenObject({ stats: { hits: 10 } });
+    expect(lines[0]).toBe('  stats: {"hits":10}');
+  });
+});
+
+describe("formatToolError", () => {
+  it("categorizes ECONNREFUSED as connection error", () => {
+    const result = formatToolError("health-check", new Error("ECONNREFUSED 127.0.0.1:3030"), "http://localhost:3030");
+    expect(result).toContain("### Error");
+    expect(result).toContain("Could not reach screenpipe");
+    expect(result).toContain("http://localhost:3030");
+  });
+
+  it("categorizes HTTP 401 with correct detail", () => {
+    const result = formatToolError("search-content", new Error("HTTP error: 401"));
+    expect(result).toContain("Invalid or missing API key.");
+  });
+
+  it("categorizes HTTP 404 with correct detail", () => {
+    const result = formatToolError("get-meeting", new Error("HTTP error: 404"));
+    expect(result).toContain("Resource not found.");
+  });
+
+  it("categorizes HTTP 503 with correct detail", () => {
+    const result = formatToolError("health-check", new Error("HTTP 503"));
+    expect(result).toContain("screenpipe service is unavailable.");
+  });
+
+  it("matches 'HTTP 404' form (export-video style)", () => {
+    const result = formatToolError("export-video", new Error("Failed to search for frames: HTTP 500"));
+    expect(result).toContain("Server returned 500.");
+  });
+
+  it("returns generic ### Error for unknown errors", () => {
+    const result = formatToolError("search-content", new Error("something unexpected"));
+    expect(result).toBe("### Error\nsomething unexpected");
+  });
+
+  it("handles non-Error thrown values", () => {
+    const result = formatToolError("health-check", "string thrown");
+    expect(result).toContain("### Error");
+    expect(result).toContain("string thrown");
+  });
+});

--- a/packages/screenpipe-mcp/src/helpers.ts
+++ b/packages/screenpipe-mcp/src/helpers.ts
@@ -1,0 +1,104 @@
+// screenpipe — AI that knows everything you've seen, said, or heard
+// https://screenpi.pe
+
+/** Render a named markdown section. Returns empty string when lines is empty. */
+export function formatSection(title: string, lines: string[]): string {
+  if (!lines.length) return "";
+  return `### ${title}\n${lines.join("\n")}`;
+}
+
+/** Like formatSection but only renders when condition is truthy. */
+export function formatOptionalSection(title: string, lines: string[], condition: boolean): string {
+  return condition ? formatSection(title, lines) : "";
+}
+
+/**
+ * Render a pagination hint. Shows a strong hint when total is known, soft hint
+ * when only a page limit was used.
+ */
+export function formatPagination(
+  count: number,
+  total: number | null | undefined,
+  offset: number,
+  toolHint: string
+): string {
+  if (total != null && offset + count < total) {
+    return `> Showing ${offset + 1}–${offset + count} of ${total} — use \`${toolHint}\` with \`offset=${offset + count}\` for more`;
+  }
+  if (total == null && count > 0) {
+    return `> ${count} results shown — if you requested a limit, increase \`offset\` by ${count} for older results`;
+  }
+  return "";
+}
+
+/**
+ * Render a ### Query section echoing the effective search parameters.
+ * Accepts Record<string, unknown> — non-primitive values are silently skipped
+ * so callers can safely pass raw MCP args without casting.
+ */
+export function formatQuery(params: Record<string, unknown>): string {
+  const lines = Object.entries(params)
+    .filter(([, v]) => {
+      if (v === null || v === undefined || v === "") return false;
+      return typeof v === "string" || typeof v === "number" || typeof v === "boolean";
+    })
+    .map(([k, v]) => `- ${k}: ${v}`);
+  return formatOptionalSection("Query", lines, lines.length > 0);
+}
+
+/**
+ * Format a deep link for a search result.
+ * Prefers frame link when frame_id is available, falls back to timeline by timestamp.
+ */
+export function formatDeepLink(frameId: number | undefined | null, timestamp?: string): string {
+  if (frameId != null) return `  → [frame ${frameId}](screenpipe://frame/${frameId})`;
+  if (timestamp) return `  → [timeline](screenpipe://timeline?timestamp=${encodeURIComponent(timestamp)})`;
+  return "";
+}
+
+/**
+ * Flatten a plain object into indented "  key: value" lines.
+ * One level deep — nested objects are JSON-stringified on the same line.
+ */
+export function flattenObject(obj: Record<string, unknown>): string[] {
+  return Object.entries(obj).map(([k, v]) => {
+    if (v !== null && typeof v === "object") {
+      return `  ${k}: ${JSON.stringify(v)}`;
+    }
+    return `  ${k}: ${v}`;
+  });
+}
+
+/**
+ * Categorize and format a tool error into a human-readable message.
+ * Distinguishes: validation, network/connect, HTTP status, and generic errors.
+ */
+export function formatToolError(toolName: string, error: unknown, apiBase?: string): string {
+  const msg = error instanceof Error ? error.message : String(error);
+
+  // Network/connect errors
+  if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed") || msg.includes("Failed to fetch")) {
+    const where = apiBase ? ` at ${apiBase}` : "";
+    return [
+      `### Error`,
+      `Could not reach screenpipe${where}.`,
+      `Make sure screenpipe is running (check \`screenpipe run\` or the desktop app).`,
+    ].join("\n");
+  }
+
+  // HTTP status errors — match both "HTTP error: 404" and "HTTP 404" patterns
+  const httpMatch = msg.match(/HTTP(?:\s+error)?:?\s+(\d+)/i);
+  if (httpMatch) {
+    const status = httpMatch[1];
+    const detail =
+      status === "401" ? "Invalid or missing API key."
+      : status === "403" ? "Access denied."
+      : status === "404" ? "Resource not found."
+      : status === "503" ? "screenpipe service is unavailable."
+      : `Server returned ${status}.`;
+    return `### Error\n${detail} (${toolName})`;
+  }
+
+  // Validation or generic errors
+  return `### Error\n${msg}`;
+}

--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -605,85 +605,19 @@ async function fetchAPI(
   });
 }
 
-/** Render a named markdown section. Returns empty string when lines is empty. */
-function formatSection(title: string, lines: string[]): string {
-  if (!lines.length) return "";
-  return `### ${title}\n${lines.join("\n")}`;
-}
+import {
+  formatSection,
+  formatOptionalSection,
+  formatPagination,
+  formatQuery,
+  formatDeepLink,
+  flattenObject,
+  formatToolError as _formatToolError,
+} from "./helpers";
 
-/** Like formatSection but only renders when condition is truthy. */
-function formatOptionalSection(title: string, lines: string[], condition: boolean): string {
-  return condition ? formatSection(title, lines) : "";
-}
-
-/**
- * Render a pagination hint. Shows a strong hint when total is known, soft hint
- * when only a page limit was used.
- */
-function formatPagination(
-  count: number,
-  total: number | null | undefined,
-  offset: number,
-  toolHint: string
-): string {
-  if (total != null && offset + count < total) {
-    return `> Showing ${offset + 1}–${offset + count} of ${total} — use \`${toolHint}\` with \`offset=${offset + count}\` for more`;
-  }
-  if (total == null && count > 0) {
-    return `> ${count} results shown — if you requested a limit, increase \`offset\` by ${count} for older results`;
-  }
-  return "";
-}
-
-/** Render a ### Query section echoing the effective search parameters. */
-function formatQuery(params: Record<string, string | number | boolean | null | undefined>): string {
-  const lines = Object.entries(params)
-    .filter(([, v]) => v !== null && v !== undefined && v !== "")
-    .map(([k, v]) => `- ${k}: ${v}`);
-  return formatOptionalSection("Query", lines, lines.length > 0);
-}
-
-/**
- * Format a deep link for a search result.
- * Prefers frame link when frame_id is available, falls back to timeline by timestamp.
- */
-function formatDeepLink(frameId: number | undefined, timestamp: string | undefined): string {
-  if (frameId != null) return `  → [frame ${frameId}](screenpipe://frame/${frameId})`;
-  if (timestamp) return `  → [timeline](screenpipe://timeline?timestamp=${encodeURIComponent(timestamp)})`;
-  return "";
-}
-
-/**
- * Categorize and format a tool error into a human-readable message.
- * Distinguishes: validation, network/connect, HTTP status, and generic errors.
- */
+/** Wrap formatToolError with the current SCREENPIPE_API base URL. */
 function formatToolError(toolName: string, error: unknown): string {
-  const msg = error instanceof Error ? error.message : String(error);
-
-  // Network/connect errors
-  if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed") || msg.includes("Failed to fetch")) {
-    return [
-      `### Error`,
-      `Could not reach screenpipe at ${SCREENPIPE_API}.`,
-      `Make sure screenpipe is running (check \`screenpipe run\` or the desktop app).`,
-    ].join("\n");
-  }
-
-  // HTTP status errors — match both "HTTP error: 404" and "HTTP 404" patterns
-  const httpMatch = msg.match(/HTTP(?:\s+error)?:?\s+(\d+)/i);
-  if (httpMatch) {
-    const status = httpMatch[1];
-    const detail =
-      status === "401" ? "Invalid or missing API key."
-      : status === "403" ? "Access denied."
-      : status === "404" ? "Resource not found."
-      : status === "503" ? "screenpipe service is unavailable."
-      : `Server returned ${status}.`;
-    return `### Error\n${detail} (${toolName})`;
-  }
-
-  // Validation or generic errors
-  return `### Error\n${msg}`;
+  return _formatToolError(toolName, error, SCREENPIPE_API);
 }
 
 // ---------------------------------------------------------------------------
@@ -716,9 +650,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         // Echo all provided args — pass through every non-null param so agents
         // can verify exactly what the server received
-        const querySection = formatQuery(
-          args as Record<string, string | number | boolean | null | undefined>
-        );
+        const querySection = formatQuery(args);
 
         if (results.length === 0) {
           const emptyText = [
@@ -885,7 +817,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           (w: {
             app_name: string;
             window_name: string;
-            browser_url: string;
+            browser_url?: string;
             minutes: number;
             frame_count: number;
           }) => {
@@ -922,7 +854,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if ((data.audio_summary?.segment_count || 0) > 0) {
           nextSteps.push(`Use \`search-content\` with \`content_type=audio\` and the same time range for full transcripts.`);
         }
-        if (data.windows?.some((w: { browser_url: string }) => w.browser_url)) {
+        if (data.windows?.some((w: { browser_url?: string }) => w.browser_url)) {
           nextSteps.push(`Use \`search-content\` with \`app_name='<browser>'\` and \`window_name='<title>'\` to narrow to a specific page.`);
         }
 
@@ -963,7 +895,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const pagination = data.pagination || {};
 
         if (elements.length === 0) {
-          const queryEcho = formatQuery(args as Record<string, string | number | boolean | null | undefined>);
+          const queryEcho = formatQuery(args);
           const sections = [
             queryEcho,
             "### Result\nNo elements found.",
@@ -987,8 +919,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const boundsStr = e.bounds
               ? ` [${e.bounds.left.toFixed(2)},${e.bounds.top.toFixed(2)} ${e.bounds.width.toFixed(2)}x${e.bounds.height.toFixed(2)}]`
               : "";
-            const deepLink = `screenpipe://frame/${e.frame_id}`;
-            return `[${e.source}] ${e.role} (frame:${e.frame_id}, depth:${e.depth})${boundsStr}\n  ${e.text || "(no text)"}\n  ${deepLink}`;
+            const deepLink = formatDeepLink(e.frame_id);
+            return `[${e.source}] ${e.role} (frame:${e.frame_id}, depth:${e.depth})${boundsStr}\n  ${e.text || "(no text)"}\n${deepLink}`;
           }
         );
 
@@ -1002,7 +934,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (paginationHint) elementLines.push("", paginationHint);
 
         const sections = [
-          formatQuery(args as Record<string, string | number | boolean | null | undefined>),
+          formatQuery(args),
           formatSection("Elements", elementLines),
           formatSection("Next steps", [
             `Use \`frame-context\` with \`frame_id=<id>\` to see the full accessibility tree for any frame.`,
@@ -1027,7 +959,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const metaLines = [
           `frame_id: ${data.frame_id}`,
           `source: ${data.text_source}`,
-          `deep_link: screenpipe://frame/${data.frame_id}`,
+          formatDeepLink(data.frame_id),
         ];
 
         const nodeLines: string[] = [];
@@ -1332,9 +1264,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (data.message) diagnosticLines.push(`Message: ${data.message}`);
         if (data.verbose_instructions) diagnosticLines.push(`Instructions: ${data.verbose_instructions}`);
         if (data.device_status_details) diagnosticLines.push(`Devices: ${data.device_status_details}`);
-        if (data.pool_stats) diagnosticLines.push(`Pool stats: ${JSON.stringify(data.pool_stats)}`);
-        if (data.pipeline) diagnosticLines.push(`Vision pipeline: ${JSON.stringify(data.pipeline)}`);
-        if (data.audio_pipeline) diagnosticLines.push(`Audio pipeline: ${JSON.stringify(data.audio_pipeline)}`);
+        if (data.pool_stats) {
+          diagnosticLines.push("Pool stats:", ...flattenObject(data.pool_stats as Record<string, unknown>));
+        }
+        if (data.pipeline) {
+          diagnosticLines.push("Vision pipeline:", ...flattenObject(data.pipeline as Record<string, unknown>));
+        }
+        if (data.audio_pipeline) {
+          diagnosticLines.push("Audio pipeline:", ...flattenObject(data.audio_pipeline as Record<string, unknown>));
+        }
 
         const sections = [
           formatSection("Status", statusLines),
@@ -1514,7 +1452,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           : null;
 
         const metaLines = [
-          `App: ${m.meeting_app || "unknown"} | Detection: ${m.detection_source || "auto"}`,
+          `App: ${m.meeting_app || "unknown"} | Detection: ${m.detection_source || "unknown"}`,
           `Start: ${m.meeting_start || "?"} → End: ${m.meeting_end || "ongoing"}` +
             (durationMin != null ? ` (${durationMin} min)` : ""),
           ...(m.attendees ? [`Attendees: ${m.attendees}`] : []),
@@ -1546,7 +1484,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = data.data || [];
         if (results.length === 0) {
           const sections = [
-            formatQuery(args as Record<string, string | number | boolean | null | undefined>),
+            formatQuery(args),
             formatSection("Result", ["No keyword search results found."]),
             formatSection("Next steps", [
               "Try `search-content` for semantic search across OCR and audio content.",
@@ -1559,12 +1497,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const formatted = results.map((r: Record<string, unknown>) => {
           const content = r.content as Record<string, unknown> | undefined;
           const frameId = (content?.frame_id as number) ?? null;
-          const deepLink = frameId ? `\n  screenpipe://frame/${frameId}` : "";
-          return `[${r.type}] ${content?.app_name || "?"} | ${content?.timestamp || ""}\n${content?.text || content?.transcription || ""}${deepLink}`;
+          const deepLink = formatDeepLink(frameId ?? null);
+          return `[${r.type}] ${content?.app_name || "?"} | ${content?.timestamp || ""}\n${content?.text || content?.transcription || ""}${deepLink ? "\n" + deepLink : ""}`;
         });
 
         const sections = [
-          formatQuery(args as Record<string, string | number | boolean | null | undefined>),
+          formatQuery(args),
           formatSection("Results", [`${results.length} match${results.length === 1 ? "" : "es"}`, "", ...formatted]),
           formatSection("Next steps", [
             `Use \`search-content\` with semantic search for conceptually related content.`,

--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -626,8 +626,8 @@ function formatPagination(
   offset: number,
   toolHint: string
 ): string {
-  if (total != null && count < total) {
-    return `> ${count} of ${total} results — use \`${toolHint}\` with \`offset=${offset + count}\` for more`;
+  if (total != null && offset + count < total) {
+    return `> Showing ${offset + 1}–${offset + count} of ${total} — use \`${toolHint}\` with \`offset=${offset + count}\` for more`;
   }
   if (total == null && count > 0) {
     return `> ${count} results shown — if you requested a limit, increase \`offset\` by ${count} for older results`;
@@ -669,8 +669,8 @@ function formatToolError(toolName: string, error: unknown): string {
     ].join("\n");
   }
 
-  // HTTP status errors
-  const httpMatch = msg.match(/HTTP error: (\d+)/);
+  // HTTP status errors — match both "HTTP error: 404" and "HTTP 404" patterns
+  const httpMatch = msg.match(/HTTP(?:\s+error)?:?\s+(\d+)/i);
   if (httpMatch) {
     const status = httpMatch[1];
     const detail =
@@ -714,18 +714,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = data.data || [];
         const pagination = data.pagination || {};
 
-        // Echo the effective query params
-        const querySection = formatQuery({
-          q: args.q as string | undefined,
-          content_type: args.content_type as string | undefined,
-          start_time: args.start_time as string | undefined,
-          end_time: args.end_time as string | undefined,
-          app_name: args.app_name as string | undefined,
-          window_name: args.window_name as string | undefined,
-          speaker_name: args.speaker_name as string | undefined,
-          limit: args.limit as number | undefined,
-          offset: args.offset as number | undefined,
-        });
+        // Echo all provided args — pass through every non-null param so agents
+        // can verify exactly what the server received
+        const querySection = formatQuery(
+          args as Record<string, string | number | boolean | null | undefined>
+        );
 
         if (results.length === 0) {
           const emptyText = [
@@ -970,13 +963,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const pagination = data.pagination || {};
 
         if (elements.length === 0) {
+          const queryEcho = formatQuery(args as Record<string, string | number | boolean | null | undefined>);
+          const sections = [
+            queryEcho,
+            "### Result\nNo elements found.",
+            "### Next steps\n- Broaden search: try a different role, source, or wider time range\n- Use `frame-context` with a specific frame_id for full page structure",
+          ].filter(Boolean);
           return {
-            content: [
-              {
-                type: "text",
-                text: "### Result\nNo elements found.\n\n### Next steps\n- Broaden search: try a different role, source, or wider time range\n- Use `frame-context` with a specific frame_id for full page structure",
-              },
-            ],
+            content: [{ type: "text", text: sections.join("\n\n") }],
           };
         }
 
@@ -1305,7 +1299,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const now = Date.now();
         const ageStr = (ts?: string) => {
           if (!ts) return "never";
-          const diff = Math.round((now - new Date(ts).getTime()) / 1000);
+          const date = new Date(ts);
+          if (Number.isNaN(date.getTime())) return "invalid date";
+          const diff = Math.round((now - date.getTime()) / 1000);
+          if (diff < 0) return "in the future";
           return diff < 60 ? `${diff}s ago` : `${Math.round(diff / 60)}m ago`;
         };
 
@@ -1548,13 +1545,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const data = await response.json();
         const results = data.data || [];
         if (results.length === 0) {
+          const sections = [
+            formatQuery(args as Record<string, string | number | boolean | null | undefined>),
+            formatSection("Result", ["No keyword search results found."]),
+            formatSection("Next steps", [
+              "Try `search-content` for semantic search across OCR and audio content.",
+            ]),
+          ].filter(Boolean);
           return {
-            content: [
-              {
-                type: "text",
-                text: `### Query\n- query: ${args.query || "(none)"}\n\n### Result\nNo keyword search results found.\n\n### Next steps\n- Try \`search-content\` for semantic search across OCR and audio content`,
-              },
-            ],
+            content: [{ type: "text", text: sections.join("\n\n") }],
           };
         }
         const formatted = results.map((r: Record<string, unknown>) => {

--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -648,7 +648,7 @@ function formatQuery(params: Record<string, string | number | boolean | null | u
  * Prefers frame link when frame_id is available, falls back to timeline by timestamp.
  */
 function formatDeepLink(frameId: number | undefined, timestamp: string | undefined): string {
-  if (frameId) return `  → [frame ${frameId}](screenpipe://frame/${frameId})`;
+  if (frameId != null) return `  → [frame ${frameId}](screenpipe://frame/${frameId})`;
   if (timestamp) return `  → [timeline](screenpipe://timeline?timestamp=${encodeURIComponent(timestamp)})`;
   return "";
 }
@@ -851,7 +851,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         ];
 
         const sections = [
-          formatSection("Meetings", [`${meetings.length} found`, "", ...formatted.join("\n---\n").split("\n")]),
+          formatSection("Meetings", [`${meetings.length} found`, "", ...formatted]),
           formatSection("Next steps", nextSteps),
         ].filter(Boolean);
 
@@ -1022,8 +1022,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "frame-context": {
         const frameId = args.frame_id as number;
-        if (!frameId) {
-          return { content: [{ type: "text", text: "Error: frame_id is required" }] };
+        if (frameId == null) {
+          return { content: [{ type: "text", text: "### Error\nframe_id is required" }] };
         }
 
         const response = await fetchAPI(`/frames/${frameId}/context`);
@@ -1077,7 +1077,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         if (!startTime || !endTime) {
           return {
-            content: [{ type: "text", text: "Error: start_time and end_time are required" }],
+            content: [{ type: "text", text: "### Error\nstart_time and end_time are required" }],
           };
         }
 
@@ -1579,8 +1579,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "get-frame-elements": {
         const frameId = args.frame_id as number;
-        if (!frameId) {
-          return { content: [{ type: "text", text: "Error: frame_id is required" }] };
+        if (frameId == null) {
+          return { content: [{ type: "text", text: "### Error\nframe_id is required" }] };
         }
         const response = await fetchAPI(`/frames/${frameId}/elements`);
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
@@ -1602,13 +1602,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "control-recording": {
         const action = args.action as string;
         if (!action) {
-          return { content: [{ type: "text", text: "Error: action is required" }] };
+          return { content: [{ type: "text", text: "### Error\naction is required" }] };
         }
         let endpoint: string;
         if (action === "start-audio") endpoint = "/audio/start";
         else if (action === "stop-audio") endpoint = "/audio/stop";
         else {
-          return { content: [{ type: "text", text: `Error: unknown action '${action}'` }] };
+          return { content: [{ type: "text", text: `### Error\nUnknown action '${action}'. Valid actions: start-audio, stop-audio` }] };
         }
         const response = await fetchAPI(endpoint, { method: "POST" });
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);

--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -588,7 +588,7 @@ Never fabricate IDs or timestamps — only use values from actual results.
 });
 
 // ---------------------------------------------------------------------------
-// Helper
+// Helpers
 // ---------------------------------------------------------------------------
 async function fetchAPI(
   endpoint: string,
@@ -603,6 +603,87 @@ async function fetchAPI(
       ...options.headers,
     },
   });
+}
+
+/** Render a named markdown section. Returns empty string when lines is empty. */
+function formatSection(title: string, lines: string[]): string {
+  if (!lines.length) return "";
+  return `### ${title}\n${lines.join("\n")}`;
+}
+
+/** Like formatSection but only renders when condition is truthy. */
+function formatOptionalSection(title: string, lines: string[], condition: boolean): string {
+  return condition ? formatSection(title, lines) : "";
+}
+
+/**
+ * Render a pagination hint. Shows a strong hint when total is known, soft hint
+ * when only a page limit was used.
+ */
+function formatPagination(
+  count: number,
+  total: number | null | undefined,
+  offset: number,
+  toolHint: string
+): string {
+  if (total != null && count < total) {
+    return `> ${count} of ${total} results — use \`${toolHint}\` with \`offset=${offset + count}\` for more`;
+  }
+  if (total == null && count > 0) {
+    return `> ${count} results shown — if you requested a limit, increase \`offset\` by ${count} for older results`;
+  }
+  return "";
+}
+
+/** Render a ### Query section echoing the effective search parameters. */
+function formatQuery(params: Record<string, string | number | boolean | null | undefined>): string {
+  const lines = Object.entries(params)
+    .filter(([, v]) => v !== null && v !== undefined && v !== "")
+    .map(([k, v]) => `- ${k}: ${v}`);
+  return formatOptionalSection("Query", lines, lines.length > 0);
+}
+
+/**
+ * Format a deep link for a search result.
+ * Prefers frame link when frame_id is available, falls back to timeline by timestamp.
+ */
+function formatDeepLink(frameId: number | undefined, timestamp: string | undefined): string {
+  if (frameId) return `  → [frame ${frameId}](screenpipe://frame/${frameId})`;
+  if (timestamp) return `  → [timeline](screenpipe://timeline?timestamp=${encodeURIComponent(timestamp)})`;
+  return "";
+}
+
+/**
+ * Categorize and format a tool error into a human-readable message.
+ * Distinguishes: validation, network/connect, HTTP status, and generic errors.
+ */
+function formatToolError(toolName: string, error: unknown): string {
+  const msg = error instanceof Error ? error.message : String(error);
+
+  // Network/connect errors
+  if (msg.includes("ECONNREFUSED") || msg.includes("fetch failed") || msg.includes("Failed to fetch")) {
+    return [
+      `### Error`,
+      `Could not reach screenpipe at ${SCREENPIPE_API}.`,
+      `Make sure screenpipe is running (check \`screenpipe run\` or the desktop app).`,
+    ].join("\n");
+  }
+
+  // HTTP status errors
+  const httpMatch = msg.match(/HTTP error: (\d+)/);
+  if (httpMatch) {
+    const status = httpMatch[1];
+    const detail =
+      status === "401" ? "Invalid or missing API key."
+      : status === "403" ? "Access denied."
+      : status === "404" ? "Resource not found."
+      : status === "503" ? "screenpipe service is unavailable."
+      : `Server returned ${status}.`;
+    return `### Error\n${detail} (${toolName})`;
+  }
+
+  // Validation or generic errors
+  return `### Error\n${msg}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -633,15 +714,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = data.data || [];
         const pagination = data.pagination || {};
 
+        // Echo the effective query params
+        const querySection = formatQuery({
+          q: args.q as string | undefined,
+          content_type: args.content_type as string | undefined,
+          start_time: args.start_time as string | undefined,
+          end_time: args.end_time as string | undefined,
+          app_name: args.app_name as string | undefined,
+          window_name: args.window_name as string | undefined,
+          speaker_name: args.speaker_name as string | undefined,
+          limit: args.limit as number | undefined,
+          offset: args.offset as number | undefined,
+        });
+
         if (results.length === 0) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: "No results found. Try: broader terms, different content_type, or wider time range.",
-              },
-            ],
-          };
+          const emptyText = [
+            querySection,
+            "No results found. Try: broader terms, different content_type, or wider time range.",
+          ].filter(Boolean).join("\n\n");
+          return { content: [{ type: "text", text: emptyText }] };
         }
 
         const contentItems: Array<
@@ -656,12 +747,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const content = result.content;
           if (!content) continue;
 
+          const deepLink = formatDeepLink(content.frame_id, content.timestamp);
+
           if (result.type === "OCR") {
             const tagsStr = content.tags?.length ? `\nTags: ${content.tags.join(", ")}` : "";
             formattedResults.push(
               `[OCR] ${content.app_name || "?"} | ${content.window_name || "?"}\n` +
-                `${content.timestamp || ""}\n` +
-                `${content.text || ""}` +
+                `${content.timestamp || ""}` +
+                (deepLink ? `\n${deepLink}` : "") +
+                `\n${content.text || ""}` +
                 tagsStr
             );
             if (includeFrames && content.frame) {
@@ -673,16 +767,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           } else if (result.type === "Audio") {
             const tagsStr = content.tags?.length ? `\nTags: ${content.tags.join(", ")}` : "";
             formattedResults.push(
-              `[Audio] ${content.device_name || "?"}\n` +
-                `${content.timestamp || ""}\n` +
-                `${content.transcription || ""}` +
+              `[Audio] ${content.device_name || "?"}` +
+                (content.speaker_name ? ` | ${content.speaker_name}` : "") +
+                `\n${content.timestamp || ""}` +
+                (deepLink ? `\n${deepLink}` : "") +
+                `\n${content.transcription || ""}` +
                 tagsStr
             );
           } else if (result.type === "UI" || result.type === "Accessibility") {
             formattedResults.push(
               `[Accessibility] ${content.app_name || "?"} | ${content.window_name || "?"}\n` +
-                `${content.timestamp || ""}\n` +
-                `${content.text || ""}`
+                `${content.timestamp || ""}` +
+                (deepLink ? `\n${deepLink}` : "") +
+                `\n${content.text || ""}`
             );
           } else if (result.type === "Memory") {
             const tagsStr = content.tags?.length ? ` [${content.tags.join(", ")}]` : "";
@@ -696,16 +793,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }
         }
 
-        const header =
-          `Results: ${results.length}/${pagination.total || "?"}` +
-          (pagination.total > results.length
-            ? ` (use offset=${(pagination.offset || 0) + results.length} for more)`
-            : "");
+        const paginationHint = formatPagination(
+          results.length,
+          pagination.total,
+          pagination.offset || 0,
+          "search-content"
+        );
 
-        contentItems.push({
-          type: "text",
-          text: header + "\n\n" + formattedResults.join("\n---\n"),
-        });
+        const resultHeader = `### Results\n${paginationHint ? paginationHint + "\n\n" : ""}${formattedResults.join("\n---\n")}`;
+
+        const sections = [querySection, resultHeader].filter(Boolean);
+        contentItems.push({ type: "text", text: sections.join("\n\n") });
 
         for (const img of images) {
           contentItems.push({ type: "text", text: `\n📷 ${img.context}` });
@@ -740,14 +838,24 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const app = m.meeting_app as string;
           const title = m.title ? ` — ${m.title}` : "";
           const attendees = m.attendees ? `\nAttendees: ${m.attendees}` : "";
-          return `[${m.detection_source}] ${app}${title}\n  ${start} → ${end}${attendees}`;
+          const durationMin = (m.meeting_start && m.meeting_end)
+            ? Math.round((new Date(m.meeting_end as string).getTime() - new Date(m.meeting_start as string).getTime()) / 60000)
+            : null;
+          const dur = durationMin != null ? ` (${durationMin} min)` : "";
+          return `[Meeting #${m.id}] [${m.detection_source}] ${app}${title}\n  ${start} → ${end}${dur}${attendees}`;
         });
 
-        return {
-          content: [
-            { type: "text", text: `Meetings: ${meetings.length}\n\n${formatted.join("\n---\n")}` },
-          ],
-        };
+        const nextSteps = [
+          `Use \`get-meeting\` with \`id=<id>\` for full details of a specific meeting.`,
+          `Use \`search-content\` with \`content_type=audio\` and the meeting time range for the transcript.`,
+        ];
+
+        const sections = [
+          formatSection("Meetings", [`${meetings.length} found`, "", ...formatted.join("\n---\n").split("\n")]),
+          formatSection("Next steps", nextSteps),
+        ].filter(Boolean);
+
+        return { content: [{ type: "text", text: sections.join("\n\n") }] };
       }
 
       case "activity-summary": {
@@ -812,25 +920,38 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }
         );
 
-        const summary = [
-          `Activity Summary (${data.time_range?.start} → ${data.time_range?.end})`,
-          `Total frames: ${data.total_frames}`,
-          "",
-          "Apps:",
-          ...(appsLines.length ? appsLines : ["  (none)"]),
-          "",
-          "Windows & Tabs:",
-          ...(windowLines.length ? windowLines.slice(0, 20) : ["  (none)"]),
-          "",
-          `Audio: ${data.audio_summary?.segment_count || 0} segments`,
-          ...(speakerLines.length ? speakerLines : []),
-          ...(transcriptLines.length ? ["", "Audio transcriptions:", ...transcriptLines.slice(0, 15)] : []),
-          "",
-          "Key content (sampled across time range):",
-          ...(textLines.length ? textLines.slice(0, 20) : ["  (none)"]),
-        ].join("\n");
+        // Build next-steps suggestions based on what was found
+        const nextSteps: string[] = [];
+        if (appsLines.length > 0) {
+          const topApp = (data.apps as Array<{ name: string }>)[0]?.name;
+          if (topApp) nextSteps.push(`Use \`search-content\` with \`app_name='${topApp}'\` to search its content.`);
+        }
+        if ((data.audio_summary?.segment_count || 0) > 0) {
+          nextSteps.push(`Use \`search-content\` with \`content_type=audio\` and the same time range for full transcripts.`);
+        }
+        if (data.windows?.some((w: { browser_url: string }) => w.browser_url)) {
+          nextSteps.push(`Use \`search-content\` with \`app_name='<browser>'\` and \`window_name='<title>'\` to narrow to a specific page.`);
+        }
 
-        return { content: [{ type: "text", text: summary }] };
+        const audioSection = [
+          `${data.audio_summary?.segment_count || 0} segments`,
+          ...speakerLines,
+          ...(transcriptLines.length ? ["", "Sample transcriptions:", ...transcriptLines.slice(0, 15)] : []),
+        ];
+
+        const sections = [
+          formatSection(
+            `Activity Summary (${data.time_range?.start} → ${data.time_range?.end})`,
+            [`Total frames: ${data.total_frames}`]
+          ),
+          formatSection("Apps", appsLines.length ? appsLines : ["(none)"]),
+          formatSection("Windows & Tabs", windowLines.length ? windowLines.slice(0, 20) : ["(none)"]),
+          formatSection("Audio", audioSection),
+          formatSection("Key content (sampled)", textLines.length ? textLines.slice(0, 20) : ["(none)"]),
+          formatOptionalSection("Next steps", nextSteps, nextSteps.length > 0),
+        ].filter(Boolean);
+
+        return { content: [{ type: "text", text: sections.join("\n\n") }] };
       }
 
       case "search-elements": {
@@ -853,7 +974,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             content: [
               {
                 type: "text",
-                text: "No elements found. Try: broader search, different role/source, or wider time range.",
+                text: "### Result\nNo elements found.\n\n### Next steps\n- Broaden search: try a different role, source, or wider time range\n- Use `frame-context` with a specific frame_id for full page structure",
               },
             ],
           };
@@ -872,18 +993,30 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             const boundsStr = e.bounds
               ? ` [${e.bounds.left.toFixed(2)},${e.bounds.top.toFixed(2)} ${e.bounds.width.toFixed(2)}x${e.bounds.height.toFixed(2)}]`
               : "";
-            return `[${e.source}] ${e.role} (frame:${e.frame_id}, depth:${e.depth})${boundsStr}\n  ${e.text || "(no text)"}`;
+            const deepLink = `screenpipe://frame/${e.frame_id}`;
+            return `[${e.source}] ${e.role} (frame:${e.frame_id}, depth:${e.depth})${boundsStr}\n  ${e.text || "(no text)"}\n  ${deepLink}`;
           }
         );
 
-        const header =
-          `Elements: ${elements.length}/${pagination.total || "?"}` +
-          (pagination.total > elements.length
-            ? ` (use offset=${(pagination.offset || 0) + elements.length} for more)`
-            : "");
+        const paginationHint = formatPagination(
+          elements.length,
+          pagination.total ?? null,
+          pagination.offset ?? 0,
+          "search-elements"
+        );
+        const elementLines = [`${elements.length} of ${pagination.total ?? "?"} total`, "", ...formatted];
+        if (paginationHint) elementLines.push("", paginationHint);
+
+        const sections = [
+          formatQuery(args as Record<string, string | number | boolean | null | undefined>),
+          formatSection("Elements", elementLines),
+          formatSection("Next steps", [
+            `Use \`frame-context\` with \`frame_id=<id>\` to see the full accessibility tree for any frame.`,
+          ]),
+        ].filter(Boolean);
 
         return {
-          content: [{ type: "text", text: header + "\n\n" + formatted.join("\n---\n") }],
+          content: [{ type: "text", text: sections.join("\n\n") }],
         };
       }
 
@@ -897,30 +1030,44 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
 
         const data = await response.json();
-        const lines = [`Frame ${data.frame_id} (source: ${data.text_source})`];
+        const metaLines = [
+          `frame_id: ${data.frame_id}`,
+          `source: ${data.text_source}`,
+          `deep_link: screenpipe://frame/${data.frame_id}`,
+        ];
 
-        if (data.urls?.length) {
-          lines.push("", "URLs:", ...data.urls.map((u: string) => `  ${u}`));
-        }
-
+        const nodeLines: string[] = [];
         if (data.nodes?.length) {
-          lines.push("", `Nodes: ${data.nodes.length}`);
           for (const node of data.nodes.slice(0, 50)) {
             const indent = "  ".repeat(Math.min(node.depth, 5));
-            lines.push(`${indent}[${node.role}] ${node.text}`);
+            nodeLines.push(`${indent}[${node.role}] ${node.text}`);
           }
           if (data.nodes.length > 50) {
-            lines.push(`  ... and ${data.nodes.length - 50} more nodes`);
+            nodeLines.push(`  ... and ${data.nodes.length - 50} more nodes`);
           }
         }
 
+        const urlLines: string[] = data.urls?.length ? data.urls.map((u: string) => `  ${u}`) : [];
+
+        const textLines: string[] = [];
         if (data.text) {
           const truncated =
             data.text.length > 2000 ? data.text.substring(0, 2000) + "..." : data.text;
-          lines.push("", "Full text:", truncated);
+          textLines.push(truncated);
         }
 
-        return { content: [{ type: "text", text: lines.join("\n") }] };
+        const sections = [
+          formatSection("Frame context", metaLines),
+          formatOptionalSection("URLs", urlLines, urlLines.length > 0),
+          formatOptionalSection(`Accessibility nodes (${data.nodes?.length ?? 0})`, nodeLines, nodeLines.length > 0),
+          formatOptionalSection("Full text", textLines, textLines.length > 0),
+          formatSection("Next steps", [
+            `Use \`search-elements\` with \`frame_id=${data.frame_id}\` to query specific UI elements in this frame.`,
+            `Use \`search-content\` with \`start_time\` and \`end_time\` around this frame's timestamp to find nearby activity.`,
+          ]),
+        ].filter(Boolean);
+
+        return { content: [{ type: "text", text: sections.join("\n\n") }] };
       }
 
       case "export-video": {
@@ -1133,10 +1280,73 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "health-check": {
         const response = await fetchAPI("/health");
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
-        const data = await response.json();
-        return {
-          content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+        const data = await response.json() as {
+          status: string;
+          status_code?: number;
+          frame_status?: string;
+          audio_status?: string;
+          last_frame_timestamp?: string;
+          last_audio_timestamp?: string;
+          message?: string;
+          verbose_instructions?: string;
+          device_status_details?: string;
+          vision_db_write_stalled?: boolean;
+          audio_db_write_stalled?: boolean;
+          drm_content_paused?: boolean;
+          schedule_paused?: boolean;
+          hostname?: string;
+          version?: string;
+          monitors?: string[];
+          pipeline?: Record<string, unknown>;
+          audio_pipeline?: Record<string, unknown>;
+          pool_stats?: Record<string, unknown>;
         };
+
+        const now = Date.now();
+        const ageStr = (ts?: string) => {
+          if (!ts) return "never";
+          const diff = Math.round((now - new Date(ts).getTime()) / 1000);
+          return diff < 60 ? `${diff}s ago` : `${Math.round(diff / 60)}m ago`;
+        };
+
+        const statusIcon = (s?: string) => (s === "ok" || s === "healthy") ? "✓" : (s ? `✗ (${s})` : "–");
+
+        const statusLines = [
+          `Recording: ${statusIcon(data.status)} ${data.status ?? "unknown"}`,
+          `Screen:    ${statusIcon(data.frame_status)}`,
+          `Audio:     ${statusIcon(data.audio_status)}`,
+          ...(data.version ? [`Version:   ${data.version}`] : []),
+          ...(data.hostname ? [`Host:      ${data.hostname}`] : []),
+        ];
+
+        const captureLines = [
+          `Last frame: ${ageStr(data.last_frame_timestamp)}`,
+          `Last audio: ${ageStr(data.last_audio_timestamp)}`,
+          ...(data.monitors?.length ? [`Monitors: ${data.monitors.join(", ")}`] : []),
+        ];
+
+        const warnings: string[] = [];
+        if (data.vision_db_write_stalled) warnings.push("⚠ Vision DB write stalled — disk full or pool exhausted?");
+        if (data.audio_db_write_stalled) warnings.push("⚠ Audio DB write stalled — disk full or pool exhausted?");
+        if (data.drm_content_paused) warnings.push("⚠ DRM content detected — capture paused for this content.");
+        if (data.schedule_paused) warnings.push("⚠ Recording paused by work-hours schedule.");
+
+        const diagnosticLines: string[] = [];
+        if (data.message) diagnosticLines.push(`Message: ${data.message}`);
+        if (data.verbose_instructions) diagnosticLines.push(`Instructions: ${data.verbose_instructions}`);
+        if (data.device_status_details) diagnosticLines.push(`Devices: ${data.device_status_details}`);
+        if (data.pool_stats) diagnosticLines.push(`Pool stats: ${JSON.stringify(data.pool_stats)}`);
+        if (data.pipeline) diagnosticLines.push(`Vision pipeline: ${JSON.stringify(data.pipeline)}`);
+        if (data.audio_pipeline) diagnosticLines.push(`Audio pipeline: ${JSON.stringify(data.audio_pipeline)}`);
+
+        const sections = [
+          formatSection("Status", statusLines),
+          formatSection("Capture stats", captureLines),
+          formatOptionalSection("Warnings", warnings, warnings.length > 0),
+          formatOptionalSection("Diagnostics", diagnosticLines, diagnosticLines.length > 0),
+        ].filter(Boolean);
+
+        return { content: [{ type: "text", text: sections.join("\n\n") }] };
       }
 
       case "list-audio-devices": {
@@ -1290,10 +1500,40 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         const response = await fetchAPI(`/meetings/${meetingId}`);
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
-        const meeting = await response.json();
-        return {
-          content: [{ type: "text", text: JSON.stringify(meeting, null, 2) }],
+        const m = await response.json() as {
+          id?: number;
+          meeting_start?: string;
+          meeting_end?: string;
+          meeting_app?: string;
+          title?: string;
+          attendees?: string;
+          note?: string;
+          detection_source?: string;
+          created_at?: string;
         };
+
+        const durationMin = (m.meeting_start && m.meeting_end)
+          ? Math.round((new Date(m.meeting_end).getTime() - new Date(m.meeting_start).getTime()) / 60000)
+          : null;
+
+        const metaLines = [
+          `App: ${m.meeting_app || "unknown"} | Detection: ${m.detection_source || "auto"}`,
+          `Start: ${m.meeting_start || "?"} → End: ${m.meeting_end || "ongoing"}` +
+            (durationMin != null ? ` (${durationMin} min)` : ""),
+          ...(m.attendees ? [`Attendees: ${m.attendees}`] : []),
+          ...(m.note ? [`Note: ${m.note}`] : []),
+        ];
+
+        const nextSteps = [
+          `Use \`search-content\` with \`content_type=audio\`, \`start_time=${m.meeting_start}\`, \`end_time=${m.meeting_end || "now"}\` to get the audio transcript.`,
+        ];
+
+        const sections = [
+          formatSection(`Meeting #${m.id ?? meetingId}`, metaLines),
+          formatSection("Next steps", nextSteps),
+        ].filter(Boolean);
+
+        return { content: [{ type: "text", text: sections.join("\n\n") }] };
       }
 
       case "keyword-search": {
@@ -1308,14 +1548,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const data = await response.json();
         const results = data.data || [];
         if (results.length === 0) {
-          return { content: [{ type: "text", text: "No keyword search results found." }] };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `### Query\n- query: ${args.query || "(none)"}\n\n### Result\nNo keyword search results found.\n\n### Next steps\n- Try \`search-content\` for semantic search across OCR and audio content`,
+              },
+            ],
+          };
         }
         const formatted = results.map((r: Record<string, unknown>) => {
           const content = r.content as Record<string, unknown> | undefined;
-          return `[${r.type}] ${content?.app_name || "?"} | ${content?.timestamp || ""}\n${content?.text || content?.transcription || ""}`;
+          const frameId = (content?.frame_id as number) ?? null;
+          const deepLink = frameId ? `\n  screenpipe://frame/${frameId}` : "";
+          return `[${r.type}] ${content?.app_name || "?"} | ${content?.timestamp || ""}\n${content?.text || content?.transcription || ""}${deepLink}`;
         });
+
+        const sections = [
+          formatQuery(args as Record<string, string | number | boolean | null | undefined>),
+          formatSection("Results", [`${results.length} match${results.length === 1 ? "" : "es"}`, "", ...formatted]),
+          formatSection("Next steps", [
+            `Use \`search-content\` with semantic search for conceptually related content.`,
+            `Use \`frame-context\` with a frame_id from the results above for full page details.`,
+          ]),
+        ].filter(Boolean);
         return {
-          content: [{ type: "text", text: `Results: ${results.length}\n\n${formatted.join("\n---\n")}` }],
+          content: [{ type: "text", text: sections.join("\n\n") }],
         };
       }
 
@@ -1363,9 +1621,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new Error(`Unknown tool: ${name}`);
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : "Unknown error";
     return {
-      content: [{ type: "text", text: `Error executing ${name}: ${errorMessage}` }],
+      content: [{ type: "text", text: formatToolError(name, error) }],
     };
   }
 });


### PR DESCRIPTION
## Summary

Closes #3037

Improves the MCP server's API output format for AI agent consumption, inspired by how playwright-mcp structures its output using `### Section` markdown headers that are machine-parseable.

## Problem

The previous output was raw JSON dumps and unstructured text, making it hard for AI agents to extract relevant information, understand what was returned, or know what to do next.

## Changes

### New helper functions
| Helper | Purpose |
|---|---|
| `formatSection` | Consistent `### Title` markdown sections |
| `formatOptionalSection` | Conditionally rendered section |
| `formatQuery` | Echoes search parameters (like playwright's "Ran code" receipt) |
| `formatPagination` | Smart pagination hints with next-offset guidance |
| `formatDeepLink` | `screenpipe://frame/<id>` and timeline deep links |
| `formatToolError` | Categorized errors: network vs HTTP status vs validation |

### Tools enhanced
| Tool | Before | After |
|---|---|---|
| `health-check` | Raw JSON | `### Status / Capture stats / Warnings / Diagnostics` |
| `get-meeting` | Raw JSON dump | `### Meeting #N` metadata + `### Next steps` (transcript path) |
| `search-content` | Plain text list | `### Query` echo + deep links + `### Results / Next steps` |
| `activity-summary` | Unstructured text | `### Apps / Audio / Key content / Next steps` |
| `list-meetings` | Plain list | Duration, IDs, `### Next steps` for transcript access |
| `search-elements` | Header + flat list | `### Query` echo + frame deep links + `### Next steps` |
| `frame-context` | Flat line list | `### Frame context / URLs / Accessibility nodes / Next steps` |
| `keyword-search` | Raw results | `### Query` echo + frame deep links + `### Next steps` |
| catch block | Generic string | Categorized `### Error` via `formatToolError` |

## Key design decisions

- **Consistent `### Section` headers** — parseable by AI agents splitting on `### `
- **Query echo** — every search tool echoes back what parameters were used (so agents can verify their call was interpreted correctly)
- **Next steps** — exploratory tools suggest follow-up actions with exact parameter values to copy
- **Deep links** — `screenpipe://frame/<id>` per result for direct navigation
- **Uniform error format** — all errors (validation + caught) use `### Error` section

## Testing
- TypeScript compiles cleanly (`tsc --noEmit` passes with 0 errors)
- No functional logic changed — only output formatting