### PR TITLE
meeting: fix recording stop button and add push-driven status stream

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -49,7 +49,7 @@ import { EnterpriseLicensePrompt } from "@/components/enterprise-license-prompt"
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { computeMeetingActive, type MeetingStatusResponse } from "@/lib/utils/meeting-state";
 import { useRouter } from "next/navigation";
-import { localFetch } from "@/lib/api";
+import { appendAuthToken, ensureApiReady, getApiBaseUrl, localFetch } from "@/lib/api";
 import {
   Tooltip,
   TooltipContent,
@@ -259,9 +259,16 @@ function HomeContent() {
 
   // Active meeting state — lights up the phone icon for ANY active meeting
   // (manual OR auto-detected: Teams, Zoom, etc.).
-  const [meetingState, setMeetingState] = useState<{ active: boolean; manualActive: boolean }>(
-    { active: false, manualActive: false },
-  );
+  const [meetingState, setMeetingState] = useState<MeetingStatusResponse & {
+    manualActive: boolean;
+  }>({
+    active: false,
+    manualActive: false,
+    activeMeetingId: null,
+    stoppableMeetingId: null,
+    meetingApp: null,
+    detectionSource: null,
+  });
   const [meetingLoading, setMeetingLoading] = useState(false);
 
   // Timestamp when user clicked start, used for a 10s grace period so a
@@ -280,20 +287,61 @@ function HomeContent() {
 
   useEffect(() => {
     let cancelled = false;
-    const check = () => {
-      localFetch("/meetings/status")
-        .then((r) => r.ok ? r.json() : null)
-        .then((status: MeetingStatusResponse | null) => {
+    let ws: WebSocket | null = null;
+    let retry: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = 1000;
+
+    const connect = () => {
+      void (async () => {
+        try {
+          await ensureApiReady();
           if (cancelled) return;
-          setMeetingState(
-            computeMeetingActive(status, manualMeetingStartedAt.current),
-          );
-        })
-        .catch(() => {});
+          const wsBase = getApiBaseUrl().replace("http://", "ws://");
+          ws = new WebSocket(appendAuthToken(`${wsBase}/ws/events`));
+          ws.onopen = () => {
+            backoffMs = 1000;
+            refreshMeetingState();
+          };
+          ws.onmessage = (event) => {
+            try {
+              const parsed = JSON.parse(event.data) as {
+                name?: string;
+                data?: MeetingStatusResponse;
+              };
+              if (parsed.name !== "meeting_status_changed") return;
+              if (cancelled) return;
+              setMeetingState(
+                computeMeetingActive(parsed.data, manualMeetingStartedAt.current),
+              );
+            } catch {
+              // ignore malformed event payloads
+            }
+          };
+          ws.onclose = (event) => {
+            if (cancelled || event.code === 1000) return;
+            retry = setTimeout(connect, backoffMs);
+            backoffMs = Math.min(backoffMs * 2, 10000);
+          };
+          ws.onerror = () => {
+            ws?.close();
+          };
+        } catch {
+          if (cancelled) return;
+          retry = setTimeout(connect, backoffMs);
+          backoffMs = Math.min(backoffMs * 2, 10000);
+        }
+      })();
     };
-    check();
-    const interval = setInterval(check, 5000);
-    return () => { cancelled = true; clearInterval(interval); };
+
+    refreshMeetingState();
+    connect();
+    return () => {
+      cancelled = true;
+      if (retry) clearTimeout(retry);
+      if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+        ws.close(1000, "unmount");
+      }
+    };
   }, [refreshMeetingState]);
 
   const toggleMeeting = useCallback(async () => {
@@ -301,10 +349,22 @@ function HomeContent() {
     try {
       if (meetingState.active) {
         // Stop the currently active meeting, whether manual or auto-detected.
-        const res = await localFetch("/meetings/stop", { method: "POST" });
+        const targetId = meetingState.stoppableMeetingId;
+        const res = await localFetch("/meetings/stop", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: targetId }),
+        });
         if (res.ok) {
           manualMeetingStartedAt.current = 0;
-          setMeetingState({ active: false, manualActive: false });
+          setMeetingState({
+            active: false,
+            manualActive: false,
+            activeMeetingId: null,
+            stoppableMeetingId: null,
+            meetingApp: null,
+            detectionSource: null,
+          });
         }
       } else {
         // No meeting active — start a manual one
@@ -315,7 +375,14 @@ function HomeContent() {
         });
         if (res.ok) {
           manualMeetingStartedAt.current = Date.now();
-          setMeetingState({ active: true, manualActive: true });
+          setMeetingState({
+            active: true,
+            manualActive: true,
+            activeMeetingId: null,
+            stoppableMeetingId: null,
+            meetingApp: "manual",
+            detectionSource: "manual",
+          });
         }
       }
     } catch (e) {
@@ -330,7 +397,7 @@ function HomeContent() {
   // two meetings depending on which UI surfaces are mounted.
   useEffect(() => {
     let unlisten: (() => void) | null = null;
-    listen<{ active?: boolean; manualActive?: boolean }>("native-shortcut-toggle-meeting", (event) => {
+    listen<MeetingStatusResponse>("native-shortcut-toggle-meeting", (event) => {
       const payload = event.payload;
       if (typeof payload?.active === "boolean") {
         if (payload.active) {
@@ -341,6 +408,10 @@ function HomeContent() {
         setMeetingState({
           active: payload.active,
           manualActive: payload.manualActive ?? false,
+          activeMeetingId: payload.activeMeetingId ?? null,
+          stoppableMeetingId: payload.stoppableMeetingId ?? payload.activeMeetingId ?? null,
+          meetingApp: payload.meetingApp ?? null,
+          detectionSource: payload.detectionSource ?? null,
         });
         return;
       }

--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -274,17 +274,6 @@ function HomeContent() {
   // Timestamp when user clicked start, used for a 10s grace period so a
   // stale poll can't clear local state before the server persists the row.
   const manualMeetingStartedAt = useRef<number>(0);
-  const refreshMeetingState = useCallback(() => {
-    localFetch("/meetings/status")
-      .then((r) => r.ok ? r.json() : null)
-      .then((status: MeetingStatusResponse | null) => {
-        setMeetingState(
-          computeMeetingActive(status, manualMeetingStartedAt.current),
-        );
-      })
-      .catch(() => {});
-  }, []);
-
   useEffect(() => {
     let cancelled = false;
     let ws: WebSocket | null = null;
@@ -297,21 +286,16 @@ function HomeContent() {
           await ensureApiReady();
           if (cancelled) return;
           const wsBase = getApiBaseUrl().replace("http://", "ws://");
-          ws = new WebSocket(appendAuthToken(`${wsBase}/ws/events`));
+          ws = new WebSocket(appendAuthToken(`${wsBase}/ws/meeting-status`));
           ws.onopen = () => {
             backoffMs = 1000;
-            refreshMeetingState();
           };
           ws.onmessage = (event) => {
             try {
-              const parsed = JSON.parse(event.data) as {
-                name?: string;
-                data?: MeetingStatusResponse;
-              };
-              if (parsed.name !== "meeting_status_changed") return;
+              const parsed = JSON.parse(event.data) as MeetingStatusResponse;
               if (cancelled) return;
               setMeetingState(
-                computeMeetingActive(parsed.data, manualMeetingStartedAt.current),
+                computeMeetingActive(parsed, manualMeetingStartedAt.current),
               );
             } catch {
               // ignore malformed event payloads
@@ -333,7 +317,6 @@ function HomeContent() {
       })();
     };
 
-    refreshMeetingState();
     connect();
     return () => {
       cancelled = true;
@@ -342,7 +325,7 @@ function HomeContent() {
         ws.close(1000, "unmount");
       }
     };
-  }, [refreshMeetingState]);
+  }, []);
 
   const toggleMeeting = useCallback(async () => {
     setMeetingLoading(true);
@@ -415,10 +398,18 @@ function HomeContent() {
         });
         return;
       }
-      refreshMeetingState();
+      void (async () => {
+        try {
+          const res = await localFetch("/meetings/status");
+          const status = res.ok ? await res.json() as MeetingStatusResponse : null;
+          setMeetingState(computeMeetingActive(status, manualMeetingStartedAt.current));
+        } catch {
+          // ignore sync failures; websocket remains source of truth
+        }
+      })();
     }).then((fn) => { unlisten = fn; });
     return () => { unlisten?.(); };
-  }, [refreshMeetingState]);
+  }, []);
 
   // Watch pipe: navigate to chat when user clicks "watch" on a running pipe
   useEffect(() => {

--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -47,7 +47,7 @@ import { useTeam } from "@/lib/hooks/use-team";
 import { useEnterprisePolicy } from "@/lib/hooks/use-enterprise-policy";
 import { EnterpriseLicensePrompt } from "@/components/enterprise-license-prompt";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
-import { computeMeetingActive, type MeetingRow } from "@/lib/utils/meeting-state";
+import { computeMeetingActive, type MeetingStatusResponse } from "@/lib/utils/meeting-state";
 import { useRouter } from "next/navigation";
 import { localFetch } from "@/lib/api";
 import {
@@ -258,8 +258,7 @@ function HomeContent() {
   }, [settings.monitorIds, settings.useAllMonitors]);
 
   // Active meeting state — lights up the phone icon for ANY active meeting
-  // (manual OR auto-detected: Teams, Zoom, etc.). manualActive is true only
-  // when the user can stop it via the icon click.
+  // (manual OR auto-detected: Teams, Zoom, etc.).
   const [meetingState, setMeetingState] = useState<{ active: boolean; manualActive: boolean }>(
     { active: false, manualActive: false },
   );
@@ -268,15 +267,26 @@ function HomeContent() {
   // Timestamp when user clicked start, used for a 10s grace period so a
   // stale poll can't clear local state before the server persists the row.
   const manualMeetingStartedAt = useRef<number>(0);
+  const refreshMeetingState = useCallback(() => {
+    localFetch("/meetings/status")
+      .then((r) => r.ok ? r.json() : null)
+      .then((status: MeetingStatusResponse | null) => {
+        setMeetingState(
+          computeMeetingActive(status, manualMeetingStartedAt.current),
+        );
+      })
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     const check = () => {
-      localFetch("/meetings?limit=5")
-        .then((r) => r.ok ? r.json() : [])
-        .then((meetings: MeetingRow[]) => {
+      localFetch("/meetings/status")
+        .then((r) => r.ok ? r.json() : null)
+        .then((status: MeetingStatusResponse | null) => {
           if (cancelled) return;
           setMeetingState(
-            computeMeetingActive(meetings, manualMeetingStartedAt.current),
+            computeMeetingActive(status, manualMeetingStartedAt.current),
           );
         })
         .catch(() => {});
@@ -284,20 +294,18 @@ function HomeContent() {
     check();
     const interval = setInterval(check, 5000);
     return () => { cancelled = true; clearInterval(interval); };
-  }, []);
+  }, [refreshMeetingState]);
 
   const toggleMeeting = useCallback(async () => {
     setMeetingLoading(true);
     try {
-      if (meetingState.manualActive) {
-        // Stop the manual meeting we previously started
-        await localFetch("/meetings/stop", { method: "POST" });
-        manualMeetingStartedAt.current = 0;
-        setMeetingState({ active: false, manualActive: false });
-      } else if (meetingState.active) {
-        // Auto-detected meeting in progress — icon is a passive indicator,
-        // user can't stop someone else's Teams/Zoom call from here
-        return;
+      if (meetingState.active) {
+        // Stop the currently active meeting, whether manual or auto-detected.
+        const res = await localFetch("/meetings/stop", { method: "POST" });
+        if (res.ok) {
+          manualMeetingStartedAt.current = 0;
+          setMeetingState({ active: false, manualActive: false });
+        }
       } else {
         // No meeting active — start a manual one
         const res = await localFetch("/meetings/start", {
@@ -317,14 +325,29 @@ function HomeContent() {
     }
   }, [meetingState]);
 
-  // Native overlay: toggle meeting when user clicks phone icon in Swift overlay
+  // Native overlay already toggles the meeting in Rust. Refresh local state
+  // here instead of toggling again, otherwise one click can create or stop
+  // two meetings depending on which UI surfaces are mounted.
   useEffect(() => {
     let unlisten: (() => void) | null = null;
-    listen("native-shortcut-toggle-meeting", () => {
-      toggleMeeting();
+    listen<{ active?: boolean; manualActive?: boolean }>("native-shortcut-toggle-meeting", (event) => {
+      const payload = event.payload;
+      if (typeof payload?.active === "boolean") {
+        if (payload.active) {
+          manualMeetingStartedAt.current = Date.now();
+        } else {
+          manualMeetingStartedAt.current = 0;
+        }
+        setMeetingState({
+          active: payload.active,
+          manualActive: payload.manualActive ?? false,
+        });
+        return;
+      }
+      refreshMeetingState();
     }).then((fn) => { unlisten = fn; });
     return () => { unlisten?.(); };
-  }, [toggleMeeting]);
+  }, [refreshMeetingState]);
 
   // Watch pipe: navigate to chat when user clicks "watch" on a running pipe
   useEffect(() => {
@@ -555,7 +578,7 @@ function HomeContent() {
                       <TooltipTrigger asChild>
                         <button
                           onClick={toggleMeeting}
-                          disabled={meetingLoading || (meetingState.active && !meetingState.manualActive)}
+                          disabled={meetingLoading}
                           className={cn(
                             "relative flex items-center justify-center h-5 w-5 rounded transition-colors",
                             isTranslucent ? "vibrant-nav-item hover:bg-white/10" : "text-muted-foreground hover:text-foreground hover:bg-muted"
@@ -568,7 +591,7 @@ function HomeContent() {
                         </button>
                       </TooltipTrigger>
                       <TooltipContent side="top" className="text-xs">
-                        {meetingState.manualActive ? "stop meeting" : meetingState.active ? "meeting detected" : "start meeting"}
+                        {meetingState.active ? "stop meeting" : "start meeting"}
                       </TooltipContent>
                     </Tooltip>
                   </div>

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -27,38 +27,23 @@ function useMeetingState() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    let abortCtrl: AbortController | null = null;
     let ws: WebSocket | null = null;
     let retry: ReturnType<typeof setTimeout> | null = null;
     let backoffMs = 1000;
-
-    const check = () => {
-      abortCtrl?.abort();
-      abortCtrl = new AbortController();
-      localFetch("/meetings/status", { signal: abortCtrl.signal })
-        .then((r) => r.json())
-        .then((d: MeetingStatusResponse) => setMeetingState(computeMeetingActive(d, 0)))
-        .catch(() => {});
-    };
 
     const connect = () => {
       void (async () => {
         try {
           await ensureApiReady();
           const wsBase = getApiBaseUrl().replace("http://", "ws://");
-          ws = new WebSocket(appendAuthToken(`${wsBase}/ws/events`));
+          ws = new WebSocket(appendAuthToken(`${wsBase}/ws/meeting-status`));
           ws.onopen = () => {
             backoffMs = 1000;
-            check();
           };
           ws.onmessage = (event) => {
             try {
-              const parsed = JSON.parse(event.data) as {
-                name?: string;
-                data?: MeetingStatusResponse;
-              };
-              if (parsed.name !== "meeting_status_changed") return;
-              setMeetingState(computeMeetingActive(parsed.data, 0));
+              const parsed = JSON.parse(event.data) as MeetingStatusResponse;
+              setMeetingState(computeMeetingActive(parsed, 0));
             } catch {
               // ignore malformed payloads
             }
@@ -78,11 +63,9 @@ function useMeetingState() {
       })();
     };
 
-    check();
     connect();
 
     return () => {
-      abortCtrl?.abort();
       if (retry) clearTimeout(retry);
       if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
         ws.close(1000, "unmount");

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -19,35 +19,87 @@ import { X, Phone } from "lucide-react";
 import { useOverlayData } from "./use-overlay-data";
 import { AudioEqualizer } from "./audio-equalizer";
 import { ScreenMatrix } from "./screen-matrix";
+import { computeMeetingActive, type MeetingStatusResponse } from "@/lib/utils/meeting-state";
+import { appendAuthToken, ensureApiReady, getApiBaseUrl } from "@/lib/api";
 
 function useMeetingState() {
-  const [active, setActive] = useState(false);
+  const [meetingState, setMeetingState] = useState(() => computeMeetingActive(null, 0));
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let abortCtrl: AbortController | null = null;
+    let ws: WebSocket | null = null;
+    let retry: ReturnType<typeof setTimeout> | null = null;
+    let backoffMs = 1000;
+
     const check = () => {
       abortCtrl?.abort();
       abortCtrl = new AbortController();
       localFetch("/meetings/status", { signal: abortCtrl.signal })
         .then((r) => r.json())
-        .then((d) => setActive(!!d.active))
+        .then((d: MeetingStatusResponse) => setMeetingState(computeMeetingActive(d, 0)))
         .catch(() => {});
     };
+
+    const connect = () => {
+      void (async () => {
+        try {
+          await ensureApiReady();
+          const wsBase = getApiBaseUrl().replace("http://", "ws://");
+          ws = new WebSocket(appendAuthToken(`${wsBase}/ws/events`));
+          ws.onopen = () => {
+            backoffMs = 1000;
+            check();
+          };
+          ws.onmessage = (event) => {
+            try {
+              const parsed = JSON.parse(event.data) as {
+                name?: string;
+                data?: MeetingStatusResponse;
+              };
+              if (parsed.name !== "meeting_status_changed") return;
+              setMeetingState(computeMeetingActive(parsed.data, 0));
+            } catch {
+              // ignore malformed payloads
+            }
+          };
+          ws.onclose = (event) => {
+            if (event.code === 1000) return;
+            retry = setTimeout(connect, backoffMs);
+            backoffMs = Math.min(backoffMs * 2, 10000);
+          };
+          ws.onerror = () => {
+            ws?.close();
+          };
+        } catch {
+          retry = setTimeout(connect, backoffMs);
+          backoffMs = Math.min(backoffMs * 2, 10000);
+        }
+      })();
+    };
+
     check();
-    const id = setInterval(check, 5000);
+    connect();
+
     return () => {
-      clearInterval(id);
       abortCtrl?.abort();
+      if (retry) clearTimeout(retry);
+      if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+        ws.close(1000, "unmount");
+      }
     };
   }, []);
 
   const toggle = useCallback(async () => {
     setLoading(true);
     try {
-      if (active) {
-        await localFetch("/meetings/stop", { method: "POST" });
-        setActive(false);
+      if (meetingState.active) {
+        await localFetch("/meetings/stop", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: meetingState.stoppableMeetingId }),
+        });
+        setMeetingState(computeMeetingActive(null, 0));
       } else {
         const res = await localFetch("/meetings/start", {
           method: "POST",
@@ -55,16 +107,21 @@ function useMeetingState() {
           body: JSON.stringify({ app: "manual" }),
         });
         if (res.ok) {
-          setActive(true);
+          setMeetingState(computeMeetingActive({
+            active: true,
+            manualActive: true,
+            meetingApp: "manual",
+            detectionSource: "manual",
+          }, Date.now()));
         }
       }
     } catch (e) {
       console.error("meeting toggle failed:", e);
     }
     setLoading(false);
-  }, [active]);
+  }, [meetingState]);
 
-  return { active, loading, toggle };
+  return { active: meetingState.active, loading, toggle };
 }
 
 export default function ShortcutReminderPage() {

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-state.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-state.test.ts
@@ -12,10 +12,18 @@ import {
 const NEVER_CLICKED = 0;
 const NOW = 1_000_000;
 
-const manualActive: MeetingStatusResponse = { active: true, manualActive: true };
-const manualLegacy: MeetingStatusResponse = { active: true, manual: true };
-const teamsActive: MeetingStatusResponse = { active: true, manualActive: false };
-const zoomActive: MeetingStatusResponse = { active: true, manualActive: false };
+const manualActive: MeetingStatusResponse = {
+  active: true, manualActive: true, activeMeetingId: 41, stoppableMeetingId: 41, meetingApp: "manual", detectionSource: "manual",
+};
+const manualLegacy: MeetingStatusResponse = {
+  active: true, manual: true, activeMeetingId: 42, stoppableMeetingId: 42, meetingApp: "manual", detectionSource: "manual",
+};
+const teamsActive: MeetingStatusResponse = {
+  active: true, manualActive: false, activeMeetingId: 51, stoppableMeetingId: 51, meetingApp: "teams", detectionSource: "ui_scan",
+};
+const zoomActive: MeetingStatusResponse = {
+  active: true, manualActive: false, activeMeetingId: 52, stoppableMeetingId: 52, meetingApp: "zoom", detectionSource: "ui_scan",
+};
 const inactive: MeetingStatusResponse = { active: false, manualActive: false };
 
 describe("computeMeetingActive", () => {
@@ -24,6 +32,7 @@ describe("computeMeetingActive", () => {
       const r = computeMeetingActive(teamsActive, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(false);
+      expect(r.stoppableMeetingId).toBe(51);
     });
 
     it("lights up for an active Zoom meeting", () => {
@@ -43,6 +52,7 @@ describe("computeMeetingActive", () => {
       const r = computeMeetingActive(manualActive, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(true);
+      expect(r.activeMeetingId).toBe(41);
     });
 
     it("supports the legacy 'manual' key for compatibility", () => {
@@ -57,6 +67,7 @@ describe("computeMeetingActive", () => {
       const r = computeMeetingActive(null, NEVER_CLICKED, NOW);
       expect(r.active).toBe(false);
       expect(r.manualActive).toBe(false);
+      expect(r.stoppableMeetingId).toBeNull();
     });
 
     it("is off when status explicitly says inactive", () => {
@@ -72,6 +83,7 @@ describe("computeMeetingActive", () => {
       const r = computeMeetingActive(null, startedAt, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(true); // grace period implies manual click
+      expect(r.detectionSource).toBe("manual");
     });
 
     it("trusts local click at exactly the start of the grace period", () => {
@@ -119,6 +131,7 @@ describe("computeMeetingActive", () => {
       const r = computeMeetingActive({ active: true }, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(false);
+      expect(r.stoppableMeetingId).toBeNull();
     });
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-state.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-state.test.ts
@@ -6,40 +6,47 @@ import { describe, it, expect } from "bun:test";
 import {
   computeMeetingActive,
   MEETING_GRACE_PERIOD_MS,
-  type MeetingRow,
+  type MeetingStatusResponse,
 } from "./meeting-state";
 
 const NEVER_CLICKED = 0;
 const NOW = 1_000_000;
 
-const manualActive: MeetingRow = { meeting_end: null, detection_source: "manual" };
-const teamsActive: MeetingRow = { meeting_end: null, detection_source: "ui_scan" };
-const zoomActive: MeetingRow = { meeting_end: null, detection_source: "ui_scan" };
-const ended: MeetingRow = { meeting_end: "2026-04-07T19:00:00Z", detection_source: "ui_scan" };
+const manualActive: MeetingStatusResponse = { active: true, manualActive: true };
+const manualLegacy: MeetingStatusResponse = { active: true, manual: true };
+const teamsActive: MeetingStatusResponse = { active: true, manualActive: false };
+const zoomActive: MeetingStatusResponse = { active: true, manualActive: false };
+const inactive: MeetingStatusResponse = { active: false, manualActive: false };
 
 describe("computeMeetingActive", () => {
   describe("auto-detected meetings (the bug we're fixing)", () => {
     it("lights up for an active Teams meeting", () => {
-      const r = computeMeetingActive([teamsActive], NEVER_CLICKED, NOW);
+      const r = computeMeetingActive(teamsActive, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(false);
     });
 
     it("lights up for an active Zoom meeting", () => {
-      const r = computeMeetingActive([zoomActive], NEVER_CLICKED, NOW);
+      const r = computeMeetingActive(zoomActive, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(false);
     });
 
     it("manualActive=false for ui_scan meetings (so user can't stop them via icon)", () => {
-      const r = computeMeetingActive([teamsActive], NEVER_CLICKED, NOW);
+      const r = computeMeetingActive(teamsActive, NEVER_CLICKED, NOW);
       expect(r.manualActive).toBe(false);
     });
   });
 
   describe("manual meetings", () => {
     it("lights up and is stoppable for an active manual meeting", () => {
-      const r = computeMeetingActive([manualActive], NEVER_CLICKED, NOW);
+      const r = computeMeetingActive(manualActive, NEVER_CLICKED, NOW);
+      expect(r.active).toBe(true);
+      expect(r.manualActive).toBe(true);
+    });
+
+    it("supports the legacy 'manual' key for compatibility", () => {
+      const r = computeMeetingActive(manualLegacy, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(true);
     });
@@ -47,61 +54,47 @@ describe("computeMeetingActive", () => {
 
   describe("no active meeting", () => {
     it("is off when there are no meetings at all", () => {
-      const r = computeMeetingActive([], NEVER_CLICKED, NOW);
+      const r = computeMeetingActive(null, NEVER_CLICKED, NOW);
       expect(r.active).toBe(false);
       expect(r.manualActive).toBe(false);
     });
 
-    it("is off when only ended meetings exist", () => {
-      const r = computeMeetingActive([ended], NEVER_CLICKED, NOW);
+    it("is off when status explicitly says inactive", () => {
+      const r = computeMeetingActive(inactive, NEVER_CLICKED, NOW);
       expect(r.active).toBe(false);
       expect(r.manualActive).toBe(false);
-    });
-  });
-
-  describe("mixed meetings", () => {
-    it("lights up if any meeting is active even when others ended", () => {
-      const r = computeMeetingActive([ended, teamsActive], NEVER_CLICKED, NOW);
-      expect(r.active).toBe(true);
-      expect(r.manualActive).toBe(false);
-    });
-
-    it("manualActive=true if both manual and auto are active", () => {
-      const r = computeMeetingActive([manualActive, teamsActive], NEVER_CLICKED, NOW);
-      expect(r.active).toBe(true);
-      expect(r.manualActive).toBe(true);
     });
   });
 
   describe("grace period after user clicks start", () => {
     it("trusts local click within grace period even if poll returns nothing", () => {
       const startedAt = NOW - 1000;
-      const r = computeMeetingActive([], startedAt, NOW);
+      const r = computeMeetingActive(null, startedAt, NOW);
       expect(r.active).toBe(true);
       expect(r.manualActive).toBe(true); // grace period implies manual click
     });
 
     it("trusts local click at exactly the start of the grace period", () => {
-      const r = computeMeetingActive([], NOW, NOW);
+      const r = computeMeetingActive(null, NOW, NOW);
       expect(r.active).toBe(true);
     });
 
     it("clears state once grace period expires", () => {
       const startedAt = NOW - MEETING_GRACE_PERIOD_MS - 1;
-      const r = computeMeetingActive([], startedAt, NOW);
+      const r = computeMeetingActive(null, startedAt, NOW);
       expect(r.active).toBe(false);
     });
 
     it("clears state right at the grace period boundary", () => {
       const startedAt = NOW - MEETING_GRACE_PERIOD_MS;
-      const r = computeMeetingActive([], startedAt, NOW);
+      const r = computeMeetingActive(null, startedAt, NOW);
       expect(r.active).toBe(false);
     });
 
     it("does NOT consider startedAt=0 as 'within grace period'", () => {
       // Edge case: if NOW is small (e.g. just after epoch in tests),
       // startedAt=0 would falsely look like "0ms ago".
-      const r = computeMeetingActive([], 0, 5_000);
+      const r = computeMeetingActive(null, 0, 5_000);
       expect(r.active).toBe(false);
     });
   });
@@ -109,29 +102,23 @@ describe("computeMeetingActive", () => {
   describe("server data wins over grace period when present", () => {
     it("active meeting from server overrides grace period", () => {
       const startedAt = NOW - 1000;
-      const r = computeMeetingActive([teamsActive], startedAt, NOW);
+      const r = computeMeetingActive(teamsActive, startedAt, NOW);
       expect(r.active).toBe(true);
-      expect(r.manualActive).toBe(false); // ui_scan, not manual
+      expect(r.manualActive).toBe(false);
     });
 
     it("active meeting from server keeps icon on after grace period", () => {
       const startedAt = NOW - MEETING_GRACE_PERIOD_MS - 5000;
-      const r = computeMeetingActive([teamsActive], startedAt, NOW);
+      const r = computeMeetingActive(teamsActive, startedAt, NOW);
       expect(r.active).toBe(true);
     });
   });
 
-  describe("regression coverage for the manual-only filter bug", () => {
-    it("does not require detection_source to be 'manual'", () => {
-      // The bug we're fixing: previous code only counted manual meetings.
-      const r = computeMeetingActive([teamsActive], NEVER_CLICKED, NOW);
+  describe("status-shape compatibility", () => {
+    it("treats missing manual flags as non-manual active meetings", () => {
+      const r = computeMeetingActive({ active: true }, NEVER_CLICKED, NOW);
       expect(r.active).toBe(true);
-    });
-
-    it("works with unknown detection_source values", () => {
-      const exotic: MeetingRow = { meeting_end: null, detection_source: "future_source" };
-      const r = computeMeetingActive([exotic], NEVER_CLICKED, NOW);
-      expect(r.active).toBe(true);
+      expect(r.manualActive).toBe(false);
     });
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-state.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-state.ts
@@ -23,12 +23,24 @@ export interface MeetingActiveState {
   active: boolean;
   /** True only if the active meeting is a manual one the user can stop */
   manualActive: boolean;
+  /** Exact active meeting row id, when known */
+  activeMeetingId: number | null;
+  /** Exact meeting id the UI should send to /meetings/stop */
+  stoppableMeetingId: number | null;
+  /** Meeting app name for the current active meeting */
+  meetingApp: string | null;
+  /** Source that created the current active meeting */
+  detectionSource: string | null;
 }
 
 export interface MeetingStatusResponse {
   active?: boolean;
   manual?: boolean;
   manualActive?: boolean;
+  activeMeetingId?: number | null;
+  stoppableMeetingId?: number | null;
+  meetingApp?: string | null;
+  detectionSource?: string | null;
 }
 
 /**
@@ -48,6 +60,10 @@ export function computeMeetingActive(
     return {
       active: true,
       manualActive: status.manualActive ?? status.manual ?? false,
+      activeMeetingId: status.activeMeetingId ?? null,
+      stoppableMeetingId: status.stoppableMeetingId ?? status.activeMeetingId ?? null,
+      meetingApp: status.meetingApp ?? null,
+      detectionSource: status.detectionSource ?? null,
     };
   }
 
@@ -59,8 +75,22 @@ export function computeMeetingActive(
     startedAtMs > 0 && nowMs - startedAtMs < MEETING_GRACE_PERIOD_MS;
 
   if (inGracePeriod) {
-    return { active: true, manualActive: true };
+    return {
+      active: true,
+      manualActive: true,
+      activeMeetingId: null,
+      stoppableMeetingId: null,
+      meetingApp: "manual",
+      detectionSource: "manual",
+    };
   }
 
-  return { active: false, manualActive: false };
+  return {
+    active: false,
+    manualActive: false,
+    activeMeetingId: null,
+    stoppableMeetingId: null,
+    meetingApp: null,
+    detectionSource: null,
+  };
 }

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-state.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-state.ts
@@ -16,11 +16,6 @@
  * "active" state. We trust the local click for 10s after start.
  */
 
-export interface MeetingRow {
-  meeting_end: string | null;
-  detection_source: string;
-}
-
 export const MEETING_GRACE_PERIOD_MS = 10_000;
 
 export interface MeetingActiveState {
@@ -30,24 +25,30 @@ export interface MeetingActiveState {
   manualActive: boolean;
 }
 
+export interface MeetingStatusResponse {
+  active?: boolean;
+  manual?: boolean;
+  manualActive?: boolean;
+}
+
 /**
- * Decide the phone-icon state given the latest poll response and the
- * timestamp of the last user click.
+ * Decide the phone-icon state given the latest meeting status response and
+ * the timestamp of the last user click.
  *
- * @param meetings  rows from GET /meetings
+ * @param status  response from GET /meetings/status
  * @param startedAtMs  timestamp (ms) of last user click on "start" (0 if never)
  * @param nowMs  current time in ms (injectable for tests)
  */
 export function computeMeetingActive(
-  meetings: MeetingRow[],
+  status: MeetingStatusResponse | null | undefined,
   startedAtMs: number,
   nowMs: number = Date.now(),
 ): MeetingActiveState {
-  const activeRows = meetings.filter((m) => m.meeting_end === null);
-  const hasActiveManual = activeRows.some((m) => m.detection_source === "manual");
-
-  if (activeRows.length > 0) {
-    return { active: true, manualActive: hasActiveManual };
+  if (status?.active) {
+    return {
+      active: true,
+      manualActive: status.manualActive ?? status.manual ?? false,
+    };
   }
 
   // No active meeting from server — but if we're within the grace period

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -1453,14 +1453,11 @@ pub async fn show_shortcut_reminder(
                 let guard = state.server.lock().await;
                 if let Some(ref core) = *guard {
                     let mut metrics_ws_url = format!("ws://127.0.0.1:{}/ws/metrics", core.port);
-                    let mut events_ws_url = format!("ws://127.0.0.1:{}/ws/events", core.port);
-                    let mut meetings_status_url =
-                        format!("http://127.0.0.1:{}/meetings/status", core.port);
+                    let mut events_ws_url = format!("ws://127.0.0.1:{}/ws/meeting-status", core.port);
                     if let Some(ref key) = core.local_api_key {
                         let enc = urlencoding::encode(key);
                         metrics_ws_url = format!("{}?token={}", metrics_ws_url, enc);
                         events_ws_url = format!("{}?token={}", events_ws_url, enc);
-                        meetings_status_url = format!("{}?token={}", meetings_status_url, enc);
                     }
                     map.insert(
                         "metrics_ws_url".to_string(),
@@ -1469,10 +1466,6 @@ pub async fn show_shortcut_reminder(
                     map.insert(
                         "events_ws_url".to_string(),
                         serde_json::json!(events_ws_url),
-                    );
-                    map.insert(
-                        "meetings_status_url".to_string(),
-                        serde_json::json!(meetings_status_url),
                     );
                 }
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -189,15 +189,24 @@ extern "C" fn native_shortcut_action_callback(action_ptr: *const std::os::raw::c
                     let client = reqwest::blocking::Client::new();
                     let status_req =
                         api.apply_auth_blocking(client.get(api.url("/meetings/status")));
-                    let status: Option<bool> = status_req
+                    let status: Option<serde_json::Value> = status_req
                         .send()
                         .ok()
-                        .and_then(|r| r.json::<serde_json::Value>().ok())
+                        .and_then(|r| r.json::<serde_json::Value>().ok());
+                    let is_active = status
+                        .as_ref()
                         .and_then(|v| v["active"].as_bool());
+                    let stoppable_id = status
+                        .as_ref()
+                        .and_then(|v| v["stoppableMeetingId"].as_i64());
                     match status {
-                        Some(true) => {
-                            let req =
-                                api.apply_auth_blocking(client.post(api.url("/meetings/stop")));
+                        Some(_) if is_active == Some(true) => {
+                            let req = api.apply_auth_blocking(
+                                client
+                                    .post(api.url("/meetings/stop"))
+                                    .header("Content-Type", "application/json")
+                                    .body(serde_json::json!({ "id": stoppable_id }).to_string()),
+                            );
                             if req.send().is_ok() {
                                 native_shortcut_reminder::set_meeting_active(false);
                                 let _ = app_clone.emit(
@@ -205,29 +214,38 @@ extern "C" fn native_shortcut_action_callback(action_ptr: *const std::os::raw::c
                                     serde_json::json!({
                                         "active": false,
                                         "manualActive": false,
+                                        "activeMeetingId": serde_json::Value::Null,
+                                        "stoppableMeetingId": serde_json::Value::Null,
+                                        "meetingApp": serde_json::Value::Null,
+                                        "detectionSource": serde_json::Value::Null,
                                     }),
                                 );
                             }
                         }
-                        Some(false) => {
+                        Some(_) if is_active == Some(false) => {
                             let req = api.apply_auth_blocking(
                                 client
                                     .post(api.url("/meetings/start"))
                                     .header("Content-Type", "application/json")
                                     .body(r#"{"app":"manual"}"#),
                             );
-                            if req.send().is_ok() {
+                            if let Ok(res) = req.send() {
+                                let meeting = res.json::<serde_json::Value>().ok();
                                 native_shortcut_reminder::set_meeting_active(true);
                                 let _ = app_clone.emit(
                                     "native-shortcut-toggle-meeting",
                                     serde_json::json!({
                                         "active": true,
                                         "manualActive": true,
+                                        "activeMeetingId": meeting.as_ref().and_then(|v| v["id"].as_i64()),
+                                        "stoppableMeetingId": meeting.as_ref().and_then(|v| v["id"].as_i64()),
+                                        "meetingApp": meeting.as_ref().and_then(|v| v["meeting_app"].as_str()),
+                                        "detectionSource": meeting.as_ref().and_then(|v| v["detection_source"].as_str()).unwrap_or("manual"),
                                     }),
                                 );
                             }
                         }
-                        None => {
+                        _ => {
                             warn!("failed to check meeting status");
                         }
                     }
@@ -1435,16 +1453,22 @@ pub async fn show_shortcut_reminder(
                 let guard = state.server.lock().await;
                 if let Some(ref core) = *guard {
                     let mut metrics_ws_url = format!("ws://127.0.0.1:{}/ws/metrics", core.port);
+                    let mut events_ws_url = format!("ws://127.0.0.1:{}/ws/events", core.port);
                     let mut meetings_status_url =
                         format!("http://127.0.0.1:{}/meetings/status", core.port);
                     if let Some(ref key) = core.local_api_key {
                         let enc = urlencoding::encode(key);
                         metrics_ws_url = format!("{}?token={}", metrics_ws_url, enc);
+                        events_ws_url = format!("{}?token={}", events_ws_url, enc);
                         meetings_status_url = format!("{}?token={}", meetings_status_url, enc);
                     }
                     map.insert(
                         "metrics_ws_url".to_string(),
                         serde_json::json!(metrics_ws_url),
+                    );
+                    map.insert(
+                        "events_ws_url".to_string(),
+                        serde_json::json!(events_ws_url),
                     );
                     map.insert(
                         "meetings_status_url".to_string(),

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -198,7 +198,16 @@ extern "C" fn native_shortcut_action_callback(action_ptr: *const std::os::raw::c
                         Some(true) => {
                             let req =
                                 api.apply_auth_blocking(client.post(api.url("/meetings/stop")));
-                            let _ = req.send();
+                            if req.send().is_ok() {
+                                native_shortcut_reminder::set_meeting_active(false);
+                                let _ = app_clone.emit(
+                                    "native-shortcut-toggle-meeting",
+                                    serde_json::json!({
+                                        "active": false,
+                                        "manualActive": false,
+                                    }),
+                                );
+                            }
                         }
                         Some(false) => {
                             let req = api.apply_auth_blocking(
@@ -207,14 +216,21 @@ extern "C" fn native_shortcut_action_callback(action_ptr: *const std::os::raw::c
                                     .header("Content-Type", "application/json")
                                     .body(r#"{"app":"manual"}"#),
                             );
-                            let _ = req.send();
+                            if req.send().is_ok() {
+                                native_shortcut_reminder::set_meeting_active(true);
+                                let _ = app_clone.emit(
+                                    "native-shortcut-toggle-meeting",
+                                    serde_json::json!({
+                                        "active": true,
+                                        "manualActive": true,
+                                    }),
+                                );
+                            }
                         }
                         None => {
                             warn!("failed to check meeting status");
                         }
                     }
-                    // Also emit to JS so the home page UI updates immediately if open
-                    let _ = app_clone.emit("native-shortcut-toggle-meeting", "");
                 }
                 _ => {}
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/native_shortcut_reminder.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/native_shortcut_reminder.rs
@@ -16,6 +16,7 @@ mod ffi {
         pub fn shortcut_is_available() -> c_int;
         pub fn shortcut_show(json: *const c_char) -> c_int;
         pub fn shortcut_hide() -> c_int;
+        pub fn shortcut_set_meeting_active(active: c_int);
         pub fn shortcut_set_action_callback(cb: Option<extern "C" fn(*const c_char)>);
     }
 
@@ -40,6 +41,12 @@ mod ffi {
         unsafe { shortcut_hide() == 0 }
     }
 
+    pub fn set_meeting_active(active: bool) {
+        unsafe {
+            shortcut_set_meeting_active(if active { 1 } else { 0 });
+        }
+    }
+
     pub fn set_action_callback(cb: extern "C" fn(*const c_char)) {
         unsafe {
             shortcut_set_action_callback(Some(cb));
@@ -59,6 +66,7 @@ mod ffi {
     pub fn hide() -> bool {
         false
     }
+    pub fn set_meeting_active(_active: bool) {}
     pub fn set_action_callback(_cb: extern "C" fn(*const std::os::raw::c_char)) {}
 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -378,11 +378,13 @@ class ShortcutReminderController: NSObject {
     @Published var isExpanded = false
     private var wsTask: URLSessionWebSocketTask?
     private var wsRetryTimer: Timer?
-    private var meetingPollTimer: Timer?
+    private var meetingWsTask: URLSessionWebSocketTask?
+    private var meetingWsRetryTimer: Timer?
     private var prevFramesCaptured: Int?
     private var prevOcrCompleted: Int?
     /// Set from Rust `show_shortcut_reminder` when API auth is enabled (includes ?token=).
     private var metricsWsUrl = "ws://127.0.0.1:3030/ws/metrics"
+    private var eventsWsUrl = "ws://127.0.0.1:3030/ws/events"
     private var meetingsStatusUrl = "http://127.0.0.1:3030/meetings/status"
 
     func show(shortcuts: String?) {
@@ -404,15 +406,15 @@ class ShortcutReminderController: NSObject {
             panel?.orderFrontRegardless()
             AnimationTick.shared.start()
             connectWebSocket()
-            startMeetingPoll()
+            checkMeetingStatus()
+            connectMeetingEventsWebSocket()
         }
     }
 
     func hide() {
         AnimationTick.shared.stop()
         disconnectWebSocket()
-        meetingPollTimer?.invalidate()
-        meetingPollTimer = nil
+        disconnectMeetingEventsWebSocket()
         DispatchQueue.main.async { [self] in
             panel?.orderOut(nil)
         }
@@ -485,14 +487,53 @@ class ShortcutReminderController: NSObject {
         }
     }
 
-    // MARK: - Meeting status polling
+    // MARK: - Meeting status events
 
-    private func startMeetingPoll() {
-        checkMeetingStatus()
-        meetingPollTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { [weak self] _ in
-            self?.checkMeetingStatus()
+    private func connectMeetingEventsWebSocket() {
+        disconnectMeetingEventsWebSocket()
+        guard let url = URL(string: eventsWsUrl) else { return }
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: url)
+        self.meetingWsTask = task
+        task.resume()
+        receiveMeetingEvent()
+    }
+
+    private func disconnectMeetingEventsWebSocket() {
+        meetingWsRetryTimer?.invalidate()
+        meetingWsRetryTimer = nil
+        meetingWsTask?.cancel(with: .goingAway, reason: nil)
+        meetingWsTask = nil
+    }
+
+    private func receiveMeetingEvent() {
+        meetingWsTask?.receive { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let message):
+                if case .string(let text) = message {
+                    self.processMeetingEventMessage(text)
+                }
+                self.receiveMeetingEvent()
+            case .failure:
+                DispatchQueue.main.async {
+                    self.meetingWsRetryTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { [weak self] _ in
+                        self?.connectMeetingEventsWebSocket()
+                        self?.checkMeetingStatus()
+                    }
+                }
+            }
         }
-        RunLoop.main.add(meetingPollTimer!, forMode: .common)
+    }
+
+    private func processMeetingEventMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let name = json["name"] as? String,
+              name == "meeting_status_changed",
+              let payload = json["data"] as? [String: Any] else { return }
+        let active = payload["active"] as? Bool ?? false
+        setMeetingActive(active)
     }
 
     private func checkMeetingStatus() {
@@ -527,6 +568,7 @@ class ShortcutReminderController: NSObject {
         if let s = dict["chat"] { chatShortcut = prettifyShortcut(s) }
         if let s = dict["search"] { searchShortcut = prettifyShortcut(s) }
         if let s = dict["metrics_ws_url"] { metricsWsUrl = s }
+        if let s = dict["events_ws_url"] { eventsWsUrl = s }
         if let s = dict["meetings_status_url"] { meetingsStatusUrl = s }
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -15,6 +15,13 @@ public func shortcutSetActionCallback(_ cb: @escaping ShortcutActionCallback) {
     gShortcutCallback = cb
 }
 
+@_cdecl("shortcut_set_meeting_active")
+public func shortcutSetMeetingActive(_ active: Int32) {
+    if #available(macOS 13.0, *) {
+        ShortcutReminderController.shared.setMeetingActive(active != 0)
+    }
+}
+
 // MARK: - Metrics data pushed from Rust
 
 struct OverlayMetrics {
@@ -501,6 +508,15 @@ class ShortcutReminderController: NSObject {
                 }
             }
         }.resume()
+    }
+
+    func setMeetingActive(_ active: Bool) {
+        DispatchQueue.main.async { [self] in
+            if self.metrics.meetingActive != active {
+                self.metrics.meetingActive = active
+                self.updateContent()
+            }
+        }
     }
 
     private func parseShortcuts(_ json: String) {

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -384,8 +384,7 @@ class ShortcutReminderController: NSObject {
     private var prevOcrCompleted: Int?
     /// Set from Rust `show_shortcut_reminder` when API auth is enabled (includes ?token=).
     private var metricsWsUrl = "ws://127.0.0.1:3030/ws/metrics"
-    private var eventsWsUrl = "ws://127.0.0.1:3030/ws/events"
-    private var meetingsStatusUrl = "http://127.0.0.1:3030/meetings/status"
+    private var eventsWsUrl = "ws://127.0.0.1:3030/ws/meeting-status"
 
     func show(shortcuts: String?) {
         DispatchQueue.main.async { [self] in
@@ -406,7 +405,6 @@ class ShortcutReminderController: NSObject {
             panel?.orderFrontRegardless()
             AnimationTick.shared.start()
             connectWebSocket()
-            checkMeetingStatus()
             connectMeetingEventsWebSocket()
         }
     }
@@ -519,7 +517,6 @@ class ShortcutReminderController: NSObject {
                 DispatchQueue.main.async {
                     self.meetingWsRetryTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { [weak self] _ in
                         self?.connectMeetingEventsWebSocket()
-                        self?.checkMeetingStatus()
                     }
                 }
             }
@@ -528,27 +525,9 @@ class ShortcutReminderController: NSObject {
 
     private func processMeetingEventMessage(_ text: String) {
         guard let data = text.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let name = json["name"] as? String,
-              name == "meeting_status_changed",
-              let payload = json["data"] as? [String: Any] else { return }
+              let payload = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
         let active = payload["active"] as? Bool ?? false
         setMeetingActive(active)
-    }
-
-    private func checkMeetingStatus() {
-        guard let url = URL(string: meetingsStatusUrl) else { return }
-        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
-            guard let self = self, let data = data,
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-            let active = json["active"] as? Bool ?? false
-            DispatchQueue.main.async {
-                if self.metrics.meetingActive != active {
-                    self.metrics.meetingActive = active
-                    self.updateContent()
-                }
-            }
-        }.resume()
     }
 
     func setMeetingActive(_ active: Bool) {
@@ -569,7 +548,6 @@ class ShortcutReminderController: NSObject {
         if let s = dict["search"] { searchShortcut = prettifyShortcut(s) }
         if let s = dict["metrics_ws_url"] { metricsWsUrl = s }
         if let s = dict["events_ws_url"] { eventsWsUrl = s }
-        if let s = dict["meetings_status_url"] { meetingsStatusUrl = s }
     }
 
     /// Convert "Super+Ctrl+S" → "⌘⌃S" for compact overlay display.

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -7013,6 +7013,17 @@ LIMIT ? OFFSET ?
         Ok(row.0 > 0)
     }
 
+    pub async fn get_active_meeting_by_id(&self, id: i64) -> Result<Option<MeetingRecord>, SqlxError> {
+        let meeting = sqlx::query_as::<_, MeetingRecord>(
+            "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, \
+             detection_source, created_at FROM meetings WHERE id = ?1 AND meeting_end IS NULL",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(meeting)
+    }
+
     pub async fn get_most_recent_active_meeting_id(&self) -> Result<Option<i64>, SqlxError> {
         let row: Option<(i64,)> = sqlx::query_as(
             "SELECT id FROM meetings WHERE meeting_end IS NULL ORDER BY id DESC LIMIT 1",
@@ -7020,6 +7031,17 @@ LIMIT ? OFFSET ?
         .fetch_optional(&self.pool)
         .await?;
         Ok(row.map(|r| r.0))
+    }
+
+    pub async fn get_most_recent_active_meeting(&self) -> Result<Option<MeetingRecord>, SqlxError> {
+        let meeting = sqlx::query_as::<_, MeetingRecord>(
+            "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, \
+             detection_source, created_at FROM meetings WHERE meeting_end IS NULL \
+             ORDER BY id DESC LIMIT 1",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(meeting)
     }
 
     pub async fn list_meetings(

--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -25,6 +25,7 @@
 
 use chrono::{DateTime, Utc};
 use futures::{FutureExt, StreamExt};
+use crate::routes::meetings::{emit_meeting_status_changed, resolve_meeting_status_from};
 use screenpipe_db::DatabaseManager;
 use screenpipe_events::subscribe_to_event;
 use serde::{Deserialize, Serialize};
@@ -2299,6 +2300,11 @@ pub async fn run_meeting_detection_loop(
                         ) {
                             warn!("meeting v2: failed to emit meeting_ended event: {}", e);
                         }
+                        if let Ok(status) =
+                            resolve_meeting_status_from(db.as_ref(), manual_meeting.as_ref()).await
+                        {
+                            emit_meeting_status_changed(&status);
+                        }
                     }
                     Err(e) => {
                         error!("meeting v2: failed to end meeting {}: {}", meeting_id, e);
@@ -2469,6 +2475,11 @@ pub async fn run_meeting_detection_loop(
                             is_browser,
                         };
                     }
+                    if let Ok(status) =
+                        resolve_meeting_status_from(db.as_ref(), manual_meeting.as_ref()).await
+                    {
+                        emit_meeting_status_changed(&status);
+                    }
                 }
                 StateAction::EndMeeting { meeting_id } => {
                     if meeting_id >= 0 {
@@ -2482,6 +2493,11 @@ pub async fn run_meeting_detection_loop(
                                     serde_json::json!({ "meeting_id": meeting_id }),
                                 ) {
                                     warn!("meeting v2: failed to emit meeting_ended event: {}", e);
+                                }
+                                if let Ok(status) =
+                                    resolve_meeting_status_from(db.as_ref(), manual_meeting.as_ref()).await
+                                {
+                                    emit_meeting_status_changed(&status);
                                 }
                             }
                             Err(e) => {

--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -2191,6 +2191,9 @@ pub async fn run_meeting_detection_loop(
     let mut cal_sub = subscribe_to_event::<Vec<CalendarEventSignal>>("calendar_events");
     let mut calendar_events: Vec<CalendarEventSignal> = Vec::new();
 
+    // Subscribe to explicit stop signals from the API layer
+    let mut stop_sub = subscribe_to_event::<DetectorStopSignal>("detector_stop_tracking");
+
     info!(
         "meeting v2: detection loop started (base_interval={:?}, profiles={})",
         base_interval,
@@ -2224,6 +2227,27 @@ pub async fn run_meeting_detection_loop(
         // Each publish replaces the full list, so we keep only the latest.
         while let Some(event) = cal_sub.next().now_or_never().flatten() {
             calendar_events = event.data.into_iter().filter(|e| !e.is_all_day).collect();
+        }
+
+        // Handle explicit stop signals from the API layer
+        if let Some(event) = stop_sub.next().now_or_never().flatten() {
+            let stop_signal = event.data;
+            if let MeetingState::Active { meeting_id, app, .. } | MeetingState::Ending {
+                meeting_id,
+                app,
+                ..
+            } = &state
+            {
+                if *meeting_id == stop_signal.meeting_id && app == &stop_signal.app {
+                    info!(
+                        "meeting v2: forced to Idle by explicit stop (meeting_id={}, app={})",
+                        meeting_id, app
+                    );
+                    state = MeetingState::Idle;
+                    current_interval = IDLE_APPS_SCAN_INTERVAL;
+                    sync_meeting_flag(false, &in_meeting_flag, &detector);
+                }
+            }
         }
 
         // Skip if manual meeting is active
@@ -2634,6 +2658,12 @@ struct CalendarEventSignal {
     pub attendees: Vec<String>,
     #[serde(default)]
     pub is_all_day: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DetectorStopSignal {
+    pub meeting_id: i64,
+    pub app: String,
 }
 
 /// Check if any non-all-day calendar event overlaps with the current time.

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -9,13 +9,15 @@ use axum::{
 };
 use oasgen::{oasgen, OaSchema};
 
+use screenpipe_db::DatabaseManager;
 use screenpipe_db::MeetingRecord;
 
 use crate::server::AppState;
 use chrono::Utc;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[derive(OaSchema, Deserialize, Debug)]
 pub struct UpdateMeetingRequest {
@@ -45,6 +47,11 @@ pub struct StartMeetingRequest {
 }
 
 #[derive(OaSchema, Deserialize, Debug)]
+pub struct StopMeetingRequest {
+    pub id: Option<i64>,
+}
+
+#[derive(OaSchema, Deserialize, Debug)]
 pub struct ListMeetingsRequest {
     pub start_time: Option<String>,
     pub end_time: Option<String>,
@@ -56,6 +63,98 @@ pub struct ListMeetingsRequest {
 
 fn default_limit() -> u32 {
     20
+}
+
+#[derive(OaSchema, Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MeetingStatusResponse {
+    pub active: bool,
+    pub manual: bool,
+    pub manual_active: bool,
+    pub active_meeting_id: Option<i64>,
+    pub stoppable_meeting_id: Option<i64>,
+    pub meeting_app: Option<String>,
+    pub detection_source: Option<String>,
+}
+
+async fn resolve_meeting_status(
+    state: &Arc<AppState>,
+) -> Result<MeetingStatusResponse, (StatusCode, JsonResponse<Value>)> {
+    resolve_meeting_status_from(&state.db, &state.manual_meeting)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                JsonResponse(json!({"error": e})),
+            )
+        })
+}
+
+pub async fn resolve_meeting_status_from(
+    db: &DatabaseManager,
+    manual_meeting: &RwLock<Option<i64>>,
+) -> Result<MeetingStatusResponse, String> {
+    let manual_id = {
+        let lock = manual_meeting.read().await;
+        *lock
+    };
+
+    if let Some(id) = manual_id {
+        match db.get_active_meeting_by_id(id).await {
+            Ok(Some(meeting)) => {
+                return Ok(MeetingStatusResponse {
+                    active: true,
+                    manual: true,
+                    manual_active: true,
+                    active_meeting_id: Some(meeting.id),
+                    stoppable_meeting_id: Some(meeting.id),
+                    meeting_app: Some(meeting.meeting_app),
+                    detection_source: Some(meeting.detection_source),
+                });
+            }
+            Ok(None) => {
+                let mut lock = manual_meeting.write().await;
+                if *lock == Some(id) {
+                    *lock = None;
+                }
+            }
+            Err(e) => {
+                return Err(e.to_string());
+            }
+        }
+    }
+
+    let active = db
+        .get_most_recent_active_meeting()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    match active {
+        Some(meeting) => Ok(MeetingStatusResponse {
+            active: true,
+            manual: false,
+            manual_active: false,
+            active_meeting_id: Some(meeting.id),
+            stoppable_meeting_id: Some(meeting.id),
+            meeting_app: Some(meeting.meeting_app),
+            detection_source: Some(meeting.detection_source),
+        }),
+        None => Ok(MeetingStatusResponse {
+            active: false,
+            manual: false,
+            manual_active: false,
+            active_meeting_id: None,
+            stoppable_meeting_id: None,
+            meeting_app: None,
+            detection_source: None,
+        }),
+    }
+}
+
+pub fn emit_meeting_status_changed(status: &MeetingStatusResponse) {
+    if let Err(e) = screenpipe_events::send_event("meeting_status_changed", status.clone()) {
+        tracing::warn!("failed to emit meeting_status_changed event: {}", e);
+    }
 }
 
 #[oasgen]
@@ -202,27 +301,8 @@ pub(crate) async fn merge_meetings_handler(
 #[oasgen]
 pub(crate) async fn meeting_status_handler(
     State(state): State<Arc<AppState>>,
-) -> Result<JsonResponse<Value>, (StatusCode, JsonResponse<Value>)> {
-    // Check manual meeting first
-    let manual_active = {
-        let lock = state.manual_meeting.read().await;
-        lock.is_some()
-    };
-
-    // Also check DB for any ongoing meeting (auto-detected)
-    let any_active = if manual_active {
-        true
-    } else {
-        state.db.has_active_meeting().await.unwrap_or(false)
-    };
-
-    Ok(JsonResponse(
-        json!({
-            "active": any_active,
-            "manual": manual_active,
-            "manualActive": manual_active,
-        }),
-    ))
+) -> Result<JsonResponse<MeetingStatusResponse>, (StatusCode, JsonResponse<Value>)> {
+    Ok(JsonResponse(resolve_meeting_status(&state).await?))
 }
 
 #[oasgen]
@@ -252,6 +332,10 @@ pub(crate) async fn start_meeting_handler(
         *lock = Some(id);
     }
 
+    if let Ok(status) = resolve_meeting_status(&state).await {
+        emit_meeting_status_changed(&status);
+    }
+
     // Emit event so triggered pipes can react
     if let Err(e) = screenpipe_events::send_event(
         "meeting_started",
@@ -273,35 +357,27 @@ pub(crate) async fn start_meeting_handler(
 #[oasgen]
 pub(crate) async fn stop_meeting_handler(
     State(state): State<Arc<AppState>>,
+    axum::Json(body): axum::Json<StopMeetingRequest>,
 ) -> Result<JsonResponse<MeetingRecord>, (StatusCode, JsonResponse<Value>)> {
-    let id = {
-        let lock = state.manual_meeting.read().await;
-        *lock
-    };
-
-    // If no manual meeting, find any active meeting (auto-detected) and end it.
-    // This lets users stop auto-detected meetings (Google Meet, Zoom, etc.)
-    // from the overlay button.
-    let id = match id {
-        Some(id) => id,
-        None => {
-            let active_id = state
-                .db
-                .get_most_recent_active_meeting_id()
-                .await
-                .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        JsonResponse(json!({"error": e.to_string()})),
-                    )
-                })?;
-            active_id.ok_or_else(|| {
-                (
+    let requested_id = body.id;
+    let status = resolve_meeting_status(&state).await?;
+    let id = match requested_id {
+        Some(id) => {
+            if status.stoppable_meeting_id == Some(id) || status.active_meeting_id == Some(id) {
+                id
+            } else {
+                return Err((
                     StatusCode::BAD_REQUEST,
-                    JsonResponse(json!({"error": "no active meeting"})),
-                )
-            })?
+                    JsonResponse(json!({"error": "requested meeting is not the active meeting"})),
+                ));
+            }
         }
+        None => status.stoppable_meeting_id.ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                JsonResponse(json!({"error": "no active meeting"})),
+            )
+        })?,
     };
 
     let now = Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
@@ -319,7 +395,13 @@ pub(crate) async fn stop_meeting_handler(
 
     {
         let mut lock = state.manual_meeting.write().await;
-        *lock = None;
+        if *lock == Some(id) {
+            *lock = None;
+        }
+    }
+
+    if let Ok(status) = resolve_meeting_status(&state).await {
+        emit_meeting_status_changed(&status);
     }
 
     // Emit event so triggered pipes can react

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -65,7 +65,7 @@ fn default_limit() -> u32 {
     20
 }
 
-#[derive(OaSchema, Debug, Serialize, Clone)]
+#[derive(OaSchema, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct MeetingStatusResponse {
     pub active: bool,

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -217,7 +217,11 @@ pub(crate) async fn meeting_status_handler(
     };
 
     Ok(JsonResponse(
-        json!({ "active": any_active, "manual": manual_active }),
+        json!({
+            "active": any_active,
+            "manual": manual_active,
+            "manualActive": manual_active,
+        }),
     ))
 }
 

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -152,6 +152,14 @@ pub async fn resolve_meeting_status_from(
 }
 
 pub fn emit_meeting_status_changed(status: &MeetingStatusResponse) {
+    tracing::info!(
+        "meeting_status_changed: active={}, manual={}, active_id={:?}, app={:?}, source={:?}",
+        status.active,
+        status.manual,
+        status.active_meeting_id,
+        status.meeting_app,
+        status.detection_source
+    );
     if let Err(e) = screenpipe_events::send_event("meeting_status_changed", status.clone()) {
         tracing::warn!("failed to emit meeting_status_changed event: {}", e);
     }
@@ -417,6 +425,18 @@ pub(crate) async fn stop_meeting_handler(
             JsonResponse(json!({"error": format!("meeting not found: {}", e)})),
         )
     })?;
+
+    // Signal detector to stop tracking this meeting immediately (skip grace period)
+    if let Err(e) = screenpipe_events::send_event(
+        "detector_stop_tracking",
+        serde_json::json!({ "meeting_id": id, "app": &meeting.meeting_app }),
+    ) {
+        tracing::warn!(
+            "failed to emit detector_stop_tracking event for meeting {}: {}",
+            id,
+            e
+        );
+    }
 
     Ok(JsonResponse(meeting))
 }

--- a/crates/screenpipe-engine/src/routes/websocket.rs
+++ b/crates/screenpipe-engine/src/routes/websocket.rs
@@ -29,6 +29,7 @@ use tracing::{debug, error};
 use crate::server::AppState;
 
 use super::health::health_check;
+use super::meetings::{resolve_meeting_status_from, MeetingStatusResponse};
 
 /// Maximum number of concurrent WebSocket connections allowed.
 /// This prevents file descriptor exhaustion from too many open connections.
@@ -215,6 +216,56 @@ pub(crate) async fn ws_metrics_handler(
             .status(StatusCode::SERVICE_UNAVAILABLE)
             .body(Body::from("Too many WebSocket connections"))
             .unwrap(),
+    }
+}
+
+pub(crate) async fn ws_meeting_status_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    match try_acquire_ws_connection(&state.ws_connection_count) {
+        Some(guard) => ws.on_upgrade(move |socket| handle_meeting_status_socket(socket, state, guard)),
+        None => Response::builder()
+            .status(StatusCode::SERVICE_UNAVAILABLE)
+            .body(Body::from("Too many WebSocket connections"))
+            .unwrap(),
+    }
+}
+
+async fn handle_meeting_status_socket(
+    mut socket: WebSocket,
+    state: Arc<AppState>,
+    _guard: WsConnectionGuard,
+) {
+    if let Ok(status) = resolve_meeting_status_from(state.db.as_ref(), state.manual_meeting.as_ref()).await {
+        if let Ok(json) = serde_json::to_string(&status) {
+            if socket.send(Message::Text(json)).await.is_err() {
+                return;
+            }
+        }
+    }
+
+    let mut stream = screenpipe_events::subscribe_to_event::<MeetingStatusResponse>("meeting_status_changed");
+    loop {
+        tokio::select! {
+            event = stream.next() => {
+                if let Some(event) = event {
+                    let json = serde_json::to_string(&event.data).unwrap_or_default();
+                    if let Err(e) = socket.send(Message::Text(json)).await {
+                        error!("Failed to send meeting status: {}", e);
+                        break;
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_secs(15)) => {
+                let _ = socket.send(Message::Ping(vec![])).await;
+            }
+            result = socket.recv() => {
+                if result.is_none() {
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/crates/screenpipe-engine/src/server.rs
+++ b/crates/screenpipe-engine/src/server.rs
@@ -54,7 +54,7 @@ use crate::{
             search_speakers_handler, undo_speaker_reassign_handler, update_speaker_handler,
         },
         streaming::{handle_video_export_post, handle_video_export_ws, stream_frames_handler},
-        websocket::{ws_events_handler, ws_health_handler, ws_metrics_handler},
+        websocket::{ws_events_handler, ws_health_handler, ws_meeting_status_handler, ws_metrics_handler},
     },
     sync_api::{self, SyncState},
     video_cache::FrameCache,
@@ -812,6 +812,7 @@ impl SCServer {
             .route("/stream/frames", get(stream_frames_handler))
             .route("/ws/events", get(ws_events_handler))
             .route("/ws/health", get(ws_health_handler))
+            .route("/ws/meeting-status", get(ws_meeting_status_handler))
             .route("/ws/metrics", get(ws_metrics_handler))
             // Browser extension bridge — DEPRECATED top-level paths.
             // Canonical paths now live under /connections/browser/* (see connections_api.rs).


### PR DESCRIPTION


# Description:

## Problem
- Explicit stop button failed to stop auto-detected meetings (grace period kept running)
- Icon updates had 3-4 second delay (polling-based state)
- Web and native overlays drifted from backend state
- Restarting meeting within grace period resurrected old recording

## Solution
Push-driven architecture with explicit stop semantics:
- Dedicated canonical meeting status model (active, activeMeetingId, stoppableMeetingId, detectionSource)
- Real-time /ws/meeting-status websocket replaces polling
- Explicit stop immediately idles meeting and cancels grace period tracking
- Native and web overlays synchronized via push events

## Changes Across 4 Commits
1. Extract meeting state into utility module
2. Add backend meeting status model and detector integration
3. Add websocket stream, remove polling from UI
4. Implement explicit stop semantics that bypass grace period

## Result
✓ Stop button works reliably (explicit target, no resurrection)
✓ Icon updates instant (push vs poll)
✓ All overlays synchronized in real-time
✓ Grace period no longer blocks explicit stops or new detections












## After




https://github.com/user-attachments/assets/c394edcf-e962-4b5f-b872-f6e5469a64e1


https://github.com/user-attachments/assets/4bf995a4-7406-4c4b-9c8b-93d8e248e99b



