### PR TITLE
feat(cli): add --disable-snapshot-compaction to skip JPEG→MP4 worker

### DIFF
--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -137,6 +137,13 @@ pub struct RecordingSettings {
     #[serde(rename = "maxSnapshotWidth", default = "default_max_snapshot_width")]
     pub max_snapshot_width: u32,
 
+    /// Skip the background JPEG→MP4 snapshot compaction worker.
+    /// Use when the MP4 timeline UI is not used (e.g. task-mining tools that consume
+    /// `accessibility_text` / `ui_events` only) — avoids the ffmpeg H.265 encoding load.
+    /// Side effect: JPEGs are not compacted, so disk usage depends on `--retention-days`.
+    #[serde(rename = "disableSnapshotCompaction", default)]
+    pub disable_snapshot_compaction: bool,
+
     // ── Filters ────────────────────────────────────────────────────────
     /// Window titles to exclude from capture.
     #[serde(rename = "ignoredWindows")]
@@ -369,6 +376,7 @@ impl Default for RecordingSettings {
             use_all_monitors: true,
             video_quality: "balanced".to_string(),
             max_snapshot_width: default_max_snapshot_width(),
+            disable_snapshot_compaction: false,
             ignored_windows: vec![],
             included_windows: vec![],
             ignored_urls: vec![],

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -869,14 +869,20 @@ async fn main() -> anyhow::Result<()> {
     // Start power manager — polls battery/thermal state and broadcasts profile changes
     let power_manager = start_power_manager();
 
-    // Start background snapshot compaction (JPEG → MP4)
-    screenpipe_engine::start_snapshot_compaction(
-        db.clone(),
-        config.video_quality.clone(),
-        shutdown_tx.subscribe(),
-        power_manager.clone(),
-        Some(hot_frame_cache.clone()),
-    );
+    // Start background snapshot compaction (JPEG → MP4) unless explicitly disabled.
+    // Skipping the worker avoids the ffmpeg H.265 encoding load for users who don't
+    // need the MP4 timeline UI (task-mining tools, headless analysis pipelines, etc.).
+    if !config.disable_snapshot_compaction {
+        screenpipe_engine::start_snapshot_compaction(
+            db.clone(),
+            config.video_quality.clone(),
+            shutdown_tx.subscribe(),
+            power_manager.clone(),
+            Some(hot_frame_cache.clone()),
+        );
+    } else {
+        info!("snapshot compaction disabled via --disable-snapshot-compaction");
+    }
 
     // Create VisionManager for event-driven capture on all monitors
     let (handle, capture_trigger_tx) = if !config.disable_vision {

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -458,6 +458,13 @@ pub struct RecordArgs {
     /// everything (legacy behavior).
     #[arg(long, value_enum, default_value_t = crate::retention::RetentionMode::Media)]
     pub retention_mode: crate::retention::RetentionMode,
+
+    /// Skip the background JPEG→MP4 snapshot compaction worker.
+    /// Use when the MP4 timeline UI is not used (e.g. task-mining tools that consume
+    /// `accessibility_text` / `ui_events` only) — avoids the ffmpeg H.265 encoding load.
+    /// Side effect: JPEGs stay uncompacted, so disk usage depends on `--retention-days`.
+    #[arg(long, default_value_t = false)]
+    pub disable_snapshot_compaction: bool,
 }
 
 impl RecordArgs {
@@ -527,6 +534,7 @@ impl RecordArgs {
                 .collect(),
             deepgram_api_key: self.deepgram_api_key.clone().unwrap_or_default(),
             video_quality: self.video_quality.clone(),
+            disable_snapshot_compaction: self.disable_snapshot_compaction,
             analytics_enabled: !self.disable_telemetry,
             ignore_incognito_windows: true,
             pause_on_drm_content: self.pause_on_drm_content,

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -131,6 +131,10 @@ pub struct RecordingConfig {
     /// Maximum width for stored snapshots (0 = no limit). Default: 1920.
     pub max_snapshot_width: u32,
 
+    /// Skip the background JPEG→MP4 snapshot compaction worker.
+    /// See `RecordingSettings.disable_snapshot_compaction` for details.
+    pub disable_snapshot_compaction: bool,
+
     /// Require authentication for remote (non-localhost) API access.
     /// When true, requests from other devices must include
     /// `Authorization: Bearer <SCREENPIPE_API_KEY>`.
@@ -243,6 +247,7 @@ impl RecordingConfig {
             schedule_enabled: settings.schedule_enabled,
             schedule_rules: settings.schedule_rules.clone(),
             max_snapshot_width: settings.max_snapshot_width,
+            disable_snapshot_compaction: settings.disable_snapshot_compaction,
             // LAN exposure is opt-in. We force `api_auth` on whenever
             // `listen_on_lan` is true so a user can never accidentally
             // publish an unauthenticated API on their local network. The


### PR DESCRIPTION
## Summary
Add an opt-in `--disable-snapshot-compaction` CLI flag (and matching `disableSnapshotCompaction` settings field) that skips the background JPEG→MP4 snapshot compaction worker.

## Motivation
The snapshot compaction worker compresses older JPEG frames into H.265 MP4 chunks every 5 minutes (great for users browsing the MP4 timeline UI, ~10-30x size reduction).

However, for tools that only consume `accessibility_text` and `ui_events` (task-mining tools, automation, headless analysis pipelines), the worker is pure overhead:
- ffmpeg H.265 encoding visibly bumps CPU usage every 5 minutes
- The generated MP4s are never read
- Disk savings can be achieved via `--retention-days` instead

`--disable-vision` already exists but is too coarse — it also skips OCR / accessibility capture, which we still need.

## Behavior
- Default: `false` — no change for existing users
- When set:
  - `start_snapshot_compaction` is not called
  - Startup log prints: `snapshot compaction disabled via --disable-snapshot-compaction`
  - Individual JPEGs persist until `--retention-days` cleans them up

## Implementation
- \`screenpipe-config\`: \`RecordingSettings.disable_snapshot_compaction\` (persisted to settings.json via \`disableSnapshotCompaction\`)
- \`screenpipe-engine/cli\`: \`--disable-snapshot-compaction\` flag on \`record\` subcommand
- \`screenpipe-engine/recording_config\`: \`RecordingConfig\` propagation
- \`screenpipe-engine/bin\`: gate \`start_snapshot_compaction()\` call

## Validation
- \`cargo build --release --target x86_64-pc-windows-msvc --workspace --exclude screenpipe-rfdetr-mlx\` passes on Windows (rebased onto current main, includes #3370)
- \`screenpipe record --help\` shows the new flag
- 15-minute run with \`--disable-snapshot-compaction --disable-audio\` confirmed:
  - No \`snapshot compaction worker started\` log line
  - No MP4 files produced
  - JPEGs accumulate as expected (cleaned later by retention)

## Context
This is the first of a few small CLI flags we're adding for task-mining / headless-recording use cases. Submitted as a small, isolated PR to keep review easy.