### PR TITLE
docs(testing): add audio reconciliation corrupt chunk regression entry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -136,6 +136,7 @@ commits: `28e5c247`
 - [ ] **Filter music toggle UI** — Verify that a "filter music" toggle exists in recording settings and correctly enables/disables music filtering.
 - [ ] **Music detection thresholds** — With "filter music" enabled, play various types of music. Verify that music is correctly detected and filtered, and that non-music speech is still captured.
 - [ ] **Audio reconciliation FK constraint loop** — Verify that audio reconciliation does not enter an infinite retry loop on foreign key constraints. (`e9e2dc252`)
+- [ ] **Audio reconciliation handles corrupt chunks gracefully** — Verify that corrupt/undecodable audio chunks (ffmpeg decode failures) are orphaned and removed from the database, rather than retried infinitely. Without this fix, a single corrupt chunk causes 2-minute reconciliation cycles indefinitely, resulting in high CPU/memory usage and app lag. Check logs for chunk orphaning. (`32e5dfc44`)
 - [ ] **Skip reconciliation when transcription disabled** — Disable audio transcription in settings. Verify that audio reconciliation is skipped. (`ceb77559d`)
 - [ ] **dead System Audio auto-reconnect** — Simulate a dead system audio stream. Verify it auto-reconnects and resumes capture. (`0f287761d`)
 - [ ] **per-device audio toggle** — In the tray menu, verify you can toggle recording for individual audio devices. (`3ee3defcb`)


### PR DESCRIPTION
## Problem

Audio reconciliation can enter an infinite loop when processing corrupt/undecodable audio chunks. This regression is critical for audio recording reliability and can cause app lag, high CPU usage, and skipped audio capture.

## Root cause

In reconciliation, only the missing-file branch orphaned chunks for deletion. Decode failures (ffmpeg unable to read corrupt files) and panic handling both logged and fell through, leaving the chunk with `transcription IS NULL` in the database.

Every subsequent reconciliation sweep (every ~2 minutes) re-selected the same corrupt chunk, spawned ffmpeg, failed, and left it in DB again. This caused a permanent retry loop.

Real-world impact: A single corrupt audio chunk led to 65+ minutes of repeated ffmpeg subprocess spawning and DB queries, resulting in user reports of 'lots of lag and high energy use.' Audio gap warnings were a knock-on effect from reconciliation thrashing.

## Fix

Commit 32e5dfc44 (fix(audio): orphan undecodable audio chunks instead of retrying forever) treats decode failures the same as missing files: chunks are pushed to `orphan_chunk_ids` for batch deletion.

## Verification needed

- Enable audio transcription in app settings
- Record audio for ~5 minutes with working device
- Verify normal transcription works
- Check logs for 'orphaned' or 'reconciliation' messages if any decode issues occur
- Monitor that there are no infinite retry loops in logs

---

This is a regression testing documentation entry for commit 32e5dfc44.