### PR TITLE
docs(testing): add speaker device seeding regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -167,6 +167,7 @@ commits: calendar_speaker_id.rs, meetings.rs, meeting_persister.rs
 - [ ] **auto-name input speaker** — with userName set, after ~2 minutes of speaking into mic, dominant input speaker named. verify: `grep "auto speaker identification: named" ~/.screenpipe/screenpipe-app.*.log`.
 - [ ] **speaker names survive restart** — speaker named pre-restart stays named post-restart. verify: `sqlite3 ~/.screenpipe/db.sqlite "SELECT id, name FROM speakers WHERE name != ''"` shows same speakers before and after restart.
 - [ ] **no duplicate speaker naming on restart** — restart during meeting, speakers already named aren't overwritten or duplicated. verify: no duplicate names in speakers table.
+- [ ] **speaker device seeding on startup** — Start a recording session. Verify that all input and output devices are pre-seeded with speaker records before any audio is recorded. This prevents speaker fragmentation when devices are swapped mid-session. Verify: `sqlite3 ~/.screenpipe/db.sqlite "SELECT device_id, COUNT(*) FROM speakers GROUP BY device_id"` shows expected device count. (`755733f15`)
 - [ ] **meeting detection stability** — Verify that meeting detection does not drop when alt-tabbing during long calls. (`7684f1d47`)
 - [ ] **speaker search deduplication** — Search for speakers in the UI. Verify that results are deduplicated and reassignment targets are stable. (`34a62c053`)
 - [ ] **meeting detection regardless of transcription mode** — Verify that meeting detection works even when transcription is disabled. (`ef39e728d`)


### PR DESCRIPTION
## Problem

Users on Windows with professional audio interfaces experienced massive speaker fragmentation — 190+ speakers created from ~2 people. Every 30s audio segment created a new speaker instead of matching existing ones.

The root cause was that speakers were not seeded when the app started recording, leading to duplicate speaker creation when audio devices were swapped mid-session.

## Root cause

Commit 755733f15 fixed the root cause by seeding all active input/output device speakers before recording starts. However, this regression wasn't documented in TESTING.md, making it susceptible to re-introduction.

## Fix

Added a regression test entry in the "meeting detection & speaker identification" section of TESTING.md that documents how to verify speaker seeding works correctly:
- Start a recording session
- Verify all input and output devices are pre-seeded with speaker records
- Prevent speaker fragmentation when devices are swapped mid-session

## Confidence: 9/10

This is a documentation-only change that adds a regression test. The underlying fix (755733f15) has been proven to work and was merged in PR #3077. This PR simply ensures we don't regress by documenting the test case.

## Verification (Tier T3)

Documentation review only — this is a TESTING.md entry that helps prevent regression of the existing fix in commit 755733f15.

## Sources (multi-source required)

- **Sentry**: 0 recent crashes (already fixed)
- **GitHub issue**: #2969 — Speaker fragmentation on Windows (CLOSED, fixed by #3077)
- **Git commit**: 755733f15 — seed all speakers to prevent fragmentation (#2969) (#3077)

---
auto-generated by issue-solver pipe