### PR TITLE
improve(connections):jump to selected integeration

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1687,19 +1687,18 @@ function ApiIntegrationPanel({ integration, onRefresh, onDisconnected }: {
 
 export function ConnectionsSection() {
   const [search, setSearch] = useState("");
-  const [selected, setSelected] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null;
-    const pending = sessionStorage.getItem("openConnection");
-    if (pending) {
-      sessionStorage.removeItem("openConnection");
-      return pending;
-    }
-    return null;
-  });
+  const [selected, setSelected] = useState<string | null>(null);
   const [integrations, setIntegrations] = useState<IntegrationInfo[]>([]);
   const [integrationsLoaded, setIntegrationsLoaded] = useState(false);
 
   const os = typeof window !== "undefined" ? platform() : "";
+
+  useEffect(() => {
+    const pending = sessionStorage.getItem("openConnection");
+    if (!pending) return;
+    sessionStorage.removeItem("openConnection");
+    setSelected(pending);
+  }, []);
 
   // Hardcoded connection status
   const [claudeInstalled, setClaudeInstalled] = useState(false);
@@ -1919,10 +1918,12 @@ export function ConnectionsSection() {
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (selected && panelRef.current) {
-      panelRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    }
-  }, [selected]);
+    if (!selected || !selectedTile || !panelRef.current) return;
+    const raf = window.requestAnimationFrame(() => {
+      panelRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+    return () => window.cancelAnimationFrame(raf);
+  }, [selected, selectedTile, integrationsLoaded]);
 
   return (
     <div className="space-y-5">


### PR DESCRIPTION
Clicking an icon in Pipes is a direct action. The user is choosing a specific integration and expects to land on that integration’s setup right away. This PR keeps the current page flow and just makes that handoff reliable, so the selected integration consistently opens and is brought into view. It doesn’t add a new UX pattern it stabilizes the existing one.


Before - 

https://github.com/user-attachments/assets/31668757-d696-4378-a08c-0e34b9874f44


After -


https://github.com/user-attachments/assets/64806c1b-fd4d-486a-95d7-ebeb00060156

