### PR TITLE
Fix disabled-audio capture CPU

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
@@ -154,16 +154,18 @@ impl CaptureSession {
         };
 
         // --- Meeting watcher ---
-        {
+        if let Some(meeting_detector) = server.meeting_detector.clone() {
             let v2_in_meeting = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let _meeting_watcher = start_meeting_watcher(
                 server.db.clone(),
                 v2_in_meeting,
                 server.manual_meeting.clone(),
                 shutdown_tx.subscribe(),
-                server.meeting_detector.clone(),
+                Some(meeting_detector),
             );
             info!("meeting watcher started (v2 UI scanning)");
+        } else {
+            info!("meeting watcher skipped because audio capture is disabled");
         }
 
         // --- Speaker identification ---

--- a/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
@@ -219,7 +219,10 @@ impl ServerCore {
             }
         }
 
-        let meeting_detector: Option<Arc<MeetingDetector>> = {
+        let meeting_detector: Option<Arc<MeetingDetector>> = if config.disable_audio {
+            info!("meeting detector disabled because audio capture is disabled");
+            None
+        } else {
             let detector = Arc::new(MeetingDetector::new());
             info!("meeting detector enabled");
             Some(detector)

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -208,6 +208,11 @@ impl AudioManager {
     }
 
     pub async fn start(&self) -> Result<()> {
+        if self.options.read().await.is_disabled {
+            info!("audio manager start skipped because audio capture is disabled");
+            return Ok(());
+        }
+
         if self.status().await == AudioManagerStatus::Running {
             return Ok(());
         }
@@ -675,52 +680,63 @@ impl AudioManager {
                         out,
                         capture_dt,
                     );
-                    if let Err(e) =
-                        write_audio_to_file(&resampled, SAMPLE_RATE, &PathBuf::from(&path), false)
-                    {
-                        error!("failed to persist audio before deferral: {:?}", e);
-                        None
-                    } else {
-                        debug!("audio persisted to disk: {}", path);
-                        // Insert into DB immediately so retranscribe can find this audio
-                        // even if transcription is deferred. No transcription yet — just the chunk.
-                        // Use the original capture timestamp so audio appears at the correct
-                        // position on the timeline, not when processing happened.
-                        // Retry DB insertion with backoff to survive transient pool saturation.
-                        // Without this, audio files are written to disk but orphaned from the DB,
-                        // causing silent data loss on the timeline.
-                        let mut inserted = false;
-                        for retry in 0..3u32 {
-                            match db.insert_audio_chunk(&path, capture_dt).await {
-                                Ok(_) => {
-                                    inserted = true;
-                                    break;
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        "failed to insert audio chunk into db (attempt {}/3): {:?}",
-                                        retry + 1,
-                                        e
-                                    );
-                                    if retry < 2 {
-                                        tokio::time::sleep(std::time::Duration::from_millis(
-                                            500 * (retry as u64 + 1),
-                                        ))
-                                        .await;
+                    let path_buf = PathBuf::from(&path);
+                    let write_result = tokio::task::spawn_blocking(move || {
+                        write_audio_to_file(&resampled, SAMPLE_RATE, &path_buf, false)
+                    })
+                    .await;
+
+                    match write_result {
+                        Ok(Ok(())) => {
+                            debug!("audio persisted to disk: {}", path);
+                            // Insert into DB immediately so retranscribe can find this audio
+                            // even if transcription is deferred. No transcription yet — just the chunk.
+                            // Use the original capture timestamp so audio appears at the correct
+                            // position on the timeline, not when processing happened.
+                            // Retry DB insertion with backoff to survive transient pool saturation.
+                            // Without this, audio files are written to disk but orphaned from the DB,
+                            // causing silent data loss on the timeline.
+                            let mut inserted = false;
+                            for retry in 0..3u32 {
+                                match db.insert_audio_chunk(&path, capture_dt).await {
+                                    Ok(_) => {
+                                        inserted = true;
+                                        break;
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "failed to insert audio chunk into db (attempt {}/3): {:?}",
+                                            retry + 1,
+                                            e
+                                        );
+                                        if retry < 2 {
+                                            tokio::time::sleep(std::time::Duration::from_millis(
+                                                500 * (retry as u64 + 1),
+                                            ))
+                                            .await;
+                                        }
                                     }
                                 }
                             }
+                            if !inserted {
+                                // path is a structured field so Sentry dedups the
+                                // issue across different devices; otherwise every
+                                // device name creates a new Sentry issue.
+                                error!(
+                                    audio_chunk_path = %path,
+                                    "audio chunk DB insert failed after 3 retries, data may be missing from timeline"
+                                );
+                            }
+                            Some(path)
                         }
-                        if !inserted {
-                            // path is a structured field so Sentry dedups the
-                            // issue across different devices; otherwise every
-                            // device name creates a new Sentry issue.
-                            error!(
-                                audio_chunk_path = %path,
-                                "audio chunk DB insert failed after 3 retries, data may be missing from timeline"
-                            );
+                        Ok(Err(e)) => {
+                            error!("failed to persist audio before deferral: {:?}", e);
+                            None
                         }
-                        Some(path)
+                        Err(e) => {
+                            error!("audio persistence worker failed: {}", e);
+                            None
+                        }
                     }
                 } else {
                     None
@@ -1119,6 +1135,11 @@ impl AudioManager {
     /// Restart central handlers regardless of whether they are dead.
     pub async fn restart_central_handlers(&self) -> CentralHandlerRestartResult {
         let mut result = CentralHandlerRestartResult::default();
+
+        if self.options.read().await.is_disabled {
+            return result;
+        }
+
         {
             let mut recording_guard = self.recording_receiver_handle.write().await;
             if let Some(handle) = recording_guard.take() {
@@ -1198,6 +1219,10 @@ impl AudioManager {
     /// so per-device recording tasks keep sending without interruption.
     pub async fn check_and_restart_central_handlers(&self) -> CentralHandlerRestartResult {
         let mut result = CentralHandlerRestartResult::default();
+
+        if self.options.read().await.is_disabled {
+            return result;
+        }
 
         // --- fast path: read-lock to check liveness ---
         let recording_dead = {

--- a/crates/screenpipe-audio/src/utils/ffmpeg.rs
+++ b/crates/screenpipe-audio/src/utils/ffmpeg.rs
@@ -23,6 +23,9 @@ fn encode_single_audio(
     let mut command = screenpipe_core::ffmpeg_cmd(find_ffmpeg_path().unwrap());
     command
         .args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
             "-f",
             "f32le",
             "-ar",
@@ -33,6 +36,8 @@ fn encode_single_audio(
             "pipe:0",
             "-c:a",
             "aac",
+            "-threads",
+            "1",
             "-b:a",
             "64k", // Reduced bitrate for higher compression
             "-profile:a",

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -798,10 +798,13 @@ async fn main() -> anyhow::Result<()> {
     // Create UI recorder config early before cli is moved
     let ui_recorder_config = config.to_ui_recorder_config();
 
-    // Create meeting detector regardless of transcription mode.
     // Meeting detection uses app focus + audio RMS only (no transcription needed).
-    // Shared between audio manager (checks state) and UI recorder (feeds events).
-    let meeting_detector: Option<Arc<MeetingDetector>> = {
+    // It still needs audio capture enabled; otherwise the UI scanner has no useful
+    // consumer and can add idle CPU.
+    let meeting_detector: Option<Arc<MeetingDetector>> = if config.disable_audio {
+        info!("meeting detector disabled because audio capture is disabled");
+        None
+    } else {
         let detector = Arc::new(MeetingDetector::new());
         info!("meeting detector enabled — independent of transcription mode");
         Some(detector)
@@ -1465,17 +1468,19 @@ async fn main() -> anyhow::Result<()> {
         }
     };
 
-    // Start v2 meeting detection (UI scanning for call controls)
-    // Independent of UI recorder — only needs accessibility permission
-    let _meeting_watcher_handle = {
+    // Start v2 meeting detection (UI scanning for call controls) when audio is enabled.
+    let _meeting_watcher_handle = if let Some(meeting_detector) = meeting_detector.clone() {
         let v2_in_meeting = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        start_meeting_watcher(
+        Some(start_meeting_watcher(
             db.clone(),
             v2_in_meeting,
             manual_meeting.clone(),
             shutdown_tx.subscribe(),
-            meeting_detector.clone(),
-        )
+            Some(meeting_detector),
+        ))
+    } else {
+        info!("meeting watcher skipped because audio capture is disabled");
+        None
     };
 
     // Start calendar-assisted speaker identification


### PR DESCRIPTION
## Summary
- Do not create the meeting detector or accessibility meeting watcher when audio capture is disabled.
- Make disabled audio managers refuse direct start/restart paths so health checks or API calls cannot wake audio handlers back up.
- Move per-chunk audio file encoding off Tokio worker threads and constrain single-chunk ffmpeg encoding to one thread with quiet logs.

## Why
We saw ScreenPipe around 58% CPU with audio enabled. After disabling audio, a 10-minute sample dropped to ~18% average / ~15.5% median and ffmpeg stayed at 0%, which points at audio-side work plus the still-running meeting watcher as the controllable hot path.

## Validation
- cargo check -p screenpipe-audio -p screenpipe-engine --bins
- CARGO_TARGET_DIR=... cargo check --bin screenpipe-app
- ffmpeg smoke test for the new AAC args with -threads 1

Note: the app check needed local, untracked bundle inputs in the temp worktree: bun/ffmpeg/ffprobe sidecars plus an empty frontend out directory.