### PR TITLE
docs(testing): add Apple Vision per-word OCR fast path regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -198,6 +198,7 @@ commits: `6dd5d98e`, `831ad258`
 - [ ] **window capture only on changed frames** — window enumeration (CGWindowList) should NOT run on skipped frames. verify by checking CPU on idle multi-monitor setup.
 - [ ] **Meeting app OCR force** — Open a meeting app (Zoom, Teams, Meet). Verify OCR is forced for these apps even if accessibility is available. (`b18ae2253`)
 - [ ] **Accessibility automation properties** — Verify automation properties (labels, roles, automation IDs) are correctly captured in the accessibility tree across Windows, macOS, and Linux. (`1b7d0db5b`)
+- [ ] **Apple Vision per-word OCR fast path** — Browse an app with lots of text (e.g., Wikipedia article with 500+ words). Verify OCR database inserts are fast (bulk VALUES insert, not 500 individual RETURNING queries). Check logs for no "Slow DB batch insert" warnings. Regression: `6f3f80dd3` (Apple per-word records now use level="0" for bulk-insert fast path, not level="5" which hit expensive per-row insert).
 - [ ] **DB write coalesce queue** — Under heavy load (e.g. many pipes + high FPS), verify no "database is locked" errors and no vision stalls due to write contention. (`39c016cb3`, `d119d060d`, `231521192`)
 - [ ] **Windows idle CPU reduction** — Verify low CPU usage on Windows when screen is idle, using event-driven hooks and caching. (`d2c9d1fb8`)
 - [ ] **reduced CPU spikes in vision/capture pipeline** — Actively browse and use applications, verifying that CPU spikes in the vision/capture pipeline are significantly reduced. (`8f7294e6`)


### PR DESCRIPTION
## Purpose
Prevent regression of the Apple Vision per-word OCR performance fix from commit 6f3f80dd3.

## What This Tests
- Apple Vision per-word OCR records use the bulk-insert fast path (level="0")
- Database inserts for word-heavy frames are fast (single bulk VALUES insert, not 1000 individual RETURNING queries)
- No "Slow DB batch insert" warnings during heavy text capture

## Regression Prevented
Commit 6f3f80dd3 fixed a performance regression where Apple Vision per-word records were being emitted with level="5", which routed every single word through the expensive per-row hierarchical insert path (intended for Tesseract's page→block→paragraph→line→word chain). Apple has no such hierarchy. Reverting to level="0" puts words back on the bulk fast path.

This regression test ensures:
1. When browsing apps with lots of text (500+ words per frame)
2. Database inserts complete quickly
3. No per-word individual RETURNING queries are issued

## Verification
Test: browse a text-heavy page (Wikipedia article with 500+ words), watch logs for no "Slow DB batch insert" warnings.

---
auto-generated by issue-solver pipe (fallback F1)