### PR TITLE
docs(testing): add tray health and audio device regression tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -78,6 +78,7 @@ commits that broke this area: `0752ea59`, `7562ec62`, `2a2bd9b5`, `f2f7f770`, `5
 - [ ] **dock right-click menu works** — right-click dock icon. "Show screenpipe", "Settings", "Check for updates" all work (`d794176a`).
 - [ ] **tray menu items don't fire twice** — click any tray menu item. action happens once, not twice (`9e151265`).
 - [ ] **tray health indicator** — tray icon shows green (healthy) or yellow/red (issues) based on recording status.
+- [ ] **transient health flaps don't show Error** — during high system load (e.g., heavy OCR or DB contention), the tray icon may briefly report degraded status, but should NOT show Error/red until 2+ minutes of sustained unhealthy status. Verify tray stays green/yellow during brief backend pressure spikes while recording continues. (`abc234aae`)
 - [ ] **tray on notched MacBook** — on 14"/16" MacBook Pro, tray icon is visible (not hidden behind notch). if hidden, user can Cmd+drag to reposition.
 - [ ] **activation policy never changes** — after ANY user interaction, dock icon should remain visible. no Accessory mode switches. verify with: `ps aux | grep screenpipe`.
 - [ ] **no autosave_name crash** — removed in `2a2bd9b5`. objc2→objc pointer cast was causing `panic_cannot_unwind`.
@@ -104,6 +105,7 @@ commits: `28e5c247`
 ### 4. audio device handling
 
 - [ ] **CoreAudio Process Tap** — On macOS 14.4+, verify that system audio defaults to CoreAudio Process Tap and rebuilds if silence is detected. (`75a52603b`, `5634664da`)
+- [ ] **transient SCK callback errors don't spam logs** — When system audio device changes while ScreenCaptureKit stream is active, the stream briefly reports "callback never fired" error, but recovery is automatic within 2 seconds without filling logs. Verify: no more than 1-2 "callback never fired" warn entries per device switch event in logs. (`4800c9246`)
 
 
 - [ ] **default audio device** — with "follow system default", recording uses whatever macOS says is default.


### PR DESCRIPTION
## Problem
Two recent regression-prone fixes have been merged but are not yet documented in TESTING.md:
1. Tray health indicator showing false Error states during transient backend load
2. Audio device callback timeout spam during system audio device switches

## Root cause
These regressions are new code paths that can be broken by future changes, so they need proactive testing coverage.

## Fix
Add two new regression test entries to TESTING.md:

1. **transient health flaps don't show Error** — During high system load (heavy OCR or DB contention), the tray icon may briefly report degraded status but should NOT show Error/red until 2+ minutes of sustained unhealthy status. Commit: `abc234aae fix(tray): stop showing Error for transient /health flaps` (2026-04-27 16:31:45 -0700)

2. **transient SCK callback errors don't spam logs** — When system audio device changes while ScreenCaptureKit stream is active, automatic recovery is expected within 2 seconds without excessive log spam. Commit: `4800c9246 fix(audio): downgrade transient SCK \"callback never fired\" to warn in device check loop (#3066)` (2026-04-26 17:00:28 -0700)

## Confidence: 9/10
Both are well-understood fixes with clear regression paths. TESTING.md update is low-risk documentation work.

## Verification (Tier T3)
Both referenced commits verified with `git cat-file -e`:
- abc234aae: tray health threshold fix (CONSECUTIVE_UNHEALTHY_THRESHOLD 10→120)
- 4800c9246: audio callback error downgrade (error→warn for transient SCK timeouts)

## Sources (multi-source)
- Commit: abc234aae (tray fix, 2026-04-27)
- Commit: 4800c9246 (audio fix, 2026-04-26)
- Git history: recent regression-prone area fixes

---
auto-generated by issue-solver pipe (fallback F1: TESTING.md update)