### PR TITLE
fix: don't propagate updater errors to caller

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -248,7 +248,7 @@ impl UpdatesManager {
                 warn!("updater check() error: {}", e);
             }
         }
-        if let Some(update) = check_result? {
+        if let Ok(Some(update)) = check_result {
             *self.update_available.lock().await = true;
 
             // Emit "update-downloading" immediately so user sees feedback


### PR DESCRIPTION
## Problem

Updater check failures ('endpoints not set' on source builds) are being logged twice:
- Once as a warning inside check_for_updates() (intended)
- Again as an error 'Failed to check for updates: ...' by the caller (unintended)

This creates Sentry noise: 36 events in the last 24h, affecting 6 users.

## Root cause

The updater check() call fails gracefully with a warning logged (line 232-237). 
However, the subsequent code at line 251 uses `check_result?` which re-propagates 
the error to the caller, triggering a second error log.

## Fix

Changed line 251 from:
```rust
if let Some(update) = check_result? {
```

To:
```rust
if let Ok(Some(update)) = check_result {
```

This allows the error to be skipped gracefully after being logged once as a warning.

## Confidence: 9/10

The root cause is obvious from code inspection. The fix is mechanical (one-line change).
The error path is already handled with a warning, so skipping the redundant error 
propagation is the intended behavior (as documented in the comment at line 233-235).

## Verification (Tier T2)

```
cargo check -p screenpipe-app
Finished successfully with no errors
```

## Sources

- **Sentry**: SCREENPIPE-APP-73 (36 events, 6 users affected, last 24h)
- **Code inspection**: updater error handling pattern (redundant error propagation)
- **Git history**: Similar error-handling improvements in recent commits

---
auto-generated by issue-solver pipe