### PR TITLE
Fix: replace page reload with client-side tab switching in Pipes section

### DIFF
--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -335,6 +335,15 @@ export function PipeStoreView() {
 
   const [activeTab, setActiveTab] = useState<"discover" | "my-pipes">("my-pipes");
 
+  // listen for tab switch events from empty state button
+  useEffect(() => {
+    const handler = ((e: CustomEvent<{ tab: "discover" | "my-pipes" }>) => {
+      setActiveTab(e.detail.tab);
+    }) as EventListener;
+    window.addEventListener('switch-pipes-tab', handler);
+    return () => window.removeEventListener('switch-pipes-tab', handler);
+  }, []);
+
   // Read ?tab= from URL after mount, then strip it so it doesn't persist
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -1642,12 +1642,16 @@ export function PipesSection() {
                     <span><strong>focus assistant</strong> — notifies you when you get distracted</span>
                   </div>
                 </div>
-                <a
-                  href="?section=pipes&tab=discover"
+                <button
+                  onClick={() => {
+                    window.dispatchEvent(new CustomEvent('switch-pipes-tab', { 
+                      detail: { tab: 'discover' }
+                    }));
+                  }}
                   className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-foreground text-background text-sm font-medium hover:bg-foreground/90 transition-colors"
                 >
                   browse the pipe store →
-                </a>
+                </button>
               </div>
             ) : pipeFilter === "team" ? (
               <p>no pipes shared with team yet</p>


### PR DESCRIPTION
## Problem

When a user has no pipes installed and clicks "browse the pipe store" from the empty state app performs a full page reload. 

## Root Cause

The "browse the pipe store" link used an anchor tag with `href="?section=pipes&tab=discover"`, which triggers a full page navigation.

## Solution

Replace the anchor tag with a button that dispatches a custom event, and add an event listener in the parent component to handle client-side tab switching.

## Screenshots

[Before: Page reload with white flash]

https://github.com/user-attachments/assets/af1e6941-2ba0-4bdc-859d-4ff109cea2ef

[After: Smooth instant tab switching]

https://github.com/user-attachments/assets/9ccd7dd5-c42e-489d-93bb-f8a05ba0d4db
