### PR TITLE
feat(cli): add --disable-meeting-detector to skip v2 meeting watcher

### DIFF
--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -137,12 +137,14 @@ pub struct RecordingSettings {
     #[serde(rename = "maxSnapshotWidth", default = "default_max_snapshot_width")]
     pub max_snapshot_width: u32,
 
-    /// Skip the background JPEG→MP4 snapshot compaction worker.
-    /// Use when the MP4 timeline UI is not used (e.g. task-mining tools that consume
-    /// `accessibility_text` / `ui_events` only) — avoids the ffmpeg H.265 encoding load.
-    /// Side effect: JPEGs are not compacted, so disk usage depends on `--retention-days`.
-    #[serde(rename = "disableSnapshotCompaction", default)]
-    pub disable_snapshot_compaction: bool,
+    /// Skip the v2 meeting detector watcher (5s-interval process / AX scan).
+    /// Use when meeting detection is not consumed (task-mining, headless analysis,
+    /// agents that read accessibility_text and ui_events only) — avoids the
+    /// constant process enumeration + AX tree walk cost.
+    /// Side effect: meeting-related DB rows are not generated; the audio pipeline's
+    /// in_meeting override flag stays false.
+    #[serde(rename = "disableMeetingDetector", default)]
+    pub disable_meeting_detector: bool,
 
     // ── Filters ────────────────────────────────────────────────────────
     /// Window titles to exclude from capture.
@@ -376,7 +378,7 @@ impl Default for RecordingSettings {
             use_all_monitors: true,
             video_quality: "balanced".to_string(),
             max_snapshot_width: default_max_snapshot_width(),
-            disable_snapshot_compaction: false,
+            disable_meeting_detector: false,
             ignored_windows: vec![],
             included_windows: vec![],
             ignored_urls: vec![],

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -804,6 +804,9 @@ async fn main() -> anyhow::Result<()> {
     let meeting_detector: Option<Arc<MeetingDetector>> = if config.disable_audio {
         info!("meeting detector disabled because audio capture is disabled");
         None
+    } else if config.disable_meeting_detector {
+        info!("meeting detector disabled via --disable-meeting-detector");
+        None
     } else {
         let detector = Arc::new(MeetingDetector::new());
         info!("meeting detector enabled — independent of transcription mode");

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -460,12 +460,13 @@ pub struct RecordArgs {
     #[arg(long, value_enum, default_value_t = crate::retention::RetentionMode::Media)]
     pub retention_mode: crate::retention::RetentionMode,
 
-    /// Skip the background JPEG→MP4 snapshot compaction worker.
-    /// Use when the MP4 timeline UI is not used (e.g. task-mining tools that consume
-    /// `accessibility_text` / `ui_events` only) — avoids the ffmpeg H.265 encoding load.
-    /// Side effect: JPEGs stay uncompacted, so disk usage depends on `--retention-days`.
+    /// Skip the v2 meeting detector watcher (5s-interval process / AX scan).
+    /// Use when meeting detection is not consumed (task-mining, headless analysis) —
+    /// avoids the constant process enumeration + AX tree walk cost.
+    /// Side effect: meeting-related DB rows are not generated; the audio pipeline's
+    /// in_meeting override flag stays false.
     #[arg(long, default_value_t = false)]
-    pub disable_snapshot_compaction: bool,
+    pub disable_meeting_detector: bool,
 }
 
 impl RecordArgs {
@@ -535,7 +536,7 @@ impl RecordArgs {
                 .collect(),
             deepgram_api_key: self.deepgram_api_key.clone().unwrap_or_default(),
             video_quality: self.video_quality.clone(),
-            disable_snapshot_compaction: self.disable_snapshot_compaction,
+            disable_meeting_detector: self.disable_meeting_detector,
             analytics_enabled: !self.disable_telemetry,
             ignore_incognito_windows: true,
             pause_on_drm_content: self.pause_on_drm_content,

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -131,9 +131,9 @@ pub struct RecordingConfig {
     /// Maximum width for stored snapshots (0 = no limit). Default: 1920.
     pub max_snapshot_width: u32,
 
-    /// Skip the background JPEG→MP4 snapshot compaction worker.
-    /// See `RecordingSettings.disable_snapshot_compaction` for details.
-    pub disable_snapshot_compaction: bool,
+    /// Skip the v2 meeting detector watcher.
+    /// See `RecordingSettings.disable_meeting_detector` for details.
+    pub disable_meeting_detector: bool,
 
     /// Require authentication for remote (non-localhost) API access.
     /// When true, requests from other devices must include
@@ -247,7 +247,7 @@ impl RecordingConfig {
             schedule_enabled: settings.schedule_enabled,
             schedule_rules: settings.schedule_rules.clone(),
             max_snapshot_width: settings.max_snapshot_width,
-            disable_snapshot_compaction: settings.disable_snapshot_compaction,
+            disable_meeting_detector: settings.disable_meeting_detector,
             // LAN exposure is opt-in. We force `api_auth` on whenever
             // `listen_on_lan` is true so a user can never accidentally
             // publish an unauthenticated API on their local network. The


### PR DESCRIPTION
## Summary
Add an opt-in `--disable-meeting-detector` CLI flag (and matching `disableMeetingDetector` settings field) that skips the v2 meeting detector's UI scanner.

## Motivation
The v2 meeting detector walks every running process's accessibility tree every 5 seconds to detect Zoom/Teams/Meet call control elements. Great for users who want automatic meeting tracking.

For tools that don't consume meeting state (task-mining tools, headless analysis pipelines, agents that only care about `accessibility_text` and `ui_events`), the scanner is pure overhead — the 5s process enumeration + AX tree walk shows up as visible CPU bursts on lower-tier machines.

Related user friction: Discord reports (e.g. bluetooth headsets being forced into HFP mode by always-on mic capture) show that users sometimes want to opt out of the meeting-detection stack altogether. This flag offers that opt-out path.

## Behavior
- Default: `false` — no change for existing users
- When set:
  - `MeetingDetector` is never instantiated (the existing `disable_audio` branch is extended)
  - The watcher is never spawned (gated by `if let Some(meeting_detector)`)
  - Startup log prints: `meeting detector disabled via --disable-meeting-detector`
  - The audio pipeline's `in_meeting` override flag stays false

## Implementation
- \`screenpipe-config\`: \`RecordingSettings.disable_meeting_detector\` (persisted to settings.json via \`disableMeetingDetector\`)
- \`screenpipe-engine/cli\`: \`--disable-meeting-detector\` flag on \`record\` subcommand
- \`screenpipe-engine/recording_config\`: \`RecordingConfig\` propagation
- \`screenpipe-engine/bin\`: extend the existing meeting_detector init branch with an \`else if config.disable_meeting_detector\` case. The watcher start path is already gated by \`if let Some(meeting_detector)\` so no change is needed there.

## Validation
- \`cargo build --release --target x86_64-pc-windows-msvc --workspace --exclude screenpipe-rfdetr-mlx\` passes on Windows
- \`screenpipe record --help\` shows the new flag
- Run with \`--disable-meeting-detector --disable-audio\` confirmed:
  - Startup log prints \`meeting detector disabled via --disable-meeting-detector\`
  - No \`meeting scanner: pid=...\` log lines (the 5s scanner is silent)

## Context
Companion PR to #3385 (`--disable-snapshot-compaction`). Both are small, isolated CLI flags for task-mining / headless-recording use cases. Submitted separately to keep review easy.