### PR TITLE
docs(testing): add db connection starvation regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -291,7 +291,7 @@ commits: `eea0c865`, `cc09de61`, `e61501da`, `d25191d7`, `60096fb9`
 - [ ] **Snapshot compaction integrity** — Verify compaction doesn't result in NULL offset_index or pool exhaustion. (`09245af5f`)
 - [ ] **Audio chunk timestamps** — `start_time` and `end_time` are correctly set for reconciled and retranscribed audio chunks in the database.
 - [ ] **SCREENPIPE_DATA_DIR usage** — Set the `SCREENPIPE_DATA_DIR` environment variable. Verify the app uses this directory for all its data storage. (`d5f30db71`)
-- [ ] **DB pool starvation prevention** — Simulate high database load (e.g., rapid screen activity, many pipes running) and monitor logs. Verify no "database is locked" errors or signs of DB pool starvation.
+- [ ] **DB pool starvation prevention** — Simulate high database load (e.g., rapid screen activity, many pipes running) and monitor logs. Verify no "database is locked" errors or signs of DB pool starvation. (`cf32f7712`)
 - [ ] **DB write coalescing queue** — verify high-frequency captures (e.g. 10 FPS) don't lock the UI or cause write errors. (`c23768f41`)
 - [ ] **Multi-byte window titles in suggestions** — Interact with suggestions for windows that have multi-byte (e.g., Unicode, emoji) characters in their titles. Verify no char boundary panics.
 - [ ] **no concurrent reconciliation issues** — Verify that concurrent reconciliation processes do not cause issues during heavy load or sync operations. (`1d436bc3`)


### PR DESCRIPTION
## Problem
The regression testing checklist had a test for DB pool starvation prevention, but did not reference the commit that fixed this issue.

## Solution
Add commit reference `cf32f7712` to the DB pool starvation test. This ensures the fix is validated during regular testing cycles and creates a clear link between the test and the implementation.

## Verification
- [x] Commit `cf32f7712` exists and contains the DB connection starvation fix
- [x] TESTING.md format is correct and matches existing entries
- [x] Entry references the correct commit hash

## Sources
- **Fix commit**: `cf32f7712` — 'fix: db connection starvation via tokio::spawn and ImmediateTx::drop (#3007)'
- **Type**: regression test documentation update (F1 fallback)

---
auto-generated by issue-solver pipe