### PR TITLE
docs(testing): add audio undecodable chunk orphaning regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -136,6 +136,7 @@ commits: `28e5c247`
 - [ ] **Filter music toggle UI** — Verify that a "filter music" toggle exists in recording settings and correctly enables/disables music filtering.
 - [ ] **Music detection thresholds** — With "filter music" enabled, play various types of music. Verify that music is correctly detected and filtered, and that non-music speech is still captured.
 - [ ] **Audio reconciliation FK constraint loop** — Verify that audio reconciliation does not enter an infinite retry loop on foreign key constraints. (`e9e2dc252`)
+- [ ] **undecodable audio chunk orphaning** — Inject a corrupt/truncated audio file in the database (either via ffmpeg write failure or manual file corruption). Verify that the next reconciliation sweep marks it as orphan for deletion instead of retrying forever. Without this fix: chunk_id retries every ~2 minutes indefinitely, eating ffmpeg subprocess budget and causing lag/high energy use. (`32e5dfc44`)
 - [ ] **Skip reconciliation when transcription disabled** — Disable audio transcription in settings. Verify that audio reconciliation is skipped. (`ceb77559d`)
 - [ ] **dead System Audio auto-reconnect** — Simulate a dead system audio stream. Verify it auto-reconnects and resumes capture. (`0f287761d`)
 - [ ] **per-device audio toggle** — In the tray menu, verify you can toggle recording for individual audio devices. (`3ee3defcb`)


### PR DESCRIPTION
## Problem
Audio reconciliation can enter an infinite retry loop on corrupt or undecodable audio files.

## Root cause
In `reconcile_untranscribed`, when ffmpeg fails to decode an audio file (corrupt header, partial write, etc.), the error was logged but the chunk remained in the database with `transcription IS NULL`. The next reconciliation sweep would re-query the same chunk, spawn ffmpeg, fail again, and retry — indefinitely.

## Fix
Commit `32e5dfc44` treats undecodable audio chunks the same as missing files: they are pushed to `orphan_chunk_ids` for batch deletion. Since the audio data is unrecoverable, retrying indefinitely only causes harm (ffmpeg subprocess overhead, DB query budget, CPU/battery impact).

## Verification (T3)
This is a documentation entry for an existing fix already merged on main. The test case provides a regression check: inject a corrupt audio file and verify the next reconciliation marks it orphan instead of retrying.

## Sources
- Commit: `32e5dfc44` — fix(audio): orphan undecodable audio chunks instead of retrying forever
- User impact: 65+ minute retry loop on single bad chunk caused reported lag and high energy use
- TESTING.md entry ensures this regression is caught in future development

---
auto-generated by fallback F1: TESTING.md update