### PR TITLE
chore(logging): downgrade permission denied log from error to debug

### DIFF
--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use screenpipe_events::PermissionKind;
 use screenpipe_screen::monitor::{list_monitors_detailed, MonitorListError};
@@ -57,7 +57,7 @@ pub async fn start_monitor_watcher(
                 permission_denied_logged = false;
             }
             Err(MonitorListError::PermissionDenied) => {
-                error!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
+                debug!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
                 permission_denied_logged = true;
                 permission_monitor::report_state(
                     PermissionKind::ScreenRecording,
@@ -188,7 +188,7 @@ pub async fn start_monitor_watcher(
                 }
                 Err(MonitorListError::PermissionDenied) => {
                     if !permission_denied_logged {
-                        error!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
+                        debug!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
                         permission_denied_logged = true;
                         permission_monitor::report_state(
                             PermissionKind::ScreenRecording,


### PR DESCRIPTION
## Problem

The "Screen recording permission denied" message is being logged at ERROR level every time users lack screen recording permission. With 738 events and 736 unique users in the last 24h (Sentry issue SCREENPIPE-CLI-49), this is generating significant noise in error logs.

This is expected behavior on first launch or when users have revoked permissions — not an error condition.

## Root cause

The log level was set to `error!` in two places in the monitor watcher's permission check logic, even though permission denial is an expected, non-exceptional state.

## Fix

Downgraded both occurrences of this message from `error!` to `debug!` level:
1. Line 60: During startup monitor list attempt
2. Line 191: During runtime monitor polling

This reduces Sentry noise while preserving the debug information for troubleshooting.

## Confidence: 9/10

This is a straightforward log-level adjustment for an expected code path. No behavioral changes; debug logs will still be available when needed. Single-line changes in a logging macro.

## Verification (Tier T2)

```
Compiling screenpipe-engine v0.3.304
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.13s
```

Clean build with no warnings after fixing the unused import.

## Sources (multi-source)

- **Sentry**: SCREENPIPE-CLI-49 (738 events, 736 unique users in 24h)
- **Git history**: Recent commits show logging-focused improvements in this file
- **Code inspection**: Permission denial message at both startup and runtime paths

---
auto-generated by issue-solver pipe