### PR TITLE
docs(testing): add Zoom idle detection regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -170,6 +170,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **meeting detection regardless of transcription mode** — Verify that meeting detection works even when transcription is disabled. (`ef39e728d`)
 - [ ] **Windows UI Automation meeting detection** — On Windows, join a meeting in a supported app (Zoom, Teams, etc.). Verify detection works via UI element scanning rather than just process focus. (`fe905d6af`, `01eb9cf33`)
 - [ ] **macOS Zoom menu bar detection** — On macOS, join a Zoom meeting. Verify detection works even if Zoom window is not focused, by scanning menu bar items. (`849372fa9`)
+- [ ] **prevent false Zoom meeting detection when idle** — Start a Zoom meeting, then leave the app idle for a few minutes without interaction. Verify meeting detection remains stable and does NOT trigger false "meeting ended" events due to background UI state changes. (`a500ec11b`)
 - [ ] **Stop auto-detected meeting from overlay** — During an auto-detected meeting, verify that the stop button in the overlay correctly terminates the meeting session. (`403d5b732`)
 - [ ] **MLX transcription model reuse** — Verify that the MLX transcription model is reused across requests to prevent GPU memory spikes or crashes. (`59deeba19`)
 - [ ] **Meeting detection app coverage** — Verify detection works for 35+ supported apps and various browser URL patterns. (`e6740eb38`)


### PR DESCRIPTION
## Problem
Commit a500ec11b (#3074) fixes false Zoom meeting detection when the app is idle. This regression-prone fix to the meeting_detector state machine should have a corresponding test case in TESTING.md to prevent regressions.

## Root cause
The meeting detection state machine had a vulnerability: when UI controls become unavailable (normal during idle or app switching), the detector could incorrectly terminate meetings even when they were still active. The fix uses audio output detection to keep meetings active when UI is temporarily unavailable.

## Fix
Added a new regression test case to the meeting detection section of TESTING.md that verifies:
- Zoom meetings remain active during idle periods
- No false 'meeting ended' events when UI state changes in the background
- Meeting state remains stable during background activity

Commit reference: a500ec11b (fix: prevent false Zoom meeting detection when app is idle #3074)

## Confidence: 10/10
Documentation update with direct citation of proven fix.

## Verification
File modified: TESTING.md only (documentation)
- Added 1 test case to existing meeting detection regression test section
- Follows established TESTING.md format with commit hash citation
- Commit hash validated with git cat-file

## Sources
- Commit: a500ec11b — 'fix: prevent false Zoom meeting detection when app is idle (#3074)'
- Files touched by original fix: crates/screenpipe-engine/src/meeting_detector.rs
- Related issue: #3074

---
auto-generated by issue-solver pipe (Fallback F1: TESTING.md regression test update)