### PR TITLE
Fix notification settings navigation

### DIFF
--- a/apps/screenpipe-app-tauri/components/notification-bell.tsx
+++ b/apps/screenpipe-app-tauri/components/notification-bell.tsx
@@ -15,7 +15,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { openSettingsWindow } from "@/lib/utils/window";
+import { useRouter } from "next/navigation";
 import { showChatWithPrefill } from "@/lib/chat-utils";
 
 interface NotificationEntry {
@@ -68,6 +68,7 @@ export function NotificationBell() {
   const [history, setHistory] = useState<NotificationEntry[]>([]);
   const [open, setOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const router = useRouter();
 
   const loadHistory = useCallback(async () => {
     try {
@@ -329,7 +330,7 @@ export function NotificationBell() {
           <button
             onClick={() => {
               setOpen(false);
-              openSettingsWindow("notifications");
+              router.push("/settings?section=notifications");
             }}
             className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
           >


### PR DESCRIPTION
Clicking **manage notification settings** from the notification bell wasn’t doing anything.

<img width="300" height="250" alt="Screenshot 2026-04-30 at 1 04 53 PM" src="https://github.com/user-attachments/assets/a0c153a4-babc-479b-9f88-ae6663e92506" />



Turns out we were using the tauri window command but settings is actually handled via next router, switched it to `router.push("/settings?section=notifications")` so it navigates correctly.

Works as expected now.
