### PR TITLE
testing: update spec from recent changes (2026-05-01)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -65,6 +65,7 @@ commits that broke this area: `0752ea59`, `d89c5f14`, `4a64fd1a`, `fa591d6e`, `8
 - [ ] **Notification panel order_out** — verify no ghost clicks after hiding notification/shortcut panels. (`32fed7c8c`)
 - [ ] **Excluded windows from screenshots** — Verify that windows specified in the ignore list are correctly excluded from full-monitor screenshots taken via ScreenCaptureKit (SCK). (`61212c429`)
 - [ ] **Swift overlay meeting toggle** — Verify that the meeting toggle in the Swift-based overlay works correctly and reflects the recording state. (`e5e955aa6`)
+- [ ] **shortcut recorder esc/click-outside cancels** — open the shortcut recorder and start recording a new key, then press Esc or click outside. recording cancels and the existing binding is preserved. UX label clearly indicates record state. (commits: `210f1a882`)
 
 
 ### 2. dock icon & tray icon (macOS)
@@ -312,6 +313,7 @@ commits: `eea0c865`, `cc09de61`, `e61501da`, `d25191d7`, `60096fb9`
 - [ ] **low disk space** — with <1GB free, app should warn user. no crash from failed writes.
 - [ ] **large database (>10GB)** — search still returns results within 2 seconds. app doesn't freeze on startup.
 - [ ] **Audio chunk timestamps** — `start_time` and `end_time` are correctly set for reconciled and retranscribed audio chunks in the database.
+- [ ] **delete-last-N-min unlinks media + drops cached frames** — Use the "delete last N minutes" retention action. Verify the corresponding `.mp4`/`.wav` files are unlinked from disk AND the in-memory hot-frame cache for the affected window is cleared (subsequent `/data` requests don't return the deleted frames). (commits: `328a3b48f`)
 
 ### 10. AI presets & settings
 
@@ -693,6 +695,7 @@ commits: `fa887407`, `815f52e6`, `60840155`, `e66c3ff8`, `c905ffbf`, `01147096`,
 - [ ] **Mermaid diagram XSS sanitization** — Verify that mermaid diagrams in the UI are correctly sanitized to prevent XSS attacks. (`3405e9793`)
 - [ ] **Per-machine pipe favorites (stars)** — Toggle the star icon for a pipe. Verify that favorites are persisted per-machine and that the filter chip correctly shows starred pipes first. (`e1a18adb9`, `0a2c1abb7`)
 - [ ] **Connected integrations @mentions in chat** — Open the filter popover in chat. Verify that connected integrations (like Notion, Slack, Google Docs) appear as @mentions for easy filtering. (`1c0c95b20`)
+- [ ] **Pipe trailing assistant prose renders** — Run a pipe whose run produces a text response without ever firing a tool call (thinking + text only). Verify the chat panel shows the response prose, not just a "thought for 0s" pill. The trailing `currentText` must be promoted into a final text content-block. (commits: `72fffdaf3`)
 
 commits: `fa887407`, `815f52e6`, `60840155`, `e66c3ff8`, `c905ffbf`, `01147096`, `5908d7f4`, `46422869`, `4f43da70`, `71a1a537`, `6abaaa36`
 
@@ -751,6 +754,7 @@ commits: `274a968af`, `dc575e48e`, `81aabbf18`, `d5e071854`, `db08f8c06`, `f4225
 ### 21. Privacy & Incognito Detection
 
 - [ ] **PII Filter** — Toggle the PII filter in chat or search. Verify that sensitive information is filtered using Tinfoil. (`fec0f1023`)
+- [ ] **Disable clipboard capture toggle** — In Privacy settings, toggle "disable clipboard capture". Verify clipboard contents stop being recorded immediately and that the CLI exposes the equivalent `--disable-clipboard` flag (recording.rs). (commits: `48fef33f1`)
 
 
 commits: `ad431b513`, `d9722bccc`, `4df21e83d`
@@ -918,6 +922,9 @@ commits: `5902dd63f`, `627418f7e`, `948689f48`, `1da3ff4f1`, `dad0267f1`, `08a6b
 - [ ] **Meeting notes in focused mode** — Switch to focused mode in meeting notes. Verify sidebar collapses and new meeting is auto-selected. (`a74a928b0`)
 - [ ] **Google Calendar integration in meeting notes** — With Google Calendar connected, verify meetings from both native and Google Calendar appear in the meeting notes list. (`08a6bc5b2`)
 - [ ] **Card-style meeting layout** — View "coming up" and past meetings. Verify card-style layout for upcoming and dense layout for past meetings. (`dad0267f1`)
+- [ ] **Sidebar can be expanded during focused meeting** — During an auto-detected meeting in focused/zen view, click the sidebar expand affordance. Verify the sidebar opens (not silently blocked by focused mode). (commits: `205bf128f`)
+- [ ] **Frame images render + scrubber spans full meeting** — Open a past meeting note. Verify all replay-strip frame images render (no broken-image placeholders) and the scrubber covers the full meeting duration (does not end early). (commits: `08898d016`)
+- [ ] **Open-in-timeline does not pop NSPanel overlay** — From a meeting note, click "open in timeline". Verify ONLY the embedded timeline section navigates; the NSPanel overlay timeline does NOT also pop open (regression: dual-surface). (commits: `bf0fe0e68`)
 
 ### 33. Browser Panel Persistence
 
@@ -925,6 +932,10 @@ commits: `e972146e7`
 
 - [ ] **Browser panel width persistence** — Open the chat panel with browser panel visible. Resize the browser panel. Close and reopen the app. Verify the width is restored to the previous size. (`e972146e7`)
 - [ ] **Browser panel collapsed state persistence** — Toggle the browser panel collapsed state in a conversation. Navigate to a different conversation. Verify the state persists per conversation. (`e972146e7`)
+- [ ] **Browser sidebar width clamped + chat shrinks** — Drag the browser panel to extreme widths. Verify width is clamped and the chat column shrinks rather than the panel overflowing the window. (commits: `35b89d072`)
+- [ ] **Browser /navigate + /snapshot endpoints** — POST to `/api/browser/navigate` with a target URL. Verify the owned-browser webview navigates via Tauri's native `navigate()` (not `eval("location.href = ...")`), the frontend receives `NAVIGATE_EVENT`, and on Windows/WebView2 navigation succeeds even when the window was hidden. POST to `/api/browser/snapshot` returns the page snapshot. (commits: `27e7a28c9`, `700258bd7`)
+- [ ] **Hidden owned-browser shown for code-only eval, then re-hidden** — With the owned-browser window hidden, issue a code-only eval (no URL). Verify the window is briefly shown so the script actually runs, then hidden again on completion or timeout (no permanent reveal). (commits: `700258bd7`)
+- [ ] **Browser-API auth resolver consolidated** — Verify `/browser/*` endpoints honor the consolidated auth-key resolver matching other authenticated endpoints. (commits: `27e7a28c9`, `d7767a5d8`)
 
 ### 34. Connections Updates (Hermes, Bee, Jira)
 
@@ -975,6 +986,10 @@ commits: `e1f55023d`, `20a0e69e4`, `d539be353`, `3def66466`
 - [ ] **Live sidebar status dot** — While current chat session streams, verify the sidebar dot pulses to indicate active streaming. (`20a0e69e4`)
 - [ ] **Chat rename broadcast** — Rename a chat. Verify the rename broadcasts across all open windows and the sidebar stays in sync. (`3def66466`)
 - [ ] **Self-heal stuck writing indicator** — If the "writing…" indicator gets stuck after session return, verify it self-heals automatically. (`d539be353`)
+- [ ] **Assistant message persists during streaming** — Start a long Pi response. Mid-stream, force-quit the app. Relaunch. Verify the partial assistant message is on disk (not silently lost); persistence happens during streaming, not only on stream-end. (commits: `35a8cfc09`)
+- [ ] **Queued messages de-emphasised + first thought collapsed** — Send several queued chat messages. Verify queued messages render with a muted/de-emphasised style and the first thinking block is collapsed by default. (commits: `2fff98866`)
+- [ ] **Auto-expand thinking + tool blocks when no prose** — In a chat message that has only thinking/tool content-blocks (no text), verify those blocks auto-expand so the user sees something. (commits: `c092166e0`)
+- [ ] **Backgrounded panel session not marked unread** — Open a chat in the panel, navigate away (currentId clears, panelSessionId still set). Verify late deltas for the panel session do NOT mark it unread. (commits: `245cbd3e6`, `11207a894` covers this in chat-store.test.ts)
 
 ### 40. PI Queue & Agent Start Gating
 
@@ -1060,6 +1075,13 @@ commits: `532f66318`
 
 - [ ] **User browser URL open toast** — Verify user browser shows toast feedback when opening URLs. (`532f66318`)
 - [ ] **Clipboard fallback for URL open** — Verify clipboard is used as fallback if `openUrl` fails. (`532f66318`)
+
+### 51. File viewer
+
+commits: `bf0fe0e68`
+
+- [ ] **Viewer cold-start latency** — Click "View Log" on a notification while in dev mode. Verify `/viewer` first-load JS dropped from ~394 kB to ~192 kB (PrismAsyncLight lazy-loads language packs) and the page becomes interactive within ~1s. (commits: `bf0fe0e68`)
+- [ ] **Viewer Copy button (⇧⌘C)** — Open the file viewer on a JSON file. Click the Copy button (or ⇧⌘C). Verify the clipboard receives prettified JSON. For non-JSON it copies content as-is. The button is hidden for images/binaries/errors/empty files. Plain ⌘C still works for OS text-selection copy. (commits: `bf0fe0e68`)
 
 ### 31. Chat (Pi)
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -907,6 +907,160 @@ commits: `c6a73b17e`, `945b687ec`
 - [ ] **CLI logout** — Run `screenpipe logout`. Verify it clears local auth tokens. (`793c3d6e9`)
 - [ ] **CLI sync remote** — Verify `screenpipe sync remote` command and its configuration. (`f46e85cb1`)
 
+
+### 32. Meeting Notes & Calendar
+
+commits: `5902dd63f`, `627418f7e`, `948689f48`, `1da3ff4f1`, `dad0267f1`, `08a6bc5b2`, `a74a928b0`
+
+- [ ] **Timeline scrubber in meeting notes** — Open meeting notes for an active/past meeting. Verify the new timeline scrubber UI allows scrubbing through meeting duration to replay specific moments. (`5902dd63f`)
+- [ ] **Meeting notes date label** — View older past meetings in the meeting notes list. Verify date labels appear for meetings older than today (not just clock time). (`1da3ff4f1`)
+- [ ] **Coming up calendar section** — Verify "coming up" section appears at top of meeting notes with auto-enriched active meeting info. (`627418f7e`)
+- [ ] **Meeting notes in focused mode** — Switch to focused mode in meeting notes. Verify sidebar collapses and new meeting is auto-selected. (`a74a928b0`)
+- [ ] **Google Calendar integration in meeting notes** — With Google Calendar connected, verify meetings from both native and Google Calendar appear in the meeting notes list. (`08a6bc5b2`)
+- [ ] **Card-style meeting layout** — View "coming up" and past meetings. Verify card-style layout for upcoming and dense layout for past meetings. (`dad0267f1`)
+
+### 33. Browser Panel Persistence
+
+commits: `e972146e7`
+
+- [ ] **Browser panel width persistence** — Open the chat panel with browser panel visible. Resize the browser panel. Close and reopen the app. Verify the width is restored to the previous size. (`e972146e7`)
+- [ ] **Browser panel collapsed state persistence** — Toggle the browser panel collapsed state in a conversation. Navigate to a different conversation. Verify the state persists per conversation. (`e972146e7`)
+
+### 34. Connections Updates (Hermes, Bee, Jira)
+
+commits: `4927a4a88`, `2d710f358`, `cff243d6e`, `d3793c918`, `9e89a6d4d`
+
+- [ ] **Hermes Agent connection** — In connections, verify the Hermes Agent card appears with instructions to paste screenpipe MCP into `~/.hermes/config.yaml`. (`4927a4a88`)
+- [ ] **Bee wearable integration** — Verify the Bee wearable connection appears in the connections panel and syncs data correctly. (`2d710f358`, `cff243d6e`)
+- [ ] **Jira OAuth 2.0 migration** — Verify Jira connection uses real OAuth 2.0 (3LO) client ID and no longer uses the maintainer-todo banner. (`d3793c918`, `e9db0dace`)
+- [ ] **Unified Hermes + OpenClaw card** — Verify that Hermes Agent and OpenClaw appear under the same AgentCard with MCP/Skill/Sync tabs. (`6802c7d5b`)
+
+### 35. AI Presets & Model Catalog
+
+commits: `8e7edcea0`, `87fe0832c`, `e599e204b`
+
+- [ ] **Live OpenAI model catalog** — In AI presets, verify OpenAI models are fetched live from the API (not hardcoded). New models appear without app update. (`8e7edcea0`)
+- [ ] **Pro vs non-pro preset defaults** — On first launch after identifying pro/non-pro status, verify pro users get pro defaults and non-pro users get standard defaults. (`87fe0832c`)
+- [ ] **Default AIPreset auto-selection** — Verify the default AI preset model is set to "auto" and stale qwen presets are migrated correctly. (`e599e204b`)
+
+### 36. Notifications & File Link Rewriting
+
+commits: `8db351cd3`, `bb232fb28`
+
+- [ ] **File links in notifications** — Send a notification with a file link via the API. Verify the notification rewrites file links to open in the in-app viewer instead of external handlers. (`8db351cd3`)
+- [ ] **Markdown link encoding in notifications** — Verify that already-encoded markdown links in notifications are not double-encoded when displayed. (`bb232fb28`)
+
+### 37. Retention Modes & Data Management
+
+commits: `1f17cb6d5`, `ec610658a`, `b2c30627b`
+
+- [ ] **Retention mode CLI flag** — Run screenpipe with `--retention-mode media-only`. Verify media files are kept while search index is deleted, reclaiming disk space. (`1f17cb6d5`)
+- [ ] **Media-only mode search** — With media-only retention enabled, verify search still works for media metadata. (`ec610658a`)
+- [ ] **Quick delete UI** — Verify one-click delete UI allows removing last 15/30/60 min of recordings. (`b2c30627b`)
+
+### 38. Onboarding & Streaming UX
+
+commits: `d9ad0b8d1`, `689f87298`, `dec32b804`, `8331f21fc`
+
+- [ ] **Streaming prose + thumbnails in onboarding** — On first launch, verify "here's what i picked up" prose streams with activity thumbnails. (`d9ad0b8d1`)
+- [ ] **Onboarding never stuck on quiet engines** — Start screenpipe with minimal activity. Verify onboarding live-feed doesn't freeze or get stuck. (`689f87298`)
+- [ ] **Prose fallback when stream fails** — If LLM stream fails during onboarding, verify friendly fallback renders locally-generated prose. (`8331f21fc`)
+- [ ] **Default prose vs technical toggle** — Verify onboarding defaults to plain prose, switches to technical only on user signals. (`460c62dc4`)
+
+### 39. Chat UX & Queueing
+
+commits: `e1f55023d`, `20a0e69e4`, `d539be353`, `3def66466`
+
+- [ ] **Queued follow-up prompts** — While Pi is streaming, queue a follow-up prompt. Verify it executes immediately after the first stream completes. (`e1f55023d`)
+- [ ] **Live sidebar status dot** — While current chat session streams, verify the sidebar dot pulses to indicate active streaming. (`20a0e69e4`)
+- [ ] **Chat rename broadcast** — Rename a chat. Verify the rename broadcasts across all open windows and the sidebar stays in sync. (`3def66466`)
+- [ ] **Self-heal stuck writing indicator** — If the "writing…" indicator gets stuck after session return, verify it self-heals automatically. (`d539be353`)
+
+### 40. PI Queue & Agent Start Gating
+
+commits: `2949c8126`
+
+- [ ] **PI queue advance gating** — Verify queue advance is gated on `agent_start`, not response ACK. Queue processing should not stall waiting for responses. (`2949c8126`)
+
+### 41. Chat Storage & Reliability
+
+commits: `e2ff708cb`, `71dcbd1ca`, `71559c011`, `6c038aeb8`, `8a13b0e4a`
+
+- [ ] **Unique tmp filename in chat saves** — With concurrent chat saves, verify unique tmp filenames prevent ENOENT errors. (`e2ff708cb`)
+- [ ] **Silent history loss prevention** — Verify chat history is no longer silently lost during concurrent saves. (`71dcbd1ca`)
+- [ ] **fs:allow-rename permission for chat** — Verify atomic chat saves have the fs:allow-rename permission granted. (`71559c011`)
+- [ ] **Windows filename sanitization** — On Windows, verify pipe-run session filenames are sanitized to prevent silent history loss. (`6c038aeb8`)
+- [ ] **Mirror messages before disk write** — Verify messages are mirrored into the store before writing to disk. (`8a13b0e4a`)
+
+### 42. Accessibility & Browser Controls
+
+commits: `43c7c249e`, `0db2466d7`, `1510f260e`, `8489471a4`, `c4051d521`
+
+- [ ] **Owned browser with Rust screen-coord math** — Verify owned browser screen coordinate math is handled on the Rust side correctly. (`43c7c249e`)
+- [ ] **Owned browser top-level WebviewWindow** — Verify owned browser uses top-level WebviewWindow instead of nested windows. (`0db2466d7`)
+- [ ] **Owned browser cross-origin eval** — Verify cross-origin eval works correctly in owned browser. (`0db2466d7`)
+- [ ] **Owned browser window parent fallback** — Verify owned browser picks any available window as parent (not just "main"). (`1510f260e`)
+- [ ] **Owned browser home in parent candidate list** — Verify "home" window appears in owned browser parent window candidate list. (`8489471a4`)
+
+### 43. AI Gateway & E2EE Proxy
+
+commits: `bbbd4c3b6`, `65f7928a2`
+
+- [ ] **E2EE proxy routes in AI gateway** — Verify tinfoil E2EE proxy routes are available in AI gateway. (`bbbd4c3b6`)
+- [ ] **AI gateway reasoning content promotion** — Verify `reasoning_content` is promoted to `content` when `content` is empty in AI gateway responses. (`65f7928a2`)
+
+### 44. Audio Pipeline Improvements
+
+commits: `da8c5b89d`, `a2e89b2ae`, `357e4dfcc`, `02c27c0b1`
+
+- [ ] **Audio diarization evaluation** — Verify audio diarization evaluation harness produces correct speaker identification metrics. (`da8c5b89d`)
+- [ ] **Zero-fill device hijack detection** — Verify audio stream detects zero-fill device hijack and alerts user. (`a2e89b2ae`)
+- [ ] **Zero-fill watchdog after stream health** — Verify zero-fill watchdog only triggers after stream has been healthy. (`357e4dfcc`)
+
+### 45. Tray & Auto-Resume
+
+commits: `bf42a9128`, `532f66318`
+
+- [ ] **Tray pause/auto-resume toggle** — Click pause in tray menu. Verify a live tooltip appears and `/notify` sends auto-resume indicator. (`532f66318`)
+- [ ] **Tray upgrade button** — Verify clicking the tray's upgrade button opens in-app checkout. (`bf42a9128`)
+- [ ] **Modernized tray menu** — Verify tray menu has the modernized design layout. (`bf42a9128`)
+- [ ] **Recording toggle in tray** — Verify tray menu has single toggle to start/stop recording. (`bf42a9128`)
+
+### 46. OCR & Vision Pipeline
+
+commits: `6f3f80dd3`, `3def66466`, `43c7c249e`
+
+- [ ] **Apple OCR word-level records** — Verify OCR keeps apple per-word records on fast path without duplication. (`6f3f80dd3`)
+- [ ] **Search highlight tightness** — Verify per-word search highlights are tight and accurate. (`790624e1e`)
+
+### 47. Timeline & Search Navigation
+
+commits: `a83afa951`, `68b936e0e`, `068151344`
+
+- [ ] **Timeline search navigation polish** — Verify search nav responds to ⌘G, strips dots from query, and pulses gently. (`a83afa951`)
+- [ ] **Timeline search chevron direction** — Verify ▶ advances forward in time and ◀ goes backward. (`68b936e0e`)
+
+### 48. Windows-specific Improvements
+
+commits: `3e5f6c63f`, `dd8f3e0a9`
+
+- [ ] **Overlay escape key in Windows** — Verify Escape key closes overlay when opened from search on Windows. (`3e5f6c63f`)
+- [ ] **Meeting recording stop button** — Verify meeting recording stop button works and push-driven status stream updates. (`dd8f3e0a9`)
+
+### 49. Skill Installation & Downloads
+
+commits: `29ca22a81`
+
+- [ ] **Skill download fs scope** — Verify skill installation grants proper `$DOWNLOAD` fs scope for downloads. (`29ca22a81`)
+- [ ] **Skill install loading UX** — Verify skill installation shows loading/saved/error UX states. (`29ca22a81`)
+
+### 50. User Browser & Clipboard
+
+commits: `532f66318`
+
+- [ ] **User browser URL open toast** — Verify user browser shows toast feedback when opening URLs. (`532f66318`)
+- [ ] **Clipboard fallback for URL open** — Verify clipboard is used as fallback if `openUrl` fails. (`532f66318`)
+
 ### 31. Chat (Pi)
 
 - [ ] **Parallel chats** — Verify that multiple chat sessions can run in parallel and their background streams remain visible when switching. (`c9d64ce23`)

--- a/apps/screenpipe-app-tauri/components/__tests__/pipe-ndjson-to-chat.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/pipe-ndjson-to-chat.test.ts
@@ -165,6 +165,44 @@ describe("parsePipeNdjsonToMessages", () => {
     expect(thinkingBlock.text).toBe("Let me think about this.");
   });
 
+  it("promotes trailing assistant text into a text contentBlock when only thinking was captured (72fffdaf3)", () => {
+    // Real bug: pipe runs that produced a text response WITHOUT ever firing
+    // a tool call left `currentText` sitting in flushAssistant. The renderer
+    // iterates contentBlocks exclusively when blocks exist, so a message
+    // with content="<long response>" + blocks=[thinking] rendered as just
+    // the thinking pill — prose was on disk but invisible. flushAssistant
+    // must promote the trailing currentText into a final text block.
+    //
+    // No `agent_end` here, so the streaming fallback runs and exits via
+    // end-of-input flushAssistant (no turn_end either). On HEAD this yields
+    // contentBlocks=[thinking, text]; on the pre-fix code it yielded
+    // contentBlocks=[thinking] only.
+    const stdout = [
+      '{"type":"message_start","message":{"role":"assistant","content":[]}}',
+      '{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"reasoning...","partial":{}}}',
+      '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":1,"delta":"Final answer prose.","partial":{}}}',
+    ].join("\n");
+
+    const msgs = parsePipeNdjsonToMessages(stdout);
+    expect(msgs).toHaveLength(1);
+    const assistant = msgs[0];
+    expect(assistant.role).toBe("assistant");
+    expect(assistant.content).toBe("Final answer prose.");
+    expect(assistant.contentBlocks).toBeDefined();
+    // The renderer iterates contentBlocks exclusively when blocks exist —
+    // the prose MUST exist as a text block, not just live in `content`.
+    const textBlock = assistant.contentBlocks!.find(
+      (b: any) => b.type === "text"
+    );
+    expect(textBlock).toBeDefined();
+    expect(textBlock!.text).toBe("Final answer prose.");
+    // Both blocks should be present, in the order they were produced.
+    expect(assistant.contentBlocks!.map((b: any) => b.type)).toEqual([
+      "thinking",
+      "text",
+    ]);
+  });
+
   // ─── multi-turn conversations ─────────────────────────────────────
 
   it("handles multi-turn: user → assistant → tool → assistant", () => {


### PR DESCRIPTION
Auto-generated testing spec update based on recent commits.

## Original update (commit `b80873911`, was `0c5edd4b7`)

20 new sections covering meeting notes, browser-panel persistence, connections (Hermes/Bee/Jira), AI presets, retention modes, onboarding streaming, chat UX & queueing, chat storage reliability, owned-browser controls, AI gateway, audio pipeline, tray/auto-resume, OCR/vision, timeline navigation, Windows fixes, skill installation, and clipboard fallback.

## Incremental update (commit `9a770708d`)

Picks up commits that landed on `main` after the original update. Adds checklist items + 1 revert-validated automated test.

### Qualifying commits added

- `210f1a882` shortcut recorder esc/click-outside cancels (sec 1)
- `328a3b48f` retention "delete last N min" unlinks `.mp4`/`.wav` + drops cached frames (sec 9)
- `72fffdaf3` pipe-ndjson promotes trailing assistant text to a content block (sec 17) — **validated test**
- `48fef33f1` privacy: disable clipboard capture toggle (sec 21)
- `205bf128f` meeting-notes sidebar can be expanded during focused meeting (sec 32)
- `08898d016` meeting-notes broken frame images + scrubber-ends-too-early (sec 32)
- `bf0fe0e68` viewer cold-start (-50% JS) + Copy button + meeting-notes timeline open (sec 32 + new sec 51)
- `27e7a28c9` browser-api `/navigate` + `/snapshot` + clean auth resolver (sec 33)
- `700258bd7` owned-browser native `navigate()` + show-during-eval for hidden window (sec 33)
- `35b89d072` browser-sidebar clamp width so chat shrinks (sec 33)
- `35a8cfc09` chat-storage persists assistant message during streaming (sec 39)
- `2fff98866` chat de-emphasises queued + collapses first thought (sec 39)
- `c092166e0` chat auto-expand thinking + tool blocks when no prose (sec 39)
- `245cbd3e6` chat doesn't mark backgrounded panel session as unread (sec 39; chat-store.test.ts coverage from `11207a894`)

### Validated test

- `apps/screenpipe-app-tauri/components/__tests__/pipe-ndjson-to-chat.test.ts`
  - 1 new case: `promotes trailing assistant text into a text contentBlock when only thinking was captured (72fffdaf3)`
  - Validates that `flushAssistant` promotes trailing `currentText` into a final text content-block — without this, `contentBlocks=[thinking]` only and the renderer hides the prose.
  - **Revert-validated against `72fffdaf3`** — test fails on the reverted code (`textBlock` is `undefined`); passes on HEAD with `contentBlocks=[thinking, text]`.

### Skipped

- `28b43bca7` ci infra (frontend test wiring)
- `d7767a5d8` refactor: API-key resolver consolidation
- `7fb0be5ca` chore: dead code removal
- `abaa5f8b4` chore: log level downgrade (warn → debug)
- `da8c5b89d` refactor: extract `screenpipe-audio-eval` crate (already covered by sec 44)
- `11207a894` test only (referenced from the `245cbd3e6` entry)