### PR TITLE
fix: preserve original db error in write queue instead of masking with PoolTimedOut

### DIFF
--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -1336,8 +1336,9 @@ async fn execute_single_write(
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
+    let err_str = error.to_string();
     for pw in batch.drain(..) {
-        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut));
+        let _ = pw.respond.send(Err(sqlx::Error::Protocol(err_str.clone().into())));
     }
     // Log the original error that caused the batch failure
     error!("write_queue: batch failed: {}", error);
@@ -1398,6 +1399,27 @@ fn is_busy_error(e: &sqlx::Error) -> bool {
 mod tests {
     use super::*;
     use sqlx::sqlite::SqlitePoolOptions;
+
+    #[test]
+    fn test_send_error_to_all_propagates_actual_error() {
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        let mut batch = vec![PendingWrite {
+            op: WriteOp::InsertAudioChunk { file_path: "test".into(), timestamp: None },
+            respond: tx,
+        }];
+        
+        let err = sqlx::Error::RowNotFound;
+        send_error_to_all(&mut batch, err);
+        
+        assert!(batch.is_empty());
+        let received = rx.try_recv().unwrap();
+        match received {
+            Err(sqlx::Error::Protocol(msg)) => {
+                assert!(msg.to_string().contains("no rows returned by a query"));
+            }
+            _ => panic!("Expected Protocol error with original message"),
+        }
+    }
 
     async fn setup_test_db() -> (Pool<Sqlite>, Arc<Semaphore>) {
         let pool = SqlitePoolOptions::new()


### PR DESCRIPTION
## Problem

The write queue's `send_error_to_all()` function was masking the actual database error with a hardcoded `sqlx::Error::PoolTimedOut`. This caused:

1. **False diagnostics**: Clients couldn't distinguish between actual pool exhaustion vs. other DB failures (locked, corrupt, disk full)
2. **Sentry noise**: All errors appeared as "pool timed out" in error traces, obscuring root causes
3. **Poor debugging**: Developers couldn't diagnose real issues from error messages

Sentry issue [7331781144](https://mediar.sentry.io/issues/7331781144/) tracked 219 events from 110 affected users experiencing database errors.

## Root cause

In `crates/screenpipe-db/src/write_queue.rs:1340`, when a batch of database writes failed:

```rust
fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
    for pw in batch.drain(..) {
        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut)); // ← Always masks error!
    }
}
```

The function received the actual error but ignored it, sending `PoolTimedOut` unconditionally to all pending write handlers.

## Fix

Preserve the original error by converting it to a `Protocol` error with the full message:

```rust
fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
    let err_str = error.to_string();
    for pw in batch.drain(..) {
        let _ = pw.respond.send(Err(sqlx::Error::Protocol(err_str.clone().into())));
    }
}
```

Now clients receive the actual error message, allowing proper diagnosis.

## Confidence: 9/10

- **Obvious bug**: Parameter `error` is received but unconditionally masked
- **Multi-source evidence**: 
  - Sentry issue 7331781144 (219 events, 110 users)
  - Previous PR #3059 attempted this exact fix
  - Current code still has the bug
- **Proven fix**: Matches approach from commit 4917ea507
- **Test coverage**: New test `test_send_error_to_all_propagates_actual_error` verifies actual errors are forwarded

## Verification (Tier T1 - Full test suite)

All 14 write_queue tests pass:

```
running 14 tests
test write_queue::tests::is_fatal_sqlite_message_recognises_io_and_corruption ... ok
test write_queue::tests::is_connection_error_classifies_transport_variants ... ok
test write_queue::tests::test_send_error_to_all_propagates_actual_error ... ok
test write_queue::tests::is_connection_error_treats_per_row_errors_as_non_fatal ... ok
test write_queue::tests::test_duplicate_transcription_skipped ... ok
test write_queue::tests::test_single_write ... ok
test write_queue::tests::test_ordering_chunk_before_transcription ... ok
test write_queue::tests::test_empty_transcription_skipped ... ok
test write_queue::tests::test_snapshot_frame_insert ... ok
test write_queue::tests::test_combined_chunk_and_transcription ... ok
test write_queue::tests::test_shutdown_flushes_pending ... ok
test write_queue::tests::test_video_chunk_insert ... ok
test write_queue::tests::test_batch_coalescing ... ok
test write_queue::tests::test_concurrent_mixed_writes ... ok

test result: ok. 14 passed; 0 failed
```

## Sources (multi-source required)

- **Sentry**: [SCREENPIPE-CLI-FZ](https://mediar.sentry.io/issues/7331781144/) — 219 events, 110 users in last 24h
- **Previous PR**: #3059 "fix: preserve original db error in write queue instead of masking with pool timed out" (closed 2026-04-24)
- **Code inspection**: Current HEAD still has the bug at line 1340

---
auto-generated by issue-solver pipe