### PR TITLE
fix(chat): new chat invisible in sidebar until app refresh

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -237,6 +237,12 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
         useChatStore.getState().actions.patch(convId, {
           title: conversation.title,
           messageCount: conversation.messages.length,
+          // Clear the draft flag on every save (including the 1.5s auto-save
+          // during streaming). Without this, the sidebar hides the chat for
+          // the entire streaming duration because the auto-save writes the
+          // file to disk but never clears draft:true in the store — so the
+          // chat appears on refresh (file exists) but not in the live sidebar.
+          draft: false,
           ...(conversation.lastUserMessageAt
             ? { lastUserMessageAt: conversation.lastUserMessageAt }
             : {}),

--- a/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
@@ -731,6 +731,17 @@ async function persistBackgroundSession(sid: string): Promise<void> {
 
       try {
         await saveConversationFile(conv);
+        // Mirror what use-chat-conversations.ts does on the foreground
+        // isLoading edge: clear the draft flag so the sidebar shows this
+        // chat immediately, without requiring a manual refresh. Without
+        // this, navigating away from a new chat before the assistant
+        // finishes leaves the session hidden (draft:true) in the sidebar
+        // even though the file is already on disk.
+        useChatStore.getState().actions.patch(sid, {
+          draft: false,
+          title: conv.title,
+          messageCount: conv.messages.length,
+        });
       } catch (e) {
         console.warn("[router] background save failed for", sid, e);
       }


### PR DESCRIPTION
### Description:


https://github.com/user-attachments/assets/e3caedb7-69da-4d46-bfbf-31a56a2b4dd3


Every new chat the user starts is silently hidden from the sidebar for its entire lifetime — until they kill and reopen the app. The chat is being saved to disk correctly, so a refresh reveals it. But during the session, it's gone. Ghost mode. Users think their chat disappeared.

### Files Changed

  - use-chat-conversations.ts — saveConversation() now patches draft: false on every save, including the 1.5s auto-save during
  streaming. Chat appears in the sidebar ~1.5s after the first token arrives, not after app restart.
  - pi-event-router.ts — persistBackgroundSession() (the background-save path when the panel's foreground handler is gone) now also
  patches draft: false + title + messageCount after a successful disk write. Covers edge cases where the user navigates away before
  the foreground hook is active.