### PR TITLE
fix(chat): allow input chip to be removed

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-mention-system.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-mention-system.ts
@@ -102,7 +102,7 @@ export function useMentionSystem(opts: {
         const pattern = timePatterns[label];
         if (pattern) newInput = newInput.replace(pattern, "").trim();
       } else if (filterType === "content") {
-        newInput = newInput.replace(/@(audio|screen)\b/gi, "").trim();
+        newInput = newInput.replace(/@(audio|screen|input)\b/gi, "").trim();
       } else if (filterType === "app" && activeFilters.appName) {
         // Remove app mention - need to find the pattern
         const appPattern = new RegExp(`@${activeFilters.appName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, "gi");

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -2255,7 +2255,7 @@ export function StandaloneChat({
       const pattern = timePatterns[label];
       if (pattern) newInput = newInput.replace(pattern, "").trim();
     } else if (filterType === "content") {
-      newInput = newInput.replace(/@(audio|screen)\b/gi, "").trim();
+      newInput = newInput.replace(/@(audio|screen|input)\b/gi, "").trim();
     } else if (filterType === "app" && activeFilters.appName) {
       // Remove app mention - need to find the pattern
       const appPattern = new RegExp(`@${activeFilters.appName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, "gi");


### PR DESCRIPTION
This PR fixes an inconsistency in mention handling where `@input `was not being removed from the chip.
Previously, only `@audio `and `@screen` were supported in the removal regex, causing `@input` to remain in the query string.
<img width="691" height="415" alt="Screenshot 2026-05-03 at 5 24 21 PM" src="https://github.com/user-attachments/assets/98c2cd4c-2f70-413a-9173-313ee0161c1c" />
