### PR TITLE
fix: disable foreign keys during accessibility_tags drop migration

### DIFF
--- a/crates/screenpipe-db/src/migrations/20260312000002_drop_accessibility_tags.sql
+++ b/crates/screenpipe-db/src/migrations/20260312000002_drop_accessibility_tags.sql
@@ -4,4 +4,8 @@
 
 -- Drop orphan table: accessibility_tags was created but never used in code.
 -- The accessibility table it references was dropped in 20260312000000.
+-- Disable foreign keys to allow dropping this table even though it has
+-- a foreign key constraint to the already-dropped accessibility table.
+PRAGMA foreign_keys = OFF;
 DROP TABLE IF EXISTS accessibility_tags;
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
## Problem
Database migration initialization crashes with 'no such table: accessibility' error when migrations 20260312000001 and 20260312000002 run sequentially.

## Root cause
Migration 20260312000001 drops the `accessibility` table. Migration 20260312000002 then attempts to drop `accessibility_tags`, which has a foreign key constraint referencing the now-dropped `accessibility` table. SQLite validates foreign key constraints during DROP TABLE operations, causing the error.

## Fix
Added `PRAGMA foreign_keys = OFF` / `PRAGMA foreign_keys = ON` around the DROP statement in migration 20260312000002. This pattern is already used in other migrations (20241207202831, 20241210111055, 20260415000000) for similar dependent table drops.

## Confidence: 9/10
- Root cause is obvious from the Sentry stack trace + migration file inspection
- Fix is mechanical (1-line pattern match with other migrations)
- Direct verification via existing test suite that exercises migrations

## Verification (Tier T1)
```
test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.91s
```

All database initialization and search tests pass with the migration fix applied.

## Sources (multi-source)
- Sentry: SCREENPIPE-APP-9P (1 event, today 13:49 UTC) — 'no such table: accessibility' during `while executing migrations`
- Git: adbbb8f84 introduced migrations that drop accessibility table without handling dependent foreign keys
- Code inspection: migrations 20260312000001/00002 show the dependency issue

---
auto-generated by issue-solver pipe