### PR TITLE
docs(testing): add Windows Discord call detection regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -180,6 +180,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **Browser meetings splitting fix** — Verify that meetings in the browser are correctly split into separate events. (`d8ba1dad3`)
 - [ ] **Meeting with hidden UI controls** — Start a Zoom/Teams meeting. Minimize the meeting window or switch apps (Zoom controls move out of accessibility tree). Verify meeting stays active and does NOT auto-terminate after 30 seconds. Audio output detection prevents false "meeting ended" events. (`4e784f620`)
 - [ ] **OpenAI-compatible transcription endpoint** — Verify that the `/v1/audio/transcriptions` endpoint works as expected, following the OpenAI specification. (`5a14e9a92`)
+- [ ] **Windows Discord call detection** — On Windows, join a Discord voice channel. Verify that the meeting is automatically detected and recording begins. This was broken from 2026-04-15 to 2026-05-07 due to elevated signal threshold that Windows' UIA scanner couldn't meet. (`7c29bc100`)
 
 ### 5. frame comparison & OCR pipeline
 


### PR DESCRIPTION
## Problem

Windows users experienced silent Discord call detection failure from 2026-04-15 through 2026-05-07. Audio recording continued (independent path), but the meeting-detector missed Discord calls entirely, preventing caller name assignment and meeting-aware recording optimizations.

## Root cause

Commit fe669f5b6 (2026-04-14) raised Discord's `min_signals_required: 1 → 2` globally to defeat a macOS false positive where Mute/Deafen menu items fired outside voice channels. The four signals it checked:
1. MenuBarItem { "Disconnect" }
2. RoleWithName { Button, "Disconnect" }
3. NameContains { "Disconnect" }
4. MenuBarItem { "Mute" }

But Windows' UIA scanner (`windows_scan_process_uia`, ~line 1285) explicitly cannot express MenuBarItem conditions — those signals are skipped entirely. This left only signals 2 and 3, both keyed on "Disconnect". The per-element matching loop short-circuits on first match, counting a single button as 1 signal, not 2.

Result: every Windows Discord call since 2026-04-15 fell below the threshold and was dropped.

## Fix

Split Discord into per-platform profiles via `#[cfg]` guards:
- **macOS**: Keep min=2 (Disconnect + Mute) — needed to defend against channel-list and user-controls false positives
- **Windows**: Use min=1 on the Disconnect signal only — Discord's UI never exposes "Disconnect" outside an active voice channel, so a single match is reliable

## Verification

This is a documentation PR (TESTING.md regression entry, not code fix). The fix itself was delivered in commit 7c29bc100. This entry ensures future meeting-detection tuning accounts for per-platform UIA limitations.

Test manually: On Windows, join a Discord voice call. Verify the call is detected as a meeting (status shows "In meeting", speaker names assigned).

## Confidence: 10/10

The regression is documented in existing fix (7c29bc100). The test entry is straightforward and directly references both the breaking change (fe669f5b6) and the fix (7c29bc100).

## Verification (Tier T3 - documentation)

```
TESTING.md updated with regression entry for Windows Discord detection.
Commit hashes verified:
- fe669f5b6: fix: reduce Discord meeting detection false positives ✓
- 7c29bc100: fix(meetings,discord,windows): unbreak Discord call detection... ✓
```

## Sources (multi-source)

- Sentry: User report (Jin Pendragon, Windows, 2026-05-07)
- GitHub issue: #3261 (related meeting detection issues)
- Git history: Commit 7c29bc100 with full root cause explanation
- Code: Platform-specific profile split in meeting_detector.rs

---
auto-generated by issue-solver pipe (F1: TESTING.md regression entry)