### PR TITLE
docs(testing): add audio reconciliation undecodable chunk orphaning test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -136,6 +136,7 @@ commits: `28e5c247`
 - [ ] **Filter music toggle UI** — Verify that a "filter music" toggle exists in recording settings and correctly enables/disables music filtering.
 - [ ] **Music detection thresholds** — With "filter music" enabled, play various types of music. Verify that music is correctly detected and filtered, and that non-music speech is still captured.
 - [ ] **Audio reconciliation FK constraint loop** — Verify that audio reconciliation does not enter an infinite retry loop on foreign key constraints. (`e9e2dc252`)
+- [ ] **Audio reconciliation undecodable chunk orphaning** — Verify that audio reconciliation does not enter an infinite retry loop on undecodable audio chunks (corrupt headers, partial writes). Check logs show chunk is marked orphan and deleted, not retried forever. (`32e5dfc44`)
 - [ ] **Skip reconciliation when transcription disabled** — Disable audio transcription in settings. Verify that audio reconciliation is skipped. (`ceb77559d`)
 - [ ] **dead System Audio auto-reconnect** — Simulate a dead system audio stream. Verify it auto-reconnects and resumes capture. (`0f287761d`)
 - [ ] **per-device audio toggle** — In the tray menu, verify you can toggle recording for individual audio devices. (`3ee3defcb`)


### PR DESCRIPTION
## Problem

Recent fix (32e5dfc44) orphans undecodable audio chunks instead of retrying forever. This prevents infinite reconciliation loops that consume ffmpeg subprocess budget and battery.

## Root cause

Previously, decode-failure and spawn_blocking-panic branches in `reconcile_untranscribed` only logged the error and fell through, leaving chunks in DB with `transcription IS NULL`. On the next reconciliation sweep, the same chunk would be selected, ffmpeg would fail to decode it again, and the cycle repeated indefinitely. Real-world impact: 29+ retries over 65+ minutes on a single bad chunk.

## Fix

Treat both error branches the same as the missing-file path: push chunk_id to `orphan_chunk_ids` for batch deletion. The audio data is unrecoverable; keeping the row in DB only causes harm.

## Verification

Added regression test to TESTING.md to catch future regressions in audio reconciliation error handling.

## Sources

- Commit: 32e5dfc44 (fix: orphan undecodable audio chunks instead of retrying forever)
- Co-authored by Louis Beaumont & Claude Opus 4.7

---
auto-generated by issue-solver fallback F1