### PR TITLE
fix(vision): retry start() when VisionManager stops after display disconnect

### DIFF
--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -54,6 +54,8 @@ pub async fn start_monitor_watcher(
         // Set true after DRM/schedule resume so the bulk re-add of monitors
         // doesn't surface as a user-facing "+N displays detected" notification.
         let mut suppress_next_topology_event = false;
+        // Warn once per recovery episode, then keep repeated retries quiet.
+        let mut recovery_retry_warned = false;
 
         // Initialize with current monitors
         match list_monitors_detailed().await {
@@ -187,6 +189,7 @@ pub async fn start_monitor_watcher(
                 match vision_manager.start().await {
                     Ok(()) => {
                         info!("VisionManager recovered after previous start failure");
+                        recovery_retry_warned = false;
                         if let Ok(monitors) = list_monitors_detailed().await {
                             known_monitors = monitors
                                 .iter()
@@ -194,8 +197,13 @@ pub async fn start_monitor_watcher(
                                 .collect();
                         }
                     }
-                    Err(_) => {
-                        debug!("VisionManager retry: still no monitors available");
+                    Err(e) => {
+                        if recovery_retry_warned {
+                            debug!(?e, "VisionManager retry still failing");
+                        } else {
+                            warn!(?e, "VisionManager retry failed; will keep retrying");
+                            recovery_retry_warned = true;
+                        }
                     }
                 }
                 continue;

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -181,9 +181,23 @@ pub async fn start_monitor_watcher(
             }
 
             // ── Normal monitor polling ──────────────────────────────────────
-            // Only poll when running
+            // If stopped (e.g. no monitors after undock/wake), retry start()
             if vision_manager.status().await != VisionManagerStatus::Running {
                 tokio::time::sleep(Duration::from_secs(5)).await;
+                match vision_manager.start().await {
+                    Ok(()) => {
+                        info!("VisionManager recovered after previous start failure");
+                        if let Ok(monitors) = list_monitors_detailed().await {
+                            known_monitors = monitors
+                                .iter()
+                                .map(|m| (m.id(), m.name().to_string()))
+                                .collect();
+                        }
+                    }
+                    Err(_) => {
+                        debug!("VisionManager retry: still no monitors available");
+                    }
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary

The monitor_watcher polling loop sleeps 5s and continues when VisionManager status is not Running, but never attempts to restart it. If displays disconnect temporarily (undocking, closing lid with external monitor), vision capture stops permanently until app restart.

## Fix

Call `start()` after the sleep so capture resumes automatically once monitors become available again. Failed retries log at debug level and the loop continues polling on the next cycle.

## Test plan

- [x] `cargo check` passes (no compilation errors)
- [ ] Manual: undock laptop (disconnect external displays), wait 10s, reconnect -- vision capture should resume without app restart
- [ ] Manual: close lid on external-monitor setup, reopen -- capture resumes

## Context

This affects users with multi-monitor setups or docking stations. The symptom is that screen capture silently stops working after undocking/redocking, with no error visible in the UI.