### PR TITLE
Fix YouTube link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <a href="https://twitter.com/screenpipe">
     <img src="https://img.shields.io/twitter/follow/screenpipe?style=for-the-badge&logo=x&logoColor=white&label=follow" alt="twitter">
   </a>
-  <a href="https://www.youtube.com/@screenpipe">
+  <a href="https://www.youtube.com/@screen_pipe">
     <img src="https://img.shields.io/youtube/channel/subscribers/UCwjkpAsb70_mENKvy7hT5bw?style=for-the-badge&logo=youtube&logoColor=white&label=subscribers" alt="youtube">
   </a>
 </p>
@@ -97,7 +97,7 @@ then ask claude `what did i see in the last 5 mins?` or `summarize today convers
     <a href="https://docs.screenpi.pe">docs</a> ·
     <a href="https://discord.gg/screenpipe">discord</a> ·
     <a href="https://twitter.com/screenpipe">x</a> ·
-    <a href="https://www.youtube.com/@screenpipe">youtube</a> ·
+    <a href="https://www.youtube.com/@screen_pipe">youtube</a> ·
     <a href="https://www.reddit.com/r/screen_pipe">reddit</a>
 </p>
 


### PR DESCRIPTION
This pr fixes the YouTube Channel link for screenpipe which was previously pointing to the random channel. 

Correct link - https://www.youtube.com/@screen_pipe