### PR TITLE
Fix tooltip clipping in connection modal

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1435,7 +1435,7 @@ export function ConnectionCredentialForm({
                       <HelpCircle className="h-3 w-3" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="left" sideOffset={4} className="text-xs max-w-[220px] space-y-1">
+                  <TooltipContent side="top" align="start" alignOffset={8} sideOffset={8} className="text-xs max-w-[220px] space-y-1">
                     <p>Learn how to find your {field.label.toLowerCase()} for this integration.</p>
                     <button onClick={() => openUrl(field.help_url)} className="underline hover:text-primary cursor-pointer">
                       Open guide →

--- a/apps/screenpipe-app-tauri/components/ui/tooltip.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/tooltip.tsx
@@ -15,16 +15,18 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, collisionPadding = 16, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    collisionPadding={collisionPadding}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-[min(calc(100vw-32px),320px)]",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 max-w-[min(calc(100vw-32px),320px)]",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
This pr fixes the tooltip clipping issue which introduced in the connection modal.

### Before - 

<img width="1024" height="603" alt="Screenshot 2026-05-12 at 8 10 57 AM" src="https://github.com/user-attachments/assets/f20ba472-7aea-46ea-9d93-e67a0de7ae92" />


### After - 

<img width="1024" height="603" alt="Screenshot 2026-05-12 at 8 11 18 AM" src="https://github.com/user-attachments/assets/2888d409-63dd-4507-a091-e6f6d0d2a533" />
