### PR TITLE
feat: browser session reuse on windows + smarter extension popup

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -28,19 +28,25 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { KeyRound, RotateCw, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { platform as getPlatform } from "@tauri-apps/plugin-os";
+import { ExternalLink, KeyRound, Loader2, RotateCw, PanelRightClose, PanelRightOpen } from "lucide-react";
 import {
   loadConversationFile,
   updateConversationFlags,
 } from "@/lib/chat-storage";
 import { Button } from "@/components/ui/button";
+import { localFetch } from "@/lib/api";
 
 const NAVIGATE_EVENT = "owned-browser:navigate";
 const SESSION_ACCESS_REQUEST_EVENT = "owned-browser:session-access-request";
+const V20_COOKIE_BLOCK_EVENT = "owned-browser:v20-cookie-blocked";
 const STATE_EVENT = "owned-browser:state";
 const DEFAULT_WIDTH = 480;
 const MIN_WIDTH = 320;
 const MIN_CHAT_WIDTH = 360;
+const CHROME_WEBSTORE_URL =
+  "https://chromewebstore.google.com/search/screenpipe%20browser%20bridge";
 
 interface BrowserSidebarProps {
   conversationId: string | null;
@@ -57,6 +63,25 @@ interface ActiveSessionAccessRequest {
   requestId: string;
   url: string;
   host: string;
+}
+
+interface V20CookieBlockEvent {
+  url: string;
+  host: string;
+  rows: number;
+  v20Count?: number;
+  v20_count?: number;
+  sources?: string[];
+  reason?: string;
+}
+
+interface ActiveV20CookieBlock {
+  url: string;
+  host: string;
+  rows: number;
+  v20Count: number;
+  sources: string[];
+  reason: string;
 }
 
 interface OwnedBrowserStateEvent {
@@ -87,6 +112,10 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
   const [sessionAccessAnswer, setSessionAccessAnswer] = useState<
     "allow" | "deny" | null
   >(null);
+  const [v20CookieBlock, setV20CookieBlock] =
+    useState<ActiveV20CookieBlock | null>(null);
+  const [extensionConnected, setExtensionConnected] = useState(false);
+  const [isMac, setIsMac] = useState(false);
   const [requestedWidth, setRequestedWidth] = useState(DEFAULT_WIDTH);
   // `availableW` = the width of the panel's flex parent (the host marked
   // with data-browser-panel-host in standalone-chat.tsx). That's the real
@@ -108,6 +137,14 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
 
   const effectiveWidth = clampWidth(requestedWidth, availableW);
   const panelOpen = visible && !collapsed && effectiveWidth > 0;
+
+  useEffect(() => {
+    try {
+      setIsMac(getPlatform() === "macos");
+    } catch {
+      // plugin unavailable in web dev mode
+    }
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Persistence
@@ -239,6 +276,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
       if (!url) return;
       setSessionAccessRequest(null);
       setSessionAccessAnswer(null);
+      setV20CookieBlock(null);
       setVisible(true);
       setCollapsed(false);
       setCurrentUrl(url);
@@ -265,6 +303,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
         };
         setSessionAccessRequest(request);
         setSessionAccessAnswer(null);
+        setV20CookieBlock(null);
         setVisible(true);
         setCollapsed(false);
         setCurrentUrl(request.url);
@@ -280,13 +319,84 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
   }, [persistState]);
 
   useEffect(() => {
-    sessionAccessActiveRef.current = sessionAccessRequest !== null;
-    if (sessionAccessRequest) {
+    const unlistenPromise = listen<V20CookieBlockEvent>(
+      V20_COOKIE_BLOCK_EVENT,
+      (e) => {
+        const payload = e.payload;
+        if (!payload?.url || !payload?.host) return;
+        const block = {
+          url: payload.url,
+          host: payload.host,
+          rows: payload.rows ?? 0,
+          v20Count: payload.v20Count ?? payload.v20_count ?? 0,
+          sources: payload.sources ?? [],
+          reason: payload.reason ?? "v20",
+        };
+        setSessionAccessRequest(null);
+        setSessionAccessAnswer(null);
+        setV20CookieBlock(block);
+        setVisible(true);
+        setCollapsed(false);
+        setCurrentUrl(block.url);
+        setCurrentTitle(null);
+        setLoading(false);
+        persistState({ url: block.url, collapsed: false });
+        invoke("owned_browser_hide").catch(() => {});
+      },
+    );
+    return () => {
+      unlistenPromise.then((fn) => fn()).catch(() => {});
+    };
+  }, [persistState]);
+
+  useEffect(() => {
+    sessionAccessActiveRef.current =
+      sessionAccessRequest !== null || v20CookieBlock !== null;
+    if (sessionAccessRequest || v20CookieBlock) {
       invoke("owned_browser_hide").catch(() => {});
     } else if (panelOpen) {
       schedulePushBounds();
     }
-  }, [sessionAccessRequest, panelOpen, schedulePushBounds]);
+  }, [sessionAccessRequest, v20CookieBlock, panelOpen, schedulePushBounds]);
+
+  // While the locked/v20 block card is visible, poll extension status every 2s.
+  // When the extension connects, auto-retry navigation and dismiss the card.
+  useEffect(() => {
+    if (!v20CookieBlock) {
+      setExtensionConnected(false);
+      return;
+    }
+    const retryUrl = v20CookieBlock.url;
+    let cancelled = false;
+
+    const check = async () => {
+      try {
+        const r = await localFetch("/connections/browser/status");
+        if (!r.ok || cancelled) return;
+        const data: { connected?: boolean } = await r.json();
+        if (data.connected) {
+          setExtensionConnected(true);
+          if (!cancelled) {
+            // Extension is now connected — retry the navigation, which will
+            // go through the extension cookie path.
+            setV20CookieBlock(null);
+            invoke("owned_browser_navigate", { url: retryUrl }).catch(() => {});
+          }
+        } else {
+          setExtensionConnected(false);
+        }
+      } catch {
+        // Server not reachable yet, ignore.
+      }
+    };
+
+    check();
+    const t = setInterval(check, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [v20CookieBlock]);
 
   useEffect(() => {
     const unlistenPromise = listen<OwnedBrowserStateEvent>(STATE_EVENT, (e) => {
@@ -327,6 +437,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
       setLoading(false);
       setSessionAccessRequest(null);
       setSessionAccessAnswer(null);
+      setV20CookieBlock(null);
       setRequestedWidth(DEFAULT_WIDTH);
       invoke("owned_browser_hide").catch(() => {});
       return () => {
@@ -375,6 +486,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
         setCurrentUrl(null);
         setCurrentTitle(null);
         setLoading(false);
+        setV20CookieBlock(null);
         invoke("owned_browser_hide").catch(() => {});
       }
     })();
@@ -581,7 +693,9 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
           <div
             ref={placeholderRef}
             className="flex-1 bg-background relative"
-            aria-hidden={sessionAccessRequest ? true : undefined}
+            aria-hidden={
+              sessionAccessRequest || v20CookieBlock ? true : undefined
+            }
           />
           {sessionAccessRequest && (
             <div className="absolute inset-0 z-40 flex items-center justify-center bg-background p-4">
@@ -604,10 +718,12 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                     your browser so the agent opens this site already signed
                     in. It does not read saved passwords.
                   </p>
-                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                    If you allow it, macOS may ask for access to browser safe
-                    storage next.
-                  </p>
+                  {isMac && (
+                    <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                      If you allow it, macOS may ask for access to browser safe
+                      storage next.
+                    </p>
+                  )}
                   <div className="mt-4 flex flex-col gap-2">
                     <Button
                       size="sm"
@@ -616,7 +732,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                       className="w-full"
                     >
                       {sessionAccessAnswer === "allow"
-                        ? "Waiting for macOS"
+                        ? isMac ? "Waiting for macOS…" : "Applying…"
                         : "Use browser session"}
                     </Button>
                     <Button
@@ -627,6 +743,89 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                       className="w-full"
                     >
                       Continue logged out
+                    </Button>
+                  </div>
+                </div>
+            </div>
+          )}
+          {v20CookieBlock && (
+            <div className="absolute inset-0 z-40 flex items-center justify-center bg-background p-4">
+                <div className="w-full max-w-sm border border-border bg-card p-4 shadow-sm">
+                  <div className="mb-3 flex items-start gap-3">
+                    <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center border border-border bg-muted text-foreground">
+                      <KeyRound className="h-4 w-4" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-foreground">
+                        Browser login is protected
+                      </div>
+                      <div className="mt-1 break-all text-xs text-muted-foreground">
+                        {v20CookieBlock.host}
+                      </div>
+                    </div>
+                  </div>
+                  {v20CookieBlock.reason === "locked" ? (
+                    <>
+                      <p className="text-xs leading-5 text-muted-foreground">
+                        {v20CookieBlock.sources.length > 0
+                          ? v20CookieBlock.sources.join(", ")
+                          : "Your browser"}{" "}
+                        is running and holds an exclusive lock on its cookie
+                        database. Screenpipe cannot read it while the browser is
+                        open.
+                      </p>
+                      <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                        Connect the Screenpipe Browser Bridge extension to share
+                        this login directly — no passwords, no closing your
+                        browser.
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-xs leading-5 text-muted-foreground">
+                        Chrome or Edge has matching session cookies, but Windows
+                        app-bound encryption prevents Screenpipe from reusing
+                        them directly.
+                      </p>
+                      <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                        Connect the Screenpipe Browser Bridge extension to reuse
+                        this login without sharing passwords.
+                      </p>
+                      <div className="mt-3 text-[11px] leading-4 text-muted-foreground">
+                        Found {v20CookieBlock.v20Count || v20CookieBlock.rows}{" "}
+                        protected cookies
+                        {v20CookieBlock.sources.length > 0
+                          ? ` in ${v20CookieBlock.sources.join(", ")}`
+                          : ""}
+                        .
+                      </div>
+                    </>
+                  )}
+                  <div className="mt-4 flex flex-col gap-2">
+                    {extensionConnected ? (
+                      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        Extension connected — retrying…
+                      </div>
+                    ) : (
+                      <Button
+                        size="sm"
+                        onClick={() => {
+                          openUrl(CHROME_WEBSTORE_URL).catch(() => {});
+                        }}
+                        className="w-full"
+                      >
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                        Connect extension
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setV20CookieBlock(null)}
+                      className="w-full"
+                    >
+                      Dismiss
                     </Button>
                   </div>
                 </div>

--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -825,7 +825,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                       onClick={() => setV20CookieBlock(null)}
                       className="w-full"
                     >
-                      Dismiss
+                      Continue without signing in
                     </Button>
                   </div>
                 </div>

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -200,8 +200,11 @@ lazy_static = "1.5.0"
 image = "0.25.5"
 windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git" }
 base64 = "0.22.1"
+aes-gcm = "0.10"
+rusqlite = { version = "0.29.0", features = ["bundled"] }
 raw-window-handle = "0.6"
 webview2-com = "=0.38.2"
+windows-core = "0.61.2"
 windows = { version = "0.58", features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -73,6 +73,7 @@ const READY_EVENT: &str = "owned-browser:ready";
 /// user's real browser. The sidebar answers through the
 /// `owned_browser_resolve_session_access` command.
 const SESSION_ACCESS_REQUEST_EVENT: &str = "owned-browser:session-access-request";
+const V20_COOKIE_BLOCK_EVENT: &str = "owned-browser:v20-cookie-blocked";
 const SESSION_ACCESS_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Marker prefix for `document.title`-based result delivery. The bridge JS
@@ -126,6 +127,19 @@ struct BrowserSessionAccessRequestPayload {
     request_id: String,
     url: String,
     host: String,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct V20CookieBlockPayload {
+    url: String,
+    host: String,
+    rows: usize,
+    v20_count: usize,
+    sources: Vec<String>,
+    /// "v20" = app-bound encryption blocked decrypt; "locked" = browser running, DB inaccessible
+    #[serde(default)]
+    reason: String,
 }
 
 static SESSION_ACCESS_PENDING: OnceLock<
@@ -702,12 +716,7 @@ async fn prepare_navigation(app: &AppHandle, state: &OwnedBrowserState, parsed: 
     // Provisional omnibox URL while a top-level navigation is in flight
     // (agent or sidebar initiated). Committed URL comes from `webview.url()`
     // on main-document load finish / title change.
-    emit_state_event(
-        app,
-        Some(parsed.as_str().to_string()),
-        None,
-        Some(true),
-    );
+    emit_state_event(app, Some(parsed.as_str().to_string()), None, Some(true));
     let _ = app.emit(NAVIGATE_EVENT, parsed.as_str());
     state.store_pending_url(parsed.clone()).await;
 }
@@ -834,15 +843,91 @@ async fn inject_cookies_for_url(app: &AppHandle, url: &url::Url) {
     }
 
     info!(host, "owned-browser cookies: pre-navigate inject starting");
-    let cookies = crate::owned_browser_cookies::cookies_for_host(host).await;
+    let mut cookies = crate::owned_browser_cookies::cookies_for_host(host).await;
     if cookies.is_empty() {
-        info!(
-            host,
-            "owned-browser cookies: 0 cookies available — navigating without inject \
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(block) = crate::owned_browser_cookies::v20_cookie_block_for_host(host).await {
+                // App-bound encrypted (v20) cookies — try extension first.
+                match extension_cookies_for_host(app, host).await {
+                    Ok(extension_cookies) if !extension_cookies.is_empty() => {
+                        info!(
+                            host,
+                            count = extension_cookies.len(),
+                            "owned-browser cookies: using extension fallback for v20 cookies"
+                        );
+                        cookies = extension_cookies;
+                    }
+                    Ok(_) => {
+                        info!(
+                            host,
+                            "owned-browser cookies: extension fallback returned no cookies for v20"
+                        );
+                    }
+                    Err(e) => {
+                        info!(
+                            host,
+                            "owned-browser cookies: extension fallback unavailable for v20 — {e}"
+                        );
+                    }
+                }
+                if cookies.is_empty() {
+                    // Extension couldn't supply cookies — show the v20 card.
+                    let payload = V20CookieBlockPayload {
+                        url: url.as_str().to_string(),
+                        host: block.host,
+                        rows: block.rows,
+                        v20_count: block.v20_count,
+                        sources: block.sources,
+                        reason: "v20".to_string(),
+                    };
+                    if let Err(e) = app.emit(V20_COOKIE_BLOCK_EVENT, payload) {
+                        warn!("owned-browser cookies: failed to emit v20 block event: {e}");
+                    }
+                    return;
+                }
+            } else if crate::owned_browser_cookies::locked_browser_block_for_host(host)
+                .await
+                .is_some()
+            {
+                // DB locked (browser running) — browser_session_decision_for_url already
+                // confirmed the extension is connected before returning UseBrowserSession,
+                // so go straight to the extension cookie path.
+                match extension_cookies_for_host(app, host).await {
+                    Ok(extension_cookies) if !extension_cookies.is_empty() => {
+                        info!(
+                            host,
+                            count = extension_cookies.len(),
+                            "owned-browser cookies: using extension cookies (browser DB locked)"
+                        );
+                        cookies = extension_cookies;
+                    }
+                    Ok(_) => {
+                        info!(
+                            host,
+                            "owned-browser cookies: extension returned no cookies for locked browser"
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        info!(
+                            host,
+                            "owned-browser cookies: extension unavailable for locked browser — {e}"
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+        if cookies.is_empty() {
+            info!(
+                host,
+                "owned-browser cookies: 0 cookies available — navigating without inject \
              (causes: real browser not installed, Keychain denied, or no cookies stored \
              for this host yet)"
-        );
-        return;
+            );
+            return;
+        }
     }
     info!(
         host,
@@ -859,21 +944,165 @@ async fn inject_cookies_for_url(app: &AppHandle, url: &url::Url) {
             "owned-browser cookies: WKHTTPCookieStore.setCookie completed"
         );
     }
-    #[cfg(not(target_os = "macos"))]
-    let _ = (app, &cookies); // until Windows/Linux injectors land
+    #[cfg(target_os = "windows")]
+    {
+        let n = inject_cookies_windows(app, &cookies).await;
+        info!(
+            host,
+            attempted = cookies.len(),
+            injected = n,
+            "owned-browser cookies: WebView2 CookieManager.AddOrUpdateCookie completed"
+        );
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let _ = (app, &cookies); // until Linux injector lands
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExtensionCookie {
+    name: String,
+    value: String,
+    domain: String,
+    path: String,
+    secure: bool,
+    http_only: bool,
+    expires_at: Option<i64>,
+    same_site: Option<String>,
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, serde::Deserialize)]
+struct ExtensionCookieResult {
+    cookies: Vec<ExtensionCookie>,
+}
+
+#[cfg(target_os = "windows")]
+#[derive(Debug, serde::Deserialize)]
+struct ExtensionCookieResponse {
+    success: bool,
+    result: Option<ExtensionCookieResult>,
+    error: Option<String>,
+}
+
+#[cfg(target_os = "windows")]
+async fn is_extension_connected(app: &AppHandle) -> bool {
+    let api = crate::recording::local_api_context_from_app(app);
+    let client = reqwest::Client::new();
+    let request = client.get(api.url("/connections/browser/status"));
+    let request = api.apply_auth(request);
+    match request.send().await {
+        Ok(resp) if resp.status().is_success() => resp
+            .json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|v| v.get("connected")?.as_bool())
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn extension_cookies_for_host(
+    app: &AppHandle,
+    host: &str,
+) -> Result<Vec<crate::owned_browser_cookies::Cookie>, String> {
+    let api = crate::recording::local_api_context_from_app(app);
+    let client = reqwest::Client::new();
+    let request = client
+        .post(api.url("/connections/browser/cookies"))
+        .json(&serde_json::json!({
+            "host": host,
+            "timeout_secs": 5,
+        }));
+    let request = api.apply_auth(request);
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| format!("extension cookie request failed: {e}"))?;
+    let status = response.status();
+    let body = response
+        .json::<ExtensionCookieResponse>()
+        .await
+        .map_err(|e| format!("extension cookie response parse failed: {e}"))?;
+
+    if !status.is_success() || !body.success {
+        return Err(body
+            .error
+            .unwrap_or_else(|| format!("extension cookie request returned HTTP {status}")));
+    }
+
+    let Some(result) = body.result else {
+        return Ok(Vec::new());
+    };
+
+    Ok(result
+        .cookies
+        .into_iter()
+        .map(|c| crate::owned_browser_cookies::Cookie {
+            name: c.name,
+            value: c.value,
+            domain: c.domain,
+            path: if c.path.is_empty() {
+                "/".to_string()
+            } else {
+                c.path
+            },
+            secure: c.secure,
+            http_only: c.http_only,
+            expires_at: c.expires_at,
+            same_site: match c.same_site.as_deref() {
+                Some("no_restriction") => 0,
+                Some("lax") => 1,
+                Some("strict") => 2,
+                _ => -1,
+            },
+        })
+        .collect())
 }
 
 async fn browser_session_decision_for_url(
     app: &AppHandle,
     url: &url::Url,
 ) -> BrowserSessionDecision {
-    let _ = app;
     let Some(host) = url.host_str() else {
         return BrowserSessionDecision::ContinueLoggedOut;
     };
     let host_key = session_host_key(host);
 
     if !crate::owned_browser_cookies::has_cookies_for_host(&host_key).await {
+        // Browser may be running with its DB locked.
+        #[cfg(target_os = "windows")]
+        if let Some(block) =
+            crate::owned_browser_cookies::locked_browser_block_for_host(&host_key).await
+        {
+            // If the Screenpipe Browser Bridge extension is already connected,
+            // skip the card entirely and let inject_cookies_for_url use the
+            // extension's cookie API instead. This also prevents the retry loop:
+            // when the frontend detects extension connected and re-calls navigate,
+            // we go straight to UseBrowserSession here instead of emitting the
+            // card event again.
+            if is_extension_connected(app).await {
+                info!(
+                    host = host_key.as_str(),
+                    "owned-browser: browser DB locked but extension is connected — using extension cookies"
+                );
+                return BrowserSessionDecision::UseBrowserSession;
+            }
+            let payload = V20CookieBlockPayload {
+                url: url.as_str().to_string(),
+                host: block.host,
+                rows: 0,
+                v20_count: 0,
+                sources: block.sources,
+                reason: "locked".to_string(),
+            };
+            if let Err(e) = app.emit(V20_COOKIE_BLOCK_EVENT, payload) {
+                warn!("owned-browser: failed to emit locked-browser event: {e}");
+            }
+        }
         return BrowserSessionDecision::ContinueLoggedOut;
     }
 
@@ -903,7 +1132,10 @@ async fn browser_session_decision_for_url(
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
-    session_access_in_flight().lock().await.insert(host_key.clone());
+    session_access_in_flight()
+        .lock()
+        .await
+        .insert(host_key.clone());
 
     let state = browser_state();
     if let Some(active) = state.active().await {
@@ -1084,6 +1316,140 @@ async fn inject_cookies_macos(
     // Tiny grace period so the WKHTTPCookieStore's own async commit to
     // its on-disk store flushes before the upcoming navigate fires its
     // request. Empirically <10ms; 50 covers slow startups.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    injected
+}
+
+/// Windows only: push real-browser cookies into the owned WebView2 instance
+/// before navigate. WebView2 exposes this through `ICoreWebView2_2`'s
+/// CookieManager; Tauri gives us the raw controller via `Webview::with_webview`.
+#[cfg(target_os = "windows")]
+async fn inject_cookies_windows(
+    app: &AppHandle,
+    cookies: &[crate::owned_browser_cookies::Cookie],
+) -> usize {
+    use webview2_com::Microsoft::Web::WebView2::Win32::{
+        ICoreWebView2_2, COREWEBVIEW2_COOKIE_SAME_SITE_KIND_LAX,
+        COREWEBVIEW2_COOKIE_SAME_SITE_KIND_NONE, COREWEBVIEW2_COOKIE_SAME_SITE_KIND_STRICT,
+    };
+    use windows_core::{Interface, HSTRING};
+
+    let Some(webview) = browser_state().active().await else {
+        warn!("owned-browser cookies: WebView2 inject skipped — no active owned browser");
+        return 0;
+    };
+
+    let cookies = cookies.to_vec();
+    let (tx, rx) = tokio::sync::oneshot::channel::<usize>();
+    let app = app.clone();
+    let tx = std::sync::Arc::new(std::sync::Mutex::new(Some(tx)));
+    let tx_for_main = tx.clone();
+    if let Err(e) = app.run_on_main_thread(move || {
+        let tx = tx_for_main;
+        let tx_for_webview = tx.clone();
+        if let Err(e) = webview.with_webview(move |platform| {
+            let mut injected: usize = 0;
+            let result: Result<(), String> = (|| unsafe {
+                let controller = platform.controller();
+                let webview = controller
+                    .CoreWebView2()
+                    .map_err(|e| format!("CoreWebView2: {e}"))?;
+                let webview: ICoreWebView2_2 = webview
+                    .cast()
+                    .map_err(|e| format!("ICoreWebView2_2: {e}"))?;
+                let cookie_manager = webview
+                    .CookieManager()
+                    .map_err(|e| format!("CookieManager: {e}"))?;
+
+                for c in &cookies {
+                    let path = if c.path.is_empty() { "/" } else { &c.path };
+                    let name = HSTRING::from(&c.name);
+                    let value = HSTRING::from(&c.value);
+                    let domain = HSTRING::from(&c.domain);
+                    let path = HSTRING::from(path);
+                    let cookie = match cookie_manager.CreateCookie(&name, &value, &domain, &path) {
+                        Ok(cookie) => cookie,
+                        Err(e) => {
+                            debug!(
+                                name = c.name.as_str(),
+                                "owned-browser cookies: CreateCookie failed: {e}"
+                            );
+                            continue;
+                        }
+                    };
+
+                    if let Some(secs) = c.expires_at {
+                        if let Err(e) = cookie.SetExpires(secs as f64) {
+                            debug!(
+                                name = c.name.as_str(),
+                                "owned-browser cookies: SetExpires failed: {e}"
+                            );
+                        }
+                    }
+                    if let Err(e) = cookie.SetIsHttpOnly(c.http_only) {
+                        debug!(
+                            name = c.name.as_str(),
+                            "owned-browser cookies: SetIsHttpOnly failed: {e}"
+                        );
+                    }
+                    if let Err(e) = cookie.SetIsSecure(c.secure) {
+                        debug!(
+                            name = c.name.as_str(),
+                            "owned-browser cookies: SetIsSecure failed: {e}"
+                        );
+                    }
+                    let same_site = match c.same_site {
+                        0 => Some(COREWEBVIEW2_COOKIE_SAME_SITE_KIND_NONE),
+                        1 => Some(COREWEBVIEW2_COOKIE_SAME_SITE_KIND_LAX),
+                        2 => Some(COREWEBVIEW2_COOKIE_SAME_SITE_KIND_STRICT),
+                        _ => None,
+                    };
+                    if let Some(same_site) = same_site {
+                        if let Err(e) = cookie.SetSameSite(same_site) {
+                            debug!(
+                                name = c.name.as_str(),
+                                "owned-browser cookies: SetSameSite failed: {e}"
+                            );
+                        }
+                    }
+
+                    match cookie_manager.AddOrUpdateCookie(&cookie) {
+                        Ok(()) => injected += 1,
+                        Err(e) => debug!(
+                            name = c.name.as_str(),
+                            "owned-browser cookies: AddOrUpdateCookie failed: {e}"
+                        ),
+                    }
+                }
+                Ok(())
+            })();
+
+            if let Err(e) = result {
+                warn!("owned-browser cookies: WebView2 inject failed: {e}");
+            }
+            if let Ok(mut tx) = tx_for_webview.lock() {
+                if let Some(tx) = tx.take() {
+                    let _ = tx.send(injected);
+                }
+            }
+        }) {
+            warn!("owned-browser cookies: WebView2 with_webview failed: {e}");
+            if let Ok(mut tx) = tx.lock() {
+                if let Some(tx) = tx.take() {
+                    let _ = tx.send(0);
+                }
+            }
+        }
+    }) {
+        warn!("owned-browser cookies: run_on_main_thread failed: {e}");
+        if let Ok(mut tx) = tx.lock() {
+            if let Some(tx) = tx.take() {
+                let _ = tx.send(0);
+            }
+        }
+    }
+
+    let injected = rx.await.unwrap_or(0);
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     injected
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -1110,6 +1110,16 @@ async fn browser_session_decision_for_url(
         return BrowserSessionDecision::UseBrowserSession;
     }
 
+    // On Windows there is no OS-level permission dialog (unlike macOS Keychain),
+    // so we don't need an explicit consent step. DPAPI cookies inject silently;
+    // if they are v20-encrypted inject_cookies_for_url will show the single
+    // "Browser login is protected" card which already acts as consent + setup.
+    // SESSION_ACCESS_ALLOWED is a macOS-only concept (remembers "user clicked
+    // allow" to skip the Keychain consent dialog next time) — we don't store
+    // anything on Windows because there is no dialog to skip.
+    #[cfg(target_os = "windows")]
+    return BrowserSessionDecision::UseBrowserSession;
+
     // Agent may navigate the same host repeatedly while the first prompt is open.
     let wait_deadline = Instant::now() + SESSION_ACCESS_TIMEOUT;
     loop {

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser_cookies.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser_cookies.rs
@@ -20,8 +20,9 @@
 //!
 //! ## Currently supports
 //!
-//! - macOS only.
-//! - Chrome / Brave / Edge / Arc default profiles.
+//! - macOS and Windows.
+//! - macOS: Chrome / Brave / Edge / Arc default profiles.
+//! - Windows: Chrome / Edge / Brave / Chromium / Vivaldi / Opera default profiles.
 //! - Default profile only. Arc's Spaces / Chrome's profiles are picked
 //!   up the day a user reports they need a non-default one.
 //!
@@ -57,21 +58,20 @@
 
 // Cross-platform module shape: the `Cookie` struct and the public
 // `cookies_for_host` entry point compile on every OS. The actual
-// readers + decryption are gated to macOS for now; Windows / Linux
-// fall through to a stub that returns an empty Vec, so the rest of
+// readers + decryption are gated per platform; Linux still falls
+// through to a stub that returns an empty Vec, so the rest of
 // the codebase can call `cookies_for_host` unconditionally without
-// per-cfg branching at the call site. Adding Windows or Linux is a
-// matter of dropping in the platform-specific reader at the bottom
-// of this file — see the TODO comments there.
+// per-cfg branching at the call site. Adding Linux is a matter of
+// dropping in the platform-specific reader at the bottom of this file.
 
 use std::time::{Duration, Instant};
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::path::PathBuf;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::sync::OnceLock;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
@@ -79,7 +79,7 @@ use tracing::{debug, info, warn};
 use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit};
 #[cfg(target_os = "macos")]
 use hmac::Hmac;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use rusqlite::OpenFlags;
 #[cfg(target_os = "macos")]
 use security_framework::passwords::get_generic_password;
@@ -109,6 +109,27 @@ pub struct Cookie {
     pub same_site: i32,
 }
 
+/// Windows-only diagnostic state for hosts whose matching real-browser
+/// cookies are present but protected by Chromium App-Bound Encryption (`v20`).
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone)]
+pub struct V20CookieBlock {
+    pub host: String,
+    pub rows: usize,
+    pub v20_count: usize,
+    pub sources: Vec<String>,
+}
+
+/// A browser whose Cookies SQLite file is locked (i.e. the browser is running
+/// and has an exclusive hold on the file). Different from v20 — the cookies
+/// exist and may be decryptable, but we can't open the database at all.
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone)]
+pub struct LockedBrowserBlock {
+    pub host: String,
+    pub sources: Vec<String>,
+}
+
 /// Public entry: fetch every cookie that would be sent to `host`,
 /// merged across every browser source the platform supports. Returns
 /// an empty Vec on platforms where the source readers haven't been
@@ -130,21 +151,24 @@ pub async fn has_cookies_for_host(host: &str) -> bool {
     has_cookies_for_host_impl(host).await
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
+pub async fn v20_cookie_block_for_host(host: &str) -> Option<V20CookieBlock> {
+    v20_cookie_blocks()
+        .lock()
+        .ok()
+        .and_then(|blocks| blocks.get(host).cloned())
+}
+
+#[cfg(target_os = "windows")]
+pub async fn locked_browser_block_for_host(host: &str) -> Option<LockedBrowserBlock> {
+    locked_browser_blocks()
+        .lock()
+        .ok()
+        .and_then(|blocks| blocks.get(host).cloned())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 async fn cookies_for_host_impl(_host: &str) -> Vec<Cookie> {
-    // Windows TODO: Chromium-on-Windows stores cookies at
-    //   %LOCALAPPDATA%\<browser>\User Data\Default\Network\Cookies
-    // The encrypted_value uses AES-256-GCM (NOT 128-CBC like macOS); the
-    // 32-byte AES key is itself DPAPI-protected and lives base64'd in the
-    // sibling `Local State` JSON's `os_crypt.encrypted_key` field.
-    // Decrypt with `windows::Win32::Security::Cryptography::CryptUnprotectData`,
-    // strip the "DPAPI" prefix, then `aes-gcm` over the 12-byte nonce +
-    // ciphertext that follows the literal "v10"/"v11" prefix on each
-    // cookie value. WebView2 cookie injection is via
-    // `ICoreWebView2CookieManager.AddOrUpdateCookie` from the COM
-    // controller — Tauri exposes the underlying `WebView2` via
-    // `WebviewWindow::with_webview`.
-    //
     // Linux TODO: Chromium-on-Linux stores cookies at
     //   ~/.config/<browser>/Default/Cookies
     // Encrypted with the same AES-128-CBC scheme as macOS but the key
@@ -157,9 +181,148 @@ async fn cookies_for_host_impl(_host: &str) -> Vec<Cookie> {
     Vec::new()
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 async fn has_cookies_for_host_impl(_host: &str) -> bool {
     false
+}
+
+#[cfg(target_os = "windows")]
+async fn cookies_for_host_impl(host: &str) -> Vec<Cookie> {
+    {
+        let cache = cache().lock().await;
+        if let Some((fetched_at, cookies)) = cache.get(host) {
+            if fetched_at.elapsed() < CACHE_TTL {
+                debug!(
+                    host,
+                    count = cookies.len(),
+                    "owned-browser cookies: cache hit"
+                );
+                return cookies.clone();
+            }
+        }
+    }
+
+    let host_owned = host.to_string();
+    let cookies = tokio::task::spawn_blocking(move || {
+        clear_v20_cookie_block(&host_owned);
+        let mut out: Vec<Cookie> = Vec::new();
+        for source in WIN_SOURCES {
+            match read_cookies_windows(source, &host_owned) {
+                Ok(mut result) => {
+                    if !result.cookies.is_empty() {
+                        info!(
+                            source = source.name,
+                            count = result.cookies.len(),
+                            "owned-browser cookies: read"
+                        );
+                    }
+                    if result.rows > 0
+                        && result.cookies.is_empty()
+                        && result.v20_count == result.rows
+                    {
+                        record_v20_cookie_block(
+                            &host_owned,
+                            source.name,
+                            result.rows,
+                            result.v20_count,
+                        );
+                    }
+                    out.append(&mut result.cookies);
+                }
+                Err(e) => {
+                    info!(source = source.name, "owned-browser cookies: skip — {e}");
+                }
+            }
+        }
+        out
+    })
+    .await
+    .unwrap_or_else(|e| {
+        warn!("owned-browser cookies: spawn_blocking join failed: {e}");
+        Vec::new()
+    });
+
+    {
+        let mut cache = cache().lock().await;
+        cache.insert(host.to_string(), (Instant::now(), cookies.clone()));
+    }
+
+    debug!(
+        host,
+        count = cookies.len(),
+        "owned-browser cookies: cache miss → read"
+    );
+    cookies
+}
+
+#[cfg(target_os = "windows")]
+async fn has_cookies_for_host_impl(host: &str) -> bool {
+    let host_owned = host.to_string();
+    tokio::task::spawn_blocking(move || {
+        // Collect locked sources locally first — don't touch the shared map
+        // until the entire scan is done. This avoids a race where a concurrent
+        // call clears the block that was just recorded by another call.
+        let mut found = false;
+        let mut locked_sources: Vec<&'static str> = Vec::new();
+        for source in WIN_SOURCES {
+            match has_cookie_rows_windows(source, &host_owned) {
+                Ok(true) => {
+                    info!(
+                        source = source.name,
+                        host = host_owned.as_str(),
+                        "owned-browser cookies: row preflight found cookies"
+                    );
+                    found = true;
+                }
+                Ok(false) => {}
+                Err(ref e) if e.starts_with("sqlite open:") => {
+                    // Browser IS installed (file exists) but the DB is locked —
+                    // browser is running with an exclusive hold on the file.
+                    info!(
+                        source = source.name,
+                        host = host_owned.as_str(),
+                        "owned-browser cookies: row preflight skip — browser running, db locked ({e})"
+                    );
+                    locked_sources.push(source.name);
+                }
+                Err(e) => info!(
+                    source = source.name,
+                    host = host_owned.as_str(),
+                    "owned-browser cookies: row preflight skip — {e}"
+                ),
+            }
+        }
+        // Atomic write: replace the entire locked block for this host in one
+        // lock acquisition. If the DB opened for at least one source (browser
+        // closed or never running), clear any stale block. If any source is
+        // locked, store exactly those sources — no incremental accumulation
+        // across concurrent calls.
+        if locked_sources.is_empty() {
+            clear_locked_browser_block(&host_owned);
+        } else {
+            if let Ok(mut blocks) = locked_browser_blocks().lock() {
+                blocks.insert(
+                    host_owned.clone(),
+                    LockedBrowserBlock {
+                        host: host_owned.clone(),
+                        sources: locked_sources
+                            .into_iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                    },
+                );
+            }
+        }
+        if !found {
+            info!(
+                host = host_owned.as_str(),
+                "owned-browser cookies: row preflight found no matching cookies"
+            );
+        }
+        found
+    })
+    .await
+    .unwrap_or(false)
 }
 
 #[cfg(target_os = "macos")]
@@ -245,6 +408,383 @@ async fn has_cookies_for_host_impl(host: &str) -> bool {
     })
     .await
     .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// Windows — Chromium-derived browsers (Chrome / Brave / Edge / Chromium /
+// Vivaldi / Opera)
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+struct WindowsBrowserSource {
+    name: &'static str,
+    env_var: &'static str,
+    user_data_subpath: &'static str,
+    profile_subpath: &'static str,
+}
+
+#[cfg(target_os = "windows")]
+const WIN_SOURCES: &[WindowsBrowserSource] = &[
+    WindowsBrowserSource {
+        name: "Chrome",
+        env_var: "LOCALAPPDATA",
+        user_data_subpath: r"Google\Chrome\User Data",
+        profile_subpath: "Default",
+    },
+    WindowsBrowserSource {
+        name: "Edge",
+        env_var: "LOCALAPPDATA",
+        user_data_subpath: r"Microsoft\Edge\User Data",
+        profile_subpath: "Default",
+    },
+    WindowsBrowserSource {
+        name: "Brave",
+        env_var: "LOCALAPPDATA",
+        user_data_subpath: r"BraveSoftware\Brave-Browser\User Data",
+        profile_subpath: "Default",
+    },
+    WindowsBrowserSource {
+        name: "Chromium",
+        env_var: "LOCALAPPDATA",
+        user_data_subpath: r"Chromium\User Data",
+        profile_subpath: "Default",
+    },
+    WindowsBrowserSource {
+        name: "Vivaldi",
+        env_var: "LOCALAPPDATA",
+        user_data_subpath: r"Vivaldi\User Data",
+        profile_subpath: "Default",
+    },
+    WindowsBrowserSource {
+        name: "Opera",
+        env_var: "APPDATA",
+        user_data_subpath: r"Opera Software\Opera Stable",
+        profile_subpath: "",
+    },
+];
+
+#[cfg(target_os = "windows")]
+static CACHE: OnceLock<Mutex<std::collections::HashMap<String, (Instant, Vec<Cookie>)>>> =
+    OnceLock::new();
+#[cfg(target_os = "windows")]
+const CACHE_TTL: Duration = Duration::from_secs(30);
+
+#[cfg(target_os = "windows")]
+fn cache() -> &'static Mutex<std::collections::HashMap<String, (Instant, Vec<Cookie>)>> {
+    CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(target_os = "windows")]
+static KEY_CACHE: OnceLock<std::sync::Mutex<std::collections::HashMap<&'static str, [u8; 32]>>> =
+    OnceLock::new();
+
+#[cfg(target_os = "windows")]
+static V20_COOKIE_BLOCKS: OnceLock<
+    std::sync::Mutex<std::collections::HashMap<String, V20CookieBlock>>,
+> = OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn v20_cookie_blocks(
+) -> &'static std::sync::Mutex<std::collections::HashMap<String, V20CookieBlock>> {
+    V20_COOKIE_BLOCKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(target_os = "windows")]
+fn clear_v20_cookie_block(host: &str) {
+    if let Ok(mut blocks) = v20_cookie_blocks().lock() {
+        blocks.remove(host);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn record_v20_cookie_block(host: &str, source: &'static str, rows: usize, v20_count: usize) {
+    if let Ok(mut blocks) = v20_cookie_blocks().lock() {
+        let entry = blocks
+            .entry(host.to_string())
+            .or_insert_with(|| V20CookieBlock {
+                host: host.to_string(),
+                rows: 0,
+                v20_count: 0,
+                sources: Vec::new(),
+            });
+        entry.rows += rows;
+        entry.v20_count += v20_count;
+        if !entry.sources.iter().any(|s| s == source) {
+            entry.sources.push(source.to_string());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Locked-browser block registry — parallel to the v20 registry
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+static LOCKED_BROWSER_BLOCKS: OnceLock<
+    std::sync::Mutex<std::collections::HashMap<String, LockedBrowserBlock>>,
+> = OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn locked_browser_blocks(
+) -> &'static std::sync::Mutex<std::collections::HashMap<String, LockedBrowserBlock>> {
+    LOCKED_BROWSER_BLOCKS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+#[cfg(target_os = "windows")]
+fn clear_locked_browser_block(host: &str) {
+    if let Ok(mut blocks) = locked_browser_blocks().lock() {
+        blocks.remove(host);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_user_data_dir(source: &WindowsBrowserSource) -> Result<PathBuf, String> {
+    let root = std::env::var_os(source.env_var).ok_or_else(|| format!("no ${}", source.env_var))?;
+    Ok(PathBuf::from(root).join(source.user_data_subpath))
+}
+
+#[cfg(target_os = "windows")]
+fn windows_profile_dir(source: &WindowsBrowserSource) -> Result<PathBuf, String> {
+    let user_data = windows_user_data_dir(source)?;
+    if source.profile_subpath.is_empty() {
+        Ok(user_data)
+    } else {
+        Ok(user_data.join(source.profile_subpath))
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_key(source: &WindowsBrowserSource) -> Result<[u8; 32], String> {
+    let cache = KEY_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+    if let Some(k) = cache.lock().ok().and_then(|c| c.get(source.name).copied()) {
+        return Ok(k);
+    }
+
+    let user_data_dir = windows_user_data_dir(source)?;
+    let key = load_dpapi_key(&user_data_dir)?;
+    if let Ok(mut c) = cache.lock() {
+        c.insert(source.name, key);
+    }
+    Ok(key)
+}
+
+#[cfg(target_os = "windows")]
+fn load_dpapi_key(user_data_dir: &std::path::Path) -> Result<[u8; 32], String> {
+    use base64::Engine;
+
+    let local_state = user_data_dir.join("Local State");
+    let text =
+        std::fs::read_to_string(&local_state).map_err(|e| format!("read Local State: {e}"))?;
+    let json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("parse Local State: {e}"))?;
+    let b64 = json
+        .get("os_crypt")
+        .and_then(|v| v.get("encrypted_key"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "no os_crypt.encrypted_key".to_string())?;
+    let mut encrypted = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .map_err(|e| format!("base64 encrypted_key: {e}"))?;
+    if encrypted.starts_with(b"DPAPI") {
+        encrypted.drain(0..5);
+    }
+    let key = dpapi_decrypt(&encrypted)?;
+    key.try_into()
+        .map_err(|_| "decrypted key is not 32 bytes".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn dpapi_decrypt(blob: &[u8]) -> Result<Vec<u8>, String> {
+    use windows::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows::Win32::Security::Cryptography::{CryptUnprotectData, CRYPT_INTEGER_BLOB};
+
+    let input = CRYPT_INTEGER_BLOB {
+        cbData: blob
+            .len()
+            .try_into()
+            .map_err(|_| "DPAPI blob too large".to_string())?,
+        pbData: blob.as_ptr() as *mut u8,
+    };
+    let mut output = CRYPT_INTEGER_BLOB::default();
+    unsafe {
+        CryptUnprotectData(&input, None, None, None, None, 0, &mut output)
+            .map_err(|e| format!("CryptUnprotectData: {e}"))?;
+        let bytes = std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec();
+        let _ = LocalFree(HLOCAL(output.pbData as *mut core::ffi::c_void));
+        Ok(bytes)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn open_cookie_db_windows(source: &WindowsBrowserSource) -> Result<rusqlite::Connection, String> {
+    let profile = windows_profile_dir(source)?;
+    let new_loc = profile.join("Network").join("Cookies");
+    let old_loc = profile.join("Cookies");
+    let cookies_path = if new_loc.exists() {
+        new_loc
+    } else if old_loc.exists() {
+        old_loc
+    } else {
+        return Err(format!("{} not installed (no Cookies file)", source.name));
+    };
+
+    let uri = format!("file:{}?mode=ro&immutable=1", cookies_path.display());
+    rusqlite::Connection::open_with_flags(
+        &uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| format!("sqlite open: {e}"))
+}
+
+#[cfg(target_os = "windows")]
+fn has_cookie_rows_windows(source: &WindowsBrowserSource, host: &str) -> Result<bool, String> {
+    let conn = open_cookie_db_windows(source)?;
+    let host_filters = host_match_clauses(host);
+    let where_clause = host_where_clause(&host_filters);
+    let sql = format!("SELECT 1 FROM cookies WHERE {where_clause} LIMIT 1");
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("prepare: {e}"))?;
+    let mut rows = stmt
+        .query(rusqlite::params_from_iter(host_filters.iter()))
+        .map_err(|e| format!("query: {e}"))?;
+    rows.next()
+        .map(|row| row.is_some())
+        .map_err(|e| format!("row: {e}"))
+}
+
+#[cfg(target_os = "windows")]
+struct WindowsReadResult {
+    cookies: Vec<Cookie>,
+    rows: usize,
+    v20_count: usize,
+}
+
+#[cfg(target_os = "windows")]
+fn read_cookies_windows(
+    source: &WindowsBrowserSource,
+    host: &str,
+) -> Result<WindowsReadResult, String> {
+    let conn = open_cookie_db_windows(source)?;
+    let host_filters = host_match_clauses(host);
+    let where_clause = host_where_clause(&host_filters);
+    let sql = format!(
+        "SELECT name, value, encrypted_value, host_key, path, \
+                is_secure, is_httponly, expires_utc, samesite \
+         FROM cookies WHERE {where_clause}"
+    );
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| format!("prepare: {e}"))?;
+    let params = rusqlite::params_from_iter(host_filters.iter());
+    let rows = stmt
+        .query_map(params, |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, Vec<u8>>(2)?,
+                r.get::<_, String>(3)?,
+                r.get::<_, String>(4)?,
+                r.get::<_, i32>(5)?,
+                r.get::<_, i32>(6)?,
+                r.get::<_, i64>(7)?,
+                r.get::<_, i32>(8)?,
+            ))
+        })
+        .map_err(|e| format!("query: {e}"))?;
+
+    let rows = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("row: {e}"))?;
+    if rows.is_empty() {
+        return Ok(WindowsReadResult {
+            cookies: Vec::new(),
+            rows: 0,
+            v20_count: 0,
+        });
+    }
+
+    let key = windows_key(source)?;
+    let mut cookies = Vec::new();
+    let mut row_count = 0usize;
+    let mut decrypt_failed = 0usize;
+    let mut v20_count = 0usize;
+    let mut sample_enc_prefix: Option<String> = None;
+    for (name, plain_val, enc_val, host_key, path, secure, http_only, expires_utc, ss) in rows {
+        row_count += 1;
+        let value = if enc_val.is_empty() {
+            plain_val
+        } else {
+            if sample_enc_prefix.is_none() {
+                let n = enc_val.len().min(3);
+                sample_enc_prefix = Some(
+                    enc_val[..n]
+                        .iter()
+                        .map(|b| format!("{:02x}", b))
+                        .collect::<String>(),
+                );
+            }
+            if enc_val.starts_with(b"v20") {
+                v20_count += 1;
+            }
+            match decrypt_windows_cookie(&enc_val, &key) {
+                Some(v) => v,
+                None => {
+                    decrypt_failed += 1;
+                    continue;
+                }
+            }
+        };
+        cookies.push(Cookie {
+            name,
+            value,
+            domain: host_key,
+            path,
+            secure: secure != 0,
+            http_only: http_only != 0,
+            expires_at: chromium_micros_to_unix_secs(expires_utc),
+            same_site: ss,
+        });
+    }
+    info!(
+        source = source.name,
+        host,
+        rows = row_count,
+        decrypted = cookies.len(),
+        decrypt_failed,
+        v20_count,
+        first_enc_prefix = sample_enc_prefix.as_deref().unwrap_or("none"),
+        "owned-browser cookies: source done"
+    );
+    Ok(WindowsReadResult {
+        cookies,
+        rows: row_count,
+        v20_count,
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn decrypt_windows_cookie(encrypted: &[u8], key: &[u8; 32]) -> Option<String> {
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Nonce};
+
+    if encrypted.len() < 15 {
+        return None;
+    }
+    match &encrypted[..3] {
+        b"v10" | b"v11" => {}
+        b"v20" => return None,
+        _ => return None,
+    }
+
+    let cipher = Aes256Gcm::new_from_slice(key).ok()?;
+    let nonce = Nonce::from_slice(&encrypted[3..15]);
+    let plain = cipher.decrypt(nonce, &encrypted[15..]).ok()?;
+    let value_bytes = if plain.len() >= 32 {
+        &plain[32..]
+    } else {
+        &plain[..]
+    };
+    String::from_utf8(value_bytes.to_vec()).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -376,7 +916,7 @@ fn open_cookie_db(source: &KeychainEntry) -> Result<rusqlite::Connection, String
     .map_err(|e| format!("sqlite open: {e}"))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn host_where_clause(filters: &[String]) -> String {
     filters
         .iter()
@@ -515,7 +1055,7 @@ fn read_cookies(source: &KeychainEntry, host: &str) -> Result<Vec<Cookie>, Strin
 /// `.com` is etld so cookies aren't actually allowed there, but Arc /
 /// Chrome don't enforce that themselves; we return whatever's stored
 /// and let WKWebView's own cookie policy filter at request time).
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn host_match_clauses(host: &str) -> Vec<String> {
     let mut out = vec![host.to_string(), format!(".{host}")];
     let mut rest = host;
@@ -532,7 +1072,7 @@ fn host_match_clauses(host: &str) -> Vec<String> {
 /// Chromium stores `expires_utc` in microseconds since 1601-01-01 UTC
 /// (the Windows FILETIME epoch — yes, even in macOS Chrome). `0` means
 /// "session cookie". Convert to seconds since 1970-01-01 for NSDate.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn chromium_micros_to_unix_secs(micros: i64) -> Option<i64> {
     if micros == 0 {
         return None;

--- a/crates/screenpipe-connect/src/connections/browser/bridge.rs
+++ b/crates/screenpipe-connect/src/connections/browser/bridge.rs
@@ -43,6 +43,13 @@ struct WsEvalRequest<'a> {
     url: Option<&'a str>,
 }
 
+#[derive(Debug, Serialize)]
+struct WsCookieRequest<'a> {
+    id: &'a str,
+    action: &'static str,
+    host: &'a str,
+}
+
 /// Why an eval call returned without a useful answer.
 #[derive(Debug, thiserror::Error)]
 pub enum EvalError {
@@ -168,6 +175,43 @@ impl BrowserBridge {
         if let Err(e) = transport.send_text(frame).await {
             self.pending.lock().await.remove(&id);
             // The transport is dead — clear it so /status reflects reality.
+            self.detach_transport(&transport).await;
+            return Err(EvalError::SendFailed(e));
+        }
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => Err(EvalError::Disconnected),
+            Err(_) => {
+                self.pending.lock().await.remove(&id);
+                Err(EvalError::Timeout(timeout.as_secs()))
+            }
+        }
+    }
+
+    pub async fn get_cookies(
+        &self,
+        host: &str,
+        timeout: Duration,
+    ) -> Result<EvalResult, EvalError> {
+        let transport = {
+            let guard = self.transport.read().await;
+            guard.as_ref().cloned().ok_or(EvalError::NotConnected)?
+        };
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id.clone(), tx);
+
+        let frame = serde_json::to_string(&WsCookieRequest {
+            id: &id,
+            action: "get_cookies",
+            host,
+        })
+        .expect("serialize cookie request");
+
+        if let Err(e) = transport.send_text(frame).await {
+            self.pending.lock().await.remove(&id);
             self.detach_transport(&transport).await;
             return Err(EvalError::SendFailed(e));
         }

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -1988,6 +1988,13 @@ async fn browser_eval(
     crate::routes::browser::browser_eval_handler(State(state.browser_bridge), body).await
 }
 
+async fn browser_cookies(
+    State(state): State<ConnectionsState>,
+    body: Json<crate::routes::browser::CookieRequestBody>,
+) -> impl axum::response::IntoResponse {
+    crate::routes::browser::browser_cookies_handler(State(state.browser_bridge), body).await
+}
+
 async fn browser_status(
     State(state): State<ConnectionsState>,
 ) -> impl axum::response::IntoResponse {
@@ -2388,6 +2395,7 @@ where
         // (Chrome v0.2.x and v0.3.0) hardcode these. Keep until usage drops.
         .route("/browser/ws", get(browser_ws))
         .route("/browser/eval", post(browser_eval))
+        .route("/browser/cookies", post(browser_cookies))
         .route("/browser/status", get(browser_status))
         // OAuth callback (must be before /:id to avoid conflict)
         .route("/oauth/callback", get(oauth_callback))

--- a/crates/screenpipe-engine/src/routes/browser.rs
+++ b/crates/screenpipe-engine/src/routes/browser.rs
@@ -60,6 +60,12 @@ pub struct EvalRequestBody {
     pub timeout_secs: Option<u64>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct CookieRequestBody {
+    pub host: String,
+    pub timeout_secs: Option<u64>,
+}
+
 /// Frames the extension sends back over the WebSocket. The `ok` field
 /// distinguishes eval responses from hello/pong messages which lack it.
 #[derive(Debug, Deserialize)]
@@ -122,6 +128,67 @@ pub async fn browser_eval_handler(
     let timeout = Duration::from_secs(body.timeout_secs.unwrap_or(30).min(120));
 
     match bridge.eval(&body.code, body.url.as_deref(), timeout).await {
+        Ok(EvalResult { ok, result, error }) => {
+            let status = if ok {
+                StatusCode::OK
+            } else {
+                StatusCode::UNPROCESSABLE_ENTITY
+            };
+            (
+                status,
+                Json(EvalResponseBody {
+                    success: ok,
+                    result,
+                    error,
+                }),
+            )
+        }
+        Err(EvalError::NotConnected) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(EvalResponseBody {
+                success: false,
+                result: None,
+                error: Some(EvalError::NotConnected.to_string()),
+            }),
+        ),
+        Err(e @ EvalError::SendFailed(_)) | Err(e @ EvalError::Disconnected) => (
+            StatusCode::BAD_GATEWAY,
+            Json(EvalResponseBody {
+                success: false,
+                result: None,
+                error: Some(e.to_string()),
+            }),
+        ),
+        Err(e @ EvalError::Timeout(_)) => (
+            StatusCode::GATEWAY_TIMEOUT,
+            Json(EvalResponseBody {
+                success: false,
+                result: None,
+                error: Some(e.to_string()),
+            }),
+        ),
+    }
+}
+
+pub async fn browser_cookies_handler(
+    State(bridge): State<Arc<InnerBridge>>,
+    Json(body): Json<CookieRequestBody>,
+) -> impl IntoResponse {
+    let timeout = Duration::from_secs(body.timeout_secs.unwrap_or(5).min(30));
+    let host = body.host.trim().trim_end_matches('.').to_ascii_lowercase();
+
+    if host.is_empty() || host.contains('/') || host.contains(':') {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(EvalResponseBody {
+                success: false,
+                result: None,
+                error: Some("invalid host".to_string()),
+            }),
+        );
+    }
+
+    match bridge.get_cookies(&host, timeout).await {
         Ok(EvalResult { ok, result, error }) => {
             let status = if ok {
                 StatusCode::OK

--- a/packages/browser-extension/dist/manifest.json
+++ b/packages/browser-extension/dist/manifest.json
@@ -14,7 +14,8 @@
     "tabs",
     "alarms",
     "storage",
-    "notifications"
+    "notifications",
+    "cookies"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/packages/browser-extension/dist/popup.html
+++ b/packages/browser-extension/dist/popup.html
@@ -103,6 +103,73 @@
       #status-bar[data-state="auth_required"],
       #status-bar[data-state="server_down"],
       #status-bar[data-state="error"]         { color: var(--red); }
+
+      /* ── Action section ── */
+      #action-section {
+        padding: 0 14px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      #action-section[hidden] { display: none; }
+      .action-btn {
+        width: 100%;
+        padding: 7px 12px;
+        font: inherit;
+        font-size: 12px;
+        font-weight: 500;
+        cursor: pointer;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        color: var(--text);
+        text-align: center;
+        letter-spacing: 0.01em;
+        transition: background 0.1s;
+      }
+      .action-btn:hover { background: var(--border); }
+      .action-btn.primary {
+        background: var(--accent-bg);
+        color: var(--accent-fg);
+        border-color: var(--accent-bg);
+      }
+      .action-btn.primary:hover { opacity: 0.88; }
+      #action-hint {
+        font-size: 11px;
+        color: var(--muted);
+        text-align: center;
+        line-height: 1.4;
+      }
+      /* ── Connected tagline ── */
+      #connected-tagline {
+        padding: 0 14px 14px;
+        font-size: 11px;
+        color: var(--muted);
+        line-height: 1.5;
+      }
+      #connected-tagline[hidden] { display: none; }
+      #pair-info[hidden] { display: none; }
+      #pair-code-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 7px 10px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        margin-bottom: 4px;
+      }
+      .pair-label {
+        font-size: 11px;
+        color: var(--muted);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      #pair-code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 14px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        color: var(--text);
+      }
     </style>
   </head>
   <body>
@@ -114,6 +181,29 @@
     <div id="status-bar" data-state="checking">
       <span id="status-dot"></span>
       <span id="status-text">checking…</span>
+    </div>
+
+    <div id="action-section" hidden>
+      <button id="connect-btn" class="action-btn primary" type="button" hidden>
+        Connect
+      </button>
+      <button id="open-btn" class="action-btn primary" type="button" hidden>
+        Open Screenpipe
+      </button>
+
+      <!-- shown during active pairing -->
+      <div id="pair-info" hidden>
+        <div id="pair-code-row">
+          <span class="pair-label">match code</span>
+          <span id="pair-code"></span>
+        </div>
+      </div>
+
+      <span id="action-hint"></span>
+    </div>
+
+    <div id="connected-tagline" hidden>
+      Screenpipe can use your browser sessions when opening sites in the sidebar.
     </div>
 
     <script src="popup.js" type="module"></script>

--- a/packages/browser-extension/dist/popup.js
+++ b/packages/browser-extension/dist/popup.js
@@ -29,6 +29,10 @@ function browserPairStatusUrl(baseHttpUrl, id) {
 }
 
 // src/popup.ts
+var SCREENPIPE_FOCUS_URL = "http://127.0.0.1:11435/focus";
+var PAIR_POLL_MS = 1000;
+var PAIR_TIMEOUT_MS = 120000;
+var SESSION_PAIR_KEY = "screenpipe_pending_pair";
 var $ = (id) => document.getElementById(id);
 async function getConfig() {
   const s = await chrome.storage.local.get([STORAGE_KEY_TOKEN, STORAGE_KEY_BASE_URL]);
@@ -37,11 +41,30 @@ async function getConfig() {
     baseUrl: s[STORAGE_KEY_BASE_URL] ?? DEFAULT_BASE_URL
   };
 }
+async function saveToken(token, baseUrl) {
+  await chrome.storage.local.set({ [STORAGE_KEY_TOKEN]: token, [STORAGE_KEY_BASE_URL]: baseUrl });
+}
+async function saveSessionPair(state) {
+  if (state) {
+    await chrome.storage.session.set({ [SESSION_PAIR_KEY]: state });
+  } else {
+    await chrome.storage.session.remove(SESSION_PAIR_KEY);
+  }
+}
+async function getSessionPair() {
+  const s = await chrome.storage.session.get(SESSION_PAIR_KEY);
+  const state = s[SESSION_PAIR_KEY];
+  if (!state)
+    return null;
+  if (Date.now() - state.startedAt > PAIR_TIMEOUT_MS) {
+    await saveSessionPair(null);
+    return null;
+  }
+  return state;
+}
 async function probeStatus(token, baseUrl) {
   try {
-    const h = await fetch(healthUrl(baseUrl), {
-      signal: AbortSignal.timeout(3000)
-    });
+    const h = await fetch(healthUrl(baseUrl), { signal: AbortSignal.timeout(3000) });
     if (!h.ok)
       return "server_down";
   } catch {
@@ -51,10 +74,7 @@ async function probeStatus(token, baseUrl) {
     const headers = {};
     if (token)
       headers["Authorization"] = `Bearer ${token}`;
-    const r = await fetch(browserStatusUrl(baseUrl), {
-      headers,
-      signal: AbortSignal.timeout(3000)
-    });
+    const r = await fetch(browserStatusUrl(baseUrl), { headers, signal: AbortSignal.timeout(3000) });
     if (r.status === 401 || r.status === 403)
       return "auth_required";
     if (!r.ok)
@@ -65,31 +85,216 @@ async function probeStatus(token, baseUrl) {
     return "error";
   }
 }
+async function startPairing(baseUrl) {
+  const manifest = chrome.runtime.getManifest();
+  const ua = navigator.userAgent;
+  const browser = ua.includes("Edg/") ? "edge" : ua.includes("Brave/") ? "brave" : ua.includes("OPR/") ? "opera" : ua.includes("Chrome/") ? "chrome" : "browser";
+  const res = await fetch(browserPairStartUrl(baseUrl), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ browser, extension_id: chrome.runtime.id, extension_version: manifest.version }),
+    signal: AbortSignal.timeout(5000)
+  });
+  if (!res.ok)
+    throw new Error(`pairing request failed: HTTP ${res.status}`);
+  return res.json();
+}
+async function pollPairStatus(baseUrl, pairId) {
+  const res = await fetch(browserPairStatusUrl(baseUrl, pairId), {
+    signal: AbortSignal.timeout(5000)
+  });
+  if (!res.ok)
+    throw new Error(`pair status HTTP ${res.status}`);
+  return res.json();
+}
+async function tryFocusScreenpipe() {
+  try {
+    const ctrl = new AbortController;
+    const t = setTimeout(() => ctrl.abort(), 2000);
+    await fetch(SCREENPIPE_FOCUS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target: "browser_pairing" }),
+      signal: ctrl.signal
+    });
+    clearTimeout(t);
+  } catch {}
+}
+function openOptionsPage() {
+  chrome.tabs.create({ url: chrome.runtime.getURL("options.html") }).finally(() => window.close());
+}
+function setPairingUI(code, hint) {
+  $("pair-code").textContent = code;
+  $("pair-info").hidden = false;
+  $("action-hint").textContent = hint;
+  $("connect-btn").hidden = true;
+  $("open-btn").hidden = true;
+  $("action-section").hidden = false;
+}
+function clearPairingUI() {
+  $("pair-info").hidden = true;
+  $("pair-code").textContent = "";
+}
 function setStatusUI(status) {
   const bar = $("status-bar");
   const text = $("status-text");
+  const section = $("action-section");
+  const connectBtn = $("connect-btn");
+  const openBtn = $("open-btn");
+  const hint = $("action-hint");
+  const tagline = $("connected-tagline");
   bar.dataset.state = status;
   const labels = {
     checking: "checking…",
     ok: "bridge connected",
-    bridge_down: "server reachable — bridge connecting…",
-    auth_required: "needs token — open settings",
+    bridge_down: "connecting…",
+    auth_required: "not connected",
     server_down: "screenpipe not running",
     error: "connection error"
   };
   text.textContent = labels[status];
+  connectBtn.hidden = true;
+  openBtn.hidden = true;
+  hint.textContent = "";
+  section.hidden = true;
+  tagline.hidden = true;
+  clearPairingUI();
+  if (status === "ok") {
+    tagline.hidden = false;
+  } else if (status === "auth_required" || status === "error") {
+    connectBtn.hidden = false;
+    connectBtn.disabled = false;
+    section.hidden = false;
+  } else if (status === "server_down") {
+    openBtn.hidden = false;
+    openBtn.disabled = false;
+    hint.textContent = "Open the Screenpipe desktop app first.";
+    section.hidden = false;
+  }
+}
+var pairingActive = false;
+async function runPairingFlow(baseUrl, existingPair) {
+  if (pairingActive)
+    return;
+  pairingActive = true;
+  const connectBtn = $("connect-btn");
+  const bar = $("status-bar");
+  const text = $("status-text");
+  try {
+    let pairId;
+    let code;
+    if (existingPair) {
+      pairId = existingPair.id;
+      code = existingPair.code;
+    } else {
+      connectBtn.disabled = true;
+      bar.dataset.state = "checking";
+      text.textContent = "checking…";
+      try {
+        const health = await fetch(healthUrl(baseUrl), { signal: AbortSignal.timeout(3000) });
+        if (!health.ok)
+          throw new Error("server_down");
+      } catch {
+        setStatusUI("server_down");
+        pairingActive = false;
+        return;
+      }
+      bar.dataset.state = "bridge_down";
+      text.textContent = "starting pairing…";
+      const pair = await startPairing(baseUrl);
+      pairId = pair.id;
+      code = pair.code;
+      await saveSessionPair({ id: pairId, code, baseUrl, startedAt: Date.now() });
+    }
+    setPairingUI(code, "Switch to Screenpipe and click Allow.");
+    bar.dataset.state = "bridge_down";
+    text.textContent = "waiting for approval…";
+    await tryFocusScreenpipe();
+    const deadline = existingPair ? existingPair.startedAt + PAIR_TIMEOUT_MS : Date.now() + PAIR_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, PAIR_POLL_MS));
+      let resp;
+      try {
+        resp = await pollPairStatus(baseUrl, pairId);
+      } catch {
+        continue;
+      }
+      if (resp.status === "pending")
+        continue;
+      await saveSessionPair(null);
+      if (resp.status === "approved") {
+        const token = resp.token ?? "";
+        await saveToken(token, baseUrl);
+        try {
+          chrome.runtime.sendMessage({ type: "wake" });
+        } catch {}
+        bar.dataset.state = "ok";
+        text.textContent = "bridge connected";
+        clearPairingUI();
+        $("action-section").hidden = true;
+        $("connected-tagline").hidden = false;
+        pairingActive = false;
+        return;
+      }
+      if (resp.status === "denied") {
+        setStatusUI("auth_required");
+        $("action-hint").textContent = "Connection was denied. Try again.";
+        $("action-section").hidden = false;
+        pairingActive = false;
+        return;
+      }
+      setStatusUI("auth_required");
+      $("action-hint").textContent = "Approval timed out. Try again.";
+      $("action-section").hidden = false;
+      pairingActive = false;
+      return;
+    }
+    await saveSessionPair(null);
+    setStatusUI("auth_required");
+    $("action-hint").textContent = "Timed out waiting for approval.";
+    $("action-section").hidden = false;
+  } catch (e) {
+    await saveSessionPair(null);
+    setStatusUI("error");
+    $("action-hint").textContent = e?.message ?? "Pairing failed — try again.";
+    $("action-section").hidden = false;
+  }
+  pairingActive = false;
+}
+async function tryOpenScreenpipe(baseUrl) {
+  const btn = $("open-btn");
+  const hint = $("action-hint");
+  btn.disabled = true;
+  hint.textContent = "Trying to open Screenpipe…";
+  await tryFocusScreenpipe();
+  await new Promise((r) => setTimeout(r, 1500));
+  const { token } = await getConfig();
+  const status = await probeStatus(token, baseUrl);
+  if (status !== "server_down") {
+    setStatusUI(status);
+  } else {
+    btn.disabled = false;
+    hint.textContent = "Screenpipe is not running — please open it.";
+  }
 }
 async function init() {
   const { token, baseUrl } = await getConfig();
-  $("settings-btn").addEventListener("click", () => {
-    const optionsUrl = chrome.runtime.getURL("options.html");
-    chrome.tabs.create({ url: optionsUrl }).finally(() => {
-      window.close();
-    });
+  $("settings-btn").addEventListener("click", openOptionsPage);
+  $("connect-btn").addEventListener("click", () => {
+    runPairingFlow(baseUrl);
+  });
+  $("open-btn").addEventListener("click", () => {
+    tryOpenScreenpipe(baseUrl);
   });
   try {
     chrome.runtime.sendMessage({ type: "wake" });
   } catch {}
+  const pendingPair = await getSessionPair();
+  if (pendingPair) {
+    setStatusUI("bridge_down");
+    runPairingFlow(pendingPair.baseUrl, pendingPair);
+    return;
+  }
   await new Promise((r) => setTimeout(r, 600));
   const status = await probeStatus(token, baseUrl);
   setStatusUI(status);

--- a/packages/browser-extension/dist/worker.js
+++ b/packages/browser-extension/dist/worker.js
@@ -141,6 +141,16 @@ async function connect() {
       } catch (err) {
         send({ id, ok: false, error: err?.message ?? String(err) });
       }
+      return;
+    }
+    if (msg.action === "get_cookies") {
+      const { id, host } = msg;
+      try {
+        const cookies = await getCookiesForHost(host);
+        send({ id, ok: true, result: { cookies } });
+      } catch (err) {
+        send({ id, ok: false, error: err?.message ?? String(err) });
+      }
     }
   };
 }
@@ -256,6 +266,54 @@ async function evalInTab(tabId, code) {
     throw new Error(desc);
   }
   return evalResult?.result?.value ?? null;
+}
+function normalizeHost(host) {
+  const normalized = host.trim().toLowerCase().replace(/\.$/, "");
+  if (!normalized || normalized.includes("/") || normalized.includes(":")) {
+    throw new Error("invalid cookie host");
+  }
+  return normalized;
+}
+function sameSiteValue(value) {
+  if (value === "no_restriction" || value === "lax" || value === "strict")
+    return value;
+  return "unspecified";
+}
+async function getCookiesForHost(host) {
+  if (!chrome.cookies?.getAll) {
+    throw new Error("extension does not have cookies permission");
+  }
+  const normalized = normalizeHost(host);
+  const hosts = new Set;
+  const parts = normalized.split(".");
+  for (let i = 0;i <= Math.max(0, parts.length - 2); i += 1) {
+    hosts.add(parts.slice(i).join("."));
+  }
+  const byKey = new Map;
+  for (const domain of hosts) {
+    const cookies = await chrome.cookies.getAll({ domain });
+    for (const c of cookies) {
+      const bareDomain = c.domain.replace(/^\./, "").toLowerCase();
+      if (normalized !== bareDomain && !normalized.endsWith(`.${bareDomain}`))
+        continue;
+      const item = {
+        name: c.name,
+        value: c.value,
+        domain: c.domain,
+        path: c.path || "/",
+        secure: Boolean(c.secure),
+        httpOnly: Boolean(c.httpOnly),
+        sameSite: sameSiteValue(c.sameSite)
+      };
+      if (typeof c.expirationDate === "number") {
+        item.expiresAt = Math.trunc(c.expirationDate);
+      }
+      byKey.set(`${item.name}
+${item.domain}
+${item.path}`, item);
+    }
+  }
+  return [...byKey.values()];
 }
 function detectBrowser() {
   const ua = navigator.userAgent;

--- a/packages/browser-extension/src/popup.ts
+++ b/packages/browser-extension/src/popup.ts
@@ -10,12 +10,25 @@ import {
   STORAGE_KEY_BASE_URL,
   healthUrl,
   browserStatusUrl,
+  browserPairStartUrl,
+  browserPairStatusUrl,
 } from "./config";
 
 type ConnStatus = "checking" | "ok" | "bridge_down" | "auth_required" | "server_down" | "error";
 
-const $ = <T extends HTMLElement>(id: string) =>
-  document.getElementById(id) as T;
+const SCREENPIPE_FOCUS_URL = "http://127.0.0.1:11435/focus";
+const PAIR_POLL_MS = 1_000;
+const PAIR_TIMEOUT_MS = 120_000;
+const SESSION_PAIR_KEY = "screenpipe_pending_pair";
+
+type PairState = { id: string; code: string; baseUrl: string; startedAt: number };
+type PairStatusResponse = { status: "pending" | "approved" | "denied" | "expired"; token?: string | null };
+
+const $ = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
 
 async function getConfig(): Promise<{ token: string; baseUrl: string }> {
   const s = await chrome.storage.local.get([STORAGE_KEY_TOKEN, STORAGE_KEY_BASE_URL]);
@@ -25,11 +38,36 @@ async function getConfig(): Promise<{ token: string; baseUrl: string }> {
   };
 }
 
+async function saveToken(token: string, baseUrl: string): Promise<void> {
+  await chrome.storage.local.set({ [STORAGE_KEY_TOKEN]: token, [STORAGE_KEY_BASE_URL]: baseUrl });
+}
+
+async function saveSessionPair(state: PairState | null): Promise<void> {
+  if (state) {
+    await chrome.storage.session.set({ [SESSION_PAIR_KEY]: state });
+  } else {
+    await chrome.storage.session.remove(SESSION_PAIR_KEY);
+  }
+}
+
+async function getSessionPair(): Promise<PairState | null> {
+  const s = await chrome.storage.session.get(SESSION_PAIR_KEY);
+  const state = s[SESSION_PAIR_KEY] as PairState | undefined;
+  if (!state) return null;
+  if (Date.now() - state.startedAt > PAIR_TIMEOUT_MS) {
+    await saveSessionPair(null);
+    return null;
+  }
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Network
+// ---------------------------------------------------------------------------
+
 async function probeStatus(token: string, baseUrl: string): Promise<ConnStatus> {
   try {
-    const h = await fetch(healthUrl(baseUrl), {
-      signal: AbortSignal.timeout(3000),
-    });
+    const h = await fetch(healthUrl(baseUrl), { signal: AbortSignal.timeout(3000) });
     if (!h.ok) return "server_down";
   } catch {
     return "server_down";
@@ -37,10 +75,7 @@ async function probeStatus(token: string, baseUrl: string): Promise<ConnStatus> 
   try {
     const headers: Record<string, string> = {};
     if (token) headers["Authorization"] = `Bearer ${token}`;
-    const r = await fetch(browserStatusUrl(baseUrl), {
-      headers,
-      signal: AbortSignal.timeout(3000),
-    });
+    const r = await fetch(browserStatusUrl(baseUrl), { headers, signal: AbortSignal.timeout(3000) });
     if (r.status === 401 || r.status === 403) return "auth_required";
     if (!r.ok) return "error";
     const data = await r.json() as { connected?: boolean };
@@ -50,41 +85,282 @@ async function probeStatus(token: string, baseUrl: string): Promise<ConnStatus> 
   }
 }
 
+async function startPairing(baseUrl: string): Promise<{ id: string; code: string }> {
+  const manifest = chrome.runtime.getManifest();
+  const ua = navigator.userAgent;
+  const browser = ua.includes("Edg/") ? "edge"
+    : ua.includes("Brave/") ? "brave"
+    : ua.includes("OPR/") ? "opera"
+    : ua.includes("Chrome/") ? "chrome"
+    : "browser";
+
+  const res = await fetch(browserPairStartUrl(baseUrl), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ browser, extension_id: chrome.runtime.id, extension_version: manifest.version }),
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`pairing request failed: HTTP ${res.status}`);
+  return res.json();
+}
+
+async function pollPairStatus(baseUrl: string, pairId: string): Promise<PairStatusResponse> {
+  const res = await fetch(browserPairStatusUrl(baseUrl, pairId), {
+    signal: AbortSignal.timeout(5000),
+  });
+  if (!res.ok) throw new Error(`pair status HTTP ${res.status}`);
+  return res.json();
+}
+
+async function tryFocusScreenpipe(): Promise<void> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 2000);
+    await fetch(SCREENPIPE_FOCUS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target: "browser_pairing" }),
+      signal: ctrl.signal,
+    });
+    clearTimeout(t);
+  } catch { /* app may not be listening — ignore */ }
+}
+
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
+
+function openOptionsPage(): void {
+  void chrome.tabs.create({ url: chrome.runtime.getURL("options.html") }).finally(() => window.close());
+}
+
+function setPairingUI(code: string, hint: string): void {
+  $("pair-code").textContent = code;
+  $("pair-info").hidden = false;
+  $("action-hint").textContent = hint;
+  $("connect-btn").hidden = true;
+  $("open-btn").hidden = true;
+  $("action-section").hidden = false;
+}
+
+function clearPairingUI(): void {
+  $("pair-info").hidden = true;
+  $("pair-code").textContent = "";
+}
+
 function setStatusUI(status: ConnStatus): void {
   const bar = $<HTMLDivElement>("status-bar");
   const text = $<HTMLSpanElement>("status-text");
+  const section = $<HTMLDivElement>("action-section");
+  const connectBtn = $<HTMLButtonElement>("connect-btn");
+  const openBtn = $<HTMLButtonElement>("open-btn");
+  const hint = $<HTMLSpanElement>("action-hint");
+  const tagline = $<HTMLDivElement>("connected-tagline");
+
   bar.dataset.state = status;
+
   const labels: Record<ConnStatus, string> = {
-    checking: "checking…",
-    ok: "bridge connected",
-    bridge_down: "server reachable — bridge connecting…",
-    auth_required: "needs token — open settings",
-    server_down: "screenpipe not running",
-    error: "connection error",
+    checking:      "checking…",
+    ok:            "bridge connected",
+    bridge_down:   "connecting…",
+    auth_required: "not connected",
+    server_down:   "screenpipe not running",
+    error:         "connection error",
   };
   text.textContent = labels[status];
+
+  connectBtn.hidden = true;
+  openBtn.hidden = true;
+  hint.textContent = "";
+  section.hidden = true;
+  tagline.hidden = true;
+  clearPairingUI();
+
+  if (status === "ok") {
+    tagline.hidden = false;
+  } else if (status === "auth_required" || status === "error") {
+    connectBtn.hidden = false;
+    connectBtn.disabled = false;
+    section.hidden = false;
+  } else if (status === "server_down") {
+    openBtn.hidden = false;
+    openBtn.disabled = false;
+    hint.textContent = "Open the Screenpipe desktop app first.";
+    section.hidden = false;
+  }
 }
+
+// ---------------------------------------------------------------------------
+// Pairing flow (runs entirely in the popup — no tab switch needed)
+// ---------------------------------------------------------------------------
+
+let pairingActive = false;
+
+async function runPairingFlow(baseUrl: string, existingPair?: PairState): Promise<void> {
+  if (pairingActive) return;
+  pairingActive = true;
+
+  const connectBtn = $<HTMLButtonElement>("connect-btn");
+  const bar = $<HTMLDivElement>("status-bar");
+  const text = $<HTMLSpanElement>("status-text");
+
+  try {
+    let pairId: string;
+    let code: string;
+
+    if (existingPair) {
+      // Resuming after popup was closed while pairing.
+      pairId = existingPair.id;
+      code = existingPair.code;
+    } else {
+      connectBtn.disabled = true;
+      bar.dataset.state = "checking";
+      text.textContent = "checking…";
+
+      // Confirm server is reachable before starting.
+      try {
+        const health = await fetch(healthUrl(baseUrl), { signal: AbortSignal.timeout(3000) });
+        if (!health.ok) throw new Error("server_down");
+      } catch {
+        setStatusUI("server_down");
+        pairingActive = false;
+        return;
+      }
+
+      bar.dataset.state = "bridge_down";
+      text.textContent = "starting pairing…";
+
+      const pair = await startPairing(baseUrl);
+      pairId = pair.id;
+      code = pair.code;
+
+      // Persist so polling can resume if popup closes when user switches to Screenpipe.
+      await saveSessionPair({ id: pairId, code, baseUrl, startedAt: Date.now() });
+    }
+
+    setPairingUI(code, "Switch to Screenpipe and click Allow.");
+    bar.dataset.state = "bridge_down";
+    text.textContent = "waiting for approval…";
+
+    // Try to bring Screenpipe to front. The popup will close as soon as the
+    // OS focuses another window — that's fine, session storage keeps state.
+    await tryFocusScreenpipe();
+
+    // Poll until approved, denied, expired, or timed out.
+    const deadline = existingPair
+      ? existingPair.startedAt + PAIR_TIMEOUT_MS
+      : Date.now() + PAIR_TIMEOUT_MS;
+
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, PAIR_POLL_MS));
+      let resp: PairStatusResponse;
+      try {
+        resp = await pollPairStatus(baseUrl, pairId);
+      } catch {
+        continue; // transient network blip — keep polling
+      }
+
+      if (resp.status === "pending") continue;
+
+      await saveSessionPair(null);
+
+      if (resp.status === "approved") {
+        const token = resp.token ?? "";
+        await saveToken(token, baseUrl);
+        try { chrome.runtime.sendMessage({ type: "wake" }); } catch { /* ignore */ }
+        bar.dataset.state = "ok";
+        text.textContent = "bridge connected";
+        clearPairingUI();
+        $("action-section").hidden = true;
+        $("connected-tagline").hidden = false;
+        pairingActive = false;
+        return;
+      }
+
+      if (resp.status === "denied") {
+        setStatusUI("auth_required");
+        $("action-hint").textContent = "Connection was denied. Try again.";
+        $("action-section").hidden = false;
+        pairingActive = false;
+        return;
+      }
+
+      // expired
+      setStatusUI("auth_required");
+      $("action-hint").textContent = "Approval timed out. Try again.";
+      $("action-section").hidden = false;
+      pairingActive = false;
+      return;
+    }
+
+    // Timeout reached.
+    await saveSessionPair(null);
+    setStatusUI("auth_required");
+    $("action-hint").textContent = "Timed out waiting for approval.";
+    $("action-section").hidden = false;
+  } catch (e: any) {
+    await saveSessionPair(null);
+    setStatusUI("error");
+    $("action-hint").textContent = e?.message ?? "Pairing failed — try again.";
+    $("action-section").hidden = false;
+  }
+
+  pairingActive = false;
+}
+
+// ---------------------------------------------------------------------------
+// Open Screenpipe flow (server_down state)
+// ---------------------------------------------------------------------------
+
+async function tryOpenScreenpipe(baseUrl: string): Promise<void> {
+  const btn = $<HTMLButtonElement>("open-btn");
+  const hint = $<HTMLSpanElement>("action-hint");
+  btn.disabled = true;
+  hint.textContent = "Trying to open Screenpipe…";
+
+  await tryFocusScreenpipe();
+  await new Promise((r) => setTimeout(r, 1500));
+
+  const { token } = await getConfig();
+  const status = await probeStatus(token, baseUrl);
+  if (status !== "server_down") {
+    setStatusUI(status);
+  } else {
+    btn.disabled = false;
+    hint.textContent = "Screenpipe is not running — please open it.";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
 
 async function init(): Promise<void> {
   const { token, baseUrl } = await getConfig();
 
-  // Open the options page. `chrome.runtime.openOptionsPage()` is unreliable in
-  // some Chromium variants (notably Arc): it resolves successfully but the
-  // page never surfaces because the popup closes before the new tab paints.
-  // Opening the URL directly via chrome.tabs.create + closing the popup is
-  // the only consistently-working path across Chrome / Arc / Brave / Edge.
-  $<HTMLButtonElement>("settings-btn").addEventListener("click", () => {
-    const optionsUrl = chrome.runtime.getURL("options.html");
-    void chrome.tabs.create({ url: optionsUrl }).finally(() => {
-      window.close();
-    });
+  $<HTMLButtonElement>("settings-btn").addEventListener("click", openOptionsPage);
+
+  $<HTMLButtonElement>("connect-btn").addEventListener("click", () => {
+    void runPairingFlow(baseUrl);
   });
 
-  // Wake the service worker so its WebSocket has a chance to establish,
-  // then probe after a short delay so we don't always flash "bridge_down".
-  try { chrome.runtime.sendMessage({ type: "wake" }); } catch { /* ignore */ }
-  await new Promise((r) => setTimeout(r, 600));
+  $<HTMLButtonElement>("open-btn").addEventListener("click", () => {
+    void tryOpenScreenpipe(baseUrl);
+  });
 
+  // Wake SW so the WS has a chance to establish, then probe.
+  try { chrome.runtime.sendMessage({ type: "wake" }); } catch { /* ignore */ }
+
+  // Check for an in-progress pairing from a previous popup open.
+  const pendingPair = await getSessionPair();
+  if (pendingPair) {
+    // Resume polling — show pairing UI immediately without re-probing.
+    setStatusUI("bridge_down");
+    void runPairingFlow(pendingPair.baseUrl, pendingPair);
+    return;
+  }
+
+  await new Promise((r) => setTimeout(r, 600));
   const status = await probeStatus(token, baseUrl);
   setStatusUI(status);
 }

--- a/packages/browser-extension/src/types.ts
+++ b/packages/browser-extension/src/types.ts
@@ -16,7 +16,13 @@ export interface PingRequest {
   action: "ping";
 }
 
-export type IncomingMessage = EvalRequest | PingRequest;
+export interface CookieRequest {
+  id: string;
+  action: "get_cookies";
+  host: string;
+}
+
+export type IncomingMessage = EvalRequest | CookieRequest | PingRequest;
 
 /** Response sent from extension back to screenpipe server */
 export interface EvalResponse {
@@ -24,6 +30,17 @@ export interface EvalResponse {
   ok: boolean;
   result?: unknown;
   error?: string;
+}
+
+export interface BrowserCookie {
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  secure: boolean;
+  httpOnly: boolean;
+  expiresAt?: number;
+  sameSite: "unspecified" | "no_restriction" | "lax" | "strict";
 }
 
 export interface PongResponse {

--- a/packages/browser-extension/src/worker.ts
+++ b/packages/browser-extension/src/worker.ts
@@ -15,7 +15,7 @@
  * and cross-origin cookies are blocked).
  */
 
-import type { IncomingMessage, EvalResponse, HelloMessage } from "./types";
+import type { BrowserCookie, IncomingMessage, EvalResponse, HelloMessage } from "./types";
 import {
   DEFAULT_BASE_URL,
   STORAGE_KEY_TOKEN,
@@ -190,6 +190,17 @@ async function connect(): Promise<void> {
         const tabId = await findTab(url);
         const result = await evalInTab(tabId, code);
         send({ id, ok: true, result } satisfies EvalResponse);
+      } catch (err: any) {
+        send({ id, ok: false, error: err?.message ?? String(err) } satisfies EvalResponse);
+      }
+      return;
+    }
+
+    if (msg.action === "get_cookies") {
+      const { id, host } = msg;
+      try {
+        const cookies = await getCookiesForHost(host);
+        send({ id, ok: true, result: { cookies } } satisfies EvalResponse);
       } catch (err: any) {
         send({ id, ok: false, error: err?.message ?? String(err) } satisfies EvalResponse);
       }
@@ -372,6 +383,60 @@ async function evalInTab(tabId: number, code: string): Promise<unknown> {
     throw new Error(desc);
   }
   return evalResult?.result?.value ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Cookie access
+// ---------------------------------------------------------------------------
+
+function normalizeHost(host: string): string {
+  const normalized = host.trim().toLowerCase().replace(/\.$/, "");
+  if (!normalized || normalized.includes("/") || normalized.includes(":")) {
+    throw new Error("invalid cookie host");
+  }
+  return normalized;
+}
+
+function sameSiteValue(value: chrome.cookies.SameSiteStatus | undefined): BrowserCookie["sameSite"] {
+  if (value === "no_restriction" || value === "lax" || value === "strict") return value;
+  return "unspecified";
+}
+
+async function getCookiesForHost(host: string): Promise<BrowserCookie[]> {
+  if (!chrome.cookies?.getAll) {
+    throw new Error("extension does not have cookies permission");
+  }
+
+  const normalized = normalizeHost(host);
+  const hosts = new Set<string>();
+  const parts = normalized.split(".");
+  for (let i = 0; i <= Math.max(0, parts.length - 2); i += 1) {
+    hosts.add(parts.slice(i).join("."));
+  }
+
+  const byKey = new Map<string, BrowserCookie>();
+  for (const domain of hosts) {
+    const cookies = await chrome.cookies.getAll({ domain });
+    for (const c of cookies) {
+      const bareDomain = c.domain.replace(/^\./, "").toLowerCase();
+      if (normalized !== bareDomain && !normalized.endsWith(`.${bareDomain}`)) continue;
+      const item: BrowserCookie = {
+        name: c.name,
+        value: c.value,
+        domain: c.domain,
+        path: c.path || "/",
+        secure: Boolean(c.secure),
+        httpOnly: Boolean(c.httpOnly),
+        sameSite: sameSiteValue(c.sameSite),
+      };
+      if (typeof c.expirationDate === "number") {
+        item.expiresAt = Math.trunc(c.expirationDate);
+      }
+      byKey.set(`${item.name}\n${item.domain}\n${item.path}`, item);
+    }
+  }
+
+  return [...byKey.values()];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description:
Windows users can now open any site in the Screenpipe browser already signed in, no re-login, no passwords.

- When Screenpipe Extension is not connected.

https://github.com/user-attachments/assets/2ec349f8-7562-471d-ae0a-f1a915ebe7b7



- When Screenpipe Extension is already connected.


https://github.com/user-attachments/assets/a3928920-a946-497c-82f0-f9e0d2f7202c



Fixes #3314



What this does:
  - Reads cookies from Chrome, Edge, Brave, Vivaldi, Opera on Windows and injects them into the owned browser before navigation — same flow macOS already had
  - Handles Chrome's app-bound encryption (v20) and locked DB (browser running) by routing through the Browser Bridge extension automatically
  - Extension popup now pairs inline with one click — no more opening a settings page just to connect
  - "Browser login is protected" card shows exactly why cookies couldn't load and what to do, auto-dismisses when extension connects
  - Fixed agent picking the wrong browser endpoint when user says "open X in browser" — now always routes to the owned sidebar browser
  - Fixed macOS-only copy ("macOS may ask for Keychain access") showing on Windows
  - Fixed popup showing "not connected" + "Connect to Screenpipe" — redundant, now just "Connect"
  - Connected state now shows a tagline instead of an empty popup
  
  ### Note: 
 
  Why the extension is needed for most sites:
  - Chrome 127+ encrypts all cookies with app-bound encryption (v20) — Google, YouTube, GitHub, Reddit, Twitter, and most major sites are all v20. Screenpipe cannot decrypt these directly; the extension is the only way to access them without closing your browser.