### PR TITLE
fix: track device recovery failures to avoid retry spam

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -459,6 +459,12 @@ pub async fn start_device_monitor(
                                             "[DEVICE_RECOVERY] failed to start new default output {}: {} — keeping old devices running",
                                             new_default_output, e
                                         );
+                                        // Track failure to avoid spammy retries
+                                        let count = failed_devices
+                                            .entry(new_default_output.clone())
+                                            .or_insert((0, Instant::now()));
+                                        count.0 += 1;
+                                        count.1 = Instant::now();
                                         false
                                     }
                                 }
@@ -530,6 +536,12 @@ pub async fn start_device_monitor(
                                             "[DEVICE_RECOVERY] failed to start communications output {}: {}",
                                             new_comm_output, e
                                         );
+                                        // Track failure to avoid spammy retries
+                                        let count = failed_devices
+                                            .entry(new_comm_output.clone())
+                                            .or_insert((0, Instant::now()));
+                                        count.0 += 1;
+                                        count.1 = Instant::now();
                                     }
                                 }
                             }


### PR DESCRIPTION
## Problem
When the device monitor attempts to recover a default or communications output device that no longer exists (e.g., the speaker was unplugged or disconnected), the error is logged but not tracked. This causes the recovery loop to continuously retry starting the missing device on every poll, generating spammy error logs.

## Root cause
In `device_monitor.rs`, when `audio_manager.start_device()` fails, the failure is logged as a warning but not recorded in the `failed_devices` map. Compare this to the input device recovery code (lines 405-420), which correctly tracks failures using:

```rust
let count = failed_devices
    .entry(device_name.clone())
    .or_insert((0, Instant::now()));
count.0 += 1;
```

The output device and Windows communications output device recovery logic was missing this tracking.

## Fix
Added the same failure tracking mechanism to both output device recovery paths:
- Default output device recovery (line 459-468)
- Windows communications output device recovery (line 536-543)

This allows the backoff mechanism to apply and prevents spammy retries.

## Confidence: 8/10

The fix is straightforward and mirrors existing, working code for input device recovery. All existing tests pass without modification.

## Verification
```
running 10 tests
test audio_manager::device_monitor::tests::test_backoff_initial_state ... ok
test audio_manager::device_monitor::tests::test_backoff_permanent_capped_at_120s ... ok
test audio_manager::device_monitor::tests::test_backoff_reset_clears_state ... ok
test audio_manager::device_monitor::tests::test_backoff_transient_capped_at_8s ... ok
test audio_manager::device_monitor::tests::test_backoff_transient_then_permanent_escalates ... ok
test audio_manager::device_monitor::tests::test_cooldown_allows_restarts_under_limit ... ok
test audio_manager::device_monitor::tests::test_cooldown_evicts_old_entries ... ok
test audio_manager::device_monitor::tests::test_cooldown_exhausted_at_limit ... ok
test audio_manager::device_monitor::tests::test_cooldown_stays_exhausted ... ok
test audio_manager::device_monitor::tests::test_is_permanent_output_error ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 74 filtered out; finished in 0.00s
```

---
auto-generated by issue-solver pipe