### PR TITLE
fix: add relative date parsing to list-meetings MCP tool

### DIFF
--- a/crates/screenpipe-engine/src/routes/data.rs
+++ b/crates/screenpipe-engine/src/routes/data.rs
@@ -259,9 +259,7 @@ pub(crate) async fn storage_preview_handler(
             _ => {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    JsonResponse(
-                        json!({"error": "provide older_than_days or both start and end"}),
-                    ),
+                    JsonResponse(json!({"error": "provide older_than_days or both start and end"})),
                 ))
             }
         }
@@ -274,17 +272,16 @@ pub(crate) async fn storage_preview_handler(
         ));
     }
 
-    let (file_count, bytes) =
-        state
-            .db
-            .estimate_evictable_bytes(start, end)
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    JsonResponse(json!({"error": format!("failed to estimate: {}", e)})),
-                )
-            })?;
+    let (file_count, bytes) = state
+        .db
+        .estimate_evictable_bytes(start, end)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                JsonResponse(json!({"error": format!("failed to estimate: {}", e)})),
+            )
+        })?;
 
     Ok(JsonResponse(StoragePreviewResponse { file_count, bytes }))
 }

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -13,7 +13,7 @@ use screenpipe_db::DatabaseManager;
 use screenpipe_db::MeetingRecord;
 
 use crate::server::AppState;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::Arc;
@@ -53,8 +53,16 @@ pub struct StopMeetingRequest {
 
 #[derive(OaSchema, Deserialize, Debug)]
 pub struct ListMeetingsRequest {
-    pub start_time: Option<String>,
-    pub end_time: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "super::time::deserialize_flexible_datetime_option"
+    )]
+    pub start_time: Option<DateTime<Utc>>,
+    #[serde(
+        default,
+        deserialize_with = "super::time::deserialize_flexible_datetime_option"
+    )]
+    pub end_time: Option<DateTime<Utc>>,
     #[serde(default = "default_limit")]
     pub limit: u32,
     #[serde(default)]
@@ -170,11 +178,14 @@ pub(crate) async fn list_meetings_handler(
     State(state): State<Arc<AppState>>,
     Query(request): Query<ListMeetingsRequest>,
 ) -> Result<JsonResponse<Vec<MeetingRecord>>, (StatusCode, JsonResponse<Value>)> {
+    let start_time_str = request.start_time.map(|dt| dt.to_rfc3339());
+    let end_time_str = request.end_time.map(|dt| dt.to_rfc3339());
+
     let meetings = state
         .db
         .list_meetings(
-            request.start_time.as_deref(),
-            request.end_time.as_deref(),
+            start_time_str.as_deref(),
+            end_time_str.as_deref(),
             request.limit,
             request.offset,
         )
@@ -439,4 +450,81 @@ pub(crate) async fn stop_meeting_handler(
     }
 
     Ok(JsonResponse(meeting))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_list_meetings_request_relative_dates() {
+        // Test that the ListMeetingsRequest can parse relative date formats
+        // like "7 days ago" via the deserialize_flexible_datetime_option deserializer
+
+        // Test "7 days ago" format
+        let json_input = json!({
+            "start_time": "7 days ago",
+            "end_time": "now",
+            "limit": 10,
+            "offset": 0
+        });
+
+        let request: Result<ListMeetingsRequest, _> = serde_json::from_value(json_input.clone());
+        assert!(
+            request.is_ok(),
+            "Failed to parse relative dates: {}",
+            request.err().unwrap()
+        );
+
+        let req = request.unwrap();
+        assert!(req.start_time.is_some(), "start_time should be parsed");
+        assert!(req.end_time.is_some(), "end_time should be parsed");
+        assert_eq!(req.limit, 10);
+        assert_eq!(req.offset, 0);
+    }
+
+    #[test]
+    fn test_list_meetings_request_iso_dates() {
+        // Test that ISO 8601 format dates still work (backward compatibility)
+        let json_input = json!({
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-31T23:59:59Z",
+            "limit": 20,
+            "offset": 0
+        });
+
+        let request: Result<ListMeetingsRequest, _> = serde_json::from_value(json_input);
+        assert!(
+            request.is_ok(),
+            "Failed to parse ISO 8601 dates: {}",
+            request.err().unwrap()
+        );
+
+        let req = request.unwrap();
+        assert!(req.start_time.is_some(), "start_time should be parsed");
+        assert!(req.end_time.is_some(), "end_time should be parsed");
+    }
+
+    #[test]
+    fn test_list_meetings_request_optional_dates() {
+        // Test that dates can be omitted
+        let json_input = json!({
+            "limit": 15,
+            "offset": 5
+        });
+
+        let request: Result<ListMeetingsRequest, _> = serde_json::from_value(json_input);
+        assert!(
+            request.is_ok(),
+            "Failed to parse request without dates: {}",
+            request.err().unwrap()
+        );
+
+        let req = request.unwrap();
+        assert!(req.start_time.is_none(), "start_time should be None");
+        assert!(req.end_time.is_none(), "end_time should be None");
+        assert_eq!(req.limit, 15);
+        assert_eq!(req.offset, 5);
+    }
 }


### PR DESCRIPTION
## Problem
The list-meetings MCP tool doesn't support relative date formats like "7 days ago" or "now". Users must provide explicit ISO 8601 timestamps, which is cumbersome in interactive MCP scenarios.

This was reported in #3124 where the user expected queries like:
```
{"start_time": "7 days ago", "end_time": "now"}
```
to work just like they do in other API endpoints.

## Root cause
The `ListMeetingsRequest` struct in `crates/screenpipe-engine/src/routes/meetings.rs` accepts `Option<String>` for date fields and passes them directly to the database without parsing flexible datetime formats.

Other endpoints like `activity-summary` and `streaming` already use the `deserialize_flexible_datetime_option` deserializer to support relative dates.

## Fix
1. Changed `ListMeetingsRequest` fields to use `Option<DateTime<Utc>>` with the `#[serde(deserialize_with = "super::time::deserialize_flexible_datetime_option")]` attribute
2. Updated the handler to convert `DateTime<Utc>` to RFC3339 strings for the database layer
3. Added comprehensive tests for relative dates, ISO 8601 dates, and optional dates

## Confidence: 9/10
This is a mechanical fix following the exact pattern already established in other endpoints. The code is trivial and thoroughly tested. The same deserializer and conversion pattern is proven in multiple places.

## Verification (Tier T1)
```
running 3 tests
test routes::meetings::tests::test_list_meetings_request_optional_dates ... ok
test routes::meetings::tests::test_list_meetings_request_iso_dates ... ok
test routes::meetings::tests::test_list_meetings_request_relative_dates ... ok

test result: ok. 3 passed; 0 failed
```

## Sources (multi-source required)
- GitHub issue #3124 (user-reported bug with clear example)
- Code inspection: Found pattern in activity_summary.rs and streaming.rs proving the approach
- Test output: All 3 new unit tests pass

---
auto-generated by issue-solver pipe