### PR TITLE
docs(testing): add per-line search highlight regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -60,6 +60,7 @@ commits that broke this area: `0752ea59`, `d89c5f14`, `4a64fd1a`, `fa591d6e`, `8
 - [ ] **text selection not blocked by URL overlays** — On URL-heavy pages, verify that text selection is not blocked by clickable URL overlays. (`eb9e65b4`)
 - [ ] **macOS focused-app capture with AX observers** — On macOS, verify that focused-app capture works correctly when switching between applications, utilizing AX observers. (`22830119`)
 - [ ] **macOS native Live Text interaction** — On macOS, verify that native Live Text interaction, including text selection and data detectors, is re-enabled and functions correctly. (`e9c76934`)
+- [ ] **Per-line search highlight accuracy** — Open a multi-line paragraph in a browser (Arc, Chrome) or note app (Obsidian). Search for a word. Verify that search highlights only hug the matched word's line, not paint the entire paragraph. On Obsidian, verify perfect line geometry. On browsers, verify via binary search on AXLineForIndex (since AXRangeForLine is unsupported). (`b86341d7a`)
 - [ ] **Livetext single worker thread** — verify no GCD thread exhaustion freeze during heavy livetext analysis. (`a3e29d42a`)
 - [ ] **VisionKit semaphore timeouts** — verify no deadlocks in vision pipeline if VisionKit hangs (10s timeout). (`397f46133`)
 - [ ] **Notification panel order_out** — verify no ghost clicks after hiding notification/shortcut panels. (`32fed7c8c`)


### PR DESCRIPTION
## Problem

Recent accessibility improvements for per-line bounding box capture for multi-line AX text nodes (commit b86341d7a) represent a regression-prone area that should have test coverage. This feature uses AX APIs that behave differently across browsers and native apps.

## Solution

Added a new regression test in TESTING.md for the per-line search highlight accuracy feature. The test verifies that search highlights hug only the matched word's line on multi-line paragraphs (not the entire paragraph) across both browser (Arc, Chrome) and native (Obsidian) implementations.

## Test Coverage

- Covers commit b86341d7a (per-line bbox capture for multi-line AX text nodes)
- Regression-prone area: window/AX tree interaction
- Tests both browser and native implementations
- Specific test instructions for verification

## Verification

Test exists in TESTING.md and references real commit hash b86341d7a which is verified to exist on main.

---
auto-generated by issue-solver pipe (fallback F1)
