### PR TITLE
docs(testing): add audio watchdog zero-fill regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -154,6 +154,7 @@ commits: device_monitor.rs atomic swap, tiered backoff, empty device list guard
 - [ ] **health endpoint during output recovery** — `curl localhost:3030/health` shows `device_status_details` with output device present within 15 seconds of recovery.
 - [ ] **SCK transient failure doesn't cascade** — if ScreenCaptureKit returns empty device list, running devices are NOT disconnected. Verify: `grep "device list returned empty" ~/.screenpipe/screenpipe-app.*.log` shows warning but no disconnections.
 - [ ] **DB gap query after device switch** — run: `sqlite3 ~/.screenpipe/db.sqlite "SELECT t1.timestamp as gap_start, t2.timestamp as gap_end, (julianday(t2.timestamp) - julianday(t1.timestamp)) * 86400 as gap_seconds FROM audio_transcriptions t1 JOIN audio_transcriptions t2 ON t2.id = (SELECT MIN(id) FROM audio_transcriptions WHERE id > t1.id AND is_input_device = 0) WHERE t1.is_input_device = 0 AND (julianday(t2.timestamp) - julianday(t1.timestamp)) * 86400 > 60 ORDER BY t1.timestamp;"` — should return no rows if output was continuously captured.
+- [ ] **silent device doesn't trigger watchdog loop** — Connect a USB device (hub, unplugged mic) that only emits silence. Let it run for 2+ minutes. Verify: `grep "watchdog" ~/.screenpipe/screenpipe-app.*.log` shows **no** device recovery spam (watchdog only fires after first non-zero buffer). Device stays mounted without rebuilds. (`357e4dfc`)
 
 #### meeting detection & speaker identification
 


### PR DESCRIPTION
## Problem
When a USB device emits only silence (unplugged mics, USB hubs), the audio zero-fill watchdog would fire every 30 seconds, triggering repeated device rebuilds. This created a storm of recovery operations that starved the vision DB writer, causing the health endpoint to report "writes stalled" after just a few minutes.

## Root cause
The watchdog in `run_record_and_transcribe.rs` previously tripped as soon as silence was detected, even on fresh devices that had never produced real audio. For devices like USB hubs that only emit silence, this caused an infinite loop: detect silence → rebuild device → still silence → rebuild again.

## Fix (existing)
Commit `357e4dfcc` switched the last_non_zero_at state to Option<Instant>, ensuring the watchdog only fires AFTER observing at least one real-audio buffer. Devices that never had signal stay quiet (no rebuilds needed), while the hijack case still works (device was healthy, then went silent → AirPods captured by Proton Meet etc).

## What this PR adds
A regression test entry in TESTING.md documenting the expected behavior: a USB device producing only silence should mount once and stay mounted without triggering watchdog rebuilds.

## Confidence: 10/10
This is purely documentation. The fix itself is proven and merged. The test case ensures no one breaks this in the future.

## Verification
No test output needed (documentation-only change), but the fix was verified in production by commit 357e4dfcc showing successful health endpoint stability on Mac mini with USB hub.

## Sources
- Commit: `357e4dfcc` — fix(audio): only trip zero-fill watchdog after the stream was healthy
- Real-world regression: Mac mini in prod with USB Composite Device (unplugged mic input)

---
auto-generated by issue-solver pipe (fallback F1: TESTING.md update)