### PR TITLE
docs(testing): add empty-state navigation button regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -376,9 +376,10 @@ commits: `87abb00d`, `9464fdc9`, `0f9e43aa`, `7ea15f32`
 
 ### 12. timeline & search
 
-commits: `f1255eac`, `25cbdc6b`, `2529367d`, `d9821624`, `e61501da`, `039d5fea`, `50ff4f4c`, `91cc4371`, `bcce42796`, `a98fa2991`, `0ff93b167`, `adbbb8f84`
+commits: `f1255eac`, `25cbdc6b`, `2529367d`, `d9821624`, `e61501da`, `039d5fea`, `50ff4f4c`, `91cc4371`, `bcce42796`, `a98fa2991`, `0ff93b167`, `adbbb8f84`, `b628048a2`
 
 - [ ] **arrow key navigation** — left/right arrow keys navigate timeline frames (`f1255eac`).
+- [ ] **empty-state navigation buttons** — In empty timeline state (no frames yet), left/right navigation buttons navigate in the correct direction (`b628048a2`).
 - [ ] **search results sorted by time** — search results appear in chronological order (`25cbdc6b`).
 - [ ] **no frame clearing during navigation** — navigating timeline doesn't cause frames to disappear and reload (`2529367d`).
 - [ ] **URL detection in frames** — URLs visible in screenshots are extracted and shown as clickable pills (`50ef52d1`, `aa992146`).


### PR DESCRIPTION
## Problem

The timeline's empty-state arrow buttons had a bug where they navigated in the wrong direction. This was fixed in commit b628048a2 but the fix was not documented in the TESTING.md regression test suite.

## Root cause

Regression test coverage gap — the bug was fixed but the test case was not added to TESTING.md to prevent future regressions in this code path.

## Fix

Added a new test case to the **12. timeline & search** section of TESTING.md to document the regression:
- Verify that in empty timeline state (no frames yet), left/right navigation buttons navigate in the correct direction

## Confidence: 8/10

This is a simple documentation addition with:
- Real commit hash verified (b628048a2)
- Specific test case for a legitimate regression-prone area (timeline navigation)
- Clear test description that can be manually verified

## Verification

TESTING.md was updated and the commit hash was verified to exist in the git history.

## Sources

- Recent commit: b628048a2 (fix: empty-state arrow buttons navigated in the wrong direction)
- Regression-prone area: timeline navigation UI
- Documentation: TESTING.md

---
auto-generated by issue-solver pipe (fallback F1)