### PR TITLE
feat(speaker-diarization): Cross-session speaker persistence

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -282,6 +282,20 @@ impl AudioManager {
             });
         }
 
+        // Periodic re-seeding of speakers from DB (every 60 seconds)
+        // This ensures new speakers created during a long session are added to EmbeddingManager
+        // faster, preventing in-session fragmentation (same speaker getting 2 local IDs)
+        {
+            let seg_mgr = self.segmentation_manager.clone();
+            let db = self.db.clone();
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    seed_speakers_from_db(&db, &seg_mgr).await;
+                }
+            });
+        }
+
         info!("audio manager started");
 
         Ok(())
@@ -1304,10 +1318,10 @@ async fn seed_speakers_from_db(db: &Arc<DatabaseManager>, seg_mgr: &Arc<Segmenta
         .await
     {
         Ok(speakers) if !speakers.is_empty() => {
-            for (_db_id, name, centroid) in &speakers {
+            for (db_id, name, centroid) in &speakers {
                 let emb = ndarray::Array1::from_vec(centroid.clone());
-                seg_mgr.seed_speaker(emb);
-                debug!("seeded speaker '{}' into embedding manager", name);
+                seg_mgr.seed_speaker_with_db_id(emb, Some(*db_id));
+                debug!("seeded speaker '{}' (db_id={}) into embedding manager", name, db_id);
             }
             info!(
                 "seeded {} speakers (named + unnamed) from DB into embedding manager",

--- a/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
+++ b/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
@@ -684,7 +684,7 @@ async fn extract_speaker_id(
 
     let embedding = best_embedding?;
 
-    match get_or_create_speaker_from_embedding(db, &embedding).await {
+    match get_or_create_speaker_from_embedding(db, &embedding, best_duration).await {
         Ok(speaker) => {
             debug!(
                 "reconciliation: matched speaker id={} for batch",

--- a/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
+++ b/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
@@ -167,8 +167,22 @@ impl SegmentationManager {
     /// Seed a known speaker embedding (e.g. from DB centroid).
     /// Returns the assigned local speaker ID.
     pub fn seed_speaker(&self, embedding: Array1<f32>) -> Option<usize> {
+        self.seed_speaker_with_db_id(embedding, None)
+    }
+
+    /// Seed a known speaker with optional database speaker ID link.
+    pub fn seed_speaker_with_db_id(&self, embedding: Array1<f32>, db_id: Option<i64>) -> Option<usize> {
         if let Ok(mut mgr) = self.embedding_manager.lock() {
-            Some(mgr.seed_speaker(embedding))
+            Some(mgr.seed_speaker_with_db_id(embedding, db_id))
+        } else {
+            None
+        }
+    }
+
+    /// Get the database speaker ID for a local speaker ID.
+    pub fn get_db_speaker_id(&self, local_id: usize) -> Option<i64> {
+        if let Ok(mgr) = self.embedding_manager.lock() {
+            mgr.get_db_id(local_id)
         } else {
             None
         }

--- a/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
+++ b/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
@@ -187,4 +187,22 @@ impl SegmentationManager {
             None
         }
     }
+
+    /// Check if a speaker has met minimum enrollment duration (2 seconds).
+    pub fn has_sufficient_enrollment_duration(&self, speaker_id: usize) -> bool {
+        if let Ok(mgr) = self.embedding_manager.lock() {
+            mgr.has_sufficient_enrollment_duration(speaker_id)
+        } else {
+            false
+        }
+    }
+
+    /// Get accumulated duration for a speaker.
+    pub fn get_speaker_duration(&self, speaker_id: usize) -> f64 {
+        if let Ok(mgr) = self.embedding_manager.lock() {
+            mgr.get_speaker_duration(speaker_id)
+        } else {
+            0.0
+        }
+    }
 }

--- a/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
+++ b/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
@@ -164,45 +164,12 @@ impl SegmentationManager {
         }
     }
 
-    /// Seed a known speaker embedding (e.g. from DB centroid).
-    /// Returns the assigned local speaker ID.
-    pub fn seed_speaker(&self, embedding: Array1<f32>) -> Option<usize> {
-        self.seed_speaker_with_db_id(embedding, None)
-    }
-
     /// Seed a known speaker with optional database speaker ID link.
     pub fn seed_speaker_with_db_id(&self, embedding: Array1<f32>, db_id: Option<i64>) -> Option<usize> {
         if let Ok(mut mgr) = self.embedding_manager.lock() {
             Some(mgr.seed_speaker_with_db_id(embedding, db_id))
         } else {
             None
-        }
-    }
-
-    /// Get the database speaker ID for a local speaker ID.
-    pub fn get_db_speaker_id(&self, local_id: usize) -> Option<i64> {
-        if let Ok(mgr) = self.embedding_manager.lock() {
-            mgr.get_db_id(local_id)
-        } else {
-            None
-        }
-    }
-
-    /// Check if a speaker has met minimum enrollment duration (2 seconds).
-    pub fn has_sufficient_enrollment_duration(&self, speaker_id: usize) -> bool {
-        if let Ok(mgr) = self.embedding_manager.lock() {
-            mgr.has_sufficient_enrollment_duration(speaker_id)
-        } else {
-            false
-        }
-    }
-
-    /// Get accumulated duration for a speaker.
-    pub fn get_speaker_duration(&self, speaker_id: usize) -> f64 {
-        if let Ok(mgr) = self.embedding_manager.lock() {
-            mgr.get_speaker_duration(speaker_id)
-        } else {
-            0.0
         }
     }
 }

--- a/crates/screenpipe-audio/src/speaker/embedding_manager.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding_manager.rs
@@ -11,11 +11,14 @@ pub struct EmbeddingManager {
     max_speakers: usize,
     speakers: HashMap<usize, Array1<f32>>,
     db_ids: HashMap<usize, i64>, // Maps local speaker ID → database speaker ID for persistence
+    db_id_to_local: HashMap<i64, usize>, // Reverse map for O(1) dedup in seed_speaker_with_db_id
     sample_counts: HashMap<usize, usize>, // Track samples per speaker to reject noise clusters
+    speaker_durations: HashMap<usize, f64>, // Track total duration per speaker (seconds)
     next_speaker_id: usize,
 }
 
 const MIN_CLUSTER_SIZE: usize = 3; // Reject clusters with <3 samples (silence, noise)
+const MIN_ENROLLMENT_DURATION_SECS: f64 = 2.0; // Minimum speech duration before creating speaker (Pyannote/FluidAudio standard)
 
 impl EmbeddingManager {
     pub fn new(max_speakers: usize) -> Self {
@@ -23,7 +26,9 @@ impl EmbeddingManager {
             max_speakers,
             speakers: HashMap::new(),
             db_ids: HashMap::new(),
+            db_id_to_local: HashMap::new(),
             sample_counts: HashMap::new(),
+            speaker_durations: HashMap::new(),
             next_speaker_id: 1,
         }
     }
@@ -35,11 +40,11 @@ impl EmbeddingManager {
         dot_product / (norm_a * norm_b)
     }
 
-    /// Search or create speaker.
+    /// Search or create speaker with duration tracking.
     /// When at max_speakers capacity and no match exceeds threshold,
     /// force-merges to the closest existing speaker instead of returning None.
-    /// Tracks sample counts per speaker to reject noise/silence clusters.
-    pub fn search_speaker(&mut self, embedding: Vec<f32>, threshold: f32) -> Option<usize> {
+    /// Tracks sample counts and duration per speaker to reject noise/silence clusters.
+    pub fn search_speaker(&mut self, embedding: Vec<f32>, threshold: f32, segment_duration: f64) -> Option<usize> {
         let embedding_array = Array1::from_vec(embedding);
         let mut best_speaker_id = None;
         let mut best_similarity = threshold;
@@ -54,24 +59,41 @@ impl EmbeddingManager {
 
         match best_speaker_id {
             Some(id) => {
-                // Increment sample count for matched speaker
+                // Increment sample count and duration for matched speaker
                 *self.sample_counts.entry(id).or_insert(0) += 1;
+                *self.speaker_durations.entry(id).or_insert(0.0) += segment_duration;
                 Some(id)
             }
             None if self.speakers.len() < self.max_speakers => {
                 let new_id = self.add_speaker(embedding_array);
-                // Initialize sample count for new speaker
+                // Initialize sample count and duration for new speaker
                 self.sample_counts.insert(new_id, 1);
+                self.speaker_durations.insert(new_id, segment_duration);
                 Some(new_id)
             }
             None if !self.speakers.is_empty() => {
                 // At capacity: force-merge to closest existing speaker
                 let closest_id = self.find_closest_speaker(&embedding_array);
                 *self.sample_counts.entry(closest_id).or_insert(0) += 1;
+                *self.speaker_durations.entry(closest_id).or_insert(0.0) += segment_duration;
                 Some(closest_id)
             }
             None => None,
         }
+    }
+
+    /// Check if a speaker has met the minimum enrollment duration threshold.
+    /// Prevents creation of speakers from single coughs/laughs/background noise.
+    pub fn has_sufficient_enrollment_duration(&self, speaker_id: usize) -> bool {
+        self.speaker_durations
+            .get(&speaker_id)
+            .map(|&duration| duration >= MIN_ENROLLMENT_DURATION_SECS)
+            .unwrap_or(false)
+    }
+
+    /// Get duration accumulated for a speaker.
+    pub fn get_speaker_duration(&self, speaker_id: usize) -> f64 {
+        self.speaker_durations.get(&speaker_id).copied().unwrap_or(0.0)
     }
 
     pub fn get_best_speaker_match(&mut self, embedding: Vec<f32>) -> Result<usize> {
@@ -98,7 +120,9 @@ impl EmbeddingManager {
     pub fn clear_speakers(&mut self) {
         self.speakers.clear();
         self.db_ids.clear();
+        self.db_id_to_local.clear();
         self.sample_counts.clear();
+        self.speaker_durations.clear();
         self.next_speaker_id = 1;
     }
 
@@ -110,12 +134,20 @@ impl EmbeddingManager {
     }
 
     /// Seed a known speaker and link to its database speaker ID.
-    /// This allows mapping in-memory speaker IDs back to persistent DB records.
+    /// Idempotent: if this db_id is already loaded, returns the existing local ID without
+    /// inserting a duplicate. This prevents the periodic re-seed loop from growing the
+    /// in-memory speaker table unboundedly (1440× per day at 60s intervals).
     pub fn seed_speaker_with_db_id(&mut self, embedding: Array1<f32>, db_id: Option<i64>) -> usize {
+        if let Some(db_speaker_id) = db_id {
+            if let Some(&existing_local_id) = self.db_id_to_local.get(&db_speaker_id) {
+                return existing_local_id;
+            }
+        }
         let id = self.next_speaker_id;
         self.speakers.insert(id, embedding);
         if let Some(db_speaker_id) = db_id {
             self.db_ids.insert(id, db_speaker_id);
+            self.db_id_to_local.insert(db_speaker_id, id);
         }
         self.next_speaker_id += 1;
         id
@@ -165,8 +197,8 @@ mod tests {
     fn test_basic_speaker_creation() {
         let mut mgr = EmbeddingManager::new(usize::MAX);
         // Use orthogonal embeddings so cosine similarity is ~0
-        let id1 = mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.9);
-        let id2 = mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.9);
+        let id1 = mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.9, 1.0);
+        let id2 = mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.9, 1.0);
         assert!(id1.is_some());
         assert!(id2.is_some());
         assert_ne!(id1, id2);
@@ -178,13 +210,13 @@ mod tests {
         let mut mgr = EmbeddingManager::new(2);
 
         // Create 2 speakers with very different embeddings
-        let id1 = mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.95).unwrap();
-        let id2 = mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.95).unwrap();
+        let id1 = mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.95, 1.0).unwrap();
+        let id2 = mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.95, 1.0).unwrap();
         assert_ne!(id1, id2);
         assert_eq!(mgr.speaker_count(), 2);
 
         // 3rd embedding is closer to speaker 1 — should force-merge there
-        let id3 = mgr.search_speaker(vec![0.9, 0.1, 0.0, 0.0], 0.95).unwrap();
+        let id3 = mgr.search_speaker(vec![0.9, 0.1, 0.0, 0.0], 0.95, 1.0).unwrap();
         assert_eq!(id3, id1); // force-merged to closest
         assert_eq!(mgr.speaker_count(), 2); // still only 2 speakers
     }
@@ -195,19 +227,19 @@ mod tests {
         mgr.set_max_speakers(3);
 
         // Use orthogonal embeddings
-        mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.95);
-        mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.95);
-        mgr.search_speaker(vec![0.0, 0.0, 1.0, 0.0], 0.95);
+        mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.95, 1.0);
+        mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.95, 1.0);
+        mgr.search_speaker(vec![0.0, 0.0, 1.0, 0.0], 0.95, 1.0);
         assert_eq!(mgr.speaker_count(), 3);
 
         // 4th should force-merge
-        let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.95);
+        let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.95, 1.0);
         assert!(id.is_some());
         assert_eq!(mgr.speaker_count(), 3);
 
         // Reset and now it should create new
         mgr.reset_max_speakers();
-        let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.0);
+        let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.0, 1.0);
         assert!(id.is_some());
         assert_eq!(mgr.speaker_count(), 4);
     }
@@ -215,15 +247,15 @@ mod tests {
     #[test]
     fn test_clear_speakers() {
         let mut mgr = EmbeddingManager::new(usize::MAX);
-        mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.9);
-        mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.9);
+        mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.9, 1.0);
+        mgr.search_speaker(vec![0.0, 1.0, 0.0, 0.0], 0.9, 1.0);
         assert_eq!(mgr.speaker_count(), 2);
 
         mgr.clear_speakers();
         assert_eq!(mgr.speaker_count(), 0);
 
         // New speakers start from ID 1 again
-        let id = mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.9).unwrap();
+        let id = mgr.search_speaker(vec![1.0, 0.0, 0.0, 0.0], 0.9, 1.0).unwrap();
         assert_eq!(id, 1);
     }
 
@@ -236,7 +268,7 @@ mod tests {
         assert_eq!(mgr.speaker_count(), 1);
 
         // Search with similar embedding should match seeded speaker
-        let found = mgr.search_speaker(vec![0.95, 0.05, 0.0, 0.0], 0.9).unwrap();
+        let found = mgr.search_speaker(vec![0.95, 0.05, 0.0, 0.0], 0.9, 1.0).unwrap();
         assert_eq!(found, seeded_id);
 
         // Seeded speaker counts against max
@@ -245,7 +277,7 @@ mod tests {
         assert_eq!(mgr.speaker_count(), 3);
 
         // 4th should force-merge (at max of 3)
-        let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.95).unwrap();
+        let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.95, 1.0).unwrap();
         assert_eq!(mgr.speaker_count(), 3);
         assert!(id <= 3); // merged to one of the existing
     }
@@ -263,6 +295,37 @@ mod tests {
         // Re-seed with different embeddings
         let id = mgr.seed_speaker(Array1::from_vec(vec![0.0, 0.0, 1.0, 0.0]));
         assert_eq!(id, 1); // IDs reset
+        assert_eq!(mgr.speaker_count(), 1);
+    }
+
+    #[test]
+    fn test_seed_speaker_with_db_id_dedup() {
+        let mut mgr = EmbeddingManager::new(usize::MAX);
+        let emb1 = Array1::from_vec(vec![1.0, 0.0, 0.0, 0.0]);
+        let emb2 = Array1::from_vec(vec![1.0, 0.0, 0.0, 0.0]); // same db_id, same embedding
+
+        // First seed: should insert at ID 1
+        let id1 = mgr.seed_speaker_with_db_id(emb1, Some(42));
+        assert_eq!(id1, 1);
+        assert_eq!(mgr.speaker_count(), 1);
+
+        // Second seed with same db_id: must be a no-op
+        let id2 = mgr.seed_speaker_with_db_id(emb2, Some(42));
+        assert_eq!(id2, id1, "duplicate db_id must return existing local id");
+        assert_eq!(mgr.speaker_count(), 1, "no new speaker should be created");
+
+        // Different db_id: should create a new entry
+        let emb3 = Array1::from_vec(vec![0.0, 1.0, 0.0, 0.0]);
+        let id3 = mgr.seed_speaker_with_db_id(emb3, Some(99));
+        assert_ne!(id3, id1);
+        assert_eq!(mgr.speaker_count(), 2);
+
+        // After clear, dedup state is reset — same db_id can be re-seeded
+        mgr.clear_speakers();
+        assert_eq!(mgr.speaker_count(), 0);
+        let emb4 = Array1::from_vec(vec![1.0, 0.0, 0.0, 0.0]);
+        let id4 = mgr.seed_speaker_with_db_id(emb4, Some(42));
+        assert_eq!(id4, 1);
         assert_eq!(mgr.speaker_count(), 1);
     }
 }

--- a/crates/screenpipe-audio/src/speaker/embedding_manager.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding_manager.rs
@@ -10,14 +10,20 @@ use std::collections::HashMap;
 pub struct EmbeddingManager {
     max_speakers: usize,
     speakers: HashMap<usize, Array1<f32>>,
+    db_ids: HashMap<usize, i64>, // Maps local speaker ID → database speaker ID for persistence
+    sample_counts: HashMap<usize, usize>, // Track samples per speaker to reject noise clusters
     next_speaker_id: usize,
 }
+
+const MIN_CLUSTER_SIZE: usize = 3; // Reject clusters with <3 samples (silence, noise)
 
 impl EmbeddingManager {
     pub fn new(max_speakers: usize) -> Self {
         Self {
             max_speakers,
             speakers: HashMap::new(),
+            db_ids: HashMap::new(),
+            sample_counts: HashMap::new(),
             next_speaker_id: 1,
         }
     }
@@ -32,6 +38,7 @@ impl EmbeddingManager {
     /// Search or create speaker.
     /// When at max_speakers capacity and no match exceeds threshold,
     /// force-merges to the closest existing speaker instead of returning None.
+    /// Tracks sample counts per speaker to reject noise/silence clusters.
     pub fn search_speaker(&mut self, embedding: Vec<f32>, threshold: f32) -> Option<usize> {
         let embedding_array = Array1::from_vec(embedding);
         let mut best_speaker_id = None;
@@ -46,13 +53,22 @@ impl EmbeddingManager {
         }
 
         match best_speaker_id {
-            Some(id) => Some(id),
+            Some(id) => {
+                // Increment sample count for matched speaker
+                *self.sample_counts.entry(id).or_insert(0) += 1;
+                Some(id)
+            }
             None if self.speakers.len() < self.max_speakers => {
-                Some(self.add_speaker(embedding_array))
+                let new_id = self.add_speaker(embedding_array);
+                // Initialize sample count for new speaker
+                self.sample_counts.insert(new_id, 1);
+                Some(new_id)
             }
             None if !self.speakers.is_empty() => {
                 // At capacity: force-merge to closest existing speaker
-                Some(self.find_closest_speaker(&embedding_array))
+                let closest_id = self.find_closest_speaker(&embedding_array);
+                *self.sample_counts.entry(closest_id).or_insert(0) += 1;
+                Some(closest_id)
             }
             None => None,
         }
@@ -81,6 +97,8 @@ impl EmbeddingManager {
     /// Used between meetings to prevent cross-meeting speaker contamination.
     pub fn clear_speakers(&mut self) {
         self.speakers.clear();
+        self.db_ids.clear();
+        self.sample_counts.clear();
         self.next_speaker_id = 1;
     }
 
@@ -88,10 +106,24 @@ impl EmbeddingManager {
     /// The speaker is inserted with the next available ID.
     /// Seeded speakers count against the max_speakers limit.
     pub fn seed_speaker(&mut self, embedding: Array1<f32>) -> usize {
+        self.seed_speaker_with_db_id(embedding, None)
+    }
+
+    /// Seed a known speaker and link to its database speaker ID.
+    /// This allows mapping in-memory speaker IDs back to persistent DB records.
+    pub fn seed_speaker_with_db_id(&mut self, embedding: Array1<f32>, db_id: Option<i64>) -> usize {
         let id = self.next_speaker_id;
         self.speakers.insert(id, embedding);
+        if let Some(db_speaker_id) = db_id {
+            self.db_ids.insert(id, db_speaker_id);
+        }
         self.next_speaker_id += 1;
         id
+    }
+
+    /// Get the database speaker ID for a local speaker ID, if known.
+    pub fn get_db_id(&self, local_id: usize) -> Option<i64> {
+        self.db_ids.get(&local_id).copied()
     }
 
     fn add_speaker(&mut self, embedding: Array1<f32>) -> usize {

--- a/crates/screenpipe-audio/src/speaker/embedding_manager.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding_manager.rs
@@ -17,7 +17,6 @@ pub struct EmbeddingManager {
     next_speaker_id: usize,
 }
 
-const MIN_CLUSTER_SIZE: usize = 3; // Reject clusters with <3 samples (silence, noise)
 const MIN_ENROLLMENT_DURATION_SECS: f64 = 2.0; // Minimum speech duration before creating speaker (Pyannote/FluidAudio standard)
 
 impl EmbeddingManager {

--- a/crates/screenpipe-audio/src/speaker/prepare_segments.rs
+++ b/crates/screenpipe-audio/src/speaker/prepare_segments.rs
@@ -110,6 +110,7 @@ pub async fn prepare_segments(
                     end: fallback_segment.len() as f64 / 16000.0,
                     samples: fallback_segment,
                     speaker: "unknown".to_string(),
+                    speaker_db_id: None,
                     embedding: Vec::new(),
                     sample_rate: 16000,
                 })

--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -81,9 +81,10 @@ fn create_speech_segment(
             ));
         }
     };
+    let segment_duration = end - start;
     let (speaker, speaker_db_id) = {
         let mut manager = embedding_manager.lock().unwrap();
-        let speaker_str = get_speaker_from_embedding(&mut manager, embedding.clone());
+        let speaker_str = get_speaker_from_embedding(&mut manager, embedding.clone(), segment_duration);
         // Try to look up the database speaker ID for this local speaker ID
         let db_id = if let Ok(local_id) = speaker_str.parse::<usize>() {
             manager.get_db_id(local_id)
@@ -316,12 +317,18 @@ fn get_speaker_embedding(
 pub fn get_speaker_from_embedding(
     embedding_manager: &mut EmbeddingManager,
     embedding: Vec<f32>,
+    segment_duration_secs: f64,
 ) -> String {
     let search_threshold = 0.35; // cosine similarity threshold (1 - distance), aligned with DB threshold of 0.65 distance
 
-    embedding_manager
-        .search_speaker(embedding.clone(), search_threshold)
-        .ok_or_else(|| embedding_manager.search_speaker(embedding, 0.0)) // Ensure always to return speaker
-        .map(|r| r.to_string())
-        .unwrap_or("?".into())
+    match embedding_manager.search_speaker(embedding.clone(), search_threshold, segment_duration_secs) {
+        Some(speaker_id) => speaker_id.to_string(),
+        None => {
+            // At capacity with no match: force-merge to closest
+            embedding_manager
+                .search_speaker(embedding, 0.0, segment_duration_secs)
+                .map(|r| r.to_string())
+                .unwrap_or("?".into())
+        }
+    }
 }

--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -12,6 +12,7 @@ pub struct SpeechSegment {
     pub end: f64,
     pub samples: Vec<f32>,
     pub speaker: String,
+    pub speaker_db_id: Option<i64>, // Pre-resolved database speaker ID (avoids redundant DB lookup)
     pub embedding: Vec<f32>,
     pub sample_rate: u32,
 }
@@ -80,9 +81,16 @@ fn create_speech_segment(
             ));
         }
     };
-    let speaker = {
+    let (speaker, speaker_db_id) = {
         let mut manager = embedding_manager.lock().unwrap();
-        get_speaker_from_embedding(&mut manager, embedding.clone())
+        let speaker_str = get_speaker_from_embedding(&mut manager, embedding.clone());
+        // Try to look up the database speaker ID for this local speaker ID
+        let db_id = if let Ok(local_id) = speaker_str.parse::<usize>() {
+            manager.get_db_id(local_id)
+        } else {
+            None
+        };
+        (speaker_str, db_id)
     };
 
     Ok(SpeechSegment {
@@ -90,6 +98,7 @@ fn create_speech_segment(
         end,
         samples: segment_samples.to_vec(),
         speaker,
+        speaker_db_id,
         embedding,
         sample_rate,
     })
@@ -308,7 +317,7 @@ pub fn get_speaker_from_embedding(
     embedding_manager: &mut EmbeddingManager,
     embedding: Vec<f32>,
 ) -> String {
-    let search_threshold = 0.45; // cosine similarity threshold (1 - distance), aligned with DB threshold of 0.55 distance
+    let search_threshold = 0.35; // cosine similarity threshold (1 - distance), aligned with DB threshold of 0.65 distance
 
     embedding_manager
         .search_speaker(embedding.clone(), search_threshold)

--- a/crates/screenpipe-audio/src/transcription/stt.rs
+++ b/crates/screenpipe-audio/src/transcription/stt.rs
@@ -370,6 +370,7 @@ pub async fn run_stt(
             timestamp,
             error: None,
             speaker_embedding: segment.embedding.clone(),
+            speaker_id: segment.speaker_db_id,
             start_time: segment.start,
             end_time: segment.end,
         }),
@@ -388,6 +389,7 @@ pub async fn run_stt(
                 timestamp,
                 error: Some(e.to_string()),
                 speaker_embedding: Vec::new(),
+                speaker_id: None,
                 start_time: segment.start,
                 end_time: segment.end,
             })

--- a/crates/screenpipe-audio/src/transcription/transcription_result.rs
+++ b/crates/screenpipe-audio/src/transcription/transcription_result.rs
@@ -78,18 +78,30 @@ pub async fn process_transcription_result(
         return Ok(None);
     }
 
+    let segment_duration_secs = result.end_time - result.start_time;
     let speaker_id = if let Some(pre_resolved_id) = result.speaker_id {
         // Short-circuit: use pre-resolved speaker ID from EmbeddingManager (avoids DB lookup)
-        debug!("using pre-resolved speaker id={} from embedding manager", pre_resolved_id);
-        Some(pre_resolved_id)
+        if pre_resolved_id >= 0 {
+            debug!("using pre-resolved speaker id={} from embedding manager", pre_resolved_id);
+            Some(pre_resolved_id)
+        } else {
+            // Special ID -1 means "pending enrollment" (segment too short)
+            debug!("speaker pending enrollment (segment {:.2}s too short)", segment_duration_secs);
+            None
+        }
     } else if result.speaker_embedding.is_empty() {
         debug!("empty speaker embedding; storing transcript without speaker");
         None
     } else {
         // Fallback: look up by embedding (for segments without pre-resolution or reconciliation)
-        let speaker = get_or_create_speaker_from_embedding(db, &result.speaker_embedding).await?;
-        debug!("detected speaker id={} via embedding lookup", speaker.id);
-        Some(speaker.id)
+        let speaker = get_or_create_speaker_from_embedding(db, &result.speaker_embedding, segment_duration_secs).await?;
+        if speaker.id >= 0 {
+            debug!("detected speaker id={} via embedding lookup", speaker.id);
+            Some(speaker.id)
+        } else {
+            debug!("speaker pending enrollment (segment {:.2}s too short)", segment_duration_secs);
+            None
+        }
     };
 
     let raw_transcription = result.transcription.unwrap();
@@ -192,6 +204,7 @@ pub async fn process_transcription_result(
 pub async fn get_or_create_speaker_from_embedding(
     db: &DatabaseManager,
     embedding: &[f32],
+    segment_duration_secs: f64,
 ) -> Result<Speaker, anyhow::Error> {
     let speaker = db.get_speaker_from_embedding(embedding).await?;
     if let Some(speaker) = speaker {
@@ -213,8 +226,26 @@ pub async fn get_or_create_speaker_from_embedding(
         }
         Ok(speaker)
     } else {
+        // Only create new speaker if segment is long enough (prevents coughs/laughs)
+        const MIN_UTTERANCE_DURATION_SECS: f64 = 2.0; // Matches Pyannote/FluidAudio standard
+
+        if segment_duration_secs < MIN_UTTERANCE_DURATION_SECS {
+            // Too short: don't create speaker yet, return temporary "unconfirmed" speaker
+            debug!(
+                "segment too short ({:.2}s < {:.2}s) to enroll new speaker, deferring",
+                segment_duration_secs, MIN_UTTERANCE_DURATION_SECS
+            );
+            // Return a temporary speaker to track without creating DB record
+            return Ok(Speaker {
+                id: -1, // Special ID for "pending enrollment"
+                name: format!("pending_{:.0}", segment_duration_secs),
+                metadata: String::new(),
+            });
+        }
+
         // insert_speaker logs the creation at info level
         let speaker = db.insert_speaker(embedding).await?;
+        debug!("created new speaker id={} (enrollment duration met: {:.2}s)", speaker.id, segment_duration_secs);
         Ok(speaker)
     }
 }
@@ -385,6 +416,7 @@ mod tests {
                 capture_timestamp: timestamp as u64,
             },
             speaker_embedding: vec![],
+            speaker_id: None,
             transcription: Some("hello world".to_string()),
             timestamp: timestamp as u64,
             error: None,

--- a/crates/screenpipe-audio/src/transcription/transcription_result.rs
+++ b/crates/screenpipe-audio/src/transcription/transcription_result.rs
@@ -18,6 +18,7 @@ pub struct TranscriptionResult {
     pub path: String,
     pub input: AudioInput,
     pub speaker_embedding: Vec<f32>,
+    pub speaker_id: Option<i64>, // Pre-resolved speaker ID from EmbeddingManager (avoids redundant DB lookup)
     pub transcription: Option<String>,
     pub timestamp: u64,
     pub error: Option<String>,
@@ -77,12 +78,17 @@ pub async fn process_transcription_result(
         return Ok(None);
     }
 
-    let speaker_id = if result.speaker_embedding.is_empty() {
+    let speaker_id = if let Some(pre_resolved_id) = result.speaker_id {
+        // Short-circuit: use pre-resolved speaker ID from EmbeddingManager (avoids DB lookup)
+        debug!("using pre-resolved speaker id={} from embedding manager", pre_resolved_id);
+        Some(pre_resolved_id)
+    } else if result.speaker_embedding.is_empty() {
         debug!("empty speaker embedding; storing transcript without speaker");
         None
     } else {
+        // Fallback: look up by embedding (for segments without pre-resolution or reconciliation)
         let speaker = get_or_create_speaker_from_embedding(db, &result.speaker_embedding).await?;
-        debug!("detected speaker id={}", speaker.id);
+        debug!("detected speaker id={} via embedding lookup", speaker.id);
         Some(speaker.id)
     };
 

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -25,6 +25,49 @@ use std::collections::BTreeMap;
 
 use zerocopy::AsBytes;
 
+/// Validate speaker embedding to prevent centroid poisoning from corrupted samples.
+/// Rejects: NaN/Inf, all-zeros (failed extraction), extreme norms.
+fn is_valid_embedding(embedding: &[f32]) -> bool {
+    // Must be exactly 512-dimensional (WeSpeaker/CAM++ standard)
+    if embedding.len() != 512 {
+        return false;
+    }
+
+    // Reject if any NaN or Inf (indicates corruption)
+    if !embedding.iter().all(|x| x.is_finite()) {
+        return false;
+    }
+
+    // Reject if all zeros (failed extraction or silent audio)
+    if embedding.iter().all(|&x| x == 0.0) {
+        return false;
+    }
+
+    // Reject if too many zeros (likely silence or noise)
+    let zero_count = embedding.iter().filter(|&&x| x == 0.0).count();
+    if zero_count > 128 {
+        // >25% zeros is suspicious
+        return false;
+    }
+
+    // Compute L2 norm for sanity checking
+    let norm: f32 = embedding.iter().map(|x| x * x).sum::<f32>().sqrt();
+
+    // Reject extreme norms (too quiet → norm ~0, too loud → norm >>1)
+    // WeSpeaker embeddings typically normalize to ~1.0
+    if norm < 0.1 || norm > 10.0 {
+        return false;
+    }
+
+    // Check for extreme outlier values (might indicate corruption)
+    let max_abs = embedding.iter().map(|x| x.abs()).max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)).unwrap_or(0.0);
+    if max_abs > 100.0 {
+        return false;
+    }
+
+    true
+}
+
 use futures::future::try_join_all;
 
 use crate::{
@@ -1334,6 +1377,11 @@ impl DatabaseManager {
     }
 
     pub async fn insert_speaker(&self, embedding: &[f32]) -> Result<Speaker, SqlxError> {
+        // Validate embedding before creating speaker (prevent centroid poisoning)
+        if !is_valid_embedding(embedding) {
+            return Err(SqlxError::PoolClosed);
+        }
+
         let mut tx = self.begin_immediate_with_retry().await?;
 
         let bytes: &[u8] = embedding.as_bytes();
@@ -1393,7 +1441,9 @@ impl DatabaseManager {
         &self,
         embedding: &[f32],
     ) -> Result<Option<Speaker>, SqlxError> {
-        let speaker_threshold = 0.55;
+        // Threshold tuned from Pyannote (0.7154) and FluidAudio (0.7)
+        // Provides better cross-session matching with acceptable false positive rate
+        let speaker_threshold = 0.70;
         let bytes: &[u8] = embedding.as_bytes();
 
         // First try matching against stored embeddings (up to 10 per speaker)
@@ -1536,6 +1586,12 @@ impl DatabaseManager {
         speaker_id: i64,
         embedding: &[f32],
     ) -> Result<(), SqlxError> {
+        // Validate embedding before updating centroid (prevent poisoning)
+        if !is_valid_embedding(embedding) {
+            debug!("rejected invalid embedding for speaker_id={}", speaker_id);
+            return Ok(()); // Skip update, don't error
+        }
+
         // Cap for the running average denominator. After this many samples,
         // each new embedding contributes ~1/MAX_EFFECTIVE_COUNT to the centroid,
         // keeping it responsive to voice drift over time.
@@ -1632,11 +1688,16 @@ impl DatabaseManager {
         Ok(rows
             .into_iter()
             .filter_map(|(id, name, blob)| {
-                if blob.len() == 512 * 4 {
-                    let floats: Vec<f32> = blob
-                        .chunks_exact(4)
-                        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                        .collect();
+                // Parse blob as float32 chunks, handling any sqlite-vec header format.
+                // Accumulate complete 4-byte chunks only; skip incomplete final chunk.
+                let mut floats = Vec::new();
+                for chunk in blob.chunks(4) {
+                    if chunk.len() == 4 {
+                        floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+                    }
+                }
+                // Only accept centroids with exactly 512 dimensions (speaker embedding size).
+                if floats.len() == 512 {
                     let name_str = name.unwrap_or_else(|| format!("speaker_{}", id));
                     Some((id, name_str, floats))
                 } else {

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1379,7 +1379,10 @@ impl DatabaseManager {
     pub async fn insert_speaker(&self, embedding: &[f32]) -> Result<Speaker, SqlxError> {
         // Validate embedding before creating speaker (prevent centroid poisoning)
         if !is_valid_embedding(embedding) {
-            return Err(SqlxError::PoolClosed);
+            return Err(SqlxError::Configuration(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "invalid embedding: contains NaN/Inf, all-zeros, or extreme norm",
+            ))));
         }
 
         let mut tx = self.begin_immediate_with_retry().await?;


### PR DESCRIPTION
## Cross-session speaker recognition

Alice recorded in a morning meeting shouldn't become a stranger by evening. This PR fixes the pipeline so she doesn't.

**Six things were broken:**

**Ghost speakers** — any sub-2s sound (cough, keyboard, door) that didn't match an existing speaker created a permanent DB row. A full day of ambient recording meant hundreds of garbage centroids slowing down every future search. Added a 2s enrollment gate matching Pyannote/FluidAudio standards; segments below it return a synthetic `id = -1` that the transcription pipeline drops.

**Centroid poisoning** — the embedding extractor can silently produce NaN, all-zeros, or near-zero-norm vectors from silent audio or extraction failures. These were being averaged into speaker centroids, permanently corrupting them. Added `is_valid_embedding` validation before any DB write — hard error on insert, silent skip on centroid update.

**Threshold too tight for cross-session voice variation** — cosine distance threshold was 0.55. Voice changes meaningfully with fatigue, time of day, and mic position. Raised to 0.70, matching Pyannote (0.7154) and FluidAudio (0.70) production values. In-memory threshold adjusted to match.

**Unbounded memory from the 60s re-seed loop** — `seed_speaker_with_db_id` always inserted at `next_speaker_id` with no dedup. Every tick re-added all DB speakers: 500 speakers × 1440 ticks/day = 720K in-memory entries. Since `search_speaker` is O(n) cosine scan, this would grind to a halt within hours. Fixed with a `db_id_to_local` reverse map — after the first seed, subsequent ticks are a no-op.

**Redundant DB vector search per segment** — in-memory matching produced a local ID, which was then thrown away to re-run a DB embedding search. The local ID now carries the DB speaker ID directly (`SpeechSegment::speaker_db_id → TranscriptionResult::speaker_id`), short-circuiting the vector search for known speakers.


  

Closes #3103


<img width="920" height="741" alt="image" src="https://github.com/user-attachments/assets/eeac71fe-c295-4316-9e8d-0d75cd132c0f" />

