### PR TITLE
docs(testing): add accessibility table migration regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -396,6 +396,7 @@ commits: `f1255eac`, `25cbdc6b`, `2529367d`, `d9821624`, `e61501da`, `039d5fea`,
 - [ ] **Search navigation persistence** — Navigate to a frame from search results. Shift focus away from the app and back. Verify the navigation is not reset. (`71dee4ca3`)
 - [ ] **Search navigation race condition** — Verify that search navigation works reliably even if the webview is still mounting (retries should handle it). (`2015137a1`)
 - [ ] **Consolidated text search** — Perform keyword searches. Verify results are correctly pulled from the consolidated `frames.full_text` and `frames_fts`. (`adbbb8f84`)
+- [ ] **Accessibility table migration regression** — Verify that Day Recap suggestions and accessibility text fetching work without 'no such table: accessibility' errors. Regression test for the consolidation migration that dropped the accessibility table. (`cb56f40b9`)
 - [ ] **Keyword search accessibility** — Keyword search should find content within accessibility-only frames and utilize `frames_fts` for comprehensive accessibility text searching.
 - [ ] **Keyword search logic** — Verify that keyword search SQL correctly uses `OR` instead of `UNION` within `IN()`.
 - [ ] **Search prompt accuracy** — Verify that search prompts are improved to prevent false negatives from over-filtering.


### PR DESCRIPTION
## Problem

When PR #3225 fixed the 'no such table: accessibility' error in suggestions.rs,
there was no regression test documented to prevent this from breaking again.

The accessibility table was consolidated into `frames.full_text` via migration
commit adbbb8f84. However, suggestions.rs still contained two queries that
referenced the dropped table, causing 'no such table: accessibility' errors in
Sentry (SCREENPIPE-APP-9P).

## Root cause

The accessibility table consolidation migration wasn't reflected in the
regression testing documentation. There was no test case to verify that
Day Recap suggestions and accessibility text queries continued working
after the schema change.

## Fix

Added a regression test entry in TESTING.md for the accessibility table
migration. This ensures:
1. Day Recap suggestions work without schema errors
2. Accessibility text fetching works correctly with the consolidated schema
3. The fix from PR #3225 (commit cb56f40b9) is maintained

## Verification (Tier T3)

This is a documentation update only. The fix itself (PR #3225) already has
test coverage. This commit simply documents the regression test needed to
prevent future regressions in this area.

## Sources (multi-source required)

- Git: commit cb56f40b9 (PR #3225 — fix merged May 6, 2026)
- Git: commit adbbb8f84 (accessibility table consolidation migration)
- Sentry: SCREENPIPE-APP-9P (2 events in last 24h before fix)

---
auto-generated by issue-solver pipe (fallback F1 — testing.md update)