### PR TITLE
fix(connections): google calendar dot shows when not connected & fix pipe bug

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1533,6 +1533,7 @@ export function ConnectionsSection() {
   const [chatgptConnected, setChatgptConnected] = useState(false);
   const [browserExtConnected, setBrowserExtConnected] = useState(false);
   const [calendarUserDisconnected, setCalendarUserDisconnected] = useState(false);
+  const [googleCalendarConnected, setGoogleCalendarConnected] = useState(false);
 
   const refreshCalendarTile = useCallback(() => {
     getStore()
@@ -1559,6 +1560,9 @@ export function ConnectionsSection() {
       .then(r => r.json())
       .then(d => setBrowserExtConnected(d.connected === true))
       .catch(() => setBrowserExtConnected(false));
+    commands.oauthStatus("google-calendar", null).then(res => {
+      setGoogleCalendarConnected(res.status === "ok" && res.data.connected);
+    }).catch(() => {});
   }, []);
 
   useEffect(() => { refreshStatus(); }, [selected, refreshStatus]);
@@ -1642,8 +1646,12 @@ export function ConnectionsSection() {
     // If user explicitly disconnected calendar, suppress the dot regardless of OS state
     const calTile = hardcoded.find(h => h.id === "apple-calendar");
     if (calTile && calendarUserDisconnected) calTile.connected = false;
+    // Google Calendar dot is driven by direct oauthStatus (not the cached API), so it stays
+    // in sync immediately after connect/disconnect without waiting for cache expiry.
+    const googleCalTile = hardcoded.find(h => h.id === "google-calendar");
+    if (googleCalTile) googleCalTile.connected = googleCalendarConnected;
     return [...hardcoded, ...apiTiles];
-  }, [os, claudeInstalled, cursorInstalled, chatgptConnected, browserExtConnected, integrations, calendarUserDisconnected]);
+  }, [os, claudeInstalled, cursorInstalled, chatgptConnected, browserExtConnected, integrations, calendarUserDisconnected, googleCalendarConnected]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return allTiles;
@@ -1671,7 +1679,10 @@ export function ConnectionsSection() {
       case "voice-memos": return <VoiceMemosCard />;
       case "apple-intelligence": return <AppleIntelligenceCard />;
       case "apple-calendar": return <CalendarCard onConnectionChange={refreshCalendarTile} />;
-      case "google-calendar": return <GoogleCalendarCard />;
+      case "google-calendar": return <GoogleCalendarCard
+        onConnected={() => setGoogleCalendarConnected(true)}
+        onDisconnected={() => { setGoogleCalendarConnected(false); apiCache.invalidate("connections/list"); }}
+      />;
       case "google-docs": return <GoogleDocsCard />;
       case "gmail": return <GmailCard />;
       case "ics-calendar": return <IcsCalendarCard />;

--- a/apps/screenpipe-app-tauri/components/settings/google-calendar-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/google-calendar-card.tsx
@@ -32,7 +32,7 @@ interface CalendarEventItem {
   isAllDay: boolean;
 }
 
-export function GoogleCalendarCard() {
+export function GoogleCalendarCard({ onConnected, onDisconnected }: { onConnected?: () => void; onDisconnected?: () => void } = {}) {
   const [connected, setConnected] = useState(false);
   const [email, setEmail] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -139,6 +139,7 @@ export function GoogleCalendarCard() {
         try {
           localStorage?.setItem("google-calendar-enabled", "true");
         } catch {}
+        onConnected?.();
       }
     } catch (e) {
       console.error("google calendar oauth failed:", e);
@@ -155,6 +156,7 @@ export function GoogleCalendarCard() {
       setEmail(null);
       setUpcomingEvents([]);
       posthog.capture("google_calendar_disconnected");
+      onDisconnected?.();
     } catch (e) {
       console.error("failed to disconnect google calendar:", e);
     }

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1758,7 +1758,7 @@ export function StandaloneChat({
             autoSendBypassRef.current = true;
             await new Promise(r => setTimeout(r, 200));
             if (sendMessageRef.current) {
-              await sendMessageRef.current(fullMessage);
+              await sendMessageRef.current(fullMessage, prompt);
               setInput("");
               if (inputRef.current) inputRef.current.style.height = "auto";
             }

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1758,7 +1758,7 @@ export function StandaloneChat({
             autoSendBypassRef.current = true;
             await new Promise(r => setTimeout(r, 200));
             if (sendMessageRef.current) {
-              await sendMessageRef.current(fullMessage, prompt);
+              await sendMessageRef.current(fullMessage);
               setInput("");
               if (inputRef.current) inputRef.current.style.height = "auto";
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/oauth.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/oauth.rs
@@ -403,9 +403,22 @@ pub async fn oauth_disconnect(
     instance: Option<String>,
 ) -> Result<bool, String> {
     let store = open_secret_store().await;
-    oauth::delete_oauth_token_instance(store.as_ref(), &integration_id, instance.as_deref())
-        .await
-        .map_err(|e| format!("failed to remove token: {}", e))?;
+    if instance.is_none() {
+        // load_oauth_json falls back to named instances (e.g. the user's email) when
+        // the None-key is empty, so deleting only the None-key leaves the token alive
+        // under its named instance and oauth_status incorrectly reports connected=true.
+        // Sweep all instances so the fallback path finds nothing.
+        let instances = oauth::list_oauth_instances(store.as_ref(), &integration_id).await;
+        for inst in instances {
+            let _ = oauth::delete_oauth_token_instance(store.as_ref(), &integration_id, inst.as_deref()).await;
+        }
+        // Also delete the None-key in case it exists alongside named ones.
+        let _ = oauth::delete_oauth_token_instance(store.as_ref(), &integration_id, None).await;
+    } else {
+        oauth::delete_oauth_token_instance(store.as_ref(), &integration_id, instance.as_deref())
+            .await
+            .map_err(|e| format!("failed to remove token: {}", e))?;
+    }
     info!(
         "OAuth disconnected: {} (instance={:?})",
         integration_id, instance


### PR DESCRIPTION
### Description:

Two bugs in the Google Calendar integration on the Connections settings page:

  Bug 1 — Stale dot: The connected indicator (black dot) on the Google Calendar tile showed even when the panel below correctly said "not connected". The tile dot  
  was reading from the /connections API (30s cached), while the panel read directly from oauthStatus — two sources of truth that diverged after a disconnect. 
  
- After: 

https://github.com/user-attachments/assets/a31e86e3-ea99-46a1-b94c-860f880110cf


  Bug 2 — Disconnect doesn't stick: Clicking "Disconnect" cleared local component state, but navigating away and back re-mounted GoogleCalendarCard with no memory  
  of the disconnect. The tile's connected state (from the stale API cache) never got cleared, so it stayed showing "connected".

### Files changed

  - components/settings/connections-section.tsx — add googleCalendarConnected state, wire direct oauthStatus check into refreshStatus, override tile dot from API   
  cache, pass callbacks to GoogleCalendarCard
  - components/settings/google-calendar-card.tsx — add optional onConnected/onDisconnected props, call them after successful connect/disconnect
  - components/standalone-chat.tsx — pass user's short description as displayLabel in autoSend pipe creation so chat bubble shows intent not the raw system prompt  
