### PR TITLE
fix(connections): hide Apple Intelligence tile on non-macOS

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1746,7 +1746,7 @@ export function ConnectionsSection() {
         { id: "browser-url", name: "Browser URL Capture", icon: "browser-url", connected: false },
         { id: "voice-memos", name: "Voice Memos", icon: "voice-memos", connected: false },
       ] : []),
-      { id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false },
+      ...(os === "macos" ? [{ id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false }] : []),
       { id: "apple-calendar", name: os === "windows" ? "Windows Calendar" : "Apple Calendar", icon: os === "windows" ? "windows-calendar" : "apple-calendar", connected: false },
       { id: "google-calendar", name: "Google Calendar", icon: "google-calendar", connected: false },
       { id: "google-docs", name: "Google Docs", icon: "google-docs", connected: false },

--- a/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
@@ -81,7 +81,7 @@ export function useHardcodedTiles(): HardcodedTile[] {
       { id: "browser-url", name: "Browser URL Capture", icon: "browser-url", connected: false },
       { id: "voice-memos", name: "Voice Memos", icon: "voice-memos", connected: false },
     ] as HardcodedTile[] : []),
-    { id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false },
+    ...(os === "macos" ? [{ id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false } as HardcodedTile] : []),
     {
       id: "apple-calendar",
       name: os === "windows" ? "Windows Calendar" : "Apple Calendar",


### PR DESCRIPTION
### Description:
Apple Intelligence was showing up in the connections list on Windows and Linux, even though it only works on macOS. Added the same `os === "macos"` guard that already wraps `browser-url` and `voice-memos`.

**Files changed**
- `components/settings/connections-section.tsx`
- `lib/hooks/use-hardcoded-tiles.ts`