### PR TITLE
docs(testing): add Zoom idle menu item false detection regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -177,6 +177,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **Meeting detection support for Signal, WhatsApp, Telegram, and Teams 2** — Verify that meetings from these apps are correctly detected and recorded. (`8d2f1a542`, `a74e393e1`)
 - [ ] **Browser meetings splitting fix** — Verify that meetings in the browser are correctly split into separate events. (`d8ba1dad3`)
 - [ ] **Meeting with hidden UI controls** — Start a Zoom/Teams meeting. Minimize the meeting window or switch apps (Zoom controls move out of accessibility tree). Verify meeting stays active and does NOT auto-terminate after 30 seconds. Audio output detection prevents false "meeting ended" events. (`4e784f620`)
+- [ ] **Zoom idle app menu item** — On macOS, have Zoom installed but NOT in an active call. Verify that the "Meeting" menu bar item does NOT trigger false meeting detection. The Zoom menu bar item persists even when idle; screenpipe must distinguish "menu item exists" from "call is active". (`a500ec11b`)
 - [ ] **OpenAI-compatible transcription endpoint** — Verify that the `/v1/audio/transcriptions` endpoint works as expected, following the OpenAI specification. (`5a14e9a92`)
 
 ### 5. frame comparison & OCR pipeline


### PR DESCRIPTION
## Problem
Zoom's menu bar item persists even when the app is idle with no active call. This caused screenpipe to incorrectly detect meetings when Zoom was installed but not in use, leading to false positive meeting events.

## Root cause
The menu bar scanner in screenpipe was treating the Zoom 'Meeting' menu bar item as confirmation of an active call, without verifying that Zoom actually has an active meeting happening.

## Fix
Commit a500ec11b prevents false Zoom meeting detection by checking for actual meeting controls in the Zoom window before treating the menu bar item as evidence of an active call.

## Verification (Tier T3)
This is a documentation-only change that documents an existing regression test requirement for this fix. Citation validated: `git cat-file -e a500ec11b` ✓

## Confidence: 9/10
- Root cause clear from PR #3074 (commit a500ec11b)
- Fix is mechanical and well-documented in source code
- Test case directly prevents regression

## Sources
- GitHub issue: #2561 (Zoom false meeting detection)
- Commit fix: a500ec11b (prevent false Zoom meeting detection when app is idle)

---
auto-generated by fallback F1 (testing regression entry)