### PR TITLE
feat(cli): add per-parameter overrides for event-driven capture intervals

### DIFF
--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -169,6 +169,30 @@ pub struct RecordingSettings {
     #[serde(rename = "disableMeetingDetector", default)]
     pub disable_meeting_detector: bool,
 
+    // ── Mitsukeru fork: event-driven capture overrides ─────────────────
+    // ミツケル拡張：PowerProfile に依らず個別パラメータを直接指定するための上書き値。
+    // None の場合は通常通り PowerProfile が決定。デスクトップ常時記録のような用途で
+    // 「AC 電源だが Balanced 相当の頻度に固定したい」ケースに対応する。
+    /// Override `EventDrivenCaptureConfig::idle_capture_interval_ms` (milliseconds).
+    /// None = follow active PowerProfile.
+    #[serde(rename = "idleCaptureIntervalMs", default)]
+    pub idle_capture_interval_ms: Option<u64>,
+
+    /// Override `EventDrivenCaptureConfig::visual_check_interval_ms` (milliseconds).
+    /// None = follow active PowerProfile.
+    #[serde(rename = "visualCheckIntervalMs", default)]
+    pub visual_check_interval_ms: Option<u64>,
+
+    /// Override `EventDrivenCaptureConfig::visual_change_threshold` (0.0–1.0).
+    /// None = follow active PowerProfile.
+    #[serde(rename = "visualChangeThreshold", default)]
+    pub visual_change_threshold: Option<f64>,
+
+    /// Override `EventDrivenCaptureConfig::min_capture_interval_ms` (milliseconds).
+    /// None = follow active PowerProfile.
+    #[serde(rename = "minCaptureIntervalMs", default)]
+    pub min_capture_interval_ms: Option<u64>,
+
     // ── Filters ────────────────────────────────────────────────────────
     /// Window titles to exclude from capture.
     #[serde(rename = "ignoredWindows")]
@@ -414,6 +438,10 @@ impl Default for RecordingSettings {
             max_snapshot_width: default_max_snapshot_width(),
             disable_snapshot_compaction: false,
             disable_meeting_detector: false,
+            idle_capture_interval_ms: None,
+            visual_check_interval_ms: None,
+            visual_change_threshold: None,
+            min_capture_interval_ms: None,
             ignored_windows: vec![],
             included_windows: vec![],
             ignored_urls: vec![],

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -401,6 +401,28 @@ pub struct RecordArgs {
     #[arg(long, default_value = "balanced")]
     pub video_quality: String,
 
+    /// Mitsukeru fork: override the active PowerProfile's idle_capture_interval_ms.
+    /// Forces this idle snapshot interval regardless of power mode. Useful for
+    /// fixed desktop / long-running recording where AC-power Performance defaults
+    /// (30s) are too aggressive. Reference: Balanced=60_000, Saver=120_000.
+    #[arg(long)]
+    pub idle_capture_interval_ms: Option<u64>,
+
+    /// Mitsukeru fork: override `EventDrivenCaptureConfig::visual_check_interval_ms`.
+    /// Sets the interval between frame-diff checks (set to 0 to disable visual change detection).
+    #[arg(long)]
+    pub visual_check_interval_ms: Option<u64>,
+
+    /// Mitsukeru fork: override `EventDrivenCaptureConfig::visual_change_threshold` (0.0–1.0).
+    /// Frame diff above this threshold triggers a VisualChange capture.
+    #[arg(long)]
+    pub visual_change_threshold: Option<f64>,
+
+    /// Mitsukeru fork: override `EventDrivenCaptureConfig::min_capture_interval_ms`.
+    /// Debounce floor between any two captures.
+    #[arg(long)]
+    pub min_capture_interval_ms: Option<u64>,
+
     /// Enable cloud sync
     #[arg(long, default_value_t = false)]
     pub enable_sync: bool,
@@ -670,6 +692,10 @@ impl RecordArgs {
             video_quality: self.video_quality.clone(),
             disable_snapshot_compaction: self.disable_snapshot_compaction,
             disable_meeting_detector: self.disable_meeting_detector,
+            idle_capture_interval_ms: self.idle_capture_interval_ms,
+            visual_check_interval_ms: self.visual_check_interval_ms,
+            visual_change_threshold: self.visual_change_threshold,
+            min_capture_interval_ms: self.min_capture_interval_ms,
             analytics_enabled: !self.disable_telemetry,
             ignore_incognito_windows: true,
             pause_on_drm_content: self.pause_on_drm_content,

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -145,6 +145,13 @@ pub struct RecordingConfig {
     /// See `RecordingSettings.disable_meeting_detector` for details.
     pub disable_meeting_detector: bool,
 
+    /// Mitsukeru fork: overrides for event-driven capture parameters.
+    /// None = follow active PowerProfile.
+    pub idle_capture_interval_ms: Option<u64>,
+    pub visual_check_interval_ms: Option<u64>,
+    pub visual_change_threshold: Option<f64>,
+    pub min_capture_interval_ms: Option<u64>,
+
     /// Require authentication for remote (non-localhost) API access.
     /// When true, requests from other devices must include
     /// `Authorization: Bearer <SCREENPIPE_API_KEY>`.
@@ -284,6 +291,10 @@ impl RecordingConfig {
             max_snapshot_width: settings.max_snapshot_width,
             disable_snapshot_compaction: settings.disable_snapshot_compaction,
             disable_meeting_detector: settings.disable_meeting_detector,
+            idle_capture_interval_ms: settings.idle_capture_interval_ms,
+            visual_check_interval_ms: settings.visual_check_interval_ms,
+            visual_change_threshold: settings.visual_change_threshold,
+            min_capture_interval_ms: settings.min_capture_interval_ms,
             // LAN exposure is opt-in. We force `api_auth` on whenever
             // `listen_on_lan` is true so a user can never accidentally
             // publish an unauthenticated API on their local network. The
@@ -363,6 +374,10 @@ impl RecordingConfig {
             pause_on_drm_content: self.pause_on_drm_content,
             languages: self.languages.clone(),
             video_quality: self.video_quality.clone(),
+            idle_capture_interval_ms: self.idle_capture_interval_ms,
+            visual_check_interval_ms: self.visual_check_interval_ms,
+            visual_change_threshold: self.visual_change_threshold,
+            min_capture_interval_ms: self.min_capture_interval_ms,
         }
     }
 }

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -44,6 +44,13 @@ pub struct VisionManagerConfig {
     /// snapshot max width via `screenpipe_core::video::*`. Values: "low",
     /// "balanced" (default), "high", "max".
     pub video_quality: String,
+
+    /// Mitsukeru fork: overrides for `EventDrivenCaptureConfig`.
+    /// Each field is applied only when `Some(_)`. None = follow active PowerProfile.
+    pub idle_capture_interval_ms: Option<u64>,
+    pub visual_check_interval_ms: Option<u64>,
+    pub visual_change_threshold: Option<f64>,
+    pub min_capture_interval_ms: Option<u64>,
 }
 
 /// Status of the VisionManager
@@ -344,10 +351,24 @@ impl VisionManager {
         // Event-driven capture config — seed jpeg_quality from the user's
         // chosen videoQuality so power-profile updates can use it as the
         // baseline ceiling (`min(profile, baseline)`) at runtime.
-        let capture_config = EventDrivenCaptureConfig {
+        let mut capture_config = EventDrivenCaptureConfig {
             jpeg_quality: baseline_q,
             ..EventDrivenCaptureConfig::default()
         };
+        // Mitsukeru fork: apply per-parameter CLI / settings overrides if any.
+        // These force the value regardless of the active PowerProfile.
+        if let Some(v) = self.config.idle_capture_interval_ms {
+            capture_config.idle_capture_interval_ms = v;
+        }
+        if let Some(v) = self.config.visual_check_interval_ms {
+            capture_config.visual_check_interval_ms = v;
+        }
+        if let Some(v) = self.config.visual_change_threshold {
+            capture_config.visual_change_threshold = v;
+        }
+        if let Some(v) = self.config.min_capture_interval_ms {
+            capture_config.min_capture_interval_ms = v;
+        }
 
         // Subscribe to the shared broadcast channel so UI events reach this monitor
         let trigger_rx = self.trigger_tx.subscribe();

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -524,6 +524,10 @@ mod tests {
             pause_on_drm_content: false,
             languages: vec![Language::English],
             video_quality: "balanced".to_string(),
+            idle_capture_interval_ms: None,
+            visual_check_interval_ms: None,
+            visual_change_threshold: None,
+            min_capture_interval_ms: None,
         };
         VisionManager::new(config, db, Handle::current())
     }


### PR DESCRIPTION
## Summary
Adds four optional overrides on `RecordingSettings` to bypass the active `PowerProfile` for individual `EventDrivenCaptureConfig` fields:

- `idle_capture_interval_ms`
- `visual_check_interval_ms`
- `visual_change_threshold`
- `min_capture_interval_ms`

Each is wired through CLI flags (`--idle-capture-interval-ms` etc.), `settings.json` (`idleCaptureIntervalMs` etc.), and propagated via `RecordingConfig` → `VisionManagerConfig`. When `None`, the active `PowerProfile` chooses the value as before; when `Some`, the override applies.

## Motivation
`PowerMode` (`Auto` / `Performance` / `BatterySaver`) is biased toward battery scenarios. Fixed-desktop / server recording use cases (e.g. long-running task mining on AC power) want an explicit "Balanced-equivalent" idle interval (e.g. 60s) without faking battery state. Today there is no way to express that.

Concrete use case: long-running screen recording on an AC-powered desktop where the `Performance` profile's 30s idle is too frequent for the a11y extraction workload, but `BatterySaver` is misleading (the user isn't on battery).

## Behavior
- Overrides are opt-in: default `None` → no behavior change for existing users
- `Some(value)` → override applied at `start_event_driven_monitor`
- `settings.json` field naming follows existing `camelCase` conventions

## Files
- `crates/screenpipe-config/src/recording.rs` — 4 `Option<T>` fields on `RecordingSettings`
- `crates/screenpipe-engine/src/cli/mod.rs` — 4 CLI flags on `RecordArgs` + propagation in `to_recording_settings`
- `crates/screenpipe-engine/src/recording_config.rs` — 4 fields on `RecordingConfig` + `from_settings` propagation
- `crates/screenpipe-engine/src/vision_manager/manager.rs` — apply overrides in `to_vision_manager_config` / `start_event_driven_monitor`

## Tested
- Built on Windows (MSVC, x86_64-pc-windows-msvc release)
- Verified flag is plumbed end-to-end: `screenpipe record --idle-capture-interval-ms 60000` applies the override

## Type
`feat` — opt-in extension, no behavior change for existing configurations.