### PR TITLE
docs(testing): add accessibility migration regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -909,6 +909,7 @@ commits: `c6a73b17e`, `945b687ec`
 
 - [ ] **CLI logout** — Run `screenpipe logout`. Verify it clears local auth tokens. (`793c3d6e9`)
 - [ ] **CLI sync remote** — Verify `screenpipe sync remote` command and its configuration. (`f46e85cb1`)
+- [ ] **Accessibility table migration regression** — Verify that suggestions.rs queries work after accessibility table consolidation into frames.full_text. Run a search query using context snippets; should not error with "no such table: accessibility". (`cb56f40b9`)
 
 ### 31. Chat (Pi)
 


### PR DESCRIPTION
## Problem
The recent accessibility table consolidation into frames.full_text (commit cb56f40b9) migrated queries but this regression pattern was not documented in TESTING.md, increasing risk of similar issues in future migrations.

## Root cause
Migration coverage in TESTING.md was incomplete. Fixes from database schema consolidations need explicit regression test entries to prevent future team members from reintroducing the dropped table query patterns.

## Fix
Added regression test entry to TESTING.md documenting the accessibility table consolidation migration. This ensures future migrations of similar patterns are properly tested.

## Confidence: 9/10
Simple documentation addition. No code changes. Prevents regression by documenting a real recent fix that touched a critical query path.

## Verification (Tier T3)
- Referenced commit cb56f40b9 verified to exist
- TESTING.md syntax validated
- Entry matches the style and conventions of existing entries

## Sources (multi-source required)
- Git: commit cb56f40b9 (fix merged May 6, 2026)
- Related migration: commit adbbb8f84 (accessibility table consolidation)
- Sentry correlation: SCREENPIPE-APP-9P (original issue)

---
auto-generated by issue-solver pipe