### PR TITLE
[codex] show connection icons in chat tool rail

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { useSettings, ChatMessage, ChatConversation } from "@/lib/hooks/use-settings";
 import { cn } from "@/lib/utils";
-import { Loader2, Send, Square, User, Settings, ExternalLink, X, ImageIcon, History, Search, Trash2, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Plus, Copy, Check, Clock, Paperclip, Filter, RefreshCw, GitBranch, MoreHorizontal, Pencil, Pin, Shield, ShieldCheck, Sparkles } from "lucide-react";
+import { Loader2, Send, Square, User, Settings, ExternalLink, X, ImageIcon, History, Search, Trash2, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Plus, Copy, Check, Clock, Paperclip, Filter, RefreshCw, GitBranch, MoreHorizontal, Pencil, Pin, Shield, ShieldCheck, Sparkles, Plug } from "lucide-react";
 import { SchedulePromptDialog } from "@/components/chat/schedule-prompt-dialog";
 import { PipeContextBanner } from "@/components/chat/pipe-context-banner";
 import { BrowserSidebar } from "@/components/browser-sidebar";
@@ -511,6 +511,7 @@ function sqlVerb(sql: string): string {
 interface CurlPresentation {
   label: string;
   appName?: string;
+  connectionIconName?: string;
 }
 
 // Maps pi's bash curl calls to the local screenpipe API into a human label.
@@ -607,12 +608,18 @@ function classifyCurl(cmd: string): CurlPresentation | null {
   if (path === "/connections/browsers/owned-default/eval") return { label: "Ran JS in agent browser" };
   if (path.startsWith("/connections/browsers/")) return { label: "Agent browser action" };
 
-  if (path === "/connections") return { label: "Listed connections" };
+  if (path === "/connections") {
+    return { label: "Listed connections", connectionIconName: "connections" };
+  }
   if (path.startsWith("/connections/")) {
     const name = path.split("/")[2];
-    if (method === "DELETE") return { label: `Removed ${name} connection` };
-    if (method === "POST" || method === "PATCH" || method === "PUT") return { label: `Configured ${name} connection` };
-    return { label: `${name} connection` };
+    if (method === "DELETE") {
+      return { label: `Removed ${name} connection`, connectionIconName: name };
+    }
+    if (method === "POST" || method === "PATCH" || method === "PUT") {
+      return { label: `Configured ${name} connection`, connectionIconName: name };
+    }
+    return { label: `${name} connection`, connectionIconName: name };
   }
 
   if (path === "/pipes") {
@@ -642,6 +649,13 @@ function classifyCurl(cmd: string): CurlPresentation | null {
 function extractAppFromToolCall(toolCall: ToolCall): string | undefined {
   if (toolCall.toolName === "bash") {
     return classifyCurl(String(toolCall.args?.command ?? ""))?.appName;
+  }
+  return undefined;
+}
+
+function extractConnectionIconFromToolCall(toolCall: ToolCall): string | undefined {
+  if (toolCall.toolName === "bash") {
+    return classifyCurl(String(toolCall.args?.command ?? ""))?.connectionIconName;
   }
   return undefined;
 }
@@ -725,6 +739,7 @@ function ToolCallRailItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: bo
   const [expanded, setExpanded] = useState(false);
   const label = friendlyToolLabel(toolCall);
   const appName = extractAppFromToolCall(toolCall);
+  const connectionIconName = extractConnectionIconFromToolCall(toolCall);
 
   return (
     <div className="relative flex min-w-0">
@@ -732,7 +747,9 @@ function ToolCallRailItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: bo
       <div className="flex flex-col items-center flex-shrink-0 w-5">
         {/* Dot */}
         <div className="relative flex items-center justify-center w-5 h-5">
-          {toolCall.isRunning ? (
+          {connectionIconName && !toolCall.isRunning && !toolCall.isError ? (
+            <ConnectionToolIcon name={connectionIconName} />
+          ) : toolCall.isRunning ? (
             // Pulsing hollow dot for running
             <motion.div
               className="w-2 h-2 border border-foreground"
@@ -764,7 +781,7 @@ function ToolCallRailItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: bo
           onClick={() => setExpanded(!expanded)}
           className="w-full flex items-center gap-1.5 text-left min-w-0 group py-0.5"
         >
-          {appName && (
+          {appName && !connectionIconName && (
             <AppIcon name={appName} sizeClass="w-3.5 h-3.5" letterClass="text-[8px]" />
           )}
           <span className="truncate flex-1 text-xs font-mono text-foreground/70 group-hover:text-foreground transition-colors duration-150">
@@ -888,9 +905,24 @@ const STATIC_APP_ICONS: Record<string, string> = {
   jira: "/images/jira.png",
   hubspot: "/images/hubspot.png",
   monday: "/images/monday.png",
+  bitrix24: "/images/bitrix24.png",
+  financialsense: "/images/financialsense.png",
+  glean: "/images/glean.svg",
+  "google-calendar": "/images/google-calendar.svg",
   "google calendar": "/images/google-calendar.svg",
+  "google-docs": "/images/google-docs.svg",
   "google docs": "/images/google-docs.svg",
+  "google-sheets": "/images/google-sheets.svg",
   "google sheets": "/images/google-sheets.svg",
+  logseq: "/images/logseq.png",
+  loops: "/images/loops.svg",
+  make: "/images/make.png",
+  n8n: "/images/n8n.png",
+  ntfy: "/images/ntfy.png",
+  pocket: "/images/pocket.png",
+  posthog: "/images/posthog.svg",
+  pushover: "/images/pushover.png",
+  quickbooks: "/images/quickbooks.svg",
   whatsapp: "/images/whatsapp.svg",
   resend: "/images/resend.svg",
   limitless: "/images/limitless.svg",
@@ -937,6 +969,43 @@ function AppIcon({
       )}
     </div>
   );
+}
+
+function ConnectionToolIcon({ name }: { name: string }) {
+  const key = normalizeAppKey(name);
+  if (key === "connections") {
+    return <Plug className="w-3.5 h-3.5 text-foreground/70" aria-label="connections" />;
+  }
+  if (key === "gmail") {
+    return (
+      <svg viewBox="0 0 999.517 749.831" className="w-3.5 h-3.5" aria-label="Gmail">
+        <path fill="#4285F4" d="M68.149 749.831h159.014V363.654L0 193.282v488.4C0 719.391 30.553 749.831 68.149 749.831"/>
+        <path fill="#34A853" d="M772.354 749.831h159.014c37.709 0 68.149-30.553 68.149-68.149v-488.4L772.354 363.654"/>
+        <path fill="#FBBC04" d="M772.354 68.342v295.312l227.163-170.372V102.417c0-84.277-96.203-132.322-163.557-81.779"/>
+        <path fill="#EA4335" d="M227.163 363.654V68.342l272.595 204.447 272.595-204.447v295.312L499.758 568.1"/>
+        <path fill="#C5221F" d="M0 102.417v90.865l227.163 170.372V68.342L163.557 20.638C96.09-29.906 0 18.139 0 102.417"/>
+      </svg>
+    );
+  }
+  if (key === "microsoft365" || key === "microsoft-365" || key === "office365" || key === "outlook") {
+    return (
+      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5" aria-label="Microsoft 365">
+        <path fill="#F25022" d="M1 1h10v10H1z"/>
+        <path fill="#7FBA00" d="M13 1h10v10H13z"/>
+        <path fill="#00A4EF" d="M1 13h10v10H1z"/>
+        <path fill="#FFB900" d="M13 13h10v10H13z"/>
+      </svg>
+    );
+  }
+  if (key === "calcom" || key === "cal.com") {
+    return (
+      <svg viewBox="0 0 24 24" className="w-3.5 h-3.5 text-foreground" fill="currentColor" aria-label="Cal.com">
+        <path d="M2.408 14.488C1.035 14.488 0 13.4 0 12.058c0-1.346.982-2.443 2.408-2.443.758 0 1.282.233 1.691.765l-.66.55a1.343 1.343 0 0 0-1.03-.442c-.93 0-1.44.711-1.44 1.57 0 .86.559 1.557 1.44 1.557.413 0 .765-.147 1.043-.443l.651.573c-.391.51-.929.743-1.695.743zM6.948 10.913h.89v3.49h-.89v-.51c-.185.362-.493.604-1.083.604-.943 0-1.695-.82-1.695-1.826 0-1.007.752-1.825 1.695-1.825.585 0 .898.241 1.083.604zm.026 1.758c0-.546-.374-.998-.964-.998-.568 0-.938.457-.938.998 0 .528.37.998.938.998.586 0 .964-.456.964-.998zM8.467 9.503h.89v4.895h-.89zM9.752 13.937a.53.53 0 0 1 .542-.528c.313 0 .533.242.533.528a.527.527 0 0 1-.533.537.534.534 0 0 1-.542-.537zM14.23 13.839c-.33.403-.832.658-1.426.658a1.806 1.806 0 0 1-1.84-1.826c0-1.007.778-1.825 1.84-1.825.572 0 1.07.241 1.4.622l-.687.577c-.172-.215-.396-.376-.713-.376-.568 0-.938.456-.938.998 0 .541.37.997.938.997.343 0 .58-.179.757-.42zM14.305 12.671c0-1.007.78-1.825 1.84-1.825 1.061 0 1.84.818 1.84 1.825 0 1.007-.779 1.826-1.84 1.826-1.06-.005-1.84-.82-1.84-1.826zm2.778 0c0-.546-.37-.998-.938-.998-.568-.004-.937.452-.937.998 0 .542.37.998.937.998.568 0 .938-.456.938-.998zM24 12.269v2.13h-.89v-1.911c0-.604-.281-.864-.704-.864-.396 0-.678.197-.678.864v1.91h-.89v-1.91c0-.604-.285-.864-.704-.864-.396 0-.744.197-.744.864v1.91h-.89v-3.49h.89v.484c.185-.376.52-.564 1.035-.564.489 0 .898.241 1.123.649.224-.417.554-.65 1.153-.65.731.005 1.299.56 1.299 1.442z"/>
+      </svg>
+    );
+  }
+
+  return <AppIcon name={name} sizeClass="w-3.5 h-3.5" letterClass="text-[8px]" />;
 }
 
 function AppStatsBlock({ content }: { content: string }) {


### PR DESCRIPTION
## Summary

- Show connection-specific icons in the chat tool rail for `/connections` API calls instead of the generic completed-command square.
- Preserve existing labels and status dots for non-connection tools, running tools, and failed tools.
- Add static icon lookups for common connection ids so Google, QuickBooks, PostHog, etc. render consistently, with inline icons for Gmail, Microsoft 365, and Cal.com.

## Why

Connection tool calls currently read as generic command bullets even when the label says `gmail connection`, `microsoft365 connection`, or `calcom connection`. The row now makes the connection identity visible at a glance.

## Validation

- `bunx tsc --noEmit --pretty false`
- `git diff --check -- apps/screenpipe-app-tauri/components/standalone-chat.tsx`
