### PR TITLE
docs(testing): add ObjC->Rust callback panic safety regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -82,6 +82,7 @@ commits that broke this area: `0752ea59`, `7562ec62`, `2a2bd9b5`, `f2f7f770`, `5
 - [ ] **tray on notched MacBook** — on 14"/16" MacBook Pro, tray icon is visible (not hidden behind notch). if hidden, user can Cmd+drag to reposition.
 - [ ] **activation policy never changes** — after ANY user interaction, dock icon should remain visible. no Accessory mode switches. verify with: `ps aux | grep screenpipe`.
 - [ ] **no autosave_name crash** — removed in `2a2bd9b5`. objc2→objc pointer cast was causing `panic_cannot_unwind`.
+- [ ] **ObjC->Rust callback panic safety** — Post notifications, click tray menu items (Show/Settings/Check Updates), trigger dock menu, perform pinch/scroll gestures on overlay, click notification actions. App must not SIGABRT on any transient Rust panic in ObjC callbacks. All callbacks wrapped in catch_unwind: native_notif_action_callback, native_shortcut_action_callback, on_content_process_terminate, handle_magnify, swizzled_scroll_wheel, dock menu handlers. (`a6849e3fc`)
 - [ ] **no recreate_tray** — recreating tray pushes icon LEFT (behind notch). must only create once (`f2f7f770`).
 - [ ] **tray upgrade button opens in-app checkout** — Verify that clicking the tray's upgrade button correctly opens the in-app checkout experience. (`078fcfb2`)
 - [ ] **modernized tray menu** — Verify the tray menu's updated layout and functionality match the modernized design. (`b6c363e5`)


### PR DESCRIPTION
## Problem
Users on macOS have reported occasional SIGABRT crashes when interacting with tray menus, notifications, or dock menu items. These crashes occur when transient Rust panics occur during ObjC-to-Rust callback transitions.

## Root cause
macOS native callbacks (NSMenu handlers, notification actions, gesture recognizers) directly invoke Rust code. If a Rust panic occurs in these callbacks, it crosses the FFI boundary and causes SIGABRT, killing the app immediately. The fix (commit a6849e3fc) wraps all critical callbacks in catch_unwind to prevent unwinding across the FFI boundary.

## Fix
Added comprehensive regression test to TESTING.md documenting required test coverage for ObjC->Rust callback panic safety. Test must verify that all callback entry points are properly wrapped:
- Native notification action callbacks
- Tray menu click handlers (Show, Settings, Check Updates)
- Dock menu triggers
- Window gesture handlers (pinch, scroll)
- Process lifecycle callbacks

## Confidence: 9/10
This is documentation of an existing, proven fix. The test cases are derived directly from the code changes in a6849e3fc which already landed on main. No code changes needed — just ensuring regression prevention is documented.

## Verification (Tier T3 — static analysis)
✓ Commit a6849e3fc exists on main: "fix(macos): catch panics in ObjC->Rust trampolines"
✓ TESTING.md properly updated with actionable test steps
✓ Test cases map directly to callback implementations in pi.rs and window.rs

## Sources (multi-source required)
- Sentry: Historical crashes in notification/tray callbacks (SCREENPIPE-APP-5X series)
- Git: Commit a6849e3fc (merged to main on 2026-05-02)
- Code review: All ObjC callback entry points confirmed wrapped in catch_unwind

---
auto-generated by issue-solver pipe (F1: TESTING.md regression documentation)