### PR TITLE
docs(testing): add Discord meeting detection Windows regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -180,6 +180,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **Browser meetings splitting fix** — Verify that meetings in the browser are correctly split into separate events. (`d8ba1dad3`)
 - [ ] **Meeting with hidden UI controls** — Start a Zoom/Teams meeting. Minimize the meeting window or switch apps (Zoom controls move out of accessibility tree). Verify meeting stays active and does NOT auto-terminate after 30 seconds. Audio output detection prevents false "meeting ended" events. (`4e784f620`)
 - [ ] **OpenAI-compatible transcription endpoint** — Verify that the `/v1/audio/transcriptions` endpoint works as expected, following the OpenAI specification. (`5a14e9a92`)
+- [ ] **Discord meeting detection on Windows** — On Windows, join a Discord voice call. Verify that the call is detected as an active meeting and recording starts automatically. (`7c29bc100`) — regression: 2026-04-15 to 2026-05-07 on Windows only due to platform-specific UIA signal filtering.
 
 ### 5. frame comparison & OCR pipeline
 


### PR DESCRIPTION
## Problem

Discord voice call detection was silently failing on Windows for 24 days (2026-04-15 to 2026-05-07).

## Root cause

Commit `fe669f5b6` (2026-04-14) raised Discord's minimum signals requirement from 1 to 2 to fix a macOS false positive. However, Windows' UIA scanner cannot express MenuBarItem signals, so Windows' total signal count was effectively cut in half. With two unrelated "Disconnect" button signals being the only matches, the per-element matching loop short-circuited on first hit, counting as 1 signal instead of 2 — below threshold.

## Fix

Commit `7c29bc100` introduced platform-specific Discord profiles: macOS keeps min=2 (both Mute/Deafen + Disconnect), Windows uses only Disconnect signals with min=1 (never appears outside active voice channels on Windows).

## Verification (Tier T3)

This is a testing-only entry documenting a recent regression fix. Static verification:
- Commit `7c29bc100` is in main (verified)
- No build changes, no runtime changes
- TESTING.md syntax valid (markdown format preserved)

## Confidence: 10/10

This is a documentation PR for a bug that was just fixed. The entry documents the fix and ensures testers catch any future regression in the same code path.

## Sources

- **GitHub issue**: #3269 (connections PR that was partly blocked by this detection gap)
- **Commit fix**: `7c29bc100` — fix(meetings,discord,windows): unbreak Discord call detection...
- **Recent regression**: 2026-04-15 to 2026-05-07 on Windows only

---
auto-generated by issue-solver pipe