### PR TITLE
docs(testing): add audio-only days calendar picker regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -396,6 +396,7 @@ commits: `f1255eac`, `25cbdc6b`, `2529367d`, `d9821624`, `e61501da`, `039d5fea`,
 - [ ] **Keyword search logic** — Verify that keyword search SQL correctly uses `OR` instead of `UNION` within `IN()`.
 - [ ] **Search prompt accuracy** — Verify that search prompts are improved to prevent false negatives from over-filtering.
 - [ ] **Past-day timeline navigation** — Navigate the timeline to past days (e.g., using date picker or arrow keys). Verify that data loads correctly and the timeline behaves as expected.
+- [ ] **Audio-only days in calendar picker** — Record audio without screen capture (mic on, screen off). Navigate to the calendar picker. Verify days with audio-only recordings appear as available (not greyed out) in the picker. (`76a0c09a3`)
 - [ ] **`content_type=all` search and pagination** — Perform search queries with `content_type=all`. Verify that the result count is accurate and pagination works correctly without missing or duplicating results.
 - [ ] **Search pagination with offset** — Perform paginated searches, particularly beyond the first page. Verify that results are not empty or incorrect due to double-applied offsets.
 - [ ] **`search_ocr()` returns results for event-driven capture** — Verify that `search_ocr()` correctly returns OCR results for event-driven captures and does not return empty when visible text is present on screen.


### PR DESCRIPTION
## Problem

The timeline's calendar date picker incorrectly greyed out days that had audio-only recordings (microphone active, screen capture off). Users couldn't navigate to these days in the timeline, reducing discoverability of audio-only sessions.

## Root cause

The `listDaysWithFrames` query only checked the `frames` table for active recording days. Days with audio transcriptions but no frames were excluded, even though audio data existed for those periods.

## Fix

Extended the query to UNION both `frames` and `audio_transcriptions` tables, ensuring days with either type of recording data appear as available in the picker.

## Confidence: 9/10

Straightforward SQL fix for a regression in timeline data query. The change is minimal and directly addresses the root cause. 

## Verification (Tier T2: static analysis)

✓ Commit 76a0c09a3 verified to exist  
✓ Query change is simple UNION to include audio_transcriptions  
✓ No lockfile changes  
✓ Regression-prone area: timeline calendar picker  

## Sources (multi-source required)

- Git: commit 76a0c09a3 (merged Apr 25, 2026)
- Code: timeline query in has-frames-date.ts

---
auto-generated by issue-solver pipe (Fallback F1: TESTING.md update)