### PR TITLE
fix(audio): gracefully handle missing/corrupted ONNX models

### DIFF
--- a/crates/screenpipe-audio/src/speaker/mod.rs
+++ b/crates/screenpipe-audio/src/speaker/mod.rs
@@ -5,12 +5,25 @@ use std::path::Path;
 use anyhow::Result;
 
 pub fn create_session<P: AsRef<Path>>(path: P) -> Result<ort::session::Session> {
-    let session = ort::session::Session::builder()?
+    let session_result = ort::session::Session::builder()?
         .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)?
         .with_intra_threads(1)?
         .with_inter_threads(1)?
-        .commit_from_file(path.as_ref())?;
-    Ok(session)
+        .commit_from_file(path.as_ref());
+        
+    match session_result {
+        Ok(session) => Ok(session),
+        Err(e) => {
+            // Sentry issue 7244944243: If the ONNX file is corrupted (e.g. Protobuf parsing failed),
+            // delete it so it can be automatically re-downloaded by the next model refresh.
+            if let Err(rm_err) = std::fs::remove_file(path.as_ref()) {
+                tracing::warn!("failed to remove potentially corrupted model file {:?}: {}", path.as_ref(), rm_err);
+            } else {
+                tracing::info!("removed potentially corrupted model file {:?}", path.as_ref());
+            }
+            Err(e.into())
+        }
+    }
 }
 pub mod embedding_manager;
 pub mod models;

--- a/crates/screenpipe-audio/src/speaker/prepare_segments.rs
+++ b/crates/screenpipe-audio/src/speaker/prepare_segments.rs
@@ -100,7 +100,7 @@ pub async fn prepare_segments(
 
     let (tx, rx) = tokio::sync::mpsc::channel(100);
     if !audio_frames.is_empty() && threshold_met {
-        if segmentation_model_path.is_none() || embedding_extractor.is_none() {
+        if segmentation_model_path.map_or(true, |p| !p.exists()) || embedding_extractor.is_none() {
             let mut fallback_segment = Vec::new();
             fallback_segment.extend_from_slice(&audio_data);
 


### PR DESCRIPTION
## Problem
Sentry issues #7244239107 (600 events) and #7244944243 (67 events).

When the Pyannote ONNX segmentation model file is missing (e.g. cache cleared) or corrupted (e.g. failed download), `process_audio_input` continuously attempts to load it for every audio chunk, causing:
1. Complete loss of audio data (audio chunk is dropped because `create_session` returns `Err`).
2. Sentry spam for the duration of the 30-second model refresh window (or indefinitely if corrupted).
3. Corrupted models are never deleted, permanently blocking re-downloads.

## Root cause
1. `prepare_segments` uses `segmentation_model_path.is_none()` which only checks if the path variable is None, not if the file actually exists on disk. When the cache is cleared, the path pointer still exists but points to a missing file.
2. `create_session` doesn't handle `ort::Error` from corrupted ONNX files—it just propagates the error without cleaning up the stranded corrupted file.

## Fix
1. **prepare_segments**: Check file existence with `segmentation_model_path.map_or(true, |p| !p.exists())` instead of just checking if the path is None. Falls back to VAD-only mode (unknown speaker), preserving audio data.
2. **create_session**: Catch `ort::Error` and delete the corrupted file. This allows the refresh cycle to re-download automatically.

## Confidence: 9/10
- Root cause is obvious from stack traces and code flow
- Fix is minimal (2 files, <20 lines)
- Addresses high-frequency user-facing Sentry issues
- Fix was previously attempted in PR #3062 but closed without merge

## Verification (Tier T2 - cargo check)
```
    Checking screenpipe-config v0.3.299 (/Users/louis/screenpipe/crates/screenpipe-config)
   Compiling screenpipe-audio v0.3.299 (/Users/louis/screenpipe/crates/screenpipe-audio)
    Checking screenpipe-events v0.3.299 (/Users/louis/screenpipe/crates/screenpipe-events)
    Checking screenpipe-db v0.3.299 (/Users/louis/screenpipe/crates/screenpipe-db)
    Checking screenpipe-core v0.3.299 (/Users/louis/screenpipe/crates/screenpipe-core)
warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:171:33
    |
171 |         let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:171:43
    |
171 |         let pool: *mut Object = msg_send![class!(NSAutoreleasePool), new];
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `class` crate for guidance on how handle this unexpected cfg
    = help: the macro `class` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `class` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:176:29
    |
176 |                 let _: () = msg_send![pool, drain];
    |                             ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:183:13
    |
183 |             msg_send![class!(NSString), stringWithUTF8String: c"soun".as_ptr()];
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: unexpected `cfg` condition value: `cargo-clippy`
   --> crates/screenpipe-core/src/permissions.rs:186:21
    |
186 |         let _: () = msg_send![pool, drain];
    |                     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: expected values for `feature` are: `cloud-sync`, `default`, `secrets`, and `security`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
    = help: try referring to `sel_impl` crate for guidance on how handle this unexpected cfg
    = help: the macro `sel_impl` may come from an old version of the `objc` crate, try updating your dependency with `cargo update -p objc`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `sel_impl` which comes from the expansion of the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

warning: `screenpipe-core` (lib) generated 7 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.70s
```

## Sources
- Sentry: SCREENPIPE-CLI-5J (600 events), SCREENPIPE-CLI-FZ (67 events)
- Git: commit 448bc93e9 (referenced fix implementation)
- Code: Direct inspection of speaker/mod.rs and prepare_segments.rs showing the exact failures

---
auto-generated by issue-solver pipe