### PR TITLE
docs(testing): add audio stream shutdown race condition regression test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -138,6 +138,7 @@ commits: `28e5c247`
 - [ ] **Audio reconciliation FK constraint loop** — Verify that audio reconciliation does not enter an infinite retry loop on foreign key constraints. (`e9e2dc252`)
 - [ ] **Skip reconciliation when transcription disabled** — Disable audio transcription in settings. Verify that audio reconciliation is skipped. (`ceb77559d`)
 - [ ] **dead System Audio auto-reconnect** — Simulate a dead system audio stream. Verify it auto-reconnects and resumes capture. (`0f287761d`)
+- [ ] **audio stream shutdown race condition** — Stop recording multiple times in quick succession. Verify no use-after-free crashes (check for SIGSEGV or memory corruption in logs). This regression test ensures the CoreAudio IO callback completes naturally instead of aborting, preventing memory safety violations during stream drop. (`6430566be`)
 - [ ] **per-device audio toggle** — In the tray menu, verify you can toggle recording for individual audio devices. (`3ee3defcb`)
 - [ ] **stable audio device order** — Verify that audio devices listed in the tray menu maintain a stable order across refreshes. (`4577ac8a6`)
 - [ ] **Mic disconnect false-positives on sleep/wake** — Put the computer to sleep and wake it up. Verify that no false-positive mic disconnect notifications or logs are generated. (`796baa619`)


### PR DESCRIPTION
## Problem
Audio stream stop() had a use-after-free crash (issue #3261) where CoreAudio IO callbacks could execute while cpal stream was being dropped, causing memory corruption and ORT initialization failures.

## Root cause
The original code used `JoinHandle::abort()` which doesn't wait for the tokio task to complete. This created a race where the CoreAudio IO callback could still execute while cpal's `stream.pause()` and `drop()` were running, leading to use-after-free memory errors.

## Fix
Commit `6430566be` fixed this by waiting for the thread to exit naturally using `is_finished()` polling instead of aborting. This ensures all cpal stream operations complete before resources are freed.

This PR adds a regression test to TESTING.md to ensure this issue doesn't resurface. The test verifies no SIGSEGV or memory corruption errors occur during rapid record stop/start cycles.

## Confidence: 8/10
The fix already exists and is in main (commit 6430566be, PR #3306). This adds documentation of the regression test case so maintainers verify the fix during testing.

## Verification (Tier T3)
Static analysis: commit `6430566be` clearly demonstrates the fix:
- Original: `join_handle.abort()` → `thread_handle.await?` (unsafe race)
- Fixed: `while !join_handle.is_finished() { ... }` → safe completion

## Sources
- GitHub: #3261 (audio use-after-free crash)
- Commit: 6430566be (fix: prevent use-after-free in audio stream stop #3306)
- Related PR: #3306 (merged)

---
auto-generated by issue-solver pipe