### PR TITLE
fix(db): pre-convert journal_mode=WAL before pool creation to avoid SQLITE_BUSY race on fresh data-dir

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -11,6 +11,8 @@ use sqlx::migrate::MigrateDatabase;
 use sqlx::pool::PoolConnection;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 use sqlx::Column;
+use sqlx::ConnectOptions;
+use sqlx::Connection;
 use sqlx::Error as SqlxError;
 use sqlx::Row;
 use sqlx::Sqlite;
@@ -299,6 +301,21 @@ impl DatabaseManager {
             // during idle periods instead. WAL grows to ~16MB max (+12MB).
             // Crash recovery: ~200ms replay at most.
             .pragma("wal_autocheckpoint", "4000");
+
+        // Fresh DB conversion to journal_mode=WAL requires an exclusive lock.
+        // When the pool opens read_pool + write_pool connections concurrently,
+        // each connection tries the WAL conversion and they race, with losers
+        // failing initialization with SQLITE_BUSY ("database is locked")
+        // (~50% reproduction with fresh data-dir). Pre-converting via a single
+        // connection before pool creation makes pool connections see a WAL'd
+        // DB and skip conversion entirely — no race.
+        {
+            let mut conn = connect_options.connect().await?;
+            sqlx::query("PRAGMA journal_mode=WAL")
+                .execute(&mut conn)
+                .await?;
+            conn.close().await?;
+        }
 
         // Read pool: handles all SELECT queries (search, timeline, API, pipes).
         let read_pool = SqlitePoolOptions::new()


### PR DESCRIPTION
## Problem

`screenpipe record` fails to start on a fresh data-dir approximately
50% of the time with `SQLITE_BUSY "database is locked"`. Retrying
always succeeds. Most users hit this on first launch after install
or after wiping the data-dir.

## Root cause

`DatabaseManager::new` opens read_pool + write_pool connections
concurrently (default `DbConfig` = `read_pool_min: 3` + write 1 = 4
connections opening in parallel). Each connection runs the
`connect_options` pragmas, which include `PRAGMA journal_mode=WAL`.

The WAL conversion of a fresh DB requires an **exclusive lock**.
When N connections race for it, one wins and the rest get
`SQLITE_BUSY`. `busy_timeout` does not reliably retry across
the `journal_mode` conversion path (known SQLite behavior).

After the first successful conversion, subsequent runs find the
DB already in WAL mode and the pragma becomes a no-op — which is
why retries always succeed.

## Fix

Open a single connection before pool creation, run
`PRAGMA journal_mode=WAL`, then close it. Pool connections then
see a WAL'd DB and skip the conversion. ~17 lines including
imports.

```rust
{
    let mut conn = connect_options.connect().await?;
    sqlx::query("PRAGMA journal_mode=WAL")
        .execute(&mut conn)
        .await?;
    conn.close().await?;
}
```

## Verification

**1. Python connection simulator** (mimics screenpipe's pool init
order with sqlite3 + threading):

| concurrent connections | failures (before fix) | failures (after fix) |
|------------------------|-----------------------|----------------------|
| 1                      | 0 / 20                | 0 / 20               |
| 2                      | 3 / 20  (15%)         | 0 / 20               |
| 4 (matches default)    | 10 / 20 (50%)         | 0 / 20               |
| 8                      | 11 / 20 (55%)         | 0 / 20               |

**2. Real binary, fresh data-dir x 10 starts:** 10/10 success,
zero `database is locked` (before fix: expected ~5 failures based
on simulator data).

## Notes

- Fix is fully backward-compatible: if the DB is already in WAL
  mode, the pre-conversion is a no-op.
- The pool's per-connection `journal_mode=WAL` pragma is kept
  (no behavior change for pool connections; they just no longer
  race).
- No new dependencies (`sqlx::Connection` and `sqlx::ConnectOptions`
  are already in `sqlx::prelude` essentially).