### PR TITLE
[codex] Fix native timeline auto-collapse

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -620,6 +620,7 @@ int32_t tl_is_available(void) { return -2; }
 int32_t tl_init(uint64_t w) { return -2; }
 int32_t tl_show(void) { return -2; }
 int32_t tl_hide(void) { return -2; }
+int32_t tl_is_visible(void) { return 0; }
 int32_t tl_init_embedded(uint64_t w) { return -2; }
 int32_t tl_update_position(double x, double y, double w, double h) { return -2; }
 int32_t tl_show_embedded(void) { return -2; }

--- a/apps/screenpipe-app-tauri/src-tauri/src/native_timeline.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/native_timeline.rs
@@ -14,6 +14,7 @@ mod ffi {
         pub fn tl_init(window_ptr: u64) -> i32;
         pub fn tl_show() -> i32;
         pub fn tl_hide() -> i32;
+        pub fn tl_is_visible() -> i32;
         pub fn tl_init_embedded(window_ptr: u64) -> i32;
         pub fn tl_update_position(x: f64, y: f64, w: f64, h: f64) -> i32;
         pub fn tl_show_embedded() -> i32;
@@ -33,6 +34,7 @@ mod ffi {
     pub fn init_panel(_window_ptr: u64) -> bool { unsafe { tl_init(0) == 0 } }
     pub fn show() -> bool { unsafe { tl_show() == 0 } }
     pub fn hide() -> bool { unsafe { tl_hide() == 0 } }
+    pub fn is_visible() -> bool { unsafe { tl_is_visible() == 1 } }
     pub fn init_embedded(window_ptr: u64) -> bool { unsafe { tl_init_embedded(window_ptr) == 0 } }
     pub fn update_position(x: f64, y: f64, w: f64, h: f64) -> bool { unsafe { tl_update_position(x, y, w, h) == 0 } }
     pub fn show_embedded() -> bool { unsafe { tl_show_embedded() == 0 } }
@@ -64,6 +66,7 @@ mod ffi {
     pub fn init_panel(_: u64) -> bool { false }
     pub fn show() -> bool { false }
     pub fn hide() -> bool { false }
+    pub fn is_visible() -> bool { false }
     pub fn init_embedded(_: u64) -> bool { false }
     pub fn update_position(_: f64, _: f64, _: f64, _: f64) -> bool { false }
     pub fn show_embedded() -> bool { false }

--- a/apps/screenpipe-app-tauri/src-tauri/src/shortcuts.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/shortcuts.rs
@@ -164,7 +164,6 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
                 use crate::native_timeline;
                 use std::sync::atomic::{AtomicBool, Ordering};
                 static NATIVE_INITED: AtomicBool = AtomicBool::new(false);
-                static NATIVE_VISIBLE: AtomicBool = AtomicBool::new(false);
 
                 if native_timeline::is_available() {
                     if !NATIVE_INITED.load(Ordering::Relaxed) {
@@ -178,14 +177,12 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
                         NATIVE_INITED.store(true, Ordering::Relaxed);
                     }
 
-                    if NATIVE_VISIBLE.load(Ordering::Relaxed) {
+                    if native_timeline::is_visible() {
                         info!("hiding native timeline");
                         native_timeline::hide();
-                        NATIVE_VISIBLE.store(false, Ordering::Relaxed);
                     } else {
                         info!("showing native timeline");
                         native_timeline::show();
-                        NATIVE_VISIBLE.store(true, Ordering::Relaxed);
                         // Tell the frontend to connect WebSocket and start pushing frames
                         let _ = app.emit("native-timeline-opened", ());
                     }

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline_bridge.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline_bridge.swift
@@ -51,6 +51,13 @@ public func tlHide() -> Int32 {
     return 0
 }
 
+@_cdecl("tl_is_visible")
+public func tlIsVisible() -> Int32 {
+    var visible = false
+    onMain { visible = TimelinePanelController.shared.isVisible }
+    return visible ? 1 : 0
+}
+
 // MARK: - Embedded mode (inside Tauri window)
 
 @_cdecl("tl_init_embedded")

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline_panel.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline_panel.swift
@@ -263,11 +263,12 @@ class TimelineDataStore: ObservableObject {
 
 // MARK: - Panel controller (overlay + embedded modes)
 
-class TimelinePanelController {
+class TimelinePanelController: NSObject, NSWindowDelegate {
     static let shared = TimelinePanelController()
 
     // Overlay mode
     private var panel: NSPanel?
+    private var autoHideWorkItem: DispatchWorkItem?
 
     // Embedded mode
     private var embeddedHostingView: NSHostingView<TimelineRootView>?
@@ -297,14 +298,51 @@ class TimelinePanelController {
         p.isMovableByWindowBackground = false // don't eat text selection drags
         p.backgroundColor = .windowBackgroundColor
         p.contentView = hosting
+        p.delegate = self
+        p.hidesOnDeactivate = false
         p.isReleasedWhenClosed = false
         p.minSize = NSSize(width: 600, height: 400)
         p.center()
         panel = p
     }
 
-    func showOverlay() { panel?.makeKeyAndOrderFront(nil) }
-    func hideOverlay() { panel?.orderOut(nil) }
+    func showOverlay() {
+        autoHideWorkItem?.cancel()
+        autoHideWorkItem = nil
+        panel?.makeKeyAndOrderFront(nil)
+    }
+
+    func hideOverlay() {
+        autoHideWorkItem?.cancel()
+        autoHideWorkItem = nil
+        panel?.orderOut(nil)
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        autoHideWorkItem?.cancel()
+        autoHideWorkItem = nil
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        scheduleAutoHide()
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        autoHideWorkItem?.cancel()
+        autoHideWorkItem = nil
+    }
+
+    private func scheduleAutoHide() {
+        autoHideWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak self] in
+            guard let self, let panel = self.panel, panel.isVisible, !panel.isKeyWindow else { return }
+            self.hideOverlay()
+            gTimelineCallback?(makeCString("{\"action\":\"auto_hide\"}"))
+        }
+        autoHideWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: item)
+    }
+
     func toggleOverlay() { isVisible ? hideOverlay() : showOverlay() }
 
     // MARK: - Embedded mode (inside Tauri window)
@@ -352,6 +390,8 @@ class TimelinePanelController {
     // MARK: - Cleanup
 
     func destroy() {
+        autoHideWorkItem?.cancel(); autoHideWorkItem = nil
+        panel?.delegate = nil
         panel?.orderOut(nil); panel = nil
         embeddedHostingView?.removeFromSuperview(); embeddedHostingView = nil
         hostContentView = nil


### PR DESCRIPTION
## Summary
- Restore native Swift timeline auto-collapse after the panel loses focus.
- Add a `tl_is_visible` bridge so the shortcut toggle reads the real panel state after close/auto-hide.
- Update the non-macOS build stub for the new bridge symbol.

## Checks
- Swift timeline bridge compiled during the Tauri build script with no Swift errors.
- `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --bin screenpipe-app` reached the app build script, then stopped because local resource `bun-aarch64-apple-darwin` is missing.