### PR TITLE
chore(logging): downgrade screen recording permission denial to warn level

### DIFF
--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use screenpipe_events::PermissionKind;
 use screenpipe_screen::monitor::{list_monitors_detailed, MonitorListError};
@@ -57,7 +57,7 @@ pub async fn start_monitor_watcher(
                 permission_denied_logged = false;
             }
             Err(MonitorListError::PermissionDenied) => {
-                error!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
+                warn!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
                 permission_denied_logged = true;
                 permission_monitor::report_state(
                     PermissionKind::ScreenRecording,
@@ -188,7 +188,7 @@ pub async fn start_monitor_watcher(
                 }
                 Err(MonitorListError::PermissionDenied) => {
                     if !permission_denied_logged {
-                        error!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
+                        warn!("Screen recording permission denied. Vision capture is disabled. Grant access in System Settings > Privacy & Security > Screen Recording");
                         permission_denied_logged = true;
                         permission_monitor::report_state(
                             PermissionKind::ScreenRecording,


### PR DESCRIPTION
## Problem
The 'Screen recording permission denied' message is being reported as an error in Sentry (748+ events/24h, SCREENPIPE-CLI-49), inflating error counts and noise.

This is benign expected behavior — the message fires when users haven't granted screen recording permissions in System Settings, which is perfectly normal.

## Root cause
The message is logged at error level even though it's handled gracefully and represents expected user behavior, not a code error.

## Fix
Changed from `error!()` to `warn!()` in two places where permission is denied. The message remains in logs for debugging, but no longer counts as an error in Sentry.

## Why warn, not info?
Permission denial is still worth flagging in logs (it stops recording), but it's not an error condition. `warn!` is the correct level for handled, non-fatal issues.

## Evidence
The code already handles this gracefully:
- `permission_denied_logged` flag prevents log spam
- `permission_monitor::report_state()` notifies the UI
- Backs off to 30s polling (no hammering system calls)
- Logs `info!()` when permission is granted again

```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.28s
```

## Verification
- ✅ `cargo check -p screenpipe-engine` passes cleanly
- ✅ No unused imports
- ✅ Message is still logged, just at warn level instead of error

## Sources
- Sentry: SCREENPIPE-CLI-49 (748 events, 736 users, 24h)
- Code: crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs (lines 60, 191)

---
auto-generated by issue-solver pipe