### PR TITLE
fix: populate updater endpoint to prevent 'no endpoints set' error

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -46,7 +46,9 @@
   },
   "plugins": {
     "updater": {
-      "endpoints": [],
+      "endpoints": [
+        "https://screenpi.pe/api/app-update/stable"
+      ],
       "pubkey": ""
     },
     "deep-link": {


### PR DESCRIPTION
## Problem

The Tauri updater plugin configuration has an empty endpoints array in tauri.conf.json.
When `check_for_updates()` runs, it fails with 'Updater does not have any endpoints set'.

This has been silently failing since the updater plugin was added, with recent Sentry 
reports showing **37 events in 24h** affecting 4 users (SCREENPIPE-APP-73).

## Root cause

In tauri.conf.json:
```json
"endpoints": []  // ← empty
```

The code in `src/updates.rs:check_for_updates()` calls:
```rust
let mut builder = self.app.updater_builder();
// ... no endpoints set here ...
builder.build()?.check().await
```

The Tauri updater requires endpoints to be either:
1. Configured in tauri.conf.json (the declarative approach), OR
2. Set at runtime via builder.endpoints() (dynamic approach)

## Fix

Populate the endpoints array in tauri.conf.json with the stable update endpoint that is 
already referenced throughout the codebase:
- Frontend: updater.tsx, update-banner.tsx
- Backend: src/updates.rs install_specific_version()

```json
"endpoints": [
  "https://screenpi.pe/api/app-update/stable"
]
```

This is the minimal, correct fix. The endpoint URL has been proven in production via 
the manual update flow.

## Verification (Tier T2)

```
$ cargo check -p screenpipe-app
  Compiling screenpipe-app v2.4.149
  warning: screenpipe-app@2.4.149: VisionKit SDK check: true
  warning: screenpipe-app@2.4.149: mlx-metallib: already present (88 MB)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.57s
```

## Confidence: 8/10

- ✅ Root cause is obvious from stack trace and code inspection
- ✅ Endpoint URL matches all existing references in codebase
- ✅ Change is minimal (one line) and declarative (config only)
- ✅ No runtime logic changes
- ✅ Compile verification passes
- ✅ Multi-source evidence (Sentry + GitHub issue #2703)

## Sources

- **Sentry SCREENPIPE-APP-73**: 37 events in last 24h, 4 affected users
- **GitHub issue #2703**: "Failed to check for updates: Updater does not have any endpoints set" (open, 26 events reported)
- **Code refs**: apps/screenpipe-app-tauri/components/updater.tsx:10, src-tauri/src/updates.rs:225-230

---
auto-generated by issue-solver pipe
