### PR TITLE
fix: increase write pool size to prevent connection timeout

### DIFF
--- a/crates/screenpipe-config/src/defaults.rs
+++ b/crates/screenpipe-config/src/defaults.rs
@@ -113,14 +113,14 @@ impl DbConfig {
                 cache_size_kb: 32_000,        // 32 MB
                 read_pool_max: 12,
                 read_pool_min: 2,
-                write_pool_max: 3,
+                write_pool_max: 6,
             },
             DeviceTier::Low => Self {
                 mmap_size: 32 * 1024 * 1024, // 32 MB
                 cache_size_kb: 8_000,        // 8 MB
                 read_pool_max: 5,
                 read_pool_min: 1,
-                write_pool_max: 2,
+                write_pool_max: 4,
             },
         }
     }
@@ -134,7 +134,7 @@ impl Default for DbConfig {
             cache_size_kb: 64_000,        // 64 MB
             read_pool_max: 27,
             read_pool_min: 3,
-            write_pool_max: 3,
+            write_pool_max: 8,
         }
     }
 }

--- a/crates/screenpipe-db/tests/db_config_test.rs
+++ b/crates/screenpipe-db/tests/db_config_test.rs
@@ -17,7 +17,7 @@ async fn low_tier_db_initializes_successfully() {
     assert_eq!(config.mmap_size, 32 * 1024 * 1024);
     assert_eq!(config.cache_size_kb, 8_000);
     assert_eq!(config.read_pool_max, 5);
-    assert_eq!(config.write_pool_max, 2);
+    assert_eq!(config.write_pool_max, 4);
 
     // DB should initialize without errors
     let _db = DatabaseManager::new("sqlite::memory:", config)
@@ -65,4 +65,45 @@ async fn low_tier_db_can_insert_and_query() {
         .insert_frame("test_device", None, None, None, None, false, None)
         .await
         .unwrap();
+}
+
+#[tokio::test]
+async fn write_pool_size_increased_for_all_tiers() {
+    // Regression test for issue SCREENPIPE-CLI-FZ: connection pool timeout
+    // Verifies that the write pool size has been increased to handle
+    // high-volume UI event batches without timing out.
+    
+    let high_config = DbConfig::default();
+    assert!(
+        high_config.write_pool_max >= 8,
+        "high-tier write_pool_max should be at least 8, was {}",
+        high_config.write_pool_max
+    );
+    
+    let mid_config = DbConfig::for_tier(screenpipe_config::DeviceTier::Mid);
+    assert!(
+        mid_config.write_pool_max >= 6,
+        "mid-tier write_pool_max should be at least 6, was {}",
+        mid_config.write_pool_max
+    );
+    
+    let low_config = DbConfig::for_tier(screenpipe_config::DeviceTier::Low);
+    assert!(
+        low_config.write_pool_max >= 4,
+        "low-tier write_pool_max should be at least 4, was {}",
+        low_config.write_pool_max
+    );
+    
+    // Verify all pool configs initialize without error
+    let _high_db = DatabaseManager::new("sqlite::memory:", high_config)
+        .await
+        .expect("high-tier DB with increased write pool should initialize");
+    
+    let _mid_db = DatabaseManager::new("sqlite::memory:", mid_config)
+        .await
+        .expect("mid-tier DB with increased write pool should initialize");
+        
+    let _low_db = DatabaseManager::new("sqlite::memory:", low_config)
+        .await
+        .expect("low-tier DB with increased write pool should initialize");
 }


### PR DESCRIPTION
## Problem

Under high load with 500+ UI events/sec and concurrent audio/transcription writes, the write connection pool exhausts while the write_queue drain loop tries to acquire a connection. Users experience `Failed to insert UI events batch: pool timed out` errors.

**Sentry**: SCREENPIPE-CLI-FZ — 210 events, 105 users affected in 24h (unresolved)
**Root cause**: write_pool_max hardcoded to 2-3 across all tiers, too small for concurrent workloads

## Root cause

The write pool was set to 3 connections (or 2 for low-tier) since write_queue was introduced. While the write_queue serializes writes through a semaphore, concurrent reads + nested transactions/retries can hold multiple connections. When the drain loop tries to acquire a connection during high-volume batches (500+ events), the 5-second timeout expires.

SQLite with WAL mode supports multiple connections, and the write_queue architecture means extra connections only provide buffering—they don't enable concurrent writes.

## Fix

Increase write_pool_max proportional to device tier:
- **High**: 3 → 8 (aligns with read_pool_max: 27)
- **Mid**: 3 → 6
- **Low**: 2 → 4

This provides adequate buffering for pending write operations without enabling write concurrency (controlled by write_semaphore).

## Confidence: 8/10

- **Multi-source evidence**: Sentry crash data + git history (write_queue PR #3069 was closed by Louis as 'slop' for parallelizing, confirming pool is the bottleneck, not concurrency)
- **Straightforward fix**: configuration value change with test verification
- **Minor uncertainty**: original low values might have been intentional for memory constraints on old hardware, but device tiering should account for that

## Verification (Tier T1: cargo test)

```
running 5 tests
test high_tier_db_initializes_successfully ... ok
test mid_tier_db_initializes_successfully ... ok
test low_tier_db_initializes_successfully ... ok
test low_tier_db_can_insert_and_query ... ok
test write_pool_size_increased_for_all_tiers ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Sources

**Sentry**: SCREENPIPE-CLI-FZ (210 events, 105 users) — pool timed out error during UI batch insert
**GitHub**: PR #3069 (closed) — attempted fix via parallelization (louis: 'does the opposite of the title')
**Git**: commit c23768f41 — write_queue introduced to serialize writes; c61722d1 (abandoned fix branch) shows attempted concurrent approach was rejected

---

auto-generated by issue-solver pipe