### PR TITLE
docs(testing): add settings-loss recovery regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -777,6 +777,7 @@ commits: `fc830b43`
 ### 24. Data Management
 
 - [ ] **Delete local data confirmation** — Use the "Delete device local data" feature. Verify an `AlertDialog` appears instead of a standard `window.confirm`. (`b5db080d6`)
+- [ ] **Settings not lost on update** — Create multiple AI presets, force an app update/restart, verify all presets survive. If 4-layer recovery triggers, `store.bin.pre-restore-*` should exist in `~/.screenpipe/`. (`5f7408bd6`)
 
 ### 25. Feedback & Support
 


### PR DESCRIPTION
## Problem

The 4-layer settings recovery system (commit 5f7408bd6) introduced critical data-loss prevention when AI presets and app settings are wiped by signed updates. This regression risk needs test coverage.

## Fix

Added regression test to TESTING.md Data Management section:
- Verify AI presets survive app restart/update
- Confirm recovery backup (.bin.pre-restore-*) exists if triggered

## Sources

- Real user pain: Louis lost 5 AI presets installing v2.4.182 today
- Commit: 5f7408bd6 — fix(store): make settings-loss on update impossible (4-layer recovery)
- Regression-prone area: data persistence, app update, settings

---
auto-generated by issue-solver pipe (fallback F1)