### PR TITLE
fix: prevent message collapse button from entering edit mode

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1091,7 +1091,11 @@ function CollapsibleUserMessage({ label, fullContent }: { label: string; fullCon
       <div className="flex items-center gap-1.5">
         <span className="flex-1 text-sm font-medium">{label}</span>
         <button
-          onClick={() => setExpanded(!expanded)}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded(!expanded);
+          }}
+          onMouseUp={(e) => e.stopPropagation()}
           className="shrink-0 p-0.5 rounded hover:bg-background/20 text-background/60 hover:text-background/90 transition-colors"
           title={expanded ? "Collapse prompt" : "Show full prompt"}
         >


### PR DESCRIPTION
Fixes the bug where clicking the ChevronDown button on user messages would incorrectly trigger edit mode instead of just expanding/collapsing the message content.

Before -


https://github.com/user-attachments/assets/11627d0a-60a9-41f2-95be-07488062c219


After - 

https://github.com/user-attachments/assets/d4591c6c-c250-48bf-baf9-cd235165d46f

