### PR TITLE
fix e2e settings spec after meetings removal

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts
@@ -97,7 +97,7 @@ describe('Settings sections', () => {
   //
   // Each test below pins a freshly-shipped feature against accidental drop.
   // Pattern: click into the subsection, assert the section's KEY content
-  // strings render. Looser than testid checks (Storage / Meetings / Privacy
+  // strings render. Looser than testid checks (Storage / Privacy
   // panels don't have section-level testids yet) but resilient to copy
   // tweaks because we OR several keywords. If a copy refresh removes ALL
   // listed keywords from the page, that's also a real regression worth
@@ -140,33 +140,6 @@ describe('Settings sections', () => {
     expect(generalBody.includes('clear cache')).toBe(false);
 
     const filepath = await saveScreenshot('settings-storage');
-    expect(existsSync(filepath)).toBe(true);
-  });
-
-  it('Meetings section renders detection / note settings (covers f983570e4, 287427705, b6730535d, 7be09346f)', async () => {
-    const navMeetings = await $('[data-testid="settings-nav-meetings"]');
-    await navMeetings.waitForExist({ timeout: 8_000 });
-    await navMeetings.click();
-    await browser.pause(800);
-
-    const body = (await browser.execute(() => document.body.innerText.toLowerCase())) as string;
-    // Recent commits put a lot of churn into meetings:
-    //   f983570e4 — promote meeting summarize button
-    //   287427705 — markdown-first note editor
-    //   b6730535d — copy meeting + transcript to clipboard
-    //   7be09346f — delete UX (modal confirm)
-    // We don't try to drive any of these; we just verify the settings panel
-    // at least mounts with vocabulary specific to this section so a future
-    // refactor that accidentally swaps in the wrong settings page (or
-    // crashes on mount) is caught.
-    const hasMeetingsContent = body.includes('meeting') ||
-      body.includes('summary') ||
-      body.includes('transcript') ||
-      body.includes('detection');
-    expect(hasMeetingsContent).toBe(true);
-    expect(body).not.toContain('unhandled runtime error');
-
-    const filepath = await saveScreenshot('settings-meetings');
     expect(existsSync(filepath)).toBe(true);
   });
 

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -123,7 +123,6 @@ ort = { version = "=2.0.0-rc.10", features = [
   "download-binaries",
   "copy-dylibs",
 ] }
-esaxx-rs = "0.1.10"
 samplerate = { version = "0.2.4" }
 libsamplerate-sys = "0.1.10"
 
@@ -131,7 +130,6 @@ libsamplerate-sys = "0.1.10"
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
 ort = { version = "=2.0.0-rc.10", default-features = false, features = ["load-dynamic"] }
 ort-sys = { version = "=2.0.0-rc.10", default-features = false }
-esaxx-rs = "0.1.10"
 samplerate = { version = "0.2.4" }
 libsamplerate-sys = "0.1.10"
 


### PR DESCRIPTION
### Description: 

- Remove the stale Meetings settings E2E smoke test now that Meetings is no longer a settings section.
- Update the settings spec comment to match the current section list.