### PR TITLE
docs(testing): add chat storage regression entries

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -312,6 +312,9 @@ commits: `eea0c865`, `cc09de61`, `e61501da`, `d25191d7`, `60096fb9`
 - [ ] **low disk space** — with <1GB free, app should warn user. no crash from failed writes.
 - [ ] **large database (>10GB)** — search still returns results within 2 seconds. app doesn't freeze on startup.
 - [ ] **Audio chunk timestamps** — `start_time` and `end_time` are correctly set for reconciled and retranscribed audio chunks in the database.
+- [ ] **concurrent chat saves don't ENOENT** — Open a chat conversation and repeatedly trigger saves (autosave + sidebar updates + router background saves). Verify no "[webview] persist browserState failed" errors in logs. (`e2ff708cb`)
+- [ ] **chat history never silently lost** — Start a conversation with 150+ messages. Force-quit the app mid-save. Relaunch. Verify all messages are present, not truncated to 100. (`71dcbd1ca`)
+- [ ] **Windows pipe-run chat sessions persist** — On Windows, run a pipe and chat about its results. Close the app. Relaunch. Verify the pipe run chat history is still present (not lost to filename sanitization). (`6c038aeb8`)
 
 ### 10. AI presets & settings
 


### PR DESCRIPTION
## Problem

Three critical chat-storage regressions shipped in v2.4.119 (Apr 30) but lack test coverage in TESTING.md. Without regression tests, these silent data loss bugs risk reoccurring.

## Root Cause

- **Concurrent saves race**: Two autosaves to the same tmp file; first rename succeeds, second ENOENT (e2ff708cb fix)
- **Silent history loss**: Message truncation at 100-message limit during save (71dcbd1ca fix)
- **Windows pipe-run loss**: Colons in session IDs fail NTFS filename validation (6c038aeb8 fix)

## Fix

Added three regression test entries to TESTING.md § 9 (database & storage):
1. Concurrent chat saves don't ENOENT (e2ff708cb)
2. Chat history never silently lost (71dcbd1ca)
3. Windows pipe-run chat sessions persist (6c038aeb8)

## Verification

Test changes are documentation-only (TESTING.md). Verified all cited commits exist and are real, high-impact fixes merged to main on Apr 30.

```
✓ e2ff708cb: fix(chat-storage): unique tmp filename so concurrent saves don't ENOENT
✓ 71dcbd1ca: fix(chat-storage): stop silent history loss
✓ 6c038aeb8: fix(chat-storage): sanitize filename — pipe-run sessions silently lost on Windows
```

## Sources (multi-source)

- Git history: 3 real recent commits to chat-storage (Apr 30 release)
- App release: v2.4.119 (changelog references all three fixes)
- Regression prevention: Prevents reversion of data loss fixes

---
auto-generated by issue-solver pipe (fallback F1: regression test coverage)