### PR TITLE
fix(meetings): delete UX — modal confirm, red button, better copy

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
@@ -348,6 +348,7 @@ export function MeetingNotesSection({
       activeId={activeId}
       activeMeeting={activeMeeting}
       onSelect={setSelectedId}
+      onDelete={handleDeleted}
       onStart={() => handleStart()}
       onStop={handleStop}
       onStartFromEvent={handleStartFromEvent}

--- a/apps/screenpipe-app-tauri/components/meeting-notes/list-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/list-view.tsx
@@ -19,6 +19,7 @@ interface ListViewProps {
   activeId: number | null;
   activeMeeting: MeetingRecord | null;
   onSelect: (id: number) => void;
+  onDelete: (id: number) => void;
   onStart: () => void | Promise<void>;
   onStop: () => void | Promise<void>;
   onStartFromEvent: (event: CalendarEvent) => void | Promise<void>;
@@ -37,6 +38,7 @@ export function ListView({
   activeId,
   activeMeeting,
   onSelect,
+  onDelete,
   onStart,
   onStop,
   onStartFromEvent,
@@ -140,6 +142,7 @@ export function ListView({
             meetings={meetings}
             activeId={activeId}
             onSelect={onSelect}
+            onDelete={onDelete}
           />
         )}
 

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -16,6 +16,17 @@ import {
   Users,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { useToast } from "@/components/ui/use-toast";
 import { localFetch } from "@/lib/api";
 import { showChatWithPrefill } from "@/lib/chat-utils";
@@ -66,7 +77,6 @@ export function NoteView({
   const [attendees, setAttendees] = useState(meeting.attendees ?? "");
   const [note, setNote] = useState(meeting.note ?? "");
   const [saveState, setSaveState] = useState<SaveState>({ kind: "idle" });
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const [summarizing, setSummarizing] = useState(false);
   const [meetingCtx, setMeetingCtx] = useState<MeetingContext | null>(null);
 
@@ -82,7 +92,6 @@ export function NoteView({
     setAttendees(meeting.attendees ?? "");
     setNote(meeting.note ?? "");
     setSaveState({ kind: "idle" });
-    setConfirmDelete(false);
     setMeetingCtx(null);
     lastSavedRef.current = {
       title: meeting.title ?? "",
@@ -340,37 +349,37 @@ export function NoteView({
             <SaveIndicator state={saveState} />
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {!isLive &&
-              (confirmDelete ? (
-                <div className="flex items-center gap-1">
+            {!isLive && (
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={handleDelete}
-                    className="h-8 px-2 text-destructive hover:text-destructive normal-case tracking-normal"
+                    title="delete this meeting"
+                    className="h-8 w-8 p-0"
                   >
-                    delete?
+                    <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
                   </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setConfirmDelete(false)}
-                    className="h-8 px-2 normal-case tracking-normal"
-                  >
-                    cancel
-                  </Button>
-                </div>
-              ) : (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setConfirmDelete(true)}
-                  title="delete this meeting"
-                  className="h-8 w-8 p-0"
-                >
-                  <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
-                </Button>
-              ))}
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>delete meeting</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      your notes and transcript will be permanently deleted.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      variant="destructive"
+                      onClick={() => void handleDelete()}
+                    >
+                      delete
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            )}
 
             {isLive ? (
               <Button

--- a/apps/screenpipe-app-tauri/components/meeting-notes/past-meetings.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/past-meetings.tsx
@@ -4,8 +4,21 @@
 "use client";
 
 import React from "react";
-import { FileText, Phone } from "lucide-react";
+import { FileText, Phone, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { localFetch } from "@/lib/api";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import {
   formatClock,
   formatDuration,
@@ -16,6 +29,7 @@ interface PastMeetingsProps {
   meetings: MeetingRecord[];
   activeId: number | null;
   onSelect: (id: number) => void;
+  onDelete: (id: number) => void;
 }
 
 interface Bucket {
@@ -61,6 +75,7 @@ export function PastMeetings({
   meetings,
   activeId,
   onSelect,
+  onDelete,
 }: PastMeetingsProps) {
   const buckets = bucketByRelativeDay(meetings);
   if (buckets.length === 0) return null;
@@ -80,6 +95,7 @@ export function PastMeetings({
                 bucket={b.label}
                 isActive={m.id === activeId}
                 onClick={() => onSelect(m.id)}
+                onDelete={onDelete}
               />
             ))}
           </ul>
@@ -94,22 +110,51 @@ function PastMeetingRow({
   bucket,
   isActive,
   onClick,
+  onDelete,
 }: {
   meeting: MeetingRecord;
   bucket: string;
   isActive: boolean;
   onClick: () => void;
+  onDelete: (id: number) => void;
 }) {
+  const { toast } = useToast();
+
+  const handleDelete = async () => {
+    try {
+      const res = await localFetch(`/meetings/${meeting.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      onDelete(meeting.id);
+    } catch (err) {
+      toast({
+        title: "couldn't delete meeting",
+        description: String(err),
+        variant: "destructive",
+      });
+    }
+  };
+
   const title = meeting.title?.trim() || titleFromApp(meeting.meeting_app);
   const hasNote = Boolean(meeting.note?.trim());
   const Icon = isActive ? Phone : hasNote ? FileText : Phone;
   const stamp = formatRowStamp(meeting.meeting_start, bucket);
+
   return (
-    <li className="border-b border-border">
-      <button
+    <li className="group border-b border-border">
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onClick}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick();
+          }
+        }}
         className={cn(
-          "group w-full flex items-center gap-3 py-2 px-1 transition-colors text-left",
+          "w-full flex items-center gap-3 py-2 px-1 transition-colors text-left cursor-pointer",
           "hover:bg-muted/30",
           isActive && "bg-muted/20",
         )}
@@ -124,6 +169,7 @@ function PastMeetingRow({
             <Icon className="h-3 w-3 text-muted-foreground" />
           )}
         </div>
+
         <div className="flex-1 min-w-0 flex items-baseline gap-2">
           <span className="text-sm text-foreground truncate">{title}</span>
           {meeting.attendees && (
@@ -132,11 +178,48 @@ function PastMeetingRow({
             </span>
           )}
         </div>
+
         <div className="shrink-0 flex items-center gap-3 text-[11px] text-muted-foreground tabular-nums">
           <span>{formatDuration(meeting.meeting_start, meeting.meeting_end)}</span>
           <span className="w-16 text-right">{stamp}</span>
         </div>
-      </button>
+
+        {/* Fixed slot keeps all rows pixel-aligned; trash appears on hover */}
+        <div
+          className="shrink-0 w-7 flex items-center justify-center"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {!isActive && (
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <button
+                  className="opacity-0 group-hover:opacity-100 transition-opacity h-7 w-7 flex items-center justify-center bg-transparent text-muted-foreground hover:text-destructive"
+                  title="delete meeting"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>delete meeting</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    your notes and transcript will be permanently deleted.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    onClick={() => void handleDelete()}
+                  >
+                    delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          )}
+        </div>
+      </div>
     </li>
   );
 }

--- a/apps/screenpipe-app-tauri/components/ui/alert-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
+import { type VariantProps } from "class-variance-authority"
 
 const AlertDialog = AlertDialogPrimitive.Root
 
@@ -98,11 +99,12 @@ AlertDialogDescription.displayName =
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> &
+    Pick<VariantProps<typeof buttonVariants>, "variant">
+>(({ className, variant, ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={cn(buttonVariants(), className)}
+    className={cn(buttonVariants({ variant }), className)}
     {...props}
   />
 ))


### PR DESCRIPTION
### Description:                                                                        


https://github.com/user-attachments/assets/9ba90450-d347-48d5-b731-57a2f0e017bd

                                                
Replace broken inline delete confirm with a proper AlertDialog, fix the delete button being white, and make the description copy actually tell users what they're losing.                                                                                            

### Files changed:
  - components/ui/alert-dialog.tsx — added variant prop to AlertDialogAction
  - components/meeting-notes/past-meetings.tsx — modal confirm, red trash hover, fixed description
  - components/meeting-notes/note-view.tsx — same modal + copy fixes, removed stale confirmDelete state