### PR TITLE
[codex] initialize secure team sharing from app

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/team-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/team-section.tsx
@@ -52,6 +52,7 @@ export function TeamSection() {
   const [showJoinInput, setShowJoinInput] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [refreshingInvite, setRefreshingInvite] = useState(false);
+  const [initializingTeamKey, setInitializingTeamKey] = useState(false);
   const [togglingAutoJoin, setTogglingAutoJoin] = useState(false);
   const [passphraseInput, setPassphraseInput] = useState("");
   const [pendingJoin, setPendingJoin] = useState<{
@@ -277,6 +278,26 @@ export function TeamSection() {
     setCopied(true);
     toast({ title: "invite link copied" });
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleInitializeTeamKey = async () => {
+    setInitializingTeamKey(true);
+    try {
+      await team.initializeTeamKey();
+      posthog.capture("team_secure_sharing_initialized");
+      toast({
+        title: "secure sharing initialized",
+        description: "you can now copy a secure invite link for teammates",
+      });
+    } catch (err: any) {
+      toast({
+        title: "failed to initialize secure sharing",
+        description: err.message,
+        variant: "destructive",
+      });
+    } finally {
+      setInitializingTeamKey(false);
+    }
   };
 
   const handleRemoveMember = async (userId: string) => {
@@ -533,6 +554,8 @@ export function TeamSection() {
   const windowFilterConfigs = team.configs.filter((c) => c.config_type === "window_filter" && c.scope === "team");
   const urlFilterConfigs = team.configs.filter((c) => c.config_type === "url_filter" && c.scope === "team");
   const totalSharedConfigs = pipeConfigs.length + windowFilterConfigs.length + urlFilterConfigs.length;
+  const canInitializeSecureSharing =
+    isAdmin && team.missingKey && team.configs.length === 0;
 
   return (
     <div className="space-y-6">
@@ -548,10 +571,17 @@ export function TeamSection() {
             <Shield className="h-3 w-3 mr-1" />
             {team.role}
           </Badge>
-          <Badge variant="outline" className="text-xs">
-            <Lock className="h-3 w-3 mr-1" />
-            e2e encrypted
-          </Badge>
+          {team.missingKey ? (
+            <Badge variant="outline" className="text-xs text-yellow-700 border-yellow-500/50">
+              <AlertTriangle className="h-3 w-3 mr-1" />
+              secure sharing pending
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="text-xs">
+              <Lock className="h-3 w-3 mr-1" />
+              e2e encrypted
+            </Badge>
+          )}
         </div>
       </div>
 
@@ -560,15 +590,35 @@ export function TeamSection() {
         <Card className="p-4 border-yellow-500/50 bg-yellow-500/5">
           <div className="flex items-center gap-2 mb-2">
             <Lock className="h-4 w-4 text-yellow-600" />
-            <h3 className="text-sm font-medium text-yellow-600">encryption key missing on this device</h3>
+            <h3 className="text-sm font-medium text-yellow-600">
+              secure team sharing is not ready on this device
+            </h3>
           </div>
           <p className="text-xs text-muted-foreground mb-3">
-            you&apos;re in the team but the encryption key isn&apos;t on this device.
-            paste the team invite link to sync the key.
+            {canInitializeSecureSharing
+              ? "the team exists, but this desktop app has not initialized the secure sharing key yet."
+              : isAdmin
+                ? "this team may already have a secure sharing key on another admin device. paste that secure invite link to sync it here."
+                : "your seat is active, but this desktop app still needs the secure invite link from an admin."}
           </p>
+          {canInitializeSecureSharing && (
+            <Button
+              size="sm"
+              onClick={handleInitializeTeamKey}
+              disabled={initializingTeamKey}
+              className="mb-3"
+            >
+              {initializingTeamKey ? (
+                <Loader2 className="h-3 w-3 animate-spin mr-1.5" />
+              ) : (
+                <Lock className="h-3 w-3 mr-1.5" />
+              )}
+              initialize secure sharing
+            </Button>
+          )}
           <div className="flex items-center gap-2">
             <Input
-              placeholder="paste invite link (https://screenpi.pe/join/...)"
+              placeholder="paste secure invite link"
               value={inviteInput}
               onChange={(e) => setInviteInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleJoinFromLink()}

--- a/apps/screenpipe-app-tauri/lib/hooks/use-team.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-team.ts
@@ -288,6 +288,47 @@ export function useTeam() {
     [token, fetchTeam]
   );
 
+  // bootstrap secure sharing for teams created on web/checkout before the
+  // desktop app had a chance to generate the local encryption key.
+  const initializeTeamKey = useCallback(async () => {
+    if (!token) throw new Error("not logged in");
+    if (!state.team) throw new Error("no team");
+    if (state.role !== "admin") {
+      throw new Error("only team admins can initialize secure sharing");
+    }
+    if (state.configs.length > 0 && !teamKeyRef.current) {
+      throw new Error(
+        "this team already has shared configs. paste a secure invite link from another admin device to sync the existing key."
+      );
+    }
+
+    const key = teamKeyRef.current ?? (await generateTeamKey());
+    await saveTeamKeyToStore(state.team.id, key);
+    teamKeyRef.current = key;
+
+    const inviteLink =
+      state.inviteLink ?? (await createInviteLink(state.team.name, key, true));
+
+    setState((s) => ({
+      ...s,
+      inviteLink,
+      invitePassphrase: null,
+      missingKey: false,
+      error: null,
+    }));
+    await fetchConfigs(state.team.id, key);
+
+    return inviteLink;
+  }, [
+    token,
+    state.team,
+    state.role,
+    state.configs.length,
+    state.inviteLink,
+    createInviteLink,
+    fetchConfigs,
+  ]);
+
   // join team via:
   // 1. new flow: claim token + passphrase (key fetched from server, unwrapped locally)
   // 2. legacy flow: raw base64 key in URL (backwards compat for old invite links)
@@ -537,6 +578,7 @@ export function useTeam() {
     ...state,
     fetchTeam,
     createTeam,
+    initializeTeamKey,
     joinTeam,
     leaveTeam,
     deleteTeam,


### PR DESCRIPTION
## Summary

- Add a desktop recovery path for admins who already have a backend Team but no local team encryption key.
- Show a clear pending secure-sharing state in Team settings instead of presenting the team as fully encrypted.
- Keep members on the existing secure-invite sync path, and prevent admins from generating a new key when shared configs already exist.

## Why

A Team can be created outside the desktop app, for example by website checkout or backend auto-create. In that flow the server has the team membership, but the app never generated the local encryption key needed for secure invite links and shared configs. This made the Team look active while app-side sharing was not ready.

## Validation

- `bun run typecheck`
- `bun test lib/__tests__/team-crypto.test.ts lib/__tests__/team-api-contract.test.ts`