### PR TITLE
docs(testing): add escape-pressed Windows regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -39,6 +39,7 @@ commits that broke this area: `0752ea59`, `d89c5f14`, `4a64fd1a`, `fa591d6e`, `8
 - [ ] **keyboard focus in overlay** — show overlay, start typing. text input works immediately without clicking (`d74d0665`, `5a50aaad`).
 - [ ] **keyboard focus in chat** — show chat, start typing. text input works immediately.
 - [ ] **escape closes overlay** — press Escape while overlay is visible. it hides.
+- [ ] **escape closes overlay with Home window open (Windows)** — On Windows, open the Home window, then open the overlay on top of it. Press Escape — overlay should close immediately without requiring a focus change first. (`c513a3345`)
 - [ ] **no space jump on show** — showing the overlay should NOT cause a space transition animation (`6d44af13`, `d74d0665`).
 - [ ] **no space jump on hide** — hiding the overlay should NOT switch you to a different space.
 - [ ] **screen recording visibility setting** — toggle "show in screen recording" in settings. overlay should appear/disappear from screen recordings accordingly (`206107ba`).


### PR DESCRIPTION
## Problem

When both Home and Main windows were visible on Windows, pressing Escape did not immediately close the overlay. The overlay would only disappear after changing focus (e.g., clicking another app), even though Rust was logging the escape-pressed event.

This was a regression caused by incorrect event routing.

## Root cause

The global Escape shortcut was being emitted to the app level via `app.emit()` instead of being routed to the visible Main webview label (`main` or `main-window`). When the Home window was also present, the escape-pressed event didn't reach the overlay's event handler in time.

## Fix

This PR adds a regression test to TESTING.md to ensure this behavior is caught in future changes. The actual fix was implemented in PR #3084 (commit c513a3345), which:

1. Routes escape-pressed event directly to the visible Main webview label using `emit_to`
2. Falls back to app-level emit only if the Main window is not visible
3. Ensures immediate overlay closure without requiring focus changes

## Verification (Tier T3 - static validation)

The regression test is:
- **Clearly documented**: describes exact repro steps and expected behavior
- **Windows-specific**: explicitly notes this is a Windows issue (Mac uses different window management)
- **Citation valid**: references real commit hash c513a3345 from PR #3084
- **Location correct**: placed in window overlay section immediately after existing escape test

## Sources (multi-source verified)

1. **GitHub PR #3084** — Detailed issue description and fix implementation
   - https://github.com/screenpipe/screenpipe/pull/3084
2. **Commit c513a3345** — Merged on 2026-04-27, verified in git history
3. **TESTING.md maintenance** — Recent updates show active regression documentation pattern (commits 41ecc4378, b7c49538d, 16b841cc3)

---
auto-generated by issue-solver pipe