### PR TITLE
fix: prevent Zoom meeting early termination with audio output signal

### DIFF
--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -1658,9 +1658,15 @@ pub fn advance_state(
                     },
                     None,
                 )
-            } else if is_browser && has_output_audio {
+            } else if has_output_audio {
                 // Audio output is still active — the user likely just switched
-                // tabs/apps while the meeting continues. Keep alive.
+                // tabs/apps, minimized the window, or switched to another meeting app.
+                // Keep the meeting alive regardless of whether UI controls are visible.
+                // This prevents false positives when:
+                // - Browser tab is switched (controls not in focused window)
+                // - App is minimized (AX tree not exposed)
+                // - Sharing screen in Zoom (controls move to floating toolbar)
+                // - Multiple desktops/Spaces (AX scanner can't reach inactive space)
                 info!(
                     "meeting v2: Ending -> Active (output audio still active, app={}, id={})",
                     app, meeting_id
@@ -2353,14 +2359,11 @@ pub async fn run_meeting_detection_loop(
 
         // 2b. Check output audio when in Ending state for browser meetings.
         // If the audio output device still has data, the meeting is likely
-        // still going — the user just switched tabs/apps.
-        let has_output_audio = if matches!(
-            state,
-            MeetingState::Ending {
-                is_browser: true,
-                ..
-            }
-        ) {
+        // still going — the user just switched tabs/apps or minimized the window.
+        // This applies to both browser meetings (e.g., Google Meet via Arc) and
+        // native meeting apps (e.g., Zoom). Audio activity is a strong signal
+        // that the user is still in the meeting even if UI controls are hidden.
+        let has_output_audio = if matches!(state, MeetingState::Ending { .. }) {
             db.has_recent_output_audio(30).await.unwrap_or(false)
         } else {
             false
@@ -3129,8 +3132,30 @@ mod tests {
     }
 
     #[test]
-    fn test_native_ending_ignores_output_audio() {
-        // Native app: output audio should NOT prevent ending (controls are reliable)
+    fn test_native_ending_respects_output_audio() {
+        // Native app (e.g., Zoom): output audio SHOULD keep meeting alive
+        // This handles cases where:
+        // - User minimizes Zoom but is still in the meeting
+        // - Zoom controls move to floating toolbar (not detected by scanner)
+        // - User is sharing screen (controls move to secondary toolbar)
+        let state = MeetingState::Ending {
+            meeting_id: 42,
+            app: "Zoom".to_string(),
+            started_at: Utc::now(),
+            since: Instant::now().checked_sub(Duration::from_secs(5)).unwrap(),
+            is_browser: false,
+        };
+        let results: Vec<ScanResult> = vec![];
+        let (new_state, action) = advance_state(state, &results, true);
+
+        // Even though timeout hasn't elapsed, audio presence keeps it Active
+        assert!(matches!(new_state, MeetingState::Active { .. }));
+        assert!(action.is_none());
+    }
+
+    #[test]
+    fn test_native_ending_no_audio_times_out() {
+        // Native app with no audio output: should still end after timeout
         let state = MeetingState::Ending {
             meeting_id: 42,
             app: "Zoom".to_string(),
@@ -3141,8 +3166,9 @@ mod tests {
             is_browser: false,
         };
         let results: Vec<ScanResult> = vec![];
-        let (new_state, action) = advance_state(state, &results, true);
+        let (new_state, action) = advance_state(state, &results, false);
 
+        // No audio + timeout elapsed → should end
         assert!(matches!(new_state, MeetingState::Idle));
         assert!(matches!(
             action,


### PR DESCRIPTION
## Problem
Zoom meetings show only ~1 minute duration when:
- User minimizes Zoom window
- User switches to another app (Zoom loses focus)
- User shares screen (controls move to floating toolbar)

## Root cause
The meeting detector scans the accessibility (AX) tree to find meeting controls (e.g., 'End Call', mute buttons). When these controls aren't visible (minimized, background window, secondary toolbars), the scanner finds no controls.

The meeting transitions to `Ending` state with a 30-second timeout. If controls don't reappear within 30s, the meeting is ended - even though the user is still on the call with audio still streaming.

This timeout was appropriate for browser-based meetings (where tab switching is quick), but too short for native apps like Zoom where users expect to minimize/background the app during long calls.

## Fix
Extend the existing audio output detection to protect native apps:
- Check if speaker/audio output is active during `Ending` state  
- If audio is flowing, the meeting is likely still happening → stay Active
- This applies to both native apps (Zoom, Teams) and browser meetings
- Audio is a strong meeting presence signal independent of UI visibility

## Changes
1. **Line 2357**: Extended `has_output_audio` check from `is_browser`-only to all apps
2. **Line 1661**: Removed `is_browser` guard from audio protection in state machine  
3. **Tests**: 
   - `test_native_ending_ignores_output_audio` → `test_native_ending_respects_output_audio` (behavior inverted)
   - `test_native_ending_no_audio_times_out` (new test ensures timeout still works)

## Verification
```
Test Results for Issue #2536 Fix
================================

Running: cargo test -p screenpipe-engine meeting_detector

✅ All 55 meeting detector tests PASSED

Key tests verifying the fix:

1. test_native_ending_respects_output_audio - NEW
   - Verifies native apps (like Zoom) with active audio output stay in Active state
   - This was the core bug: Zoom meetings would end immediately when minimized

2. test_native_ending_no_audio_times_out - NEW
   - Verifies native apps without audio still timeout correctly after ENDING_TIMEOUT (30s)
   - Ensures we don't break the timeout mechanism for silent calls

3. test_browser_ending_stays_active_with_output_audio - EXISTING
   - Browser meetings (Google Meet, etc.) with audio stay active ✓ (still works)

4. test_ending_to_idle_timeout - EXISTING
   - Timeout logic for ending state works correctly ✓

5. test_ending_to_active_controls_reappear - EXISTING  
   - Meeting resumes if controls reappear ✓

All other meeting detector tests also passed:
- test_zoom_menu_bar_item_meeting
- test_active_to_ending
- test_rapid_app_switching
- ... and 47 more

test result: ok. 55 passed; 0 failed; 2 ignored; 0 measured
```

## Confidence: 9/10
- ✅ Targets exact root cause (AX unavailability during minimize/background)
- ✅ Extensive test coverage (55 passing tests)  
- ✅ Audio is a reliable meeting presence indicator
- ⚠️ Only concern: false positives if unrelated app audio plays during Ending state (low risk)

---
auto-generated by issue-solver pipe