### PR TITLE
Fix (sidebar New chat): open a real new thread and stop selection jumping to old chats

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -23,7 +23,7 @@ import {
   X,
 } from "lucide-react";
 import { emit } from "@tauri-apps/api/event";
-import { useChatStore, getOrCreateEmptyChatId } from "@/lib/stores/chat-store";
+import { useChatStore } from "@/lib/stores/chat-store";
 import { useOverlayData } from "@/app/shortcut-reminder/use-overlay-data";
 import { cn } from "@/lib/utils";
 import { AppSidebar, SidebarProvider, useSidebarContext } from "@/components/app-sidebar";
@@ -154,16 +154,19 @@ function HomeContent() {
   }, [setActiveSection]);
 
   // Clear the sidebar's "current" highlight when leaving the chat
-  // view; restore it from panelSessionId when coming back. The chat
-  // panel stays mounted (display:none) and keeps streaming, but
-  // visually the row shouldn't look "selected" while the user is
-  // looking at Pipes/Memories/etc.
+  // view. The chat panel stays mounted (display:none) and keeps streaming.
+  //
+  // Do NOT setCurrent(panelSessionId) when entering home — that ran
+  // after the same click as "New chat" / chat-load-conversation and
+  // overwrote the freshly chosen id with the stale foreground id,
+  // so the sidebar jumped to an old row (felt like cycling recents)
+  // instead of the blank session the user just asked for. Highlight
+  // sync on home is handled by: row clicks + emit, chat-current-session
+  // from StandaloneChat when conversationId updates, and the New chat
+  // handler below (setCurrent before emit).
   useEffect(() => {
     const { actions } = useChatStore.getState();
-    if (activeSection === "home") {
-      const panelId = useChatStore.getState().panelSessionId;
-      if (panelId) actions.setCurrent(panelId);
-    } else {
+    if (activeSection !== "home") {
       actions.setCurrent(null);
     }
   }, [activeSection]);
@@ -382,9 +385,8 @@ function HomeContent() {
   // Top-level nav items (filtered by enterprise policy)
   const mainSections = [
     // The first nav item doubles as "go to chat view + start a fresh
-    // conversation". Replaces the old "Home" + the "+" inside the chat
-    // sidebar (single, obvious entry point). The click handler below
-    // both switches the active section AND spins up a new chat session.
+    // conversation". Each click allocates a new session id (empty
+    // rows are not reused — that felt like opening an old recent).
     { id: "home", label: "New chat", icon: <Plus className="h-3.5 w-3.5" /> },
     { id: "pipes", label: "Pipes", icon: <Workflow className="h-3.5 w-3.5" /> },
     { id: "timeline", label: "Timeline", icon: <Clock className="h-3.5 w-3.5" /> },
@@ -565,7 +567,7 @@ function HomeContent() {
                           <Phone className="h-3 w-3" />
                         </button>
                       </TooltipTrigger>
-                      <TooltipContent side="bottom" className="text-xs">
+                      <TooltipContent side="top" className="text-xs">
                         {meetingState.manualActive ? "stop meeting" : meetingState.active ? "meeting detected" : "start meeting"}
                       </TooltipContent>
                     </Tooltip>
@@ -653,30 +655,26 @@ function HomeContent() {
                       onClick={() => {
                         setActiveSection(section.id);
                         // The "home" slot is the New Chat affordance —
-                        // clicking it (from any view) spawns a fresh
-                        // chat session and switches to it. Mirrors the
-                        // sidebar's "+ new chat" behaviour exactly so
-                        // the two entry points stay in sync.
+                        // clicking it (from any view) always spawns a
+                        // new chat session and switches to it.
                         if (section.id === "home") {
-                          // Reuse an existing empty chat if there is one;
-                          // otherwise create. Mirrors the sidebar's
-                          // "+ new chat" handler so spamming the nav
-                          // doesn't pile up empty rows.
-                          const { id, isNew } = getOrCreateEmptyChatId();
+                          // Always start a brand-new session. Reusing an
+                          // empty row (getOrCreateEmptyChatId) felt like
+                          // "nothing happened" / jumping to an old blank
+                          // row in recents instead of a fresh compose view.
+                          const id = crypto.randomUUID();
                           const store = useChatStore.getState();
-                          if (isNew) {
-                            store.actions.upsert({
-                              id,
-                              title: "new chat",
-                              preview: "",
-                              status: "idle",
-                              messageCount: 0,
-                              createdAt: Date.now(),
-                              updatedAt: Date.now(),
-                              pinned: false,
-                              unread: false,
-                            });
-                          }
+                          store.actions.upsert({
+                            id,
+                            title: "new chat",
+                            preview: "",
+                            status: "idle",
+                            messageCount: 0,
+                            createdAt: Date.now(),
+                            updatedAt: Date.now(),
+                            pinned: false,
+                            unread: false,
+                          });
                           store.actions.setCurrent(id);
                           void emit("chat-load-conversation", {
                             conversationId: id,

--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -664,6 +664,11 @@ function HomeContent() {
                           // row in recents instead of a fresh compose view.
                           const id = crypto.randomUUID();
                           const store = useChatStore.getState();
+                          // Drop stale drafts before creating a new one so
+                          // repeated "New chat" clicks don't accumulate empty rows.
+                          Object.values(store.sessions).forEach((s) => {
+                            if (s.draft) store.actions.drop(s.id);
+                          });
                           store.actions.upsert({
                             id,
                             title: "new chat",
@@ -674,6 +679,7 @@ function HomeContent() {
                             updatedAt: Date.now(),
                             pinned: false,
                             unread: false,
+                            draft: true,
                           });
                           store.actions.setCurrent(id);
                           void emit("chat-load-conversation", {

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -106,6 +106,8 @@ export function ChatSidebar({ className }: ChatSidebarProps) {
     for (const s of sessions) {
       const isPipeKind = s.kind === "pipe-watch" || s.kind === "pipe-run";
       if (isPipeKind && liveScheduledSids.has(s.id)) continue;
+      // Hide draft sessions — they haven't received an assistant reply yet.
+      if (s.draft) continue;
       (s.pinned ? p : r).push(s);
     }
     return { pinned: p, recents: r };
@@ -142,6 +144,7 @@ export function ChatSidebar({ className }: ChatSidebarProps) {
         updatedAt: Date.now(),
         pinned: false,
         unread: false,
+        draft: true,
       });
       actions.setCurrent(fresh);
       emit("chat-load-conversation", { conversationId: fresh });

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -40,7 +40,6 @@ import {
   useChatStore,
   useChatActions,
   useOrderedSessions,
-  getOrCreateEmptyChatId,
   type SessionRecord,
 } from "@/lib/stores/chat-store";
 import { updateConversationFlags } from "@/lib/chat-storage";
@@ -111,31 +110,6 @@ export function ChatSidebar({ className }: ChatSidebarProps) {
     }
     return { pinned: p, recents: r };
   }, [sessions, liveScheduledSids]);
-
-  const handleNew = () => {
-    // Reuse an existing empty chat instead of spawning a fresh one
-    // every time. Spamming "+ new chat" otherwise floods the sidebar
-    // with rows the user never typed in.
-    const { id, isNew } = getOrCreateEmptyChatId();
-    if (isNew) {
-      actions.upsert({
-        id,
-        title: "new chat",
-        preview: "",
-        status: "idle",
-        messageCount: 0,
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-        pinned: false,
-        unread: false,
-      });
-    }
-    actions.setCurrent(id);
-    // chat-load-conversation with an unknown id is treated by
-    // standalone-chat's listener as "start a new chat with this id" —
-    // see the matching handler in components/standalone-chat.tsx.
-    emit("chat-load-conversation", { conversationId: id });
-  };
 
   const handleSelect = (id: string) => {
     // No early return for id === currentId. Two reasons:

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -237,6 +237,15 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       const allPipe = messages.every((m) => m.id?.startsWith("pipe-"));
       if (!allPipe) {
         saveConversation(messages);
+        // Reveal this session in the sidebar — the assistant has replied,
+        // so it's no longer an empty draft.
+        void (async () => {
+          const { useChatStore } = await import("@/lib/stores/chat-store");
+          const sid = piSessionIdRef.current;
+          if (sid && useChatStore.getState().sessions[sid]?.draft) {
+            useChatStore.getState().actions.patch(sid, { draft: false });
+          }
+        })();
       }
     }
     prevIsLoadingRef.current = isLoading;

--- a/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
@@ -76,6 +76,11 @@ export interface SessionRecord {
    *  instant the user makes that session current. Sidebar renders unread
    *  rows in bold, like an email inbox. */
   unread: boolean;
+  /** True until the assistant has replied at least once. Draft sessions
+   *  are hidden in the sidebar so the user can't accumulate empty chats
+   *  by clicking "New chat" repeatedly. Cleared on the first successful
+   *  save (after the assistant replies). */
+  draft?: boolean;
 
   // ── Live session content (Phase 3) ─────────────────────────────────
   // The chat panel reads these instead of holding its own per-render


### PR DESCRIPTION
### Description: 
We fixed the sidebar so “New chat” always starts a fresh conversation (like the in-chat New button) and no longer snaps the highlight back to an older chat because of a race when returning to the home view.

- before: 

https://github.com/user-attachments/assets/0f62f850-05ab-44d9-9918-4199e0b1b24b


- After:


https://github.com/user-attachments/assets/b3aaf4e0-1ab0-4f20-9c6c-5505697ac50b



**Files changed**  
- `apps/screenpipe-app-tauri/app/home/page.tsx` — always create a new session id on “New chat”; move meeting tooltip above the row so it doesn’t cover New chat; stop overwriting `currentId` with `panelSessionId` when entering home (that was resetting the sidebar after each click).  
- `apps/screenpipe-app-tauri/components/chat-sidebar.tsx` — remove unused `handleNew` / `getOrCreateEmptyChatId` left over from the old flow.