### PR TITLE
docs(testing): add Windows GetWindowRect bounds regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -481,6 +481,7 @@ commits: `eea0c865`, `fe9060db`, `c99c3967`, `aeaa446b`, `5a219688`, `caae1ebc`,
 - [ ] **Windows multi-line pipe prompts** — Multi-line pipe prompts should be preserved on Windows.
 - [ ] **Windows ARM64 support** — On a Windows ARM64 device, verify the app installs and runs correctly. (`d62360bc4`)
 - [ ] **Windows app matching for meetings** — On Windows, verify that meeting detection correctly matches active applications. (`ef39e728d`)
+- [ ] **Window bounds capture on x86_64 and ARM64 Windows** — On both x86_64 and ARM64 Windows, verify that accessibility tree bounds are correctly captured via `GetWindowRect`. App must compile and run on both architectures without E0425 errors. Regression: `13a44d517` fixed missing import of `GetWindowRect` that blocked v2.4.129 release.
 - [ ] **Alt+S shortcut activates overlay with keyboard focus** — On Windows, press `Alt+S`. Verify that the overlay window appears and immediately receives keyboard focus, allowing immediate typing.
 - [ ] **OcrTextBlock deserialization handles Windows OCR format** — On Windows, verify that `OcrTextBlock` deserialization correctly handles the specific Windows OCR format. (`c49ccb55`)
 - [ ] **populate accessibility tree bounds for text overlay on Windows** — On Windows, verify that accessibility tree bounds are correctly populated for text overlay, ensuring accurate positioning and interaction. (`4d20803a`)


### PR DESCRIPTION
## Problem

Windows GetWindowRect bounds capture regression wasn't covered in testing. Commit `13a44d517` had to fix a missing import of `GetWindowRect` that blocked the v2.4.129 release — both x86_64 and ARM64 Windows builds were failing with E0425 (unresolved reference).

## Root cause

No regression test for Windows accessibility tree bounds capture on both architectures. The missing import went unnoticed until release testing.

## Fix

Added test case to TESTING.md under Windows-specific section to verify:
- Window bounds capture works on both x86_64 and ARM64 Windows
- App compiles and runs on both architectures without E0425 errors
- GetWindowRect import is properly declared

## Verification (Tier T3)

Static analysis only: the test references the actual fix commit hash (`13a44d517`) which is verified to exist in the repository. The regression is documented with exact architecture coverage requirements.

## Sources (multi-source required)

- Git commit history: `13a44d517` (Windows GetWindowRect import fix)
- Affected area: `crates/screenpipe-a11y/src/tree/windows.rs` (line 353 GetWindowRect call)
- Release notes: v2.4.129 Windows build was blocked until this import was added

---
fallback-F1: testing.md update with real recent regression