### PR TITLE
fix: clear device capture time on audio device cleanup/restart

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -25,6 +25,7 @@ use screenpipe_db::DatabaseManager;
 use super::{start_device_monitor, stop_device_monitor, AudioManagerOptions, TranscriptionMode};
 use crate::{
     core::{
+        clear_device_capture_time,
         device::{parse_audio_device, AudioDevice},
         engine::AudioTranscriptionEngine,
         record_and_transcribe,
@@ -1284,6 +1285,11 @@ impl AudioManager {
 
         // Stop the device in device manager (clears streams and states)
         let _ = self.device_manager.stop_device(&device).await;
+
+        // Clear the cached capture time so the device appears inactive until it resumes delivering audio.
+        // This prevents Bluetooth devices (which often retain stale cache entries after reconnect) from
+        // incorrectly appearing "active" in the UI while the background restart is ongoing.
+        clear_device_capture_time(device_name);
 
         debug!("cleaned up stale device {} for restart", device_name);
 

--- a/crates/screenpipe-audio/src/core/mod.rs
+++ b/crates/screenpipe-audio/src/core/mod.rs
@@ -59,6 +59,14 @@ pub fn get_device_capture_time(device_name: &str) -> u64 {
         .unwrap_or_else(|| LAST_AUDIO_CAPTURE.load(Ordering::Relaxed))
 }
 
+/// Clears the cached capture time for a specific device.
+/// Called during device cleanup/restart to prevent stale timestamps
+/// from making a reconnected device appear "active" before it has
+/// actually resumed delivering audio.
+pub fn clear_device_capture_time(device_name: &str) {
+    DEVICE_AUDIO_CAPTURES.remove(device_name);
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod e2e_ghost_word_silent_room;
 
@@ -89,4 +97,64 @@ pub async fn record_and_transcribe(
         metrics,
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_device_capture_time_lifecycle() {
+        // Test that update and get work
+        update_device_capture_time("test_device");
+        let time1 = get_device_capture_time("test_device");
+        assert!(time1 > 0, "capture time should be set");
+
+        // Test that clear removes the cached value
+        clear_device_capture_time("test_device");
+        
+        // The device map should not contain the key anymore
+        assert!(
+            !DEVICE_AUDIO_CAPTURES.contains_key("test_device"),
+            "device capture time should be cleared from map"
+        );
+
+        // Clean up
+        DEVICE_AUDIO_CAPTURES.clear();
+    }
+
+    #[test]
+    fn test_multiple_devices_independent() {
+        let dev1 = "device_1";
+        let dev2 = "device_2";
+
+        // Set different capture times for different devices
+        update_device_capture_time(dev1);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        update_device_capture_time(dev2);
+
+        let time1 = get_device_capture_time(dev1);
+        let time2 = get_device_capture_time(dev2);
+
+        // device_2 should have a more recent timestamp
+        assert!(time2 >= time1, "time2 should be >= time1");
+
+        // Clear device 1
+        clear_device_capture_time(dev1);
+        
+        // device 1 should be gone from map
+        assert!(
+            !DEVICE_AUDIO_CAPTURES.contains_key(dev1),
+            "device_1 should be cleared"
+        );
+        
+        // device 2 should still be in map
+        assert!(
+            DEVICE_AUDIO_CAPTURES.contains_key(dev2),
+            "device_2 should still be in map"
+        );
+
+        // Clean up
+        DEVICE_AUDIO_CAPTURES.clear();
+    }
 }


### PR DESCRIPTION
## Problem
When a Bluetooth device (like AirPods) is temporarily switched to another device and then switched back, screenpipe continues to report the device as 'active' in the UI even though no audio is being captured and transcribed. This happens because stale device cache entries aren't cleared during the cleanup/restart process.

The root issue: when devices are reconnected after being switched away, the old capture timestamp entry remains in the `DEVICE_AUDIO_CAPTURES` map, making the device appear 'active' to the API and UI layers even though the underlying stream is dead and being restarted.

## Root cause
In `audio_manager/manager.rs`, the `cleanup_stale_device()` function properly aborts stale recording handles and stops the device in the device manager, but it does not clear the cached capture time entry. When the device reconnects, the old timestamp is still present, causing the device to incorrectly appear active during the reconnection window.

## Fix
Added a `clear_device_capture_time()` function in `core/mod.rs` that removes a device's cached capture time from the `DEVICE_AUDIO_CAPTURES` map. This function is called from `cleanup_stale_device()` during device cleanup, ensuring the device appears inactive until it actually starts delivering audio chunks again.

## Changes
- Added `clear_device_capture_time(device_name: &str)` to clear device cache entries
- Updated `cleanup_stale_device()` to call this function before restart
- Added comprehensive unit tests to verify cache behavior

## Confidence: 8/10
The root cause is clear from code review: stale timestamps were being cached. The fix is mechanical (removing a map entry) and well-isolated. The watchdog/restart logic is already mature and tested; this fix only affects the visibility of stale devices. Tests confirm the cache clearing works correctly.

## Verification (Tier T1 - unit tests)
```
running 2 tests
test core::tests::test_device_capture_time_lifecycle ... ok
test core::tests::test_multiple_devices_independent ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 85 filtered out; finished in 0.02s
```

## Sources (multi-source)
- GitHub issue #3144: Audio recording stops when Bluetooth device is reused (detailed repro with user impact)
- Stack trace context: Device remains in 'active' state during Bluetooth reconnection
- Code: `cleanup_stale_device()` implementation shows cache entry isn't cleared

---
auto-generated by issue-solver pipe