### PR TITLE
Fix inline edit to preserve user message

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1562,7 +1562,7 @@ export function StandaloneChat({
   const lastUserMessageRef = useRef<string>("");
 
   // Ref to sendMessage so useEffect callbacks can call it without stale closures
-  const sendMessageRef = useRef<(msg: string) => Promise<void>>();
+  const sendMessageRef = useRef<(msg: string, displayLabel?: string) => Promise<void>>();
   // Bypass guard for auto-send from chat-prefill (Pi confirmed running but React state stale)
   const autoSendBypassRef = useRef(false);
 
@@ -4854,7 +4854,7 @@ export function StandaloneChat({
                       const idx = messages.findIndex((m) => m.id === message.id);
                       if (idx === -1) return;
                       setMessages((prev) => prev.slice(0, idx));
-                      sendMessage(trimmed);
+                      sendMessage(trimmed, message.displayContent);
                     }}
                     onKeyDown={(e) => {
                       if (e.key === "Escape") { e.preventDefault(); setEditingMessageId(null); }


### PR DESCRIPTION
This restores the intended inline-edit behavior in user message so that when a user edits a message that originally had displayContent, the resent message keeps that label and stays in the collapsed UI instead of expanding to the full raw prompt.

Before - 

https://github.com/user-attachments/assets/ecd12edc-47d4-45a3-ba5a-17089e0017da

After -


https://github.com/user-attachments/assets/8ad1f0e5-f65b-45d1-a2b7-b1cc97e687eb


