### PR TITLE
chore(logging): downgrade screen recording permission denial to debug

### DIFF
--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use screenpipe_events::PermissionKind;
 use screenpipe_screen::monitor::{list_monitors_detailed, MonitorListError};
@@ -57,7 +57,7 @@ pub async fn start_monitor_watcher(
                 permission_denied_logged = false;
             }
             Err(MonitorListError::PermissionDenied) => {
-                error!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
+                debug!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
                 permission_denied_logged = true;
                 permission_monitor::report_state(
                     PermissionKind::ScreenRecording,
@@ -188,7 +188,7 @@ pub async fn start_monitor_watcher(
                 }
                 Err(MonitorListError::PermissionDenied) => {
                     if !permission_denied_logged {
-                        error!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
+                        debug!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
                         permission_denied_logged = true;
                         permission_monitor::report_state(
                             PermissionKind::ScreenRecording,


### PR DESCRIPTION
## Problem

'Screen recording permission denied' is logged at error level (747 events/24h in Sentry) even though this is expected benign behavior when users haven't yet granted permission in System Settings.

This creates noise in production logs and error dashboards.

## Root cause

The message in `monitor_watcher.rs` uses `error!()` macro when permission check fails at startup or runtime, even though this is not an error condition — it's a normal state until the user grants permission.

## Fix

Downgrade both `error!()` calls to `debug!()` level:
- Line 60 (startup permission check)
- Line 191 (runtime permission check)

Also remove the now-unused `error` import from the tracing macro.

## Confidence: 9/10

This is a straightforward log-level downgrade. The message content remains unchanged, only the severity level changes from error → debug. The user still gets prompted in the UI to grant permission; we just reduce log noise. Zero risk of side effects.

## Verification (Tier T2)

```
cargo check -p screenpipe-engine: ✓ Finished `dev` profile [unoptimized + debuginfo]
```

Compilation clean with no warnings after import cleanup.

## Sources (multi-source)

- Sentry: SCREENPIPE-CLI-49 (747 events, 736 users in 24h, benign permission warning)
- Code inspection: confirmed message is expected behavior, not an error

---
auto-generated by issue-solver pipe