### PR TITLE
docs(testing): add AI image PII redaction regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -340,6 +340,7 @@ commits: `8a5f51dd`, `0b0d8090`, `7e58564e`, `2522a7e2`, `f3e55dbc`, `79f2913f`
 - [ ] **privacy settings reordering** — Verify that the Security section appears first in the Privacy settings tab. (`4718785b6`)
 - [ ] **password field filtering** — Verify that password fields are skipped in the accessibility tree and not stored as OCR/text. (`8159641f5`, `d39e42e5b`)
 - [ ] **browser extension popup filtering** — Verify that browser extension popups (like Bitwarden) are filtered and not captured in the accessibility tree or as black frames. (`52d20987a`, `449ae7a68`, `931db40b6`)
+- [ ] **AI image PII redaction default threshold** — Open Settings → Privacy → AI PII removal and enable the toggle. Browse a complex technical page (IDE, GitHub repo, terminal output) with code, file paths, version numbers, URLs. Verify that normal content (code identifiers, paths, timestamps) is NOT over-redacted. The default policy should only redact [Secret] labels at score ≥0.9 confidence, preventing false positives. Check timeline frames are preserved. Regression: `0d55e6c4b` (rfdetr_v8 with loose policy was flagging code as Url/Date/Handle, blacking out 30%+ of normal content; now uses [Secret] only at 0.9).
 
 commits: `8a5f51dd`, `0b0d8090`
 


### PR DESCRIPTION
## Problem
The default image redaction policy was over-aggressive, flagging ~30% of
normal technical content (code identifiers, file paths, version strings) as
sensitive (Person, Url, Date, Handle, etc.). This led to destructive frame
overwrites when users enabled AI PII detection.

## Root cause
ImageRedactionPolicy::default() included a wide allow-list [Person, Email,
Phone, Address, Url, Company, Repo, Handle, Channel, Id, Date, Secret]
with min_score=0.3. The rfdetr_v8 model has ~30% false-positive rate on
technical content, routinely mis-classifying code as Url, version numbers as
Date, identifiers as Handle.

## Fix
Commit 0d55e6c4b narrowed the default to [Secret] only at min_score=0.9,
ensuring only genuine secrets are redacted. Broader policies now require
per-class precision benchmarks before shipping.

## Verification
This PR adds a TESTING.md regression entry documenting the test case:
- Enable AI PII removal toggle
- Browse complex technical content (IDE, GitHub, terminal)
- Verify normal code/paths/versions are NOT redacted
- Check timeline frames are preserved

## Sources
- Commit 0d55e6c4b (fix: default policy to Secret-only @ 0.9)
- Sentry: Related to image redaction regressions
- Root cause analysis in 0d55e6c4b commit message

---
auto-generated by issue-solver pipe (fallback F1: TESTING.md regression entry)