### PR TITLE
[pr] Fix shortcut reminder size with encrypted store

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -1414,6 +1414,11 @@ pub async fn show_shortcut_reminder(
 
     info!("show_shortcut_reminder called");
 
+    let shortcut_overlay_size = crate::store::SettingsStore::get(&app_handle)
+        .unwrap_or_default()
+        .unwrap_or_default()
+        .shortcut_overlay_size;
+
     // On macOS, try the native SwiftUI shortcut reminder first
     #[cfg(target_os = "macos")]
     {
@@ -1469,6 +1474,10 @@ pub async fn show_shortcut_reminder(
                     );
                 }
             }
+            map.insert(
+                "shortcutOverlaySize".to_string(),
+                serde_json::Value::String(shortcut_overlay_size.clone()),
+            );
             if let Some(state) = app_handle.try_state::<RecordingState>() {
                 let guard = state.server.lock().await;
                 if let Some(ref core) = *guard {
@@ -1499,12 +1508,7 @@ pub async fn show_shortcut_reminder(
 
     // Window dimensions: 2-row grid (3 shortcuts + activity viz)
     // Scale based on overlay size setting
-    let scale = match crate::store::SettingsStore::get(&app_handle)
-        .unwrap_or_default()
-        .unwrap_or_default()
-        .shortcut_overlay_size
-        .as_str()
-    {
+    let scale = match shortcut_overlay_size.as_str() {
         "large" => 2.0_f64,
         "medium" => 1.5,
         _ => 1.0,

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -343,17 +343,11 @@ struct HoverIconButton: View {
     }
 }
 
-// MARK: - Overlay scale (read from ~/.screenpipe/store.bin)
+// MARK: - Overlay scale
 
 private var gOverlayScale: CGFloat = 1.0
 
-private func loadOverlayScale() {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let storePath = home.appendingPathComponent(".screenpipe/store.bin").path
-    guard let data = FileManager.default.contents(atPath: storePath),
-          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-          let settings = json["settings"] as? [String: Any],
-          let size = settings["shortcutOverlaySize"] as? String else { return }
+private func setOverlayScale(_ size: String?) {
     switch size {
     case "large": gOverlayScale = 2.0
     case "medium": gOverlayScale = 1.5
@@ -388,11 +382,10 @@ class ShortcutReminderController: NSObject {
 
     func show(shortcuts: String?) {
         DispatchQueue.main.async { [self] in
+            let prevScale = gOverlayScale
             if let shortcuts = shortcuts {
                 parseShortcuts(shortcuts)
             }
-            let prevScale = gOverlayScale
-            loadOverlayScale()
             if panel == nil || prevScale != gOverlayScale {
                 panel?.orderOut(nil)
                 panel = nil
@@ -540,12 +533,13 @@ class ShortcutReminderController: NSObject {
     }
 
     private func parseShortcuts(_ json: String) {
-        // Expects {"overlay":"…","chat":"…","search":"…"} plus optional URLs from Rust when API auth is on.
+        // Expects shortcut labels, size, and optional authenticated API URLs from Rust.
         guard let data = json.data(using: .utf8),
               let dict = try? JSONDecoder().decode([String: String].self, from: data) else { return }
         if let s = dict["overlay"] { overlayShortcut = prettifyShortcut(s) }
         if let s = dict["chat"] { chatShortcut = prettifyShortcut(s) }
         if let s = dict["search"] { searchShortcut = prettifyShortcut(s) }
+        if let s = dict["shortcutOverlaySize"] { setOverlayScale(s) }
         if let s = dict["metrics_ws_url"] { metricsWsUrl = s }
         if let s = dict["events_ws_url"] { eventsWsUrl = s }
     }


### PR DESCRIPTION
## description

Fixes the macOS native shortcut reminder overlay size setting when `store.bin` is encrypted.

The native Swift overlay previously read `~/.screenpipe/store.bin` directly and parsed it as plaintext JSON. Encrypted stores start with `SPSTORE1`, so parsing failed and the overlay always used the default scale. Rust already has access to decrypted settings through `SettingsStore`, so this change passes `shortcutOverlaySize` through the existing native shortcut reminder payload and lets Swift consume that value.

related issue: #3159

## before

With store encryption enabled and `shortcutOverlaySize` set to `large`, the shortcut reminder stayed at the default small size.

## after

The native shortcut reminder receives `shortcutOverlaySize` from Rust and recreates the panel when the scale changes, so encrypted and plaintext stores follow the same size setting.

## how to test

1. Enable store encryption so `~/.screenpipe/store.bin` starts with `SPSTORE1`.
2. Set `settings.shortcutOverlaySize` to `medium` or `large`.
3. Restart Screenpipe or hide/show the shortcut reminder and confirm the overlay size changes.

## validation

- `xcrun swiftc -parse apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift`
- `git diff --check -- apps/screenpipe-app-tauri/src-tauri/src/commands.rs apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift`
- `bun run build`
- `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --package screenpipe-app`

## setup note

Local validation required installing `git-lfs`, running `git lfs install && git lfs pull`, then running the app prebuild so the ignored Tauri sidecar binaries are available.