### PR TITLE
fix: meeting transcript loss when live STT fails

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
@@ -12,6 +12,7 @@ import React, {
 } from "react";
 import {
   ArrowDown,
+  AlertTriangle,
   Check,
   Copy,
   Loader2,
@@ -22,6 +23,7 @@ import { listen } from "@tauri-apps/api/event";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { SpeakerAssignPopover } from "@/components/speaker-assign-popover";
+import { useHealthCheck } from "@/lib/hooks/use-health-check";
 import {
   fetchMeetingAudio,
   type MeetingAudioChunk,
@@ -264,6 +266,7 @@ export function TranscriptPanel({
   const [isFollowingLive, setIsFollowingLive] = useState(true);
   const [hasUnseenLive, setHasUnseenLive] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const { health } = useHealthCheck();
 
   // Time bounds for the meeting. Live meetings extend to "now" so newly
   // captured chunks are included on each refetch.
@@ -575,6 +578,16 @@ export function TranscriptPanel({
   const showSearch = displayBlocks.length > 0 || Boolean(query.trim());
   const showFollowButton =
     isLive && !query.trim() && hasTranscriptContent && !isFollowingLive;
+  const pendingTranscriptSegments =
+    health?.audio_pipeline?.pending_transcription_segments ?? 0;
+  const showRecoveryBanner =
+    isLive &&
+    Boolean(liveError || (pendingTranscriptSegments > 0 && liveStatus?.active));
+  const recoveryMessage = liveError
+    ? `${liveErrorSummary(liveError)}. Still recording; background transcription will recover missing audio.`
+    : `Still recording; ${pendingTranscriptSegments} audio segment${
+        pendingTranscriptSegments === 1 ? "" : "s"
+      } waiting for background transcription.`;
 
   return (
     <>
@@ -623,6 +636,13 @@ export function TranscriptPanel({
             </Button>
           </div>
         </header>
+
+        {showRecoveryBanner && (
+          <div className="flex items-start gap-2 border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-xs text-amber-900 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span className="leading-5">{recoveryMessage}</span>
+          </div>
+        )}
 
         {showSearch && (
           <div className="px-4 py-2 border-b border-border shrink-0">

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
@@ -667,7 +667,6 @@ export async function fetchMeetingAudio(
   meetingId?: number,
 ): Promise<MeetingAudioChunk[]> {
   const routedRows = await fetchRoutedMeetingTranscript(meetingId, cap);
-  if (routedRows.length > 0) return routedRows;
 
   const out: MeetingAudioChunk[] = [];
   const seen = new Set<string>();
@@ -711,7 +710,32 @@ export async function fetchMeetingAudio(
       break;
     }
   }
-  return sortAudioChunks(out);
+  return mergeMeetingAudioChunks(routedRows, out, cap);
+}
+
+function mergeMeetingAudioChunks(
+  liveRows: MeetingAudioChunk[],
+  backgroundRows: MeetingAudioChunk[],
+  cap: number,
+): MeetingAudioChunk[] {
+  const merged = sortAudioChunks([...liveRows, ...backgroundRows]);
+  const seen = new Set<string>();
+  const out: MeetingAudioChunk[] = [];
+
+  for (const chunk of merged) {
+    const key = [
+      Math.round(timestampMs(chunk.timestamp) / 1000),
+      chunk.deviceType,
+      chunk.speakerName,
+      chunk.transcription.replace(/\s+/g, " ").trim().toLowerCase(),
+    ].join("|");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(chunk);
+    if (out.length >= cap) break;
+  }
+
+  return out;
 }
 
 async function fetchRoutedMeetingTranscript(

--- a/crates/screenpipe-audio/src/meeting_streaming/controller.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/controller.rs
@@ -21,7 +21,7 @@ use super::{
     events::{
         MeetingAudioFrame, MeetingAudioTap, MeetingLifecycleEvent, MeetingStreamingError,
         MeetingStreamingSessionEnded, MeetingStreamingSessionStarted,
-        MeetingStreamingStatusChanged, MeetingTranscriptFinal,
+        MeetingStreamingStatusChanged, MeetingTranscriptDelta, MeetingTranscriptFinal,
     },
     openai_realtime, selected_engine, MeetingStreamingConfig, MeetingStreamingProvider,
 };
@@ -43,6 +43,8 @@ struct ActiveMeetingStream {
     audio_frames_seen: u64,
     audio_samples_seen: u64,
     last_audio_activity_at: Instant,
+    live_transcript_seen: bool,
+    last_live_transcript_at: Option<Instant>,
     device_senders: HashMap<String, mpsc::Sender<MeetingAudioFrame>>,
     device_retry_after: HashMap<String, Instant>,
 }
@@ -72,8 +74,14 @@ pub fn start_meeting_streaming_loop(
             screenpipe_events::subscribe_to_event::<MeetingLifecycleEvent>("meeting_started");
         let mut ended_sub =
             screenpipe_events::subscribe_to_event::<MeetingLifecycleEvent>("meeting_ended");
+        let mut delta_sub = screenpipe_events::subscribe_to_event::<MeetingTranscriptDelta>(
+            "meeting_transcript_delta",
+        );
         let mut final_sub = screenpipe_events::subscribe_to_event::<MeetingTranscriptFinal>(
             "meeting_transcript_final",
+        );
+        let mut error_sub = screenpipe_events::subscribe_to_event::<MeetingStreamingError>(
+            "meeting_streaming_error",
         );
         let mut inactivity_tick = tokio::time::interval(LIVE_INACTIVITY_CHECK_INTERVAL);
         let mut active: Option<ActiveMeetingStream> = None;
@@ -164,6 +172,9 @@ pub fn start_meeting_streaming_loop(
                     }
                 }
                 Some(event) = final_sub.next() => {
+                    if let Some(session) = active.as_mut() {
+                        note_live_transcript(&audio_tap, session, event.data.meeting_id);
+                    }
                     if !config.persist_finals {
                         continue;
                     }
@@ -171,6 +182,16 @@ pub fn start_meeting_streaming_loop(
                     tokio::spawn(async move {
                         persist_live_final_with_retry(db, event.data).await;
                     });
+                }
+                Some(event) = delta_sub.next() => {
+                    if let Some(session) = active.as_mut() {
+                        note_live_transcript(&audio_tap, session, event.data.meeting_id);
+                    }
+                }
+                Some(event) = error_sub.next() => {
+                    if let Some(session) = active.as_mut() {
+                        note_live_transcription_error(&audio_tap, session, &event.data);
+                    }
                 }
                 frame = audio_rx.recv() => {
                     match frame {
@@ -258,7 +279,7 @@ async fn start_streaming_session(
         session_config.provider.supports_live_transcription() && readiness_error.is_none();
     let provider = session_config.provider.as_str().to_string();
     audio_tap.set_active(live_transcription_enabled);
-    audio_tap.set_background_suppressed(live_transcription_enabled);
+    audio_tap.set_background_suppressed(false);
     *active = Some(ActiveMeetingStream {
         meeting_id,
         provider: provider.clone(),
@@ -268,6 +289,8 @@ async fn start_streaming_session(
         audio_frames_seen: 0,
         audio_samples_seen: 0,
         last_audio_activity_at: Instant::now(),
+        live_transcript_seen: false,
+        last_live_transcript_at: None,
         device_senders: HashMap::new(),
         device_retry_after: HashMap::new(),
     });
@@ -464,10 +487,10 @@ fn route_frame_to_provider(
 
     match sender.try_send(frame) {
         Ok(()) => {
-            audio_tap.set_background_suppressed(true);
+            audio_tap.set_background_suppressed(session.live_transcript_seen);
         }
         Err(mpsc::error::TrySendError::Full(_)) => {
-            audio_tap.set_background_suppressed(true);
+            audio_tap.set_background_suppressed(session.live_transcript_seen);
             debug!(
                 "meeting streaming: provider queue full; dropping live audio frame for {}",
                 key
@@ -475,9 +498,9 @@ fn route_frame_to_provider(
         }
         Err(mpsc::error::TrySendError::Closed(_)) => {
             session.device_senders.remove(&key);
-            if session.device_senders.is_empty() {
-                audio_tap.set_background_suppressed(session.live_transcription_enabled);
-            }
+            session.live_transcript_seen = false;
+            session.last_live_transcript_at = None;
+            audio_tap.set_background_suppressed(false);
             session.device_retry_after.insert(
                 key.clone(),
                 Instant::now() + PROVIDER_STREAM_RESTART_BACKOFF,
@@ -489,6 +512,41 @@ fn route_frame_to_provider(
             );
         }
     }
+}
+
+fn note_live_transcript(
+    audio_tap: &MeetingAudioTap,
+    session: &mut ActiveMeetingStream,
+    meeting_id: i64,
+) {
+    if session.meeting_id != meeting_id || !session.live_transcription_enabled {
+        return;
+    }
+
+    session.live_transcript_seen = true;
+    session.last_live_transcript_at = Some(Instant::now());
+    audio_tap.set_background_suppressed(true);
+}
+
+fn note_live_transcription_error(
+    audio_tap: &MeetingAudioTap,
+    session: &mut ActiveMeetingStream,
+    event: &MeetingStreamingError,
+) {
+    if session.meeting_id != event.meeting_id {
+        return;
+    }
+
+    session.live_transcript_seen = false;
+    session.last_live_transcript_at = None;
+    audio_tap.set_background_suppressed(false);
+    emit_status(
+        true,
+        Some(session.meeting_id),
+        &session.provider,
+        session.live_transcription_enabled,
+        Some(event.message.clone()),
+    );
 }
 
 fn device_stream_key(frame: &MeetingAudioFrame) -> String {
@@ -665,6 +723,8 @@ mod tests {
             audio_frames_seen: 0,
             audio_samples_seen: 0,
             last_audio_activity_at: now,
+            live_transcript_seen: false,
+            last_live_transcript_at: None,
             device_senders: HashMap::new(),
             device_retry_after: HashMap::new(),
         }
@@ -676,7 +736,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_ready_session_suppresses_background_recording() {
+    async fn live_ready_session_keeps_background_recording_until_transcript_arrives() {
         let audio_tap = test_audio_tap();
         let transcription_engine = Arc::new(RwLock::new(None));
         let mut active = None;
@@ -703,7 +763,7 @@ mod tests {
         let session = active.expect("active live session");
         assert!(session.live_transcription_enabled);
         assert!(audio_tap.is_active());
-        assert!(audio_tap.background_suppressed());
+        assert!(!audio_tap.background_suppressed());
     }
 
     #[tokio::test]
@@ -761,6 +821,41 @@ mod tests {
             now - LIVE_NO_AUDIO_ACTIVITY_TIMEOUT - Duration::from_secs(1);
 
         assert!(!should_request_auto_end_for_inactivity(&session, now));
+    }
+
+    #[test]
+    fn live_transcript_arrival_suppresses_background_recording() {
+        let audio_tap = test_audio_tap();
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+
+        note_live_transcript(&audio_tap, &mut session, 42);
+
+        assert!(session.live_transcript_seen);
+        assert!(session.last_live_transcript_at.is_some());
+        assert!(audio_tap.background_suppressed());
+    }
+
+    #[tokio::test]
+    async fn live_transcription_error_resumes_background_recording() {
+        let audio_tap = test_audio_tap();
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+        note_live_transcript(&audio_tap, &mut session, 42);
+
+        let event = MeetingStreamingError {
+            meeting_id: 42,
+            provider: "selected-engine".to_string(),
+            model: None,
+            device_name: Some("airpods".to_string()),
+            message: "websocket failed".to_string(),
+            occurred_at: Utc::now(),
+        };
+        note_live_transcription_error(&audio_tap, &mut session, &event);
+
+        assert!(!session.live_transcript_seen);
+        assert!(session.last_live_transcript_at.is_none());
+        assert!(!audio_tap.background_suppressed());
     }
 
     #[tokio::test]

--- a/crates/screenpipe-audio/src/meeting_streaming/events.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/events.rs
@@ -148,7 +148,7 @@ pub struct MeetingStreamingSessionEnded {
     pub audio_samples_seen: u64,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MeetingTranscriptDelta {
     pub meeting_id: i64,
     pub provider: String,
@@ -175,7 +175,7 @@ pub struct MeetingTranscriptFinal {
     pub captured_at: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MeetingStreamingError {
     pub meeting_id: i64,
     pub provider: String,

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1041,27 +1041,6 @@ impl DatabaseManager {
              LEFT JOIN audio_transcriptions at ON ac.id = at.audio_chunk_id
              WHERE at.id IS NULL
                AND ac.timestamp >= ?1
-               AND NOT EXISTS (
-                 SELECT 1
-                 FROM meetings m
-                 WHERE EXISTS (
-                     SELECT 1
-                     FROM meeting_transcript_segments mts
-                     WHERE mts.meeting_id = m.id
-                   )
-                   AND julianday(ac.timestamp) >= julianday(datetime(m.meeting_start, '-60 seconds'))
-                   AND julianday(ac.timestamp) <= julianday(datetime(
-                     COALESCE(
-                       m.meeting_end,
-                       (
-                         SELECT datetime(MAX(mts2.captured_at), '+10 minutes')
-                         FROM meeting_transcript_segments mts2
-                         WHERE mts2.meeting_id = m.id
-                       )
-                     ),
-                     '+60 seconds'
-                   ))
-               )
              ORDER BY ac.timestamp DESC
              LIMIT ?2",
         )
@@ -1092,27 +1071,6 @@ impl DatabaseManager {
                AND ac.timestamp >= ?1
                AND ac.timestamp <= ?2
                AND ac.file_path NOT LIKE 'cloud://%'
-               AND NOT EXISTS (
-                 SELECT 1
-                 FROM meetings m
-                 WHERE EXISTS (
-                     SELECT 1
-                     FROM meeting_transcript_segments mts
-                     WHERE mts.meeting_id = m.id
-                   )
-                   AND julianday(ac.timestamp) >= julianday(datetime(m.meeting_start, '-60 seconds'))
-                   AND julianday(ac.timestamp) <= julianday(datetime(
-                     COALESCE(
-                       m.meeting_end,
-                       (
-                         SELECT datetime(MAX(mts2.captured_at), '+10 minutes')
-                         FROM meeting_transcript_segments mts2
-                         WHERE mts2.meeting_id = m.id
-                       )
-                     ),
-                     '+60 seconds'
-                   ))
-               )
              ORDER BY ac.timestamp ASC
              LIMIT ?3",
         )
@@ -1141,27 +1099,6 @@ impl DatabaseManager {
                AND ac.timestamp >= ?2
                AND ac.timestamp <= ?3
                AND ac.file_path NOT LIKE 'cloud://%'
-               AND NOT EXISTS (
-                 SELECT 1
-                 FROM meetings m
-                 WHERE EXISTS (
-                     SELECT 1
-                     FROM meeting_transcript_segments mts
-                     WHERE mts.meeting_id = m.id
-                   )
-                   AND julianday(ac.timestamp) >= julianday(datetime(m.meeting_start, '-60 seconds'))
-                   AND julianday(ac.timestamp) <= julianday(datetime(
-                     COALESCE(
-                       m.meeting_end,
-                       (
-                         SELECT datetime(MAX(mts2.captured_at), '+10 minutes')
-                         FROM meeting_transcript_segments mts2
-                         WHERE mts2.meeting_id = m.id
-                       )
-                     ),
-                     '+60 seconds'
-                   ))
-               )
              LIMIT 1",
         )
         .bind(chunk_id)
@@ -1186,28 +1123,7 @@ impl DatabaseManager {
              WHERE at.id IS NULL
                AND ac.timestamp >= ?1
                AND ac.timestamp <= ?2
-               AND ac.file_path NOT LIKE 'cloud://%'
-               AND NOT EXISTS (
-                 SELECT 1
-                 FROM meetings m
-                 WHERE EXISTS (
-                     SELECT 1
-                     FROM meeting_transcript_segments mts
-                     WHERE mts.meeting_id = m.id
-                   )
-                   AND julianday(ac.timestamp) >= julianday(datetime(m.meeting_start, '-60 seconds'))
-                   AND julianday(ac.timestamp) <= julianday(datetime(
-                     COALESCE(
-                       m.meeting_end,
-                       (
-                         SELECT datetime(MAX(mts2.captured_at), '+10 minutes')
-                         FROM meeting_transcript_segments mts2
-                         WHERE mts2.meeting_id = m.id
-                       )
-                     ),
-                     '+60 seconds'
-                   ))
-               )",
+               AND ac.file_path NOT LIKE 'cloud://%'",
         )
         .bind(since)
         .bind(older_than)
@@ -8317,13 +8233,6 @@ LIMIT ? OFFSET ?
                 FROM meetings
                 WHERE id = ?1
             ),
-            live_bounds AS (
-                SELECT
-                    MIN(julianday(captured_at)) AS first_live_at_jd,
-                    MAX(julianday(captured_at)) AS last_live_at_jd
-                FROM meeting_transcript_segments
-                WHERE meeting_id = ?1
-            ),
             live_segments AS (
                 SELECT
                     id,
@@ -8370,17 +8279,11 @@ LIMIT ? OFFSET ?
                 JOIN audio_chunks ac ON ac.id = at.audio_chunk_id
                 JOIN meeting_window mw ON 1 = 1
                 LEFT JOIN speakers s ON s.id = at.speaker_id
-                CROSS JOIN live_bounds lb
                 WHERE julianday(at.timestamp) >= julianday(mw.meeting_start)
                   AND julianday(at.timestamp) <= julianday(mw.meeting_end)
                   AND TRIM(at.transcription) != ''
                   AND ac.file_path NOT LIKE 'cloud://%'
                   AND (s.id IS NULL OR s.hallucination = 0)
-                  AND NOT (
-                      lb.first_live_at_jd IS NOT NULL
-                      AND julianday(at.timestamp) >= lb.first_live_at_jd - (60.0 / 86400.0)
-                      AND julianday(at.timestamp) <= lb.last_live_at_jd + (60.0 / 86400.0)
-                  )
             )
             SELECT * FROM (
                 SELECT * FROM live_segments

--- a/crates/screenpipe-db/tests/untranscribed_chunks_test.rs
+++ b/crates/screenpipe-db/tests/untranscribed_chunks_test.rs
@@ -196,7 +196,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_live_meeting_transcript_skips_background_reconciliation() {
+    async fn test_live_meeting_transcript_does_not_block_background_reconciliation() {
         let db = setup_test_db().await;
 
         let ts = Utc::now() - Duration::minutes(1);
@@ -239,8 +239,8 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            candidates.iter().all(|c| c.id != chunk),
-            "background reconciliation should skip chunks covered by live meeting streaming"
+            candidates.iter().any(|c| c.id == chunk),
+            "partial live meeting transcript should not block background recovery"
         );
 
         let background_count: i64 = sqlx::query_scalar(
@@ -254,7 +254,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_ongoing_live_meeting_transcript_skips_background_reconciliation() {
+    async fn test_ongoing_live_meeting_transcript_does_not_block_background_reconciliation() {
         let db = setup_test_db().await;
 
         let ts = Utc::now() - Duration::minutes(30);
@@ -294,8 +294,8 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            candidates.iter().all(|c| c.id != chunk),
-            "background reconciliation should skip chunks from an ongoing live meeting"
+            candidates.iter().any(|c| c.id == chunk),
+            "ongoing live meeting transcript should not block old chunks from background recovery"
         );
     }
 
@@ -453,6 +453,7 @@ mod tests {
             vec![
                 "background before live",
                 "live meeting text",
+                "background duplicate near live",
                 "background after live"
             ]
         );
@@ -469,12 +470,10 @@ mod tests {
         assert_eq!(rows[1].speaker_name.as_deref(), Some("Louis"));
 
         assert_eq!(rows[2].source, "background");
-        assert_eq!(rows[2].audio_chunk_id, Some(after_chunk));
-        assert!(
-            rows.iter()
-                .all(|row| row.transcript != "background duplicate near live"),
-            "background rows inside the live capture window should not duplicate live transcript"
-        );
+        assert_eq!(rows[2].audio_chunk_id, Some(overlap_chunk));
+
+        assert_eq!(rows[3].source, "background");
+        assert_eq!(rows[3].audio_chunk_id, Some(after_chunk));
     }
 
     #[tokio::test]

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -541,15 +541,18 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
 
     // Audio degradation: chunks_channel_full > 0 means the Whisper consumer
     // couldn't keep up and audio was dropped even after a 30s backpressure wait.
+    // A reconciliation backlog means audio exists but transcript has not landed
+    // yet, which should be visible instead of reported as healthy.
     let audio_degraded = if !state.audio_disabled && audio_snap.uptime_secs > 120.0 {
         let channel_full = audio_snap.chunks_channel_full > 0;
+        let transcription_backlog = pending_transcription_segments.is_some();
         if channel_full {
             warn!(
                 "health_check: {} audio chunk(s) dropped (transcription engine too slow)",
                 audio_snap.chunks_channel_full
             );
         }
-        channel_full || audio_db_write_stalled
+        channel_full || audio_db_write_stalled || transcription_backlog
     } else {
         false
     };
@@ -623,6 +626,12 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
                 detail_parts.push(format!(
                     "audio transcription writes stalled for {}s — audio captured, transcription not landing",
                     now_ts.saturating_sub(audio_snap.last_db_write_ts)
+                ));
+            }
+            if let Some(count) = pending_transcription_segments {
+                detail_parts.push(format!(
+                    "{} audio segment(s) waiting for background transcription",
+                    count
                 ));
             }
         }


### PR DESCRIPTION
### Description: 

<img width="1623" height="677" alt="image" src="https://github.com/user-attachments/assets/906a8ba3-d644-492c-b703-6b06b6ecd9c2" />


<img width="1612" height="621" alt="image" src="https://github.com/user-attachments/assets/6098c467-a848-4737-b7e2-fe36e4b91da1" />




Fixes a meeting transcription failure mode where live STT could fail while Screenpipe still showed recording/audio as healthy and failed to recover most of the transcript.

This keeps background transcription available until live STT is actually producing transcript output, resumes recovery when live STT errors, and makes Meeting Notes show both live and recovered background transcript rows.

### Changes

- Do not suppress background transcription when live meeting STT is merely configured.
- Suppress background transcription only after a real live transcript delta/final arrives.
- Resume background transcription when live STT errors or provider streams close.
- Allow reconciliation to recover untranscribed meeting audio even when partial live transcript rows exist.
- Merge live meeting transcript rows with recovered background transcript rows in Meeting Notes.
- Show a Meeting Notes recovery warning when live transcription fails.
- Mark `/health` degraded when old audio segments are waiting for background transcription.