### PR TITLE
fix: correct merge-speakers JSON field names in MCP

### DIFF
--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -389,10 +389,10 @@ const TOOLS: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
-        speaker_to_keep: { type: "integer", description: "Speaker ID to keep" },
-        speaker_to_merge: { type: "integer", description: "Speaker ID to merge into the kept one" },
+        speaker_to_keep_id: { type: "integer", description: "Speaker ID to keep" },
+        speaker_to_merge_id: { type: "integer", description: "Speaker ID to merge into the kept one" },
       },
-      required: ["speaker_to_keep", "speaker_to_merge"],
+      required: ["speaker_to_keep_id", "speaker_to_merge_id"],
     },
   },
   {
@@ -1244,14 +1244,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case "merge-speakers": {
-        const keepId = args.speaker_to_keep as number;
-        const mergeId = args.speaker_to_merge as number;
+        const keepId = args.speaker_to_keep_id as number;
+        const mergeId = args.speaker_to_merge_id as number;
         if (!keepId || !mergeId) {
-          return { content: [{ type: "text", text: "Error: speaker_to_keep and speaker_to_merge are required" }] };
+          return { content: [{ type: "text", text: "Error: speaker_to_keep_id and speaker_to_merge_id are required" }] };
         }
         const response = await fetchAPI("/speakers/merge", {
           method: "POST",
-          body: JSON.stringify({ speaker_to_keep: keepId, speaker_to_merge: mergeId }),
+          body: JSON.stringify({ speaker_to_keep_id: keepId, speaker_to_merge_id: mergeId }),
         });
         if (!response.ok) throw new Error(`HTTP error: ${response.status}`);
         return {


### PR DESCRIPTION
## Problem
The merge-speakers MCP tool was sending incorrect JSON field names to the backend API. The schema and implementation were using `speaker_to_keep` and `speaker_to_merge`, but the backend REST API endpoint expects `speaker_to_keep_id` and `speaker_to_merge_id`.

This caused the tool to fail when invoked because the deserialization of `MergeSpeakersRequest` in the backend would fail due to missing fields.

## Root cause
Schema definition mismatch between MCP client and backend REST API. The backend's `MergeSpeakersRequest` struct (in crates/screenpipe-engine/src/routes/speakers.rs) clearly defines:
```rust
pub(crate) struct MergeSpeakersRequest {
    speaker_to_keep_id: i64,
    speaker_to_merge_id: i64,
}
```

But the MCP was sending differently-named fields, causing a deserialization error.

## Fix
Updated both the schema definition and the API call in packages/screenpipe-mcp/src/index.ts:
- Schema now declares: `speaker_to_keep_id` and `speaker_to_merge_id`
- JSON payload now sends: `{ speaker_to_keep_id, speaker_to_merge_id }`

## Confidence: 9/10
- Schema mismatch is obvious from the code (schema vs. backend struct definition)
- Fix is mechanical (rename 4 occurrences to match backend)
- Backend implementation verified in speakers.rs
- TypeScript compilation passes

## Verification (Tier T2)
```
> screenpipe-mcp@0.16.3 build
> tsc

```
(empty output = successful TypeScript compilation)

## Sources
- GitHub Issue: #3123
- Backend API: crates/screenpipe-engine/src/routes/speakers.rs (MergeSpeakersRequest)
- Fix commit: 9a2de1202

---
auto-generated by issue-solver pipe