### PR TITLE
[codex] fix Windows ONNX Runtime version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,9 @@ jobs:
       - name: Download ONNX Runtime (CPU)
         shell: pwsh
         run: |
-          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-win-x64-1.19.2.zip"
-          $zipFile = "onnxruntime-win-x64-1.19.2.zip"
-          $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-win-x64-1.22.0.zip"
+          $zipFile = "onnxruntime-win-x64-1.22.0.zip"
+          $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0"
           Invoke-WebRequest -Uri $url -OutFile $zipFile
           if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
           7z x $zipFile -o"apps/screenpipe-app-tauri/src-tauri/" -y
@@ -157,7 +157,7 @@ jobs:
       - name: Stage ONNX Runtime DLLs next to test binary
         shell: pwsh
         run: |
-          $src = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2/lib"
+          $src = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0/lib"
           $dst = "${{ github.workspace }}/target/x86_64-pc-windows-msvc/release/deps"
           if (-not (Test-Path $dst)) {
             New-Item -ItemType Directory -Path $dst -Force | Out-Null
@@ -217,7 +217,7 @@ jobs:
       - name: Add ONNX lib dir to PATH for cargo tests
         shell: pwsh
         run: |
-          $ortLib = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2/lib"
+          $ortLib = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0/lib"
           echo $ortLib | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           Write-Host "PATH appended: $ortLib"
 
@@ -225,7 +225,7 @@ jobs:
         env:
           RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
-          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
         run: cargo test -p screenpipe-screen test_process_ocr_task_windows --release --target x86_64-pc-windows-msvc
@@ -234,7 +234,7 @@ jobs:
         env:
           RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
-          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
         run: cargo test -p screenpipe-core pii_removal --release --target x86_64-pc-windows-msvc
@@ -243,7 +243,7 @@ jobs:
         env:
           RUSTFLAGS: "-C link-arg=/LTCG"
           ORT_STRATEGY: system
-          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
         run: cargo test -p screenpipe-engine --lib pii_redaction_tests --release --target x86_64-pc-windows-msvc

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -67,7 +67,7 @@ jobs:
         path: |
           apps/screenpipe-app-tauri/src-tauri/ffmpeg
           apps/screenpipe-app-tauri/src-tauri/vcredist
-          apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+          apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
           apps/screenpipe-app-tauri/src-tauri/bun-x86_64-pc-windows-msvc.exe
         key: Windows-e2e-artifacts-v2-${{ hashFiles('apps/screenpipe-app-tauri/scripts/pre_build.js') }}
         restore-keys: |
@@ -110,12 +110,12 @@ jobs:
     - name: Download ONNX Runtime (CPU) for Windows
       shell: pwsh
       run: |
-        $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-win-x64-1.19.2.zip"
-        $tauriDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2"
+        $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-win-x64-1.22.0.zip"
+        $tauriDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0"
         $ortDir = "ort-system-lib"
-        Invoke-WebRequest -Uri $url -OutFile "onnxruntime-win-x64-1.19.2.zip"
+        Invoke-WebRequest -Uri $url -OutFile "onnxruntime-win-x64-1.22.0.zip"
         if (Test-Path $tauriDir) { Remove-Item $tauriDir -Recurse -Force }
-        7z x onnxruntime-win-x64-1.19.2.zip -o"apps/screenpipe-app-tauri/src-tauri/" -y
+        7z x onnxruntime-win-x64-1.22.0.zip -o"apps/screenpipe-app-tauri/src-tauri/" -y
         if (Test-Path $ortDir) { Remove-Item $ortDir -Recurse -Force }
         Copy-Item -Path $tauriDir -Destination $ortDir -Recurse -Force
 

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -483,7 +483,7 @@ jobs:
           } else {
             $arch = 'x64'
           }
-          $version = '1.19.2'
+          $version = '1.22.0'
           $url = "https://github.com/microsoft/onnxruntime/releases/download/v$version/onnxruntime-win-$arch-$version.zip"
           $zipFile = "onnxruntime-win-$arch-$version.zip"
           $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-$arch-$version"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -281,9 +281,9 @@ jobs:
         shell: pwsh
         run: |
           # Pre-download CPU onnxruntime so ort crate finds it via ORT_LIB_LOCATION
-          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-win-x64-1.19.2.zip"
-          $zipFile = "onnxruntime-win-x64-1.19.2.zip"
-          $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-win-x64-1.22.0.zip"
+          $zipFile = "onnxruntime-win-x64-1.22.0.zip"
+          $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0"
           Invoke-WebRequest -Uri $url -OutFile $zipFile
           if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
           7z x $zipFile -o"apps/screenpipe-app-tauri/src-tauri/" -y
@@ -341,7 +341,7 @@ jobs:
           GGML_AVX512_BF16: "OFF"
           CMAKE_ARGS: "-DGGML_NATIVE=OFF -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF -DGGML_AVX512_BF16=OFF -DCMAKE_C_FLAGS=/arch:AVX2 -DCMAKE_CXX_FLAGS=/arch:AVX2"
           ORT_STRATEGY: system
-          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+          ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
           OPENBLAS_PATH: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/openblas
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
@@ -386,7 +386,7 @@ jobs:
           # Copy onnxruntime.dll - try target dir first (ort copy-dylibs), fallback to ORT_LIB_LOCATION
           $ortDll = "target/x86_64-pc-windows-msvc/release/onnxruntime.dll"
           if (!(Test-Path $ortDll)) {
-            $ortDll = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2/lib/onnxruntime.dll"
+            $ortDll = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0/lib/onnxruntime.dll"
           }
           Copy-Item $ortDll "$packageDir/bin/"
           # Copy OpenBLAS DLL(s) for qwen3-asr (libopenblas.dll or openblas.dll)

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -100,7 +100,7 @@ jobs:
             apps/screenpipe-app-tauri/src-tauri/lib/ollama
             apps/screenpipe-app-tauri/src-tauri/ui_monitor-*
             apps/screenpipe-app-tauri/src-tauri/ffmpeg-*
-            apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+            apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
           key: windows-2022-x86_64-pc-windows-msvc-pre-build-${{ hashFiles('**/Cargo.lock', '**/bun.lockb') }}
           restore-keys: |
             windows-2022-x86_64-pc-windows-msvc-pre-build-
@@ -142,12 +142,12 @@ jobs:
       - name: Download ONNX Runtime (CPU) for Windows
         shell: pwsh
         run: |
-          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-win-x64-1.19.2.zip"
-          $tauriDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-win-x64-1.22.0.zip"
+          $tauriDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0"
           $ortDir = "ort-system-lib"
-          Invoke-WebRequest -Uri $url -OutFile "onnxruntime-win-x64-1.19.2.zip"
+          Invoke-WebRequest -Uri $url -OutFile "onnxruntime-win-x64-1.22.0.zip"
           if (Test-Path $tauriDir) { Remove-Item $tauriDir -Recurse -Force }
-          7z x onnxruntime-win-x64-1.19.2.zip -o"apps/screenpipe-app-tauri/src-tauri/" -y
+          7z x onnxruntime-win-x64-1.22.0.zip -o"apps/screenpipe-app-tauri/src-tauri/" -y
           if (Test-Path $ortDir) { Remove-Item $ortDir -Recurse -Force }
           Copy-Item -Path $tauriDir -Destination $ortDir -Recurse -Force
 

--- a/.github/workflows/windows-integration-test.yml
+++ b/.github/workflows/windows-integration-test.yml
@@ -85,9 +85,9 @@ jobs:
     - name: Download ONNX Runtime (CPU)
       shell: pwsh
       run: |
-        $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-win-x64-1.19.2.zip"
-        $zipFile = "onnxruntime-win-x64-1.19.2.zip"
-        $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2"
+        $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-win-x64-1.22.0.zip"
+        $zipFile = "onnxruntime-win-x64-1.22.0.zip"
+        $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0"
         Invoke-WebRequest -Uri $url -OutFile $zipFile
         if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
         7z x $zipFile -o"apps/screenpipe-app-tauri/src-tauri/" -y
@@ -97,7 +97,7 @@ jobs:
       env:
         RUSTFLAGS: "-C link-arg=/LTCG"
         ORT_STRATEGY: system
-        ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.19.2
+        ORT_LIB_LOCATION: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.22.0
         # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
         AWS_LC_SYS_PREBUILT_NASM: "1"
       run: cargo build --release -p screenpipe-engine --bin screenpipe --target x86_64-pc-windows-msvc
@@ -112,7 +112,7 @@ jobs:
           ".\target\release\screenpipe.exe"
         }
         # Copy onnxruntime.dll next to the binary
-        $ortDll = "apps\screenpipe-app-tauri\src-tauri\onnxruntime-win-x64-1.19.2\lib\onnxruntime.dll"
+        $ortDll = "apps\screenpipe-app-tauri\src-tauri\onnxruntime-win-x64-1.22.0\lib\onnxruntime.dll"
         if (Test-Path $ortDll) {
           Copy-Item $ortDll (Split-Path $exePath) -Force
         }

--- a/crates/screenpipe-audio/build.rs
+++ b/crates/screenpipe-audio/build.rs
@@ -89,13 +89,13 @@ fn install_onnxruntime() {
     let arch = arch_var.as_deref().unwrap_or("x86_64");
     let (pkg_name, zip_name) = if arch == "aarch64" {
         (
-            "onnxruntime-win-arm64-1.19.2",
-            "onnxruntime-win-arm64-1.19.2.zip",
+            "onnxruntime-win-arm64-1.22.0",
+            "onnxruntime-win-arm64-1.22.0.zip",
         )
     } else {
         (
-            "onnxruntime-win-x64-1.19.2",
-            "onnxruntime-win-x64-1.19.2.zip",
+            "onnxruntime-win-x64-1.22.0",
+            "onnxruntime-win-x64-1.22.0.zip",
         )
     };
     let target_dir = Path::new("../../apps/screenpipe-app-tauri/src-tauri").join(pkg_name);
@@ -113,7 +113,7 @@ fn install_onnxruntime() {
     // Command keeps the build script free of any TLS dep.
     if !target_dir.join("lib").join("onnxruntime.lib").exists() {
         let url = format!(
-            "https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/{}",
+            "https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/{}",
             zip_name
         );
         let status = Command::new("curl")

--- a/crates/screenpipe-engine/build.rs
+++ b/crates/screenpipe-engine/build.rs
@@ -6,7 +6,7 @@ fn link_onnx() {
     if arch == "aarch64" {
         return;
     }
-    let pkg = "onnxruntime-win-x64-1.19.2";
+    let pkg = "onnxruntime-win-x64-1.22.0";
     println!(
         "cargo:rustc-link-search=native=../../apps/screenpipe-app-tauri/src-tauri/{}/lib",
         pkg


### PR DESCRIPTION
## Summary
- bump Windows ONNX Runtime downloads from 1.19.2 to 1.22.0 in the CLI release, app release, enterprise release, CI, e2e, and Windows integration workflows
- update the Windows build-script link/download paths to use the same 1.22.0 runtime
- keep the packaged/runtime DLL aligned with `ort = 2.0.0-rc.10`, which requests ORT API v22

## Root cause
`ort` now requests ORT API v22, but the Windows CLI package and CI jobs were still downloading and bundling ONNX Runtime 1.19.2, whose build only exposes API v19. That makes `npx screenpipe@latest record` panic on startup with `Failed to initialize ORT API`.

Fixes #3339.

## Validation
- `git diff --check`
- parsed edited workflow YAML with Ruby `YAML.load_file`
- verified no stale `1.19.2` ONNX Runtime references remain under `.github`, `crates/screenpipe-audio`, or `crates/screenpipe-engine`
- verified GitHub release assets exist for `onnxruntime-win-x64-1.22.0.zip` and `onnxruntime-win-arm64-1.22.0.zip`

Note: I could not run the Windows release job locally from macOS; this is validated by config/static checks plus asset availability.
