### PR TITLE
[codex] fix connections permission prompts

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/browser-url-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/browser-url-card.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Check, Circle, ExternalLink, RefreshCw, X } from "lucide-react";
+import { Check, Circle, ExternalLink, Loader2, RefreshCw, X } from "lucide-react";
 import { commands } from "@/lib/utils/tauri";
 import { platform } from "@tauri-apps/plugin-os";
 
@@ -16,21 +16,37 @@ interface BrowserStatus {
   running: boolean;
 }
 
-export function BrowserUrlCard() {
+interface BrowserUrlCardProps {
+  onStatusChange?: (connected: boolean) => void;
+}
+
+export function BrowserUrlCard({ onStatusChange }: BrowserUrlCardProps) {
   const [browsers, setBrowsers] = useState<BrowserStatus[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingError, setLoadingError] = useState(false);
+  const [requesting, setRequesting] = useState(false);
   const isMac = platform() === "macos";
 
   const refresh = useCallback(async () => {
-    if (!isMac) return;
+    if (!isMac) {
+      setLoading(false);
+      onStatusChange?.(false);
+      return;
+    }
     try {
       const statuses = await commands.getBrowsersAutomationStatus();
       setBrowsers(statuses);
+      setLoadingError(false);
+      onStatusChange?.(
+        statuses.length > 0 && statuses.every((b) => b.status === "granted")
+      );
     } catch {
       setBrowsers([]);
+      setLoadingError(true);
+      onStatusChange?.(false);
     }
     setLoading(false);
-  }, [isMac]);
+  }, [isMac, onStatusChange]);
 
   useEffect(() => {
     refresh();
@@ -46,11 +62,30 @@ export function BrowserUrlCard() {
     }
   };
 
-  if (!isMac) return null;
-  if (loading) return null;
-  if (browsers.length === 0) return null;
+  const handleEnableAll = async () => {
+    setRequesting(true);
+    const hadBrowsers = browsers.length > 0;
+    try {
+      await commands.requestBrowsersAutomationPermission();
+      if (!hadBrowsers) await commands.openPermissionSettings("automation");
+      setTimeout(refresh, 1000);
+    } catch {
+      try {
+        await commands.openPermissionSettings("automation");
+      } catch {
+        // ignore
+      }
+      setTimeout(refresh, 1000);
+    } finally {
+      setTimeout(() => setRequesting(false), 1000);
+    }
+  };
 
-  const allGranted = browsers.every((b) => b.status === "granted");
+  if (!isMac) return null;
+
+  const allGranted =
+    browsers.length > 0 && browsers.every((b) => b.status === "granted");
+  const hasPromptableBrowser = browsers.some((b) => b.running && b.status !== "granted");
 
   return (
     <Card className="border-border bg-card overflow-hidden">
@@ -85,59 +120,122 @@ export function BrowserUrlCard() {
               enabled).
             </p>
 
-            <div className="space-y-1.5">
-              {browsers.map((b) => (
-                <div
-                  key={b.name}
-                  className="flex items-center justify-between py-1"
-                >
-                  <div className="flex items-center gap-2">
-                    {b.status === "granted" ? (
-                      <Check className="h-3.5 w-3.5 text-green-500" />
-                    ) : b.status === "denied" ? (
-                      <X className="h-3.5 w-3.5 text-red-500" />
-                    ) : (
-                      <Circle className="h-3.5 w-3.5 text-muted-foreground" />
-                    )}
-                    <span className="text-xs font-medium">{b.name}</span>
-                    {!b.running && b.status !== "granted" && (
-                      <span className="text-[10px] text-muted-foreground">
-                        (not running)
-                      </span>
-                    )}
-                  </div>
-
-                  {b.status === "granted" ? (
-                    <span className="text-[10px] text-green-600">enabled</span>
-                  ) : b.status === "denied" ? (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 text-[10px] px-2"
-                      onClick={() =>
-                        commands.openPermissionSettings("automation")
-                      }
-                    >
-                      <ExternalLink className="h-3 w-3 mr-1" />
-                      open settings
-                    </Button>
-                  ) : b.running ? (
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                checking browser permissions...
+              </div>
+            ) : browsers.length > 0 ? (
+              <div className="space-y-3">
+                {!allGranted && (
+                  <div className="flex flex-wrap gap-2">
                     <Button
                       variant="outline"
                       size="sm"
-                      className="h-6 text-[10px] px-2"
-                      onClick={() => handleEnable(b.name)}
+                      className="h-7 text-xs gap-1.5 normal-case font-sans tracking-normal"
+                      onClick={handleEnableAll}
+                      disabled={requesting}
                     >
-                      enable
+                      {requesting ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Check className="h-3 w-3" />
+                      )}
+                      {hasPromptableBrowser
+                        ? "request automation permission"
+                        : "open automation settings"}
                     </Button>
-                  ) : (
-                    <span className="text-[10px] text-muted-foreground">
-                      open browser first
-                    </span>
-                  )}
+                  </div>
+                )}
+
+                <div className="space-y-1.5">
+                  {browsers.map((b) => (
+                    <div
+                      key={b.name}
+                      className="flex items-center justify-between py-1"
+                    >
+                      <div className="flex items-center gap-2">
+                        {b.status === "granted" ? (
+                          <Check className="h-3.5 w-3.5 text-green-500" />
+                        ) : b.status === "denied" ? (
+                          <X className="h-3.5 w-3.5 text-red-500" />
+                        ) : (
+                          <Circle className="h-3.5 w-3.5 text-muted-foreground" />
+                        )}
+                        <span className="text-xs font-medium">{b.name}</span>
+                        {!b.running && b.status !== "granted" && (
+                          <span className="text-[10px] text-muted-foreground">
+                            (not running)
+                          </span>
+                        )}
+                      </div>
+
+                      {b.status === "granted" ? (
+                        <span className="text-[10px] text-green-600">enabled</span>
+                      ) : b.status === "denied" ? (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 text-[10px] px-2"
+                          onClick={() =>
+                            commands.openPermissionSettings("automation")
+                          }
+                        >
+                          <ExternalLink className="h-3 w-3 mr-1" />
+                          open settings
+                        </Button>
+                      ) : b.running ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="h-6 text-[10px] px-2"
+                          onClick={() => handleEnable(b.name)}
+                        >
+                          enable
+                        </Button>
+                      ) : (
+                        <span className="text-[10px] text-muted-foreground">
+                          open browser first
+                        </span>
+                      )}
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
+              </div>
+            ) : (
+              <div className="space-y-2 rounded-lg border border-dashed border-border p-3">
+                <p className="text-xs text-muted-foreground">
+                  {loadingError
+                    ? "couldn't read browser automation status. try requesting permission, then refresh."
+                    : "no supported Chromium browser was detected. open Chrome, Arc, Brave, Edge, or another Chromium browser, then refresh."}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs gap-1.5 normal-case font-sans tracking-normal"
+                    onClick={handleEnableAll}
+                    disabled={requesting}
+                  >
+                    {requesting ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <Check className="h-3 w-3" />
+                    )}
+                    request automation permission
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs gap-1.5 normal-case font-sans tracking-normal"
+                    onClick={() => commands.openPermissionSettings("automation")}
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    open settings
+                  </Button>
+                </div>
+              </div>
+            )}
 
             <button
               onClick={refresh}

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1187,7 +1187,17 @@ function ChatGptPanel() {
 // Generic OAuth panel — used for any integration with is_oauth: true
 // ---------------------------------------------------------------------------
 
-function OAuthPanel({ integrationId, integrationName }: { integrationId: string; integrationName: string }) {
+function OAuthPanel({
+  integrationId,
+  integrationName,
+  onConnected,
+  onDisconnected,
+}: {
+  integrationId: string;
+  integrationName: string;
+  onConnected?: () => void;
+  onDisconnected?: () => void;
+}) {
   const { settings } = useSettings();
   const isPro = !!settings.user?.cloud_subscribed;
   const [status, setStatus] = useState<"idle" | "loading" | "connected">("idle");
@@ -1225,6 +1235,7 @@ function OAuthPanel({ integrationId, integrationName }: { integrationId: string;
       if (res.status === "ok" && res.data.connected) {
         setStatus("connected");
         await fetchStatus();
+        onConnected?.();
       } else {
         setStatus("idle");
       }
@@ -1250,6 +1261,7 @@ function OAuthPanel({ integrationId, integrationName }: { integrationId: string;
     await commands.oauthDisconnect(integrationId, null);
     setStatus("idle");
     setDisplayName(null);
+    onDisconnected?.();
   };
 
   return (
@@ -1837,6 +1849,7 @@ export function ConnectionsSection() {
   const [cursorInstalled, setCursorInstalled] = useState(false);
   const [codexInstalled, setCodexInstalled] = useState(false);
   const [chatgptConnected, setChatgptConnected] = useState(false);
+  const [browserUrlConnected, setBrowserUrlConnected] = useState(false);
   const [calendarUserDisconnected, setCalendarUserDisconnected] = useState(false);
   const [googleCalendarConnected, setGoogleCalendarConnected] = useState(false);
 
@@ -1865,6 +1878,13 @@ export function ConnectionsSection() {
     commands.oauthStatus("google-calendar", null).then(res => {
       setGoogleCalendarConnected(res.status === "ok" && res.data.connected);
     }).catch(() => {});
+    if (typeof window !== "undefined" && platform() === "macos") {
+      commands.getBrowsersAutomationStatus().then(statuses => {
+        setBrowserUrlConnected(
+          statuses.length > 0 && statuses.every(b => b.status === "granted")
+        );
+      }).catch(() => setBrowserUrlConnected(false));
+    }
   }, []);
 
   useEffect(() => { refreshStatus(); }, [selected, refreshStatus]);
@@ -1906,6 +1926,12 @@ export function ConnectionsSection() {
 
   useEffect(() => { fetchIntegrations(); }, [fetchIntegrations]);
 
+  const refreshIntegrationConnection = useCallback((id: string, connected: boolean) => {
+    setIntegrations(prev => prev.map(i => i.id === id ? { ...i, connected } : i));
+    apiCache.invalidate("connections/list");
+    fetchIntegrations();
+  }, [fetchIntegrations]);
+
   // Build unified tile list
   const allTiles: ConnectionTile[] = useMemo(() => {
     const hardcoded: ConnectionTile[] = [
@@ -1916,7 +1942,7 @@ export function ConnectionsSection() {
       { id: "warp", name: "Warp", icon: "warp", connected: false },
       { id: "chatgpt", name: "ChatGPT", icon: "chatgpt", connected: chatgptConnected },
       ...(os === "macos" ? [
-        { id: "browser-url", name: "Browser URL Capture", icon: "browser-url", connected: false },
+        { id: "browser-url", name: "Browser URL Capture", icon: "browser-url", connected: browserUrlConnected },
         { id: "voice-memos", name: "Voice Memos", icon: "voice-memos", connected: false },
       ] : []),
       ...(os === "macos" ? [{ id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false }] : []),
@@ -1957,7 +1983,7 @@ export function ConnectionsSection() {
     const googleCalTile = hardcoded.find(h => h.id === "google-calendar");
     if (googleCalTile) googleCalTile.connected = googleCalendarConnected;
     return [...hardcoded, ...apiTiles];
-  }, [os, claudeInstalled, cursorInstalled, codexInstalled, chatgptConnected, integrations, calendarUserDisconnected, googleCalendarConnected]);
+  }, [os, claudeInstalled, cursorInstalled, codexInstalled, chatgptConnected, browserUrlConnected, integrations, calendarUserDisconnected, googleCalendarConnected]);
 
   const filtered = useMemo(() => {
     if (!search.trim()) return allTiles;
@@ -1985,7 +2011,7 @@ export function ConnectionsSection() {
       case "claude-code": return <ClaudeCodePanel />;
       case "chatgpt": return <ChatGptPanel />;
       case "user-browser": return <UserBrowserCard />;
-      case "browser-url": return <BrowserUrlCard />;
+      case "browser-url": return <BrowserUrlCard onStatusChange={setBrowserUrlConnected} />;
       case "voice-memos": return <VoiceMemosCard />;
       case "apple-intelligence": return <AppleIntelligenceCard />;
       case "apple-calendar": return <CalendarCard onConnectionChange={refreshCalendarTile} />;
@@ -2015,7 +2041,12 @@ export function ConnectionsSection() {
       default:
         if (selectedIntegration) {
           if (selectedIntegration.is_oauth) {
-            return <OAuthPanel integrationId={selectedIntegration.id} integrationName={selectedIntegration.name} />;
+            return <OAuthPanel
+              integrationId={selectedIntegration.id}
+              integrationName={selectedIntegration.name}
+              onConnected={() => refreshIntegrationConnection(selectedIntegration.id, true)}
+              onDisconnected={() => refreshIntegrationConnection(selectedIntegration.id, false)}
+            />;
           }
           return <ApiIntegrationPanel
             integration={selectedIntegration}


### PR DESCRIPTION
## Summary

Fixes the connections UI regressions seen in user feedback around Browser URL Capture and OAuth connection state.

- Keep the Browser URL Capture dialog populated while permissions are loading, unavailable, or unreadable instead of rendering a blank modal.
- Add a macOS Automation permission CTA that calls the existing browser automation permission command, with System Settings as fallback.
- Surface Browser URL Capture as connected when detected browsers are granted.
- Refresh the connections list after OAuth connect/disconnect so tiles such as GitHub show the connected dot immediately.

## Root Cause

Browser URL Capture returned null while loading and when no browser statuses were returned, which left the dialog body empty. OAuth panels updated only their local panel state, while the tile grid continued to read from the cached `/connections` list.

## Validation

- `bun run typecheck`
- `git diff --check`