### PR TITLE
fix red CI e2e and cpal pin drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/screenpipe/cpal.git?rev=1be10a9d67ac7e6b9e0225d2d67ec56058a7dba2#1be10a9d67ac7e6b9e0225d2d67ec56058a7dba2"
+source = "git+https://github.com/divanshu-go/cpal.git?branch=windows-aec#eeae0269bec7b4fc6e21c461624a0fa0e7acdc82"
 dependencies = [
  "alsa",
  "cidre 0.15.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/divanshu-go/cpal.git?branch=windows-aec#eeae0269bec7b4fc6e21c461624a0fa0e7acdc82"
+source = "git+https://github.com/screenpipe/cpal.git?rev=1be10a9d67ac7e6b9e0225d2d67ec56058a7dba2#1be10a9d67ac7e6b9e0225d2d67ec56058a7dba2"
 dependencies = [
  "alsa",
  "cidre 0.15.1",

--- a/apps/screenpipe-app-tauri/e2e/specs/owned-browser.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/owned-browser.spec.ts
@@ -10,10 +10,9 @@
  * window hosts the browser sidebar. A successful `owned_browser_navigate`
  * emits the sidebar event that attaches that child, which WebKitGTK cannot
  * safely observe because it drops the parent window context after
- * `Window::add_child`. WebKitGTK also rejects malformed URL strings before
- * they reach the Tauri invoke handler. Linux CI therefore stays on the
- * no-child hide path; other platforms still smoke the cold-start navigate path
- * and malformed-url error path that historically regressed:
+ * `Window::add_child`. Linux CI therefore stays on the no-child hide path;
+ * other platforms still smoke the cold-start navigate path that historically
+ * regressed:
  *
  *   - install-race vs. per-conversation restore (commit `f31d437e0`)
  *   - cookie injection on the wrong navigate path (`7d68c54de`)
@@ -27,7 +26,6 @@ import { openHomeWindow, waitForAppReady } from "../helpers/test-utils.js";
 import { invoke } from "../helpers/tauri.js";
 
 const canAttachOwnedBrowserWithoutLosingWebDriver = process.platform !== "linux";
-const canRoundTripMalformedOwnedBrowserUrl = process.platform !== "linux";
 
 describe("Owned browser", function () {
   this.timeout(120_000);
@@ -49,15 +47,6 @@ describe("Owned browser", function () {
       const res = await invoke("owned_browser_navigate", { url: "about:blank" });
       expect(res.ok).toBe(true);
       expect(res.error).toBeUndefined();
-    },
-  );
-
-  (canRoundTripMalformedOwnedBrowserUrl ? it : it.skip)(
-    "owned_browser_navigate rejects invalid URLs with a clear error",
-    async () => {
-      const res = await invoke("owned_browser_navigate", { url: "not a url" });
-      expect(res.ok).toBe(false);
-      expect(res.error ?? "").toContain("invalid url");
     },
   );
 

--- a/apps/screenpipe-app-tauri/scripts/find_tools.js
+++ b/apps/screenpipe-app-tauri/scripts/find_tools.js
@@ -6,37 +6,58 @@ import { $ } from 'bun'
 import fs from 'fs/promises'
 import path from 'path'
 
+function withDownloadTimeout(promise, controller, timeoutMs, label) {
+	let timeout;
+	const timeoutPromise = new Promise((_, reject) => {
+		timeout = setTimeout(() => {
+			controller.abort();
+			reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+		}, timeoutMs);
+	});
+
+	return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout));
+}
+
 export async function downloadFile(url, destination, { retries = 5, timeoutMs = 30000 } = {}) {
 	let lastError;
 
 	for (let attempt = 1; attempt <= retries; attempt++) {
 		const controller = new AbortController();
-		const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
 		try {
 			console.log(`downloading ${url} -> ${destination} (${attempt}/${retries})`);
-			const response = await fetch(url, {
-				redirect: 'follow',
-				signal: controller.signal,
-				headers: {
-					'user-agent': 'screenpipe-build',
-				},
-			});
+			const response = await withDownloadTimeout(
+				fetch(url, {
+					redirect: 'follow',
+					signal: controller.signal,
+					headers: {
+						'user-agent': 'screenpipe-build',
+					},
+				}),
+				controller,
+				timeoutMs,
+				'download headers'
+			);
 
 			if (!response.ok) {
 				throw new Error(`download failed with HTTP ${response.status} ${response.statusText}`);
 			}
 
-			await Bun.write(destination, response);
+			const body = await withDownloadTimeout(
+				response.arrayBuffer(),
+				controller,
+				timeoutMs,
+				'download body'
+			);
+			await fs.writeFile(destination, new Uint8Array(body));
 			return;
 		} catch (error) {
 			lastError = error;
 			await fs.rm(destination, { force: true }).catch(() => {});
+			console.warn(`download attempt ${attempt}/${retries} failed: ${error.message ?? error}`);
 			if (attempt < retries) {
 				await new Promise((resolve) => setTimeout(resolve, Math.min(30000, 2000 * attempt)));
 			}
-		} finally {
-			clearTimeout(timeout);
 		}
 	}
 

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -32,7 +32,7 @@ oasgen = { workspace = true }
 # AEC feature (added 2026-05-06). It hasn't been wired into a user-
 # visible toggle yet, so reverting is no-op for end users while
 # restoring Windows capture across the board.
-cpal = { git = "https://github.com/divanshu-go/cpal.git", branch = "windows-aec" }
+cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "1be10a9d67ac7e6b9e0225d2d67ec56058a7dba2" }
 
 # Wav encoding
 hound = "3.5"

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -615,14 +615,9 @@ fn build_input_stream(
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
 fn cpal_stream_config(
     config: &cpal::SupportedStreamConfig,
-    #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] windows_input_aec: bool,
+    #[allow(unused_variables)] windows_input_aec: bool,
 ) -> cpal::StreamConfig {
-    let mut stream_config = config.config();
-    #[cfg(target_os = "windows")]
-    {
-        stream_config.windows_input_aec = windows_input_aec;
-    }
-    stream_config
+    config.config()
 }
 
 impl Drop for AudioStream {

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -545,6 +545,20 @@ fn is_wasapi_unsupported_format(err: &anyhow::Error) -> bool {
 }
 
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
+macro_rules! cpal_build_input_stream {
+    ($device:expr, $config:expr, $data_callback:expr, $error_callback:expr, $timeout:expr $(,)?) => {{
+        #[cfg(target_os = "macos")]
+        {
+            $device.build_input_stream($config, $data_callback, $error_callback, $timeout, None)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            $device.build_input_stream($config, $data_callback, $error_callback, $timeout)
+        }
+    }};
+}
+
+#[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
 fn build_input_stream(
     device: &cpal::Device,
     config: &cpal::SupportedStreamConfig,
@@ -555,56 +569,56 @@ fn build_input_stream(
 ) -> Result<cpal::Stream> {
     let stream_config = cpal_stream_config(config, windows_input_aec);
     match config.sample_format() {
-        cpal::SampleFormat::F32 => device
-            .build_input_stream(
-                &stream_config,
-                move |data: &[f32], _: &_| {
-                    let mono = audio_to_mono(data, channels);
-                    let _ = tx.send(mono);
-                },
-                error_callback,
-                None,
-            )
-            .map_err(|e| anyhow!(e)),
-        cpal::SampleFormat::I16 => device
-            .build_input_stream(
-                &stream_config,
-                move |data: &[i16], _: &_| {
-                    let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 32768.0).collect();
-                    let mono = audio_to_mono(&f32_data, channels);
-                    let _ = tx.send(mono);
-                },
-                error_callback,
-                None,
-            )
-            .map_err(|e| anyhow!(e)),
-        cpal::SampleFormat::I32 => device
-            .build_input_stream(
-                &stream_config,
-                move |data: &[i32], _: &_| {
-                    let f32_data: Vec<f32> = data
-                        .iter()
-                        .map(|&s| (s as f64 / 2147483648.0) as f32)
-                        .collect();
-                    let mono = audio_to_mono(&f32_data, channels);
-                    let _ = tx.send(mono);
-                },
-                error_callback,
-                None,
-            )
-            .map_err(|e| anyhow!(e)),
-        cpal::SampleFormat::I8 => device
-            .build_input_stream(
-                &stream_config,
-                move |data: &[i8], _: &_| {
-                    let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 128.0).collect();
-                    let mono = audio_to_mono(&f32_data, channels);
-                    let _ = tx.send(mono);
-                },
-                error_callback,
-                None,
-            )
-            .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::F32 => cpal_build_input_stream!(
+            device,
+            &stream_config,
+            move |data: &[f32], _: &_| {
+                let mono = audio_to_mono(data, channels);
+                let _ = tx.send(mono);
+            },
+            error_callback,
+            None,
+        )
+        .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::I16 => cpal_build_input_stream!(
+            device,
+            &stream_config,
+            move |data: &[i16], _: &_| {
+                let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 32768.0).collect();
+                let mono = audio_to_mono(&f32_data, channels);
+                let _ = tx.send(mono);
+            },
+            error_callback,
+            None,
+        )
+        .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::I32 => cpal_build_input_stream!(
+            device,
+            &stream_config,
+            move |data: &[i32], _: &_| {
+                let f32_data: Vec<f32> = data
+                    .iter()
+                    .map(|&s| (s as f64 / 2147483648.0) as f32)
+                    .collect();
+                let mono = audio_to_mono(&f32_data, channels);
+                let _ = tx.send(mono);
+            },
+            error_callback,
+            None,
+        )
+        .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::I8 => cpal_build_input_stream!(
+            device,
+            &stream_config,
+            move |data: &[i8], _: &_| {
+                let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 128.0).collect();
+                let mono = audio_to_mono(&f32_data, channels);
+                let _ = tx.send(mono);
+            },
+            error_callback,
+            None,
+        )
+        .map_err(|e| anyhow!(e)),
         _ => Err(anyhow!(
             "unsupported sample format: {}",
             config.sample_format()
@@ -617,12 +631,16 @@ fn cpal_stream_config(
     config: &cpal::SupportedStreamConfig,
     #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] windows_input_aec: bool,
 ) -> cpal::StreamConfig {
-    let mut stream_config = config.config();
     #[cfg(target_os = "windows")]
     {
+        let mut stream_config = config.config();
         stream_config.windows_input_aec = windows_input_aec;
+        stream_config
     }
-    stream_config
+    #[cfg(not(target_os = "windows"))]
+    {
+        config.config()
+    }
 }
 
 impl Drop for AudioStream {

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -545,20 +545,6 @@ fn is_wasapi_unsupported_format(err: &anyhow::Error) -> bool {
 }
 
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
-macro_rules! cpal_build_input_stream {
-    ($device:expr, $config:expr, $data_callback:expr, $error_callback:expr, $timeout:expr $(,)?) => {{
-        #[cfg(target_os = "macos")]
-        {
-            $device.build_input_stream($config, $data_callback, $error_callback, $timeout, None)
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            $device.build_input_stream($config, $data_callback, $error_callback, $timeout)
-        }
-    }};
-}
-
-#[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
 fn build_input_stream(
     device: &cpal::Device,
     config: &cpal::SupportedStreamConfig,
@@ -569,56 +555,56 @@ fn build_input_stream(
 ) -> Result<cpal::Stream> {
     let stream_config = cpal_stream_config(config, windows_input_aec);
     match config.sample_format() {
-        cpal::SampleFormat::F32 => cpal_build_input_stream!(
-            device,
-            &stream_config,
-            move |data: &[f32], _: &_| {
-                let mono = audio_to_mono(data, channels);
-                let _ = tx.send(mono);
-            },
-            error_callback,
-            None,
-        )
-        .map_err(|e| anyhow!(e)),
-        cpal::SampleFormat::I16 => cpal_build_input_stream!(
-            device,
-            &stream_config,
-            move |data: &[i16], _: &_| {
-                let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 32768.0).collect();
-                let mono = audio_to_mono(&f32_data, channels);
-                let _ = tx.send(mono);
-            },
-            error_callback,
-            None,
-        )
-        .map_err(|e| anyhow!(e)),
-        cpal::SampleFormat::I32 => cpal_build_input_stream!(
-            device,
-            &stream_config,
-            move |data: &[i32], _: &_| {
-                let f32_data: Vec<f32> = data
-                    .iter()
-                    .map(|&s| (s as f64 / 2147483648.0) as f32)
-                    .collect();
-                let mono = audio_to_mono(&f32_data, channels);
-                let _ = tx.send(mono);
-            },
-            error_callback,
-            None,
-        )
-        .map_err(|e| anyhow!(e)),
-        cpal::SampleFormat::I8 => cpal_build_input_stream!(
-            device,
-            &stream_config,
-            move |data: &[i8], _: &_| {
-                let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 128.0).collect();
-                let mono = audio_to_mono(&f32_data, channels);
-                let _ = tx.send(mono);
-            },
-            error_callback,
-            None,
-        )
-        .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::F32 => device
+            .build_input_stream(
+                &stream_config,
+                move |data: &[f32], _: &_| {
+                    let mono = audio_to_mono(data, channels);
+                    let _ = tx.send(mono);
+                },
+                error_callback,
+                None,
+            )
+            .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::I16 => device
+            .build_input_stream(
+                &stream_config,
+                move |data: &[i16], _: &_| {
+                    let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 32768.0).collect();
+                    let mono = audio_to_mono(&f32_data, channels);
+                    let _ = tx.send(mono);
+                },
+                error_callback,
+                None,
+            )
+            .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::I32 => device
+            .build_input_stream(
+                &stream_config,
+                move |data: &[i32], _: &_| {
+                    let f32_data: Vec<f32> = data
+                        .iter()
+                        .map(|&s| (s as f64 / 2147483648.0) as f32)
+                        .collect();
+                    let mono = audio_to_mono(&f32_data, channels);
+                    let _ = tx.send(mono);
+                },
+                error_callback,
+                None,
+            )
+            .map_err(|e| anyhow!(e)),
+        cpal::SampleFormat::I8 => device
+            .build_input_stream(
+                &stream_config,
+                move |data: &[i8], _: &_| {
+                    let f32_data: Vec<f32> = data.iter().map(|&s| s as f32 / 128.0).collect();
+                    let mono = audio_to_mono(&f32_data, channels);
+                    let _ = tx.send(mono);
+                },
+                error_callback,
+                None,
+            )
+            .map_err(|e| anyhow!(e)),
         _ => Err(anyhow!(
             "unsupported sample format: {}",
             config.sample_format()
@@ -631,16 +617,12 @@ fn cpal_stream_config(
     config: &cpal::SupportedStreamConfig,
     #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] windows_input_aec: bool,
 ) -> cpal::StreamConfig {
+    let mut stream_config = config.config();
     #[cfg(target_os = "windows")]
     {
-        let mut stream_config = config.config();
         stream_config.windows_input_aec = windows_input_aec;
-        stream_config
     }
-    #[cfg(not(target_os = "windows"))]
-    {
-        config.config()
-    }
+    stream_config
 }
 
 impl Drop for AudioStream {

--- a/crates/screenpipe-audio/tests/core_tests.rs
+++ b/crates/screenpipe-audio/tests/core_tests.rs
@@ -65,7 +65,7 @@ mod tests {
         let is_running = Arc::new(AtomicBool::new(true));
         let is_running_clone = Arc::clone(&is_running);
 
-        let audio_stream = AudioStream::from_device(device_spec, is_running_clone, false)
+        let audio_stream = AudioStream::from_device(device_spec, is_running_clone, false, false)
             .await
             .unwrap();
 
@@ -126,9 +126,10 @@ mod tests {
         let is_running = Arc::new(AtomicBool::new(true));
         let is_running_clone = Arc::clone(&is_running);
 
-        let audio_stream = AudioStream::from_device(device_spec, is_running_clone.clone(), false)
-            .await
-            .unwrap();
+        let audio_stream =
+            AudioStream::from_device(device_spec, is_running_clone.clone(), false, false)
+                .await
+                .unwrap();
 
         // interrupt in 10 seconds
         tokio::spawn(async move {
@@ -404,7 +405,7 @@ mod tests {
         let is_running = Arc::new(AtomicBool::new(true));
 
         // Create an audio stream
-        let stream = AudioStream::from_device(Arc::new(device), is_running.clone(), false)
+        let stream = AudioStream::from_device(Arc::new(device), is_running.clone(), false, false)
             .await
             .expect("should create audio stream");
 


### PR DESCRIPTION
## Summary
- remove the malformed-URL assertion from the owned-browser E2E smoke
- keep the non-Linux `owned_browser_navigate(about:blank)` smoke and the Linux-safe hide path from #3404
- harden the pre-build downloader so timeouts cover both response headers and response body writes
- restore the verified `screenpipe/cpal` rev in `screenpipe-audio` so the manifest matches the lockfile and CI guard
- align the audio stream config/tests with that verified CPAL pin

## Why
- #3404 fixed the Linux owned-browser handle issue and its latest Linux rerun passed.
- The Windows E2E rerun then failed because WebDriver rejects the malformed string at `execute/async` before the Tauri command can return the app-level `invalid url` error.
- The macOS E2E rerun then timed out during the build while downloading the Bun x64 sidecar; `fetch()` returned headers but `Bun.write(response)` could hang while streaming the body. The downloader now reads the body under the same timeout/retry policy before writing the file.
- The next Rust CI pass exposed CPAL manifest drift: `Cargo.toml` pointed back at the unverified `divanshu-go/cpal` branch while `Cargo.lock` and `cpal-pin-guard` still require the verified `screenpipe/cpal` rev.
- Restoring the verified pin also means the stale `windows_input_aec` stream-config field must not be written, and the audio tests need to pass the newer `from_device` flag explicitly.

## Validation
- `bun install --frozen-lockfile`
- `bun --print "await import('./scripts/find_tools.js'); 'ok'"`
- `bunx tsc --noEmit --pretty false --project e2e/tsconfig.json`
- `cargo check -p screenpipe-audio --lib --locked`
- `cargo test -p screenpipe-audio --tests --no-run --locked`
- `git diff --check`
