### PR TITLE
docs(testing): add Windows AVX2 CPU support regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -467,7 +467,7 @@ commits: `b3628788`, `738178da`
 
 ### 15. Windows-specific
 
-commits: `eea0c865`, `fe9060db`, `c99c3967`, `aeaa446b`, `5a219688`, `caae1ebc`, `67caf1d1`, `ff4af7b5`
+commits: `eea0c865`, `fe9060db`, `c99c3967`, `aeaa446b`, `5a219688`, `caae1ebc`, `67caf1d1`, `ff4af7b5`, `a74be160a`
 
 - [ ] **COM thread conflict** — audio and vision threads don't conflict on COM initialization (`eea0c865`).
 - [ ] **high-DPI display (150%, 200%)** — OCR captures at correct resolution.
@@ -475,6 +475,7 @@ commits: `eea0c865`, `fe9060db`, `c99c3967`, `aeaa446b`, `5a219688`, `caae1ebc`,
 - [ ] **Windows Defender** — app not blocked by default security.
 - [ ] **Windows default mode** — On Windows, the app should default to window mode on first launch.
 - [ ] **Windows taskbar icon** — The app should display a taskbar icon on Windows.
+- [ ] **Windows AVX2 CPU support check** — On Windows CPUs without AVX2 (e.g., QEMU qemu64, older cloud VMs), the app shows a clear error dialog instead of crashing silently. Test by booting QEMU with `-cpu qemu64` and verifying the user sees a friendly message. (`a74be160a`)
 - [ ] **Windows audio transcription accuracy** — On Windows, verify improved audio transcription accuracy due to native Silero VAD frame size and lower speech threshold.
 - [ ] **Windows multi-line pipe prompts** — Multi-line pipe prompts should be preserved on Windows.
 - [ ] **Windows ARM64 support** — On a Windows ARM64 device, verify the app installs and runs correctly. (`d62360bc4`)


### PR DESCRIPTION
## Problem

Windows users on older CPUs (e.g., QEMU qemu64, older cloud VMs) that lack AVX2 instruction support were seeing silent crashes at app startup. The crash was caused by heavy dependencies (e.g., ort, vision pipelines) attempting to initialize with instructions not available on the CPU.

## Root cause

The app depended on AVX2 instructions without checking CPU capabilities first. On CPUs without AVX2, the heavy dependencies would panic during initialization, causing a silent crash instead of a user-friendly error.

## Fix

Commit a74be160a ("fix: check AVX2 CPU support before app initialization") adds an early CPU capability check at Windows app startup that:
- Detects AVX2 support using CPUID
- Shows a user-friendly dialog if AVX2 is missing
- Exits cleanly before any heavy dependencies initialize

This regression test entry documents the expected behavior and how to validate it.

## Confidence: 10/10

This is a documentation-only change that adds a regression test entry for an existing, merged fix. The fix is in place and working. No code changes are needed.

## Verification (Tier T3 — documentation)

The change adds a regression test entry to TESTING.md with:
- Clear description of the expected behavior
- Test environment (QEMU with `-cpu qemu64`)
- Reference to the fix commit (a74be160a)
- Expected user experience (friendly error dialog, not silent crash)

## Sources (multi-source required)

- GitHub issue: #3125 (Windows app silently crashes on launch on CPUs without AVX2)
- Fix commit: a74be160a (by CI Fixer, merged in main)
- Regression category: app initialization / CPU support (Windows-specific)

---
auto-generated by issue-solver pipe
