### PR TITLE
[codex] open website for version downloads

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -10,7 +10,7 @@ import { Switch } from "@/components/ui/switch";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Rocket, Moon, Sun, Monitor, FlaskConical, Shield, ExternalLink, Layers, RefreshCw, Undo2, MessageSquare, Sparkles } from "lucide-react";
+import { Rocket, Moon, Sun, Monitor, FlaskConical, Shield, ExternalLink, Layers, RefreshCw, MessageSquare, Sparkles } from "lucide-react";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { useToast } from "@/components/ui/use-toast";
 import { Button } from "@/components/ui/button";
@@ -19,15 +19,13 @@ import { getVersion } from "@tauri-apps/api/app";
 import { commands } from "@/lib/utils/tauri";
 import { UpdateBanner } from "@/components/update-banner";
 import { useIsEnterpriseBuild } from "@/lib/hooks/use-is-enterprise-build";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 
 export default function GeneralSettings() {
   const isEnterprise = useIsEnterpriseBuild();
   const { settings, updateSettings } = useSettings();
   const { toast } = useToast();
   const [currentVersion, setCurrentVersion] = useState<string | null>(null);
-  const [availableVersions, setAvailableVersions] = useState<string[]>([]);
-  const [isRollingBack, setIsRollingBack] = useState(false);
-  const [showVersions, setShowVersions] = useState(false);
 
   useEffect(() => {
     getVersion().then(setCurrentVersion).catch(() => {});
@@ -39,46 +37,37 @@ export default function GeneralSettings() {
     }
   };
 
-  const fetchVersions = async () => {
-    if (availableVersions.length > 0) {
-      setShowVersions(!showVersions);
-      return;
-    }
+  const getDesktopPlatform = async () => {
     try {
       const { arch, type: osType } = await import("@tauri-apps/plugin-os").then(m => ({ arch: m.arch(), type: m.type() }));
-      let targetArch = "darwin-aarch64";
-      if (osType === "macos") targetArch = arch === "x86_64" ? "darwin-x86_64" : "darwin-aarch64";
-      else if (osType === "windows") targetArch = "windows-x86_64";
-
-      const resp = await fetch(`https://screenpi.pe/api/app-update/versions/${targetArch}`);
-      if (!resp.ok) throw new Error("failed to fetch versions");
-      const data = await resp.json();
-      const versions = (data.versions || []).filter((v: string) => v !== currentVersion);
-      setAvailableVersions(versions);
-      setShowVersions(true);
-    } catch (e: any) {
-      toast({ title: "failed to load versions", description: e?.toString(), variant: "destructive" });
+      if (osType === "macos") return arch === "x86_64" ? "darwin-x86_64" : "darwin-aarch64";
+      if (osType === "windows") return "windows-x86_64";
+      if (osType === "linux") return "linux-x86_64";
+    } catch {
+      return null;
     }
+    return null;
   };
 
-  const handleRollback = async (version: string) => {
-    if (isRollingBack) return;
-    setIsRollingBack(true);
+  const handleOpenVersions = async () => {
+    const params = new URLSearchParams({ source: "desktop" });
+    if (currentVersion) params.set("app_version", currentVersion);
+
+    const platform = await getDesktopPlatform();
+    if (platform) params.set("platform", platform);
+
+    const path = isEnterprise ? "/enterprise" : "/account/versions";
+    if (isEnterprise) params.set("tab", "builds");
+    const url = `https://screenpi.pe${path}?${params.toString()}`;
+
     try {
-      toast({
-        title: "downloading...",
-        description: `installing v${version}. this is at your own risk — db migrations are not reversed.`,
-        duration: 10000,
-      });
-      const result = await commands.rollbackToVersion(version);
-      if (result.status === "error") throw new Error(result.error);
+      await openUrl(url);
     } catch (e: any) {
-      setIsRollingBack(false);
+      window.open(url, "_blank");
       toast({
-        title: "rollback failed",
-        description: e?.toString() || "unknown error",
+        title: "opened in browser",
+        description: e?.toString() || "check your browser for version downloads",
         variant: "destructive",
-        duration: 5000,
       });
     }
   };
@@ -195,55 +184,34 @@ export default function GeneralSettings() {
           </CardContent>
         </Card>
 
-        {!isEnterprise && (
-          <Card className="border-border bg-card">
-            <CardContent className="px-3 py-2.5">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-2.5">
-                  <Undo2 className="h-4 w-4 text-muted-foreground shrink-0" />
-                  <div>
-                    <h3 className="text-sm font-medium text-foreground">
-                      Version{currentVersion ? ` ${currentVersion}` : ""}
-                    </h3>
-                    <p className="text-xs text-muted-foreground">
-                      Install a previous version (at your own risk)
-                    </p>
-                  </div>
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={fetchVersions}
-                  disabled={isRollingBack}
-                  className="ml-4 h-7 text-xs"
-                >
-                  {isRollingBack ? "installing..." : showVersions ? "hide" : "show versions"}
-                </Button>
-              </div>
-              {showVersions && availableVersions.length > 0 && (
-                <div className="mt-3 space-y-1 border-t pt-2">
-                  <p className="text-[10px] text-muted-foreground mb-2">
-                    ⚠️ database migrations are not reversed. use at your own risk.
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">
+                    Version{currentVersion ? ` ${currentVersion}` : ""}
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {isEnterprise
+                      ? "Open builds managed by your organization"
+                      : "Open recent stable versions on screenpipe.com"}
                   </p>
-                  {availableVersions.map((v) => (
-                    <div key={v} className="flex items-center justify-between py-0.5">
-                      <span className="text-xs text-muted-foreground">v{v}</span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => handleRollback(v)}
-                        disabled={isRollingBack}
-                        className="h-6 text-[11px] px-2"
-                      >
-                        install
-                      </Button>
-                    </div>
-                  ))}
                 </div>
-              )}
-            </CardContent>
-          </Card>
-        )}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleOpenVersions}
+                className="ml-4 h-7 text-xs gap-1.5"
+              >
+                open
+                <ExternalLink className="h-3 w-3" />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
 
       </div>
 


### PR DESCRIPTION
## What changed
- Replaced the in-app rollback/install UI in desktop Settings with a web handoff.
- Consumer builds open https://screenpi.pe/account/versions with desktop source, current version, and platform query params.
- Enterprise builds open https://screenpi.pe/enterprise?tab=builds so version access is governed on the website.

## Why
The previous rollback UI had server support, but the actual downgrade/install path was risky and hard to observe. This moves version selection to the web surface where we can gate, explain, and support it safely.

## Validation
- bun run typecheck in apps/screenpipe-app-tauri passed.