### PR TITLE
docs(testing): add tray-only mode regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -85,6 +85,7 @@ commits that broke this area: `0752ea59`, `7562ec62`, `2a2bd9b5`, `f2f7f770`, `5
 - [ ] **tray upgrade button opens in-app checkout** — Verify that clicking the tray's upgrade button correctly opens the in-app checkout experience. (`078fcfb2`)
 - [ ] **modernized tray menu** — Verify the tray menu's updated layout and functionality match the modernized design. (`b6c363e5`)
 - [ ] **Recording toggle in tray** — Verify that the tray menu has a single toggle to start/stop recording (replacing separate items). (`cdc1d0fd9`)
+- [ ] **tray-only mode (no main window)** — Close the main window to run the app in tray-only mode. Start recording. Verify that owned-browser installation succeeds even with the main window closed. The app should not get stuck on `ready=false` if the main webview isn't available. (`28869d02c`)
 
 ### 3. monitor plug/unplug
 


### PR DESCRIPTION
## Problem
The TESTING.md regression checklist doesn't document the tray-only mode (main window closed) edge case, which broke in the past and was fixed in commit 28869d02c.

## Root cause
When the app runs in tray-only mode (user closes main window), `get_webview_window('main')` returns None. The 15-second owned-browser install budget wasn't sufficient to retry indefinitely, so the app would get stuck on `ready=false` until the next recording restart. Commit 28869d02c fixed this by switching from fixed retries to event-driven installation with a 30-minute fallback poll.

## Fix
Add a regression test entry to the tray icon section documenting:
- The tray-only mode scenario (close main window, start recording)
- Expected behavior: owned-browser installation should succeed
- What to verify: app shouldn't get stuck on ready=false

This prevents future regressions in the owned-browser installation logic when the main webview isn't available.

## Sources (multi-source)
- Recent commit: 28869d02c `fix(owned-browser): survive tray-only mode`
- TESTING.md has similar entries for other regression-prone areas (commits 0752ea59, 7562ec62, etc.)
- Regression from unreliable retry logic in previous implementation

---
auto-generated by issue-solver pipe (fallback F1)