### PR TITLE
docs(testing): add macOS bundle signature integrity regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -275,6 +275,7 @@ commits: `94531265`, `d794176a`, `9070639c`, `0378cab1`, `4a3313d3`, `7ffdd4f1`,
 - [ ] **Tokio shutdown stability** — Verify that the `tokio` shutdown process is stable and doesn't panic in the tree walker, especially during application exit or process restarts.
 - [ ] **No ggml Metal destructor crash on quit** — Perform multiple quick quits (Cmd+Q, tray quit) and restarts. Verify that the app exits cleanly without a `ggml Metal destructor crash`.
 - [ ] **Properly wait for UI recorder tasks before exit** — During a clean quit, verify that all UI recorder tasks complete properly and no orphaned processes or partial recordings remain.
+- [ ] **macOS bundle signature integrity** — On macOS, launch the app on v2.4.150+ and verify it does NOT show repeated "screenpipe is damaged" Gatekeeper popups or drop localhost:3030 connection after launch. The signed bundle must not be mutated post-signing on first launch. (`14d813c1b`)
 - [ ] **recording watchdog diagnostics** — Verify that the recording watchdog correctly diagnoses and handles recording issues, and provides useful diagnostic information. (`af2b4f3d`)
 - [ ] **capture stall detection** — Simulate or observe a capture stall. Verify that a notification appears with a "Restart" button to recover. (`d3ead88eb`)
 - [ ] **DB write stall detection** — if DB writes stall, verify a notification appears with a "Restart" button. (`1b4bf7918`)


### PR DESCRIPTION
## Problem
Issue #3268 reported repeated "screenpipe is damaged" Gatekeeper popups on macOS 26.4+ that invalidate the signed app bundle.

## Root cause
In v2.4.133–v2.4.149, `src-tauri/src/main.rs` created a symlink at `Contents/MacOS/mlx.metallib` pointing into `Contents/Resources/` on first launch. This post-signing file modification invalidated the Code Directory hash. macOS 26.4 tightened cdhash recheck on every launch, triggering the Gatekeeper rejection.

## Fix
Commit 14d813c1b (v2.4.150) removed the symlink creation and moved mlx.metallib handling into the Tauri resources map at build time, keeping all signed Contents/ entries sealed.

## Verification (Tier T3 — static analysis)
- `git cat-file -e 14d813c1b` ✓
- Real user report (mrcasilli@gmail.com, 2026-05-07) ✓
- Recent PR #3268 discussion ✓

## Sources (multi-source required)
- GitHub issue: #3268 — self-mutated signed app bundle
- Commit: 14d813c1b — fix(macos,signing): stop mutating signed bundle on launch (parakeet-mlx)
- Tauri release notes: v2.4.150 — app restart without server connection

---
auto-generated by fallback F1 (testing regression)