### PR TITLE
docs(testing): add false Zoom idle detection regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -177,6 +177,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **Meeting detection support for Signal, WhatsApp, Telegram, and Teams 2** — Verify that meetings from these apps are correctly detected and recorded. (`8d2f1a542`, `a74e393e1`)
 - [ ] **Browser meetings splitting fix** — Verify that meetings in the browser are correctly split into separate events. (`d8ba1dad3`)
 - [ ] **Meeting with hidden UI controls** — Start a Zoom/Teams meeting. Minimize the meeting window or switch apps (Zoom controls move out of accessibility tree). Verify meeting stays active and does NOT auto-terminate after 30 seconds. Audio output detection prevents false "meeting ended" events. (`4e784f620`)
+- [ ] **No false Zoom idle detection** — Open Zoom but do NOT start a call. Verify meeting detector does NOT trigger. Leave Zoom running idle for >5 minutes. Verify no false meeting entry in the app. Repeat with multiple idle apps. Confirms: idle UI signals (menu bar items, window presence) no longer trigger false positives. (`a500ec11b`, fixes #2561)
 - [ ] **OpenAI-compatible transcription endpoint** — Verify that the `/v1/audio/transcriptions` endpoint works as expected, following the OpenAI specification. (`5a14e9a92`)
 
 ### 5. frame comparison & OCR pipeline


### PR DESCRIPTION
## Problem
Meeting detector v2 had a regression where it would trigger false positives when a meeting app (Zoom, Teams, etc.) was running but idle (not in an active call). This was fixed in commit a500ec11b, but no regression test was added to TESTING.md.

## Root cause
The fix removed idle UI signals (menu bar items, window presence) from the Zoom detection profile, preventing false state transitions from Confirming → Active. This needs to be verified in regression testing.

## Fix
Added regression test to TESTING.md under "meeting detection & speaker identification" section to verify:
1. No false meeting detection when app is idle
2. Idle apps (>5m) don't trigger meeting state  
3. Multiple idle apps don't accumulate false positives

## Confidence: 9/10
Documentation-only change, straightforward regression test addition.

## Verification (Tier T3 - static analysis)
✓ Citation validation passed:
- commit a500ec11b verified (git cat-file -e)
- issue #2561 verified (gh issue view)

File diff:
```
+ [ ] **No false Zoom idle detection** — Open Zoom but do NOT start a call. Verify meeting detector does NOT trigger. Leave Zoom running idle for >5 minutes. Verify no false meeting entry in the app. Repeat with multiple idle apps. Confirms: idle UI signals (menu bar items, window presence) no longer trigger false positives. (`a500ec11b`, fixes #2561)
```

## Sources (multi-source required)
- Git history: commit a500ec11b (merged to main) — real Zoom meeting false positive fix
- GitHub issue: #2561 — User-reported regression: "Meeting detector v2 triggers on app presence, not active call state"
- Code review: meeting_detector.rs shows idle 'Meeting' menu bar item signal removed, min_signals_required reduced from 2→1

---
auto-generated by fallback F1 (TESTING.md regression entry)