### PR TITLE
feat(audio): Windows microphone AEC

### DIFF
--- a/apps/screenpipe-app-tauri/components/cli-command-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/cli-command-dialog.tsx
@@ -110,6 +110,9 @@ export function CliCommandDialog({ settings }: CliCommandDialogProps) {
     if (settings.disableAudio) {
       args.push("--disable-audio");
     }
+    if (settings.windowsInputAecEnabled) {
+      args.push("--windows-input-aec-enabled");
+    }
     if (settings.disableClipboardCapture) {
       args.push("--disable-clipboard-capture");
     }

--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -1446,6 +1446,7 @@ export function RecordingSettings() {
   const isDisabled = health?.status_code === 500;
   const audioPipeline = health?.audio_pipeline ?? null;
   const [isMacOS, setIsMacOS] = useState(false);
+  const [isWindows, setIsWindows] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [showOpenAIApiKey, setShowOpenAIApiKey] = useState(false);
   const [isRefreshingSubscription, setIsRefreshingSubscription] = useState(false);
@@ -1589,6 +1590,7 @@ export function RecordingSettings() {
     const checkPlatform = async () => {
       const currentPlatform = platform();
       setIsMacOS(currentPlatform === "macos");
+      setIsWindows(currentPlatform === "windows");
       // Auto-migrate macOS users off qwen3-asr (CPU-only, no Metal support)
       if (currentPlatform === "macos" && settings.audioTranscriptionEngine === "qwen3-asr") {
         handleSettingsChange({ audioTranscriptionEngine: "whisper-large-v3-turbo-quantized" }, true);
@@ -2856,6 +2858,32 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
           vocabularyWords={settings.vocabularyWords ?? []}
           onChange={(words) => handleSettingsChange({ vocabularyWords: words }, true)}
         />
+        )}
+
+        {/* Windows microphone AEC */}
+        {!settings.disableAudio && isWindows && (
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Mic className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">
+                    Microphone echo cancellation
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Use Windows WASAPI AEC for supported input devices
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="windowsInputAecEnabled"
+                checked={Boolean(settings.windowsInputAecEnabled ?? false)}
+                onCheckedChange={(checked) => handleSettingsChange({ windowsInputAecEnabled: checked }, true)}
+              />
+            </div>
+          </CardContent>
+        </Card>
         )}
 
         {/* CoreAudio System Audio (macOS 14.4+ only; default on) */}

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -242,6 +242,8 @@ export type Settings = SettingsStore & {
 	/** Experimental: capture System Audio via CoreAudio Process Tap (macOS 14.4+) instead of ScreenCaptureKit.
 	 *  Off by default. Ignored on macOS <14.4 and non-macOS — falls back to SCK. */
 	experimentalCoreaudioSystemAudio?: boolean;
+	/** Experimental: request Windows WASAPI microphone AEC when supported. */
+	windowsInputAecEnabled?: boolean;
 	/** Continue recording audio when the screen is locked (default: false) */
 	recordWhileLocked?: boolean;
 	/** Auto-delete local data older than retention days (free alternative to cloud archive) */
@@ -484,6 +486,7 @@ let DEFAULT_SETTINGS: Settings = {
 			pauseOnDrmContent: false,
 			disableClipboardCapture: false,
 			experimentalCoreaudioSystemAudio: false,
+			windowsInputAecEnabled: false,
 			recordWhileLocked: false,
 			localRetentionEnabled: false,
 			localRetentionDays: 14,

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -32,7 +32,7 @@ oasgen = { workspace = true }
 # AEC feature (added 2026-05-06). It hasn't been wired into a user-
 # visible toggle yet, so reverting is no-op for end users while
 # restoring Windows capture across the board.
-cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "1be10a9d67ac7e6b9e0225d2d67ec56058a7dba2" }
+cpal = { git = "https://github.com/divanshu-go/cpal.git", branch = "windows-aec" }
 
 # Wav encoding
 hound = "3.5"

--- a/crates/screenpipe-audio/src/audio_manager/builder.rs
+++ b/crates/screenpipe-audio/src/audio_manager/builder.rs
@@ -64,6 +64,8 @@ pub struct AudioManagerOptions {
     /// When false (default), System Audio uses ScreenCaptureKit as before.
     /// Has no effect on non-macOS or macOS <14.4 — falls back to SCK.
     pub experimental_coreaudio_system_audio: bool,
+    /// Experimental: request Windows WASAPI microphone AEC when the endpoint supports it.
+    pub windows_input_aec_enabled: bool,
     /// Controls when local Whisper transcription runs.
     /// `Realtime` = immediate (default), `Batch` = accumulate longer chunks for quality.
     pub transcription_mode: TranscriptionMode,
@@ -107,6 +109,7 @@ impl Default for AudioManagerOptions {
             filter_music: false,
             use_system_default_audio: true,
             experimental_coreaudio_system_audio: false,
+            windows_input_aec_enabled: false,
             transcription_mode: TranscriptionMode::default(),
             meeting_detector: None,
             meeting_streaming: MeetingStreamingConfig::default(),
@@ -198,6 +201,11 @@ impl AudioManagerBuilder {
 
     pub fn experimental_coreaudio_system_audio(mut self, enabled: bool) -> Self {
         self.options.experimental_coreaudio_system_audio = enabled;
+        self
+    }
+
+    pub fn windows_input_aec_enabled(mut self, enabled: bool) -> Self {
+        self.options.windows_input_aec_enabled = enabled;
         self
     }
 

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -149,8 +149,11 @@ pub struct CentralHandlerRestartResult {
 
 impl AudioManager {
     pub async fn new(options: AudioManagerOptions, db: Arc<DatabaseManager>) -> Result<Self> {
-        let device_manager =
-            DeviceManager::new(options.experimental_coreaudio_system_audio).await?;
+        let device_manager = DeviceManager::new(
+            options.experimental_coreaudio_system_audio,
+            options.windows_input_aec_enabled,
+        )
+        .await?;
         let segmentation_manager = Arc::new(SegmentationManager::new(options.is_disabled).await?);
         let status = RwLock::new(AudioManagerStatus::Stopped);
         let vad_engine: Arc<Mutex<Box<dyn VadEngine + Send>>> = if options.is_disabled {

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -97,6 +97,7 @@ impl AudioStream {
         device: Arc<AudioDevice>,
         is_running: Arc<AtomicBool>,
         #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] use_coreaudio_tap: bool,
+        #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] windows_input_aec: bool,
     ) -> Result<Self> {
         let (tx, _) = broadcast::channel::<Vec<f32>>(1000);
         let tx_clone = tx.clone();
@@ -156,6 +157,7 @@ impl AudioStream {
                                 &is_running,
                                 &is_disconnected,
                                 &stream_control_tx,
+                                windows_input_aec,
                             )
                             .await?
                         }
@@ -173,6 +175,7 @@ impl AudioStream {
                     &is_running,
                     &is_disconnected,
                     &stream_control_tx,
+                    windows_input_aec,
                 )
                 .await?
             }
@@ -198,11 +201,13 @@ impl AudioStream {
         is_running: &Arc<AtomicBool>,
         is_disconnected: &Arc<AtomicBool>,
         stream_control_tx: &mpsc::Sender<StreamControl>,
+        windows_input_aec: bool,
     ) -> Result<(AudioStreamConfig, tokio::task::JoinHandle<()>)> {
         let (cpal_audio_device, config) = get_cpal_device_and_config(device).await?;
         let audio_config = AudioStreamConfig::from(&config);
         let channels = config.channels();
         let is_running_weak = Arc::downgrade(is_running);
+        let input_aec = windows_input_aec && device.device_type == super::device::DeviceType::Input;
 
         let thread = Self::spawn_audio_thread(
             cpal_audio_device,
@@ -213,6 +218,7 @@ impl AudioStream {
             is_running_weak,
             is_disconnected.clone(),
             stream_control_tx.clone(),
+            input_aec,
         )
         .await?;
         Ok((audio_config, thread))
@@ -229,6 +235,7 @@ impl AudioStream {
         is_running_weak: std::sync::Weak<AtomicBool>,
         is_disconnected: Arc<AtomicBool>,
         stream_control_tx: mpsc::Sender<StreamControl>,
+        windows_input_aec: bool,
     ) -> Result<tokio::task::JoinHandle<()>> {
         let device_name = device.name()?;
 
@@ -254,6 +261,7 @@ impl AudioStream {
                 channels,
                 tx.clone(),
                 primary_cb,
+                windows_input_aec,
             ) {
                 Ok(s) => Some(s),
                 Err(primary_err) if is_wasapi_unsupported_format(&primary_err) => {
@@ -276,6 +284,7 @@ impl AudioStream {
                                 fb_channels,
                                 tx,
                                 fallback_cb,
+                                windows_input_aec,
                             ) {
                                 Ok(s) => Some(s),
                                 Err(fallback_err) => {
@@ -542,11 +551,13 @@ fn build_input_stream(
     channels: u16,
     tx: broadcast::Sender<Vec<f32>>,
     error_callback: impl FnMut(CpalError) + Send + 'static,
+    windows_input_aec: bool,
 ) -> Result<cpal::Stream> {
+    let stream_config = cpal_stream_config(config, windows_input_aec);
     match config.sample_format() {
         cpal::SampleFormat::F32 => device
             .build_input_stream(
-                &config.config(),
+                &stream_config,
                 move |data: &[f32], _: &_| {
                     let mono = audio_to_mono(data, channels);
                     let _ = tx.send(mono);
@@ -557,7 +568,7 @@ fn build_input_stream(
             .map_err(|e| anyhow!(e)),
         cpal::SampleFormat::I16 => device
             .build_input_stream(
-                &config.config(),
+                &stream_config,
                 move |data: &[i16], _: &_| {
                     let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 32768.0).collect();
                     let mono = audio_to_mono(&f32_data, channels);
@@ -569,7 +580,7 @@ fn build_input_stream(
             .map_err(|e| anyhow!(e)),
         cpal::SampleFormat::I32 => device
             .build_input_stream(
-                &config.config(),
+                &stream_config,
                 move |data: &[i32], _: &_| {
                     let f32_data: Vec<f32> = data
                         .iter()
@@ -584,7 +595,7 @@ fn build_input_stream(
             .map_err(|e| anyhow!(e)),
         cpal::SampleFormat::I8 => device
             .build_input_stream(
-                &config.config(),
+                &stream_config,
                 move |data: &[i8], _: &_| {
                     let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 128.0).collect();
                     let mono = audio_to_mono(&f32_data, channels);
@@ -599,6 +610,19 @@ fn build_input_stream(
             config.sample_format()
         )),
     }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
+fn cpal_stream_config(
+    config: &cpal::SupportedStreamConfig,
+    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] windows_input_aec: bool,
+) -> cpal::StreamConfig {
+    let mut stream_config = config.config();
+    #[cfg(target_os = "windows")]
+    {
+        stream_config.windows_input_aec = windows_input_aec;
+    }
+    stream_config
 }
 
 impl Drop for AudioStream {

--- a/crates/screenpipe-audio/src/device/device_manager.rs
+++ b/crates/screenpipe-audio/src/device/device_manager.rs
@@ -18,10 +18,12 @@ pub struct DeviceManager {
     /// AudioStream::from_device at device-start time. Has no effect on
     /// macOS <14.4 or non-macOS — falls back to SCK there.
     use_coreaudio_tap: bool,
+    /// When true, Windows WASAPI input streams request endpoint AEC.
+    windows_input_aec: bool,
 }
 
 impl DeviceManager {
-    pub async fn new(use_coreaudio_tap: bool) -> Result<Self> {
+    pub async fn new(use_coreaudio_tap: bool, windows_input_aec: bool) -> Result<Self> {
         let streams = Arc::new(DashMap::new());
         let states = Arc::new(DashMap::new());
 
@@ -29,6 +31,7 @@ impl DeviceManager {
             streams,
             states,
             use_coreaudio_tap,
+            windows_input_aec,
         })
     }
 
@@ -50,6 +53,7 @@ impl DeviceManager {
             Arc::new(device.clone()),
             is_running.clone(),
             self.use_coreaudio_tap,
+            self.windows_input_aec,
         )
         .await
         {

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -99,6 +99,11 @@ pub struct RecordingSettings {
     )]
     pub experimental_coreaudio_system_audio: bool,
 
+    /// Experimental: request Windows WASAPI microphone Acoustic Echo Cancellation.
+    /// Ignored on non-Windows platforms and fail-open when unsupported by device/driver.
+    #[serde(rename = "windowsInputAecEnabled", default)]
+    pub windows_input_aec_enabled: bool,
+
     /// Duration of each audio chunk in seconds before transcription.
     /// Stored as i32 to match existing store.bin schema (cast to u64 by engine).
     #[serde(rename = "audioChunkDuration")]
@@ -396,6 +401,7 @@ impl Default for RecordingSettings {
             audio_devices: vec![],
             use_system_default_audio: true,
             experimental_coreaudio_system_audio: false,
+            windows_input_aec_enabled: false,
             audio_chunk_duration: 30,
             deepgram_api_key: String::new(),
             filter_music: false,

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -299,6 +299,11 @@ pub struct RecordArgs {
     #[arg(long, default_value_t = false)]
     pub experimental_coreaudio_system_audio: bool,
 
+    /// [experimental, Windows] Request WASAPI microphone AEC when supported.
+    /// Ignored on non-Windows platforms and unsupported endpoints.
+    #[arg(long, default_value_t = false)]
+    pub windows_input_aec_enabled: bool,
+
     /// Data directory. Default to $HOME/.screenpipe
     #[arg(long, value_hint = ValueHint::DirPath)]
     pub data_dir: Option<String>,
@@ -485,6 +490,7 @@ pub struct RecordArgSources {
     pub audio_device: bool,
     pub use_system_default_audio: bool,
     pub experimental_coreaudio_system_audio: bool,
+    pub windows_input_aec_enabled: bool,
     pub audio_transcription_engine: bool,
     pub monitor_id: bool,
     pub use_all_monitors: bool,
@@ -527,6 +533,7 @@ impl RecordArgSources {
                 record,
                 "experimental_coreaudio_system_audio",
             ),
+            windows_input_aec_enabled: from_command_line(record, "windows_input_aec_enabled"),
             audio_transcription_engine: from_command_line(record, "audio_transcription_engine"),
             monitor_id: from_command_line(record, "monitor_id"),
             use_all_monitors: from_command_line(record, "use_all_monitors"),
@@ -561,6 +568,7 @@ impl RecordArgSources {
             || self.audio_device
             || self.use_system_default_audio
             || self.experimental_coreaudio_system_audio
+            || self.windows_input_aec_enabled
             || self.audio_transcription_engine
             || self.monitor_id
             || self.use_all_monitors
@@ -643,6 +651,7 @@ impl RecordArgs {
             audio_devices: self.audio_device.clone(),
             use_system_default_audio: self.use_system_default_audio,
             experimental_coreaudio_system_audio: self.experimental_coreaudio_system_audio,
+            windows_input_aec_enabled: self.windows_input_aec_enabled,
             monitor_ids: self.monitor_id.iter().map(|id| id.to_string()).collect(),
             // Explicit `--monitor-id` implies opting out of `--use-all-monitors`.
             // `use_all_monitors` has `default_value_t = true`, so without this
@@ -828,6 +837,9 @@ impl RecordArgs {
         }
         if sources.experimental_coreaudio_system_audio {
             settings.experimental_coreaudio_system_audio = self.experimental_coreaudio_system_audio;
+        }
+        if sources.windows_input_aec_enabled {
+            settings.windows_input_aec_enabled = self.windows_input_aec_enabled;
         }
         if sources.audio_transcription_engine {
             settings.audio_transcription_engine =

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -58,6 +58,8 @@ pub struct RecordingConfig {
     pub use_system_default_audio: bool,
     /// Experimental: use CoreAudio Process Tap for System Audio on macOS 14.4+.
     pub experimental_coreaudio_system_audio: bool,
+    /// Experimental: request Windows WASAPI microphone AEC when supported.
+    pub windows_input_aec_enabled: bool,
     pub monitor_ids: Vec<String>,
     pub use_all_monitors: bool,
 
@@ -217,6 +219,7 @@ impl RecordingConfig {
             audio_devices: settings.audio_devices.clone(),
             use_system_default_audio: settings.use_system_default_audio,
             experimental_coreaudio_system_audio: settings.experimental_coreaudio_system_audio,
+            windows_input_aec_enabled: settings.windows_input_aec_enabled,
             monitor_ids: settings.monitor_ids.clone(),
             use_all_monitors: settings.use_all_monitors,
             ignored_windows: settings.ignored_windows.clone(),
@@ -319,6 +322,7 @@ impl RecordingConfig {
             .enabled_devices(audio_devices)
             .use_system_default_audio(self.use_system_default_audio)
             .experimental_coreaudio_system_audio(self.experimental_coreaudio_system_audio)
+            .windows_input_aec_enabled(self.windows_input_aec_enabled)
             .deepgram_api_key(self.deepgram_api_key.clone())
             .output_path(output_path)
             .use_pii_removal(self.use_pii_removal)


### PR DESCRIPTION
## Summary

Adds a Screenpipe setting and CLI flag to request Windows WASAPI Acoustic Echo Cancellation for microphone/input capture, while preserving separate system/output audio capture.

This is intended for desktop meeting capture:

- microphone/input stream: optional Windows AEC to reduce speaker/output echo in the local mic lane
- system/output stream: captured separately as before for other participants/app audio

## Details

- Adds `--windows-input-aec-enabled` to the CLI.
- Includes the flag in generated CLI command output.
---
- Adds a Windows-only desktop settings toggle: `Microphone echo cancellation`.
- Applies the flag only to input devices. Output/system-audio capture is untouched.


