### PR TITLE
docs(testing): add zero-fill watchdog regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -141,6 +141,7 @@ commits: `28e5c247`
 - [ ] **per-device audio toggle** — In the tray menu, verify you can toggle recording for individual audio devices. (`3ee3defcb`)
 - [ ] **stable audio device order** — Verify that audio devices listed in the tray menu maintain a stable order across refreshes. (`4577ac8a6`)
 - [ ] **Mic disconnect false-positives on sleep/wake** — Put the computer to sleep and wake it up. Verify that no false-positive mic disconnect notifications or logs are generated. (`796baa619`)
+- [ ] **zero-fill watchdog doesn't fire on never-healthy devices** — Plug in a USB device (broken mic, USB hub, disconnected input) that produces only silence or zero samples. Let it record for 2+ minutes without ever producing real audio. Verify: (1) no `DEVICE_RECOVERY` log entries for this device, (2) health endpoint shows normal audio status (not "recovery" state), (3) vision DB writer keeps writing normally (health endpoint shows no "writes stalled"). The watchdog must only rebuild devices that *were* healthy then went silent (e.g., AirPods hijacked by Proton Meet), not devices that never had signal. (`357e4dfcc`)
 
 
 #### Audio device recovery (monitor unplug / device switch)


### PR DESCRIPTION
## Problem

Audio device recovery was previously broken due to a zero-fill watchdog that would fire on devices that never produced real audio (e.g., broken USB mics, USB hubs, disconnected inputs). This caused a continuous recovery storm: rebuild → still zeros → rebuild again, which starved the vision DB writer and caused health endpoint errors.

## Root cause

The watchdog didn't distinguish between:
1. **Never-healthy devices** (should stay quiet)
2. **Devices that were healthy then went silent** (should trigger rebuild)

## Fix

Added regression test from commit 357e4dfcc which implements an `Option<Instant>` check: only trip the watchdog after we've seen at least one real-audio buffer. Devices that never had signal now stay quiet—rebuilding wouldn't help anyway, and the rebuild loop itself is harmful.

## Verification (Tier T1)

Test references:
- Real commit: 357e4dfcc ✓
- Real crate: screenpipe-audio ✓
- Real module: core/run_record_and_transcribe.rs ✓

## Sources (multi-source)

- Sentry: Audio watchdog firing every 30s on Mac mini with USB device (production data)
- Commit: 357e4dfcc (merged on main, Apr 29)
- Regression: Previous watchdog fires on never-healthy devices

---
auto-generated by issue-solver pipe (fallback F1)