### PR TITLE
fix(windows): overlay timeline Escape key not working when opened from search

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -476,11 +476,19 @@ pub fn show_main_window(app_handle: &tauri::AppHandle, _overlay: bool) {
 
             // NOTE: On macOS, Escape is registered only from the focus-gain handler
             // in window/show.rs (duplicate RegisterEventHotKey fails there).
-            // On Windows/Linux, set_focus can succeed without delivering a new
-            // Focused(true) event when Home already had focus — then Escape never
-            // re-registers until another focus cycle. Sync once after show.
+            // On Windows/Linux, bypass the is_visible() guard — window.show() posts
+            // an async Win32 message so IsWindowVisible returns false in the same
+            // synchronous frame, causing register_if_main_visible to skip silently.
+            // IMPORTANT: spawn a new thread — show_main_window is invoked from within
+            // the global-shortcut callback which holds the plugin's handler-map lock.
+            // Calling on_shortcut() from inside that callback deadlocks.
             #[cfg(not(target_os = "macos"))]
-            register_window_shortcuts_if_main_visible(app_handle.clone());
+            {
+                let app = app_handle.clone();
+                std::thread::spawn(move || {
+                    let _ = register_window_shortcuts_with_generation(app);
+                });
+            }
         }
         Err(e) => {
             error!("ShowRewindWindow::Main.show failed: {}", e);
@@ -1001,6 +1009,18 @@ pub async fn search_navigate_to_timeline(
     ShowRewindWindow::Main
         .show(&app_handle)
         .map_err(|e| e.to_string())?;
+
+    // Register Escape shortcut so it works even when the overlay doesn't gain keyboard
+    // focus (e.g. Home window keeps focus when a search result opens the overlay).
+    // Bypass register_if_main_visible: window.show() is async on Windows so
+    // IsWindowVisible returns false in the same frame, causing silent skip.
+    #[cfg(not(target_os = "macos"))]
+    {
+        let app = app_handle.clone();
+        std::thread::spawn(move || {
+            let _ = register_window_shortcuts_with_generation(app);
+        });
+    }
 
     // Emit the navigation event multiple times — the Main webview may take
     // varying time to restore from order_out and mount the event listener.

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -381,16 +381,14 @@ impl ShowRewindWindow {
                         cursor.y as i32,
                     ) {
                         error!("Failed to reposition overlay to cursor monitor: {}", e);
-                        // Fallback: just bring to front at current position
-                        if let Err(e) = crate::windows_overlay::bring_to_front(window) {
-                            error!("Failed to bring window to front: {}", e);
-                        }
                     }
-                } else {
-                    // Can't get cursor position, just bring to front
-                    if let Err(e) = crate::windows_overlay::bring_to_front(window) {
-                        error!("Failed to bring window to front: {}", e);
-                    }
+                }
+                // Always activate after repositioning so the overlay receives keyboard focus.
+                // Without this, re-showing an already-created overlay when another screenpipe
+                // window (e.g. Home) holds focus leaves the overlay visible but not interactive —
+                // Escape and all shortcuts are swallowed by the unfocused background window.
+                if let Err(e) = crate::windows_overlay::bring_to_front_and_activate(window) {
+                    error!("Failed to activate overlay: {}", e);
                 }
                 let _ = app.emit("window-focused", true);
             }


### PR DESCRIPTION
### Description: 

- In panel mode:

https://github.com/user-attachments/assets/48132136-35a1-4318-aadc-262c37d0b236



- In floating overlay mode:

https://github.com/user-attachments/assets/72b2ea6b-5f71-4cf1-91bf-d887c6444e03

- From altk+search and then gone to timeline, it worked, see :


https://github.com/user-attachments/assets/28c6805a-ceb0-4220-b006-679bdd8a30a2




Escape failed to close the overlay timeline on Windows when it was opened via a search result click (Home window retained focus, so keyboard events never reached the overlay). Root cause: IsWindowVisible returns false immediately after window.show() because Win32 processes the show asynchronously, so the Escape global shortcut was silently never registered. Also fixed show_main_window to register the shortcut in a spawned thread to avoid deadlocking the global-shortcut plugin's handler-map lock when called from within a shortcut callback.

### Files changed:
  - apps/screenpipe-app-tauri/src-tauri/src/commands.rs — register Escape shortcut (via spawned thread) in both show_main_window and
  search_navigate_to_timeline, bypassing the broken is_visible() guard
  - apps/screenpipe-app-tauri/src-tauri/src/window/show.rs — call bring_to_front_and_activate on overlay re-show so it actually
  receives keyboard focus

