### PR TITLE
fix(settings): api key regenerate cancel, apply button, manual edit

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -204,12 +204,12 @@ export function PrivacySection() {
   const [filterView, setFilterView] = useState<"all" | "personal" | "team">("all");
   const [pushingFilter, setPushingFilter] = useState<string | null>(null);
 
-  // Live API auth key — fetched from the running server, not user-editable.
-  // Letting users set their own opens the door to weak/known keys; the server
-  // auto-generates a strong `sp-<uuid8>` and persists it to the secret store.
   const [liveApiKey, setLiveApiKey] = useState<string | null>(null);
   const [revealApiKey, setRevealApiKey] = useState(false);
   const [regeneratingKey, setRegeneratingKey] = useState(false);
+  // Tracks a manually-typed key that hasn't been persisted yet. Set on input
+  // change, cleared after handleUpdate saves it to the secret store.
+  const [pendingApiKey, setPendingApiKey] = useState<string | null>(null);
 
   const loadLiveApiKey = useCallback(async () => {
     try {
@@ -263,6 +263,12 @@ export function PrivacySection() {
     });
 
     try {
+      if (pendingApiKey) {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("set_api_auth_key", { key: pendingApiKey });
+        setPendingApiKey(null);
+      }
+
       // Offline mode force-disables PostHog but keeps Sentry for crash reports
       const analyticsEffective = settings.offlineMode ? false : settings.analyticsEnabled;
       if (!analyticsEffective) {
@@ -536,8 +542,8 @@ export function PrivacySection() {
               <div className="mt-2.5 flex items-center space-x-2.5 pl-6.5">
                 <Input
                   type="text"
-                  readOnly
-                  placeholder={liveApiKey ? "" : "(loading…)"}
+                  readOnly={!revealApiKey}
+                  placeholder="e.g. sp-abc12345"
                   value={
                     liveApiKey
                       ? revealApiKey
@@ -545,6 +551,23 @@ export function PrivacySection() {
                         : "•".repeat(Math.min(liveApiKey.length, 32))
                       : ""
                   }
+                  onChange={(e) => {
+                    if (!revealApiKey) return;
+                    const val = e.target.value;
+                    setLiveApiKey(val);
+                    setPendingApiKey(val);
+                    if (!val.trim()) {
+                      setValidationErrors((prev) => ({ ...prev, apiKey: "API key cannot be empty" }));
+                    } else {
+                      setValidationErrors(({ apiKey: _, ...rest }) => rest);
+                    }
+                    setHasUnsavedChanges(true);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && pendingApiKey && pendingApiKey.trim()) {
+                      handleUpdate();
+                    }
+                  }}
                   onClick={(e) => (e.target as HTMLInputElement).select()}
                   className="h-8 text-xs font-mono cursor-text select-all"
                 />
@@ -590,19 +613,19 @@ export function PrivacySection() {
                   title="Regenerate key"
                   disabled={regeneratingKey}
                   onClick={async () => {
-                    if (
-                      !window.confirm(
-                        "Regenerate API key? The browser extension and any other clients will need the new key. The new key takes effect after you Apply & Restart.",
-                      )
-                    ) {
-                      return;
-                    }
+                    const { confirm } = await import("@tauri-apps/plugin-dialog");
+                    const confirmed = await confirm(
+                      "Regenerate API key? The browser extension and any other clients will need the new key. The new key takes effect after you Apply & Restart.",
+                      { title: "screenpipe", kind: "info" },
+                    );
+                    if (!confirmed) return;
                     setRegeneratingKey(true);
                     try {
                       const { invoke } = await import("@tauri-apps/api/core");
                       const newKey = await invoke<string>("regenerate_api_auth_key");
                       setLiveApiKey(newKey);
                       setRevealApiKey(true);
+                      setHasUnsavedChanges(true);
                       toast({
                         title: "API key regenerated",
                         description: "Click Apply & Restart for the new key to take effect.",

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -305,6 +305,17 @@ pub async fn regenerate_api_auth_key() -> Result<String, String> {
         .map_err(|e| e.to_string())
 }
 
+/// Persist a user-supplied API auth key to the secret store.
+/// The running server keeps its in-memory key until restart.
+#[tauri::command]
+#[specta::specta]
+pub async fn set_api_auth_key(key: String) -> Result<(), String> {
+    let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
+    screenpipe_engine::auth_key::set_api_auth_key(&data_dir, &key)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 /// Read the enterprise license key from `enterprise.json`.
 /// Checks in order:
 /// 1. Next to executable (pushed via Intune/MDM to Program Files / .app bundle)

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -962,6 +962,7 @@ async fn main() {
             commands::is_enterprise_build_cmd,
             commands::get_local_api_config,
             commands::regenerate_api_auth_key,
+            commands::set_api_auth_key,
             commands::get_enterprise_license_key,
             enterprise_policy::set_enterprise_policy,
             commands::save_enterprise_license_key,

--- a/crates/screenpipe-engine/src/auth_key.rs
+++ b/crates/screenpipe-engine/src/auth_key.rs
@@ -79,6 +79,24 @@ fn resolve_without_env(
     (k, "auto-generated")
 }
 
+/// Persist a user-supplied key to the secret store, replacing whatever was
+/// there before. The running server keeps its in-memory key until restart.
+pub async fn set_api_auth_key(data_dir: &Path, key: &str) -> Result<()> {
+    anyhow::ensure!(!key.is_empty(), "api auth key must not be empty");
+    let store = open_secret_store(data_dir)
+        .await
+        .map_err(|e| anyhow::anyhow!("could not open secret store: {e}"))?;
+    store
+        .set("api_auth_key", key.as_bytes())
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to persist api auth key: {e}"))?;
+    if let Some(home) = dirs::home_dir() {
+        let _ = std::fs::remove_file(home.join(".screenpipe/auth.json"));
+    }
+    tracing::info!("api auth: key updated by user");
+    Ok(())
+}
+
 /// Wipe the persisted key and write a fresh `sp-<uuid8>` to the secret store.
 /// The running server will keep using its in-memory key until restart — caller
 /// is responsible for prompting the user to apply & restart for the new key


### PR DESCRIPTION
### Description:


https://github.com/user-attachments/assets/8bca5056-73dd-4edd-97f9-a67e2ebd6099


Fix 3 bugs in the API key security section: cancel on regenerate dialog no longer changes the key (was using non-blocking       window.confirm), Apply & Restart button now appears after regeneration, and the key field is manually editable when revealed with Enter-to-save, empty validation, and a useful placeholder.                                                                          

### Files changed: 
- privacy-section.tsx, commands.rs, main.rs, auth_key.rs