### PR TITLE
docs(testing): add ORT panic regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -105,6 +105,7 @@ commits: `28e5c247`
 ### 4. audio device handling
 
 - [ ] **CoreAudio Process Tap** — On macOS 14.4+, verify that system audio defaults to CoreAudio Process Tap and rebuilds if silence is detected. (`75a52603b`, `5634664da`)
+- [ ] **ORT panic on speaker init** — With speaker audio capture enabled, restart the app 10+ times. Verify no "Failed to initialize ORT API" panic in logs. App should catch ORT init failures gracefully and log warning instead of crashing. (`14a441f2b`)
 
 
 - [ ] **default audio device** — with "follow system default", recording uses whatever macOS says is default.


### PR DESCRIPTION
## Problem
Windows and macOS users with speaker audio enabled were hitting "Failed to initialize ORT API" panics on startup in older app versions (v2.4.160 and earlier), causing the tokio worker thread to crash and the app to become unresponsive.

## Root cause
The ORT (ONNX Runtime) initialization for Whisper speech-to-text can fail on some systems (missing libraries, incompatible hardware). Without error handling, this panic would crash the entire tokio runtime instead of gracefully degrading to text-only mode.

## Fix
Commit 14a441f2b added try-catch error handling in `screenpipe-audio/src/speaker/mod.rs` to catch ORT init panics and convert them to warnings. This allows the app to continue running even if speaker audio initialization fails.

## Verification (Tier T3)
The regression test documents the expected behavior: after the fix, restarting the app multiple times with speaker audio enabled should NOT produce ORT initialization panics. The fix catches these errors and logs them as warnings instead.

This is a critical regression guard since users who previously hit this crash would benefit from a re-release, and any future changes to audio init code must preserve this error handling.

## Confidence: 8/10
- Multi-source evidence: 93 Sentry events (v2.4.160), confirmed in commit 14a441f2b with test coverage
- Fix is already merged and tested
- Regression test documents the guard for future maintainers
- Fallback F1: Adding documented regression test for recent fix

## Sources
- Sentry: SCREENPIPE-APP-Q2 (93 events, v2.4.160)
- Fix commit: 14a441f2b "fix(audio): catch ort init panic so speaker init can't kill tokio worker (#3290)"
- PR reference: #3290

---
auto-generated by issue-solver pipe