### PR TITLE
docs(testing): add zero-fill device watchdog regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -113,6 +113,7 @@ commits: `28e5c247`
 - [ ] **bluetooth device connect/disconnect** — AirPods connect mid-recording. audio continues without gap.
 - [ ] **no audio device available** — unplug all audio. app continues (vision still works). log shows warning, not crash.
 - [ ] **audio stream timeout recovery** — if audio stream times out (30s no data), it should reconnect automatically.
+- [ ] **zero-fill device watchdog prevents recovery storm** — Connect a device that produces only silence (e.g. unplugged USB hub mistaken for audio device). Verify the watchdog does NOT repeatedly rebuild the stream; instead, the silent device stays quiet without recovery attempts. Old hijacked devices (was healthy, then went silent) should still trigger watchdog recovery. (`357e4dfcc`)
 - [ ] **multiple audio devices simultaneously** — input (mic) + output (speakers) both recording. both show in device list.
 - [ ] **disable audio setting** — toggling "disable audio" stops all audio recording. re-enabling restarts it.
 - [ ] **Metal GPU for whisper** — transcription uses GPU acceleration on macOS (`f882caef`). verify with Activity Monitor GPU tab.


### PR DESCRIPTION
## Problem

The zero-fill device watchdog fix (357e4dfcc) prevents recovery storm when a
device produces only silence. This regression should be tested to ensure:
1. Silent devices don't trigger repeated recovery attempts
2. Devices that go silent after being healthy still trigger recovery
3. The fix correctly differentiates between 'always silent' and 'went silent'

## Solution

Added a comprehensive test entry in TESTING.md that guides the tester through
the scenario and expected behavior.

## Verification (T3: docs-only)

- [x] Commit hash 357e4dfcc resolves and matches fix title
- [x] Hash format matches TESTING.md convention
- [x] Test description is actionable for manual testing
- [x] No lockfile changes

## Sources

- Commit: 357e4dfcc (fix: audio watchdog)
- Area: audio device recovery (regression-prone)
- Type: Fallback F1 (TESTING.md update)

---
auto-generated by issue-solver pipe