### PR TITLE
fix: prevent speaker name duplicates across dissimilar voices (#3228)

### DIFF
--- a/crates/screenpipe-engine/src/calendar_speaker_id.rs
+++ b/crates/screenpipe-engine/src/calendar_speaker_id.rs
@@ -354,7 +354,38 @@ async fn deduplicate_speaker_by_name(
     newly_named_id: i64,
     name: &str,
 ) {
-    // Get voice-similar speakers first — this is the strong signal
+    // First, check for exact name collision (prevents duplicates even if voice-dissimilar)
+    // This catches cases where loopback output and mic input both get named "Alice"
+    if let Ok(Some(existing)) = db.find_speaker_by_name(name).await {
+        if existing.id != newly_named_id {
+            // Found an existing speaker with the same exact name.
+            // Count samples and merge the smaller into the larger.
+            let (our_res, their_res) = tokio::join!(
+                db.count_embeddings_for_speaker(newly_named_id),
+                db.count_embeddings_for_speaker(existing.id),
+            );
+            let our_count = our_res.unwrap_or(0);
+            let their_count = their_res.unwrap_or(0);
+
+            let (keep_id, merge_id) = if our_count > their_count {
+                (newly_named_id, existing.id)
+            } else {
+                (existing.id, newly_named_id)
+            };
+
+            info!(
+                "speaker dedup: merging {} into {} (exact name collision: '{}', samples {} vs {})",
+                merge_id, keep_id, name, our_count, their_count
+            );
+
+            if let Err(e) = db.merge_speakers(keep_id, merge_id).await {
+                warn!("speaker dedup: merge failed: {}", e);
+            }
+            return;
+        }
+    }
+
+    // Get voice-similar speakers — secondary deduplication signal
     let similar = match db.get_similar_speakers(newly_named_id, 10).await {
         Ok(v) => v,
         Err(e) => {
@@ -1230,5 +1261,49 @@ mod tests {
         // Cleanup: delete the temporary speakers
         let _ = db.delete_speaker(id_a).await;
         let _ = db.delete_speaker(id_b).await;
+    }
+
+    #[tokio::test]
+    async fn test_dedup_exact_name_collision_merges_dissimilar_voices() {
+        // Issue #3228: loopback output + mic input both get named "Alice" from calendar.
+        // They have different embeddings (acoustic artifacts), so voice-similarity check fails.
+        // But exact-name check must catch this and merge them.
+        let db = setup_db().await;
+
+        // Different embeddings (e.g., loopback vs mic)
+        let embedding_loopback: Vec<f32> = (0..512).map(|i| if i == 0 { 1.0 } else { 0.0 }).collect();
+        let embedding_mic: Vec<f32> = (0..512).map(|i| if i == 1 { 1.0 } else { 0.0 }).collect();
+
+        // Speaker A: loopback, already named "Alice"
+        let id_loopback = seed_speaker(&db, &embedding_loopback, Some("Alice")).await;
+
+        // Speaker B: mic input, unnamed
+        let id_mic = seed_speaker(&db, &embedding_mic, None).await;
+
+        // Both get named "Alice" from calendar
+        db.update_speaker_name(id_mic, "Alice")
+            .await
+            .unwrap();
+
+        // Run dedup on the mic speaker — should merge despite different voices
+        deduplicate_speaker_by_name(&db, id_mic, "Alice").await;
+
+        // After merge: both should be consolidated into one "Alice"
+        let alice_speakers: Vec<_> = db
+            .search_speakers("Alice")
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|s| !s.name.is_empty())
+            .collect();
+        assert!(
+            alice_speakers.len() == 1,
+            "exact name collision should merge voice-dissimilar speakers into one 'Alice', got {} speakers",
+            alice_speakers.len()
+        );
+
+        // Cleanup
+        let _ = db.delete_speaker(id_loopback).await;
+        let _ = db.delete_speaker(id_mic).await;
     }
 }


### PR DESCRIPTION
## Problem

When transcribing a meeting with acoustic loopback (e.g., meeting playing on speakers), screenpipe captures the audio twice:
- Once directly from the microphone (user's voice)
- Once as loopback output (other attendees' voices, playback on speakers)

Both sources get named from the calendar (e.g., "Alice" for the same attendee), creating duplicate speaker rows with **identical names but different embeddings** (acoustic artifacts make them voice-dissimilar). This breaks speaker continuity and creates data integrity issues.

## Root cause

The existing `deduplicate_speaker_by_name()` function relies on **voice-similarity first**. It queries `get_similar_speakers()` (which uses embeddings), then checks if names match. 

When two speakers have:
- The **exact same name** ("Alice")
- But **very different embeddings** (mic vs loopback)

...they fail the voice-similarity filter and never get merged, even though they should be.

## Fix

Add an **exact-name collision check** that runs **before** voice-similarity. Now the dedup pipeline is:

1. **Exact name check**: if any existing speaker has this exact name → merge immediately
2. **Voice-similarity + name match**: existing logic for cases where names are similar/fuzzy

This ensures duplicate names are always caught, regardless of embedding distance.

## Verification

Added test `test_dedup_exact_name_collision_merges_dissimilar_voices` that reproduces the issue (two speakers named "Alice" with dissimilar embeddings) and verifies they are correctly merged:

```
test calendar_speaker_id::tests::test_dedup_exact_name_collision_merges_dissimilar_voices ... ok
test calendar_speaker_id::tests::test_dedup_merges_email_and_display_name ... ok
test calendar_speaker_id::tests::test_dedup_does_not_merge_different_voices ... ok

test result: ok. 40 passed; 0 failed
```

All 40 tests in calendar_speaker_id module pass, including existing voice-dedup logic.

## Confidence: 8/10

- Root cause is clear from code inspection and issue description
- Fix is minimal (one new database query before existing checks)
- Existing behavior is preserved (voice-similarity still works as fallback)
- Test explicitly reproduces the bug scenario
- All existing tests pass

The only reason not 9/10: This relies on `find_speaker_by_name()` case-sensitivity matching the issue's expectation (exact match). Verified it exists and is stable.

## Sources (multi-source verified)

- **GitHub issue #3228**: User-reported exact duplicate speaker rows with meeting transcript corruption
- **Code inspection**: Clear root cause in `deduplicate_speaker_by_name()` (voice-similarity filter first)