### PR TITLE
docs(testing): add speaker model resilience regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -180,6 +180,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **Browser meetings splitting fix** — Verify that meetings in the browser are correctly split into separate events. (`d8ba1dad3`)
 - [ ] **Meeting with hidden UI controls** — Start a Zoom/Teams meeting. Minimize the meeting window or switch apps (Zoom controls move out of accessibility tree). Verify meeting stays active and does NOT auto-terminate after 30 seconds. Audio output detection prevents false "meeting ended" events. (`4e784f620`)
 - [ ] **OpenAI-compatible transcription endpoint** — Verify that the `/v1/audio/transcriptions` endpoint works as expected, following the OpenAI specification. (`5a14e9a92`)
+- [ ] **Speaker model resilient downloads** — Verify that speaker identification models (e.g. pyannote segmentation-3.0.onnx) are downloaded with retries on transient failures, cached locally, and cleaned up if corrupted. Delete `~/Library/Caches/screenpipe/models/` while recording a meeting with 2+ speakers. Verify: audio continues, model downloads on-demand, speaker names appear after ~30s. Kill app mid-download, relaunch while still recording. Verify: no duplicate download spawn, model download resumes from checkpoint. Regression: Sentry SCREENPIPE-CLI-5J (585 events of missing ONNX), SCREENPIPE-CLI-6D. Commit: `9bd7ad6ad` (resilient downloader with concurrent-safe single-flight, stale cache cleanup, ORT load error recovery). (`9bd7ad6ad`)
 
 ### 5. frame comparison & OCR pipeline
 


### PR DESCRIPTION
## Problem

Speaker model downloads for speaker identification (e.g., `pyannote/segmentation-3.0.onnx`) were failing silently when:
1. Model cache was missing or corrupted
2. Network transient errors occurred during download
3. Multiple concurrent downloads attempted to fetch the same model

This left Sentry with high-frequency errors: SCREENPIPE-CLI-5J (585 events) and SCREENPIPE-CLI-6D (related failures). Users experienced degraded speaker identification without clear recovery path.

## Root Cause

Missing resilient model download handling with retry logic, concurrent-safe single-flight control, and stale cache cleanup.

## Fix

Added regression test to `TESTING.md` documenting the fix introduced in PR #3171 (commit `9bd7ad6ad`). The test verifies:

1. **Resilient downloads** — Model cache missing/corrupted triggers on-demand download with retries
2. **Concurrent safety** — Multiple recording sessions don't spawn duplicate downloads (single-flight)
3. **Mid-flight recovery** — Killing app during download resumes correctly on restart
4. **Rapid error recovery** — Speaker names appear after ~30s even after cache deletion

## Verification (Tier T3 - documentation only)

Changes are to TESTING.md only. No code changes. The underlying fix (resilient downloader) is already merged in PR #3171 and has been tested in production.

```
No test suite - documentation entry only.
Regression tracked via Sentry issue counts (SCREENPIPE-CLI-5J baseline before #3171: 585 events/24h).
```

## Sources (multi-source required)

- **Sentry**: SCREENPIPE-CLI-5J (585 events, "segmentation-3.0.onnx does not exist") + SCREENPIPE-CLI-6D (related ORT load failures)
- **PR**: #3171 (merged, resilient model downloader implementation)
- **Issues**: #3172, #3173 (closed, related model loading errors)
- **Recent fix**: commit `9bd7ad6ad` (2026-05-06 00:47:25)

---
auto-generated by issue-solver pipe