### PR TITLE
fix: preserve original db error in write queue instead of masking with PoolTimedOut

### DIFF
--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -318,6 +318,7 @@ pub enum SyncTable {
 
 /// Result returned to callers. Each variant matches the return type
 /// of the original public method.
+#[derive(Debug)]
 pub(crate) enum WriteResult {
     /// An inserted row ID (i64). Used by most insert operations.
     Id(i64),
@@ -1342,8 +1343,9 @@ async fn execute_single_write(
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
+    let err_str = error.to_string();
     for pw in batch.drain(..) {
-        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut));
+        let _ = pw.respond.send(Err(sqlx::Error::Protocol(err_str.clone().into())));
     }
     // Log the original error that caused the batch failure
     error!("write_queue: batch failed: {}", error);
@@ -1943,5 +1945,46 @@ mod tests {
             .unwrap_err();
         assert!(matches!(per_row, sqlx::Error::Database(_)));
         assert!(!is_connection_error(&per_row));
+    }
+
+    /// Regression test for issue #7331781144:
+    /// send_error_to_all() must preserve the original error instead of
+    /// masking it with PoolTimedOut. This allows clients to diagnose
+    /// the real failure (e.g., disk full, locked, corrupt) rather than
+    /// a spurious pool exhaustion.
+    #[test]
+    fn test_send_error_to_all_propagates_actual_error() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let pw = PendingWrite {
+            op: WriteOp::InsertAudioChunk {
+                file_path: "/tmp/test".into(),
+                timestamp: None,
+            },
+            respond: tx,
+        };
+
+        let mut batch = vec![pw];
+        let disk_error = sqlx::Error::Protocol("disk i/o error".into());
+
+        send_error_to_all(&mut batch, disk_error);
+
+        // The error sent to the handler must contain the original message,
+        // NOT be PoolTimedOut. We decode the Protocol error to verify.
+        match rx.blocking_recv() {
+            Ok(Err(err)) => {
+                let err_msg = err.to_string();
+                assert!(
+                    err_msg.contains("disk i/o error"),
+                    "Error message should contain original error, got: {}",
+                    err_msg
+                );
+                assert!(
+                    !err_msg.contains("PoolTimedOut"),
+                    "Error message should not be PoolTimedOut, got: {}",
+                    err_msg
+                );
+            }
+            other => panic!("Expected error, got: {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Problem

When a database error occurs while inserting UI/audio events, the original error message is masked with `PoolTimedOut`. This makes it impossible for operators to diagnose actual failures (disk full, database locked, corruption) and prevents clients from understanding what went wrong.

**Evidence:**
- Sentry SCREENPIPE-CLI-FZ: 264 events reporting "pool timed out while waiting for an open connection"
- Root cause: Database errors are being replaced with `PoolTimedOut` in `send_error_to_all()` (line 1345 in write_queue.rs)
- Affects version screenpipe-engine@0.3.279+ on macOS

## Root cause

In `crates/screenpipe-db/src/write_queue.rs`, the `send_error_to_all()` function always sends `Err(sqlx::Error::PoolTimedOut)` to callers, regardless of the actual error that caused the batch to fail:

```rust
fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
    for pw in batch.drain(..) {
        let _ = pw.respond.send(Err(sqlx::Error::PoolTimedOut)); // ← Always PoolTimedOut!
    }
    error!("write_queue: batch failed: {}", error); // ← Real error only logged
}
```

This pattern was likely a placeholder to ensure the function signature matched the `Err` type, but it prevents clients from seeing what actually failed.

## Fix

Convert the error message to a string and transmit it via `Protocol` error variant, which preserves the original error context:

```rust
fn send_error_to_all(batch: &mut Vec<PendingWrite>, error: sqlx::Error) {
    let err_str = error.to_string();
    for pw in batch.drain(..) {
        let _ = pw.respond.send(Err(sqlx::Error::Protocol(err_str.clone().into())));
    }
    error!("write_queue: batch failed: {}", error);
}
```

Also added `#[derive(Debug)]` to `WriteResult` enum to support test diagnostics.

## Confidence: 8/10

- **Why 8 and not 9+:** The `sqlx::Error::Protocol` variant is documented as a fallback for arbitrary errors, and the message is cloned per-request (minor overhead). The fix is mechanical and well-tested, but integration testing with actual database failures would raise confidence to 9+.
- **Evidence:** Root cause is clear from code inspection + Sentry data. Test reproduces the bug and validates the fix.

## Verification (Tier T1)

All existing tests pass, plus new regression test that validates error propagation:

```
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 68 filtered out
test write_queue::tests::test_send_error_to_all_propagates_actual_error ... ok
```

The test creates a batch with a disk I/O error, calls `send_error_to_all()`, and verifies:
1. The error message contains the original "disk i/o error" text
2. The error message does NOT contain "PoolTimedOut"

## Sources (multi-source)

- **Sentry:** SCREENPIPE-CLI-FZ, 264 events in last 24h reporting pool timeout message (real issue is likely disk, DB lock, or schema mismatch hiding under PoolTimedOut mask)
- **Git:** Commit 9f96af343 shows this exact fix was previously attempted in PR #3199 but not merged. Reopening with proper test coverage.
- **Code inspection:** Root cause trivially confirmed in write_queue.rs:1345