### PR TITLE
feat: attach app_name and window_title to text events on macOS

### DIFF
--- a/crates/screenpipe-a11y/src/events.rs
+++ b/crates/screenpipe-a11y/src/events.rs
@@ -906,4 +906,22 @@ mod tests {
         assert_eq!(EventType::from_str("text"), Some(EventType::Text));
         assert_eq!(EventType::from_str("invalid"), None);
     }
+
+    #[test]
+    fn test_text_event_accepts_app_context() {
+        let mut event = UiEvent::text(Utc::now(), 100, "hello world".to_string());
+        assert!(event.app_name.is_none());
+        assert!(event.window_title.is_none());
+
+        event.app_name = Some("Cursor".to_string());
+        event.window_title = Some("main.rs — my-project".to_string());
+
+        assert_eq!(event.app_name.as_deref(), Some("Cursor"));
+        assert_eq!(event.window_title.as_deref(), Some("main.rs — my-project"));
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event_type\":\"text\""));
+        assert!(json.contains("\"app_name\":\"Cursor\""));
+        assert!(json.contains("main.rs"));
+    }
 }

--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -438,8 +438,10 @@ fn run_event_tap(
                 } else {
                     s
                 };
-                let event =
+                let mut event =
                     UiEvent::text(Utc::now(), state.start.elapsed().as_millis() as u64, text);
+                event.app_name = (**state.current_app.load()).clone();
+                event.window_title = (**state.current_window.load()).clone();
                 let _ = state.tx.try_send(event);
             }
         }
@@ -453,7 +455,9 @@ fn run_event_tap(
         } else {
             s
         };
-        let event = UiEvent::text(Utc::now(), state.start.elapsed().as_millis() as u64, text);
+        let mut event = UiEvent::text(Utc::now(), state.start.elapsed().as_millis() as u64, text);
+        event.app_name = (**state.current_app.load()).clone();
+        event.window_title = (**state.current_window.load()).clone();
         let _ = state.tx.try_send(event);
     }
 


### PR DESCRIPTION
## Summary

Text events (`event_type = 'text'`) in the `ui_events` table have null `app_name` and `window_title`, while click events have them populated. This makes it impossible to know which app/window the user was typing in without a lossy timestamp join against the `frames` table.

This PR reads from the existing `current_app` and `current_window` state (already tracked via `ArcSwap`, lock-free) at text buffer flush time — both the periodic flush in the run loop and the final flush on stop.

## Changes

- `crates/screenpipe-a11y/src/platform/macos.rs` — 4 lines added across 2 flush sites
- `crates/screenpipe-a11y/src/events.rs` — unit test verifying text events serialize with app context

## Before

```sql
SELECT text_content, app_name, window_title FROM ui_events WHERE event_type = 'text' LIMIT 3;
-- "hello world", NULL, NULL
-- "how are you", NULL, NULL
```

## After

```sql
SELECT text_content, app_name, window_title FROM ui_events WHERE event_type = 'text' LIMIT 3;
-- "hello world", "Messages", "Sharon & Cole"
-- "how are you", "Cursor", "main.rs — my-project"
```

## Test plan

- [x] `cargo test -p screenpipe-a11y --lib events::tests` — 4/4 passing
- [x] Manual test: ran patched binary for 60s, typed across Messages, Cursor, and Chrome — all text events had correct app_name and window_title