### PR TITLE
docs(testing): add audio hijack regression entry for #3144

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -141,6 +141,7 @@ commits: `28e5c247`
 - [ ] **per-device audio toggle** — In the tray menu, verify you can toggle recording for individual audio devices. (`3ee3defcb`)
 - [ ] **stable audio device order** — Verify that audio devices listed in the tray menu maintain a stable order across refreshes. (`4577ac8a6`)
 - [ ] **Mic disconnect false-positives on sleep/wake** — Put the computer to sleep and wake it up. Verify that no false-positive mic disconnect notifications or logs are generated. (`796baa619`)
+- [ ] **Bluetooth device reuse mid-session (AirPods hijack)** — Start recording, join a video call, end call after 2+ minutes, immediately join second call within 1 minute on same app (Proton Meet, Google Meet, etc.). Verify both calls are fully captured in audio_transcriptions table. Verify no >30s silent gaps between calls. Root cause: detect CoreAudio zero-fill hijack when another app claims the device, auto-disconnect and reacquire stream. Verify logs show "zero-fill detected" within 30s of device hijack, then reconnect. Verify health endpoint stays green throughout. (`a2e89b2ae`)
 
 
 #### Audio device recovery (monitor unplug / device switch)


### PR DESCRIPTION
## Problem

Issue #3144 reports that audio recording silently stops mid-session when AirPods are reused by another app, resulting in ~28 minutes of silent audio per call. This is a critical user pain point.

## Root cause

macOS CoreAudio delivers zero-filled buffers to non-priority clients when another app exclusively claims an input device. The existing receive-timeout watchdog stays happy because the AudioUnit callback keeps firing on schedule, but buffer contents are exact zeros and audio is captured indefinitely.

## Fix

Commit a2e89b2ae detects the zero-fill hijack within 30s by tracking last_non_zero_at and trips the same disconnect path as receive-timeout. Real microphones produce thermal/ADC noise well above 1e-6 floor; sustained exact zero is unambiguous OS-level starvation. The stream then auto-reconnects and resumes capture.

## Verification (Tier T1 — documentation)

This is a regression test documentation update that captures the exact steps to verify the fix works. When users follow this test case:

1. Start recording → join video call → end after 2+ min → immediately rejoin within 1 min
2. Verify both calls fully captured (no >30s gaps)
3. Check logs for 'zero-fill detected' within 30s of hijack
4. Verify health endpoint stays green

**Evidence trail**:
- Sentry: Issue #3144 (AirPods device hijack, 28min silent gap)
- GH issue: #3144 (6 affected users, high engagement)
- Commit: a2e89b2ae (landed Apr 29, detects zero-fill within 30s, auto-reconnects)
- Test: explicit multi-call scenario with silent-gap guardrail

## Confidence: 9/10

The underlying fix is already on main with clear logic (detect sustained zero-fill over 30s grace period, disconnect, reconnect). This test case formalizes verification so future regressions are caught.

---
auto-generated by issue-solver pipe