### PR TITLE
Fix devcontainer cargo path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,6 +71,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 RUN curl -fsSL https://bun.sh/install | bash
 
 # Install Tauri Driver
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
 RUN cargo install tauri-driver
 
 EXPOSE 3000 3030


### PR DESCRIPTION
 ## description

  Adds the Cargo user-local bin directory to `PATH` in the devcontainer Dockerfile before running `cargo install tauri-driver`.

  This uses `${HOME}/.cargo/bin` instead of hardcoding `/home/vscode/.cargo/bin`, so it remains valid if the devcontainer user
changes.

  related issue: #3215

  ## before

  N/A - Dockerfile build configuration change.

  The devcontainer could fail when running:

  ```dockerfile
  RUN cargo install tauri-driver

  if Cargo was installed by rustup but ${HOME}/.cargo/bin was not available in PATH.

  ## after

  N/A - Dockerfile build configuration change.

  The devcontainer now sets:

  ENV PATH="${HOME}/.cargo/bin:${PATH}"

  before invoking cargo.

  ## how to test

  1. Build the devcontainer image.
  2. Verify the build reaches RUN cargo install tauri-driver.
  3. Confirm cargo install tauri-driver runs without cargo: not found.