### PR TITLE
fix(connections): allow typing in remote sync host input

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/agent-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/agent-card.tsx
@@ -569,7 +569,11 @@ function RemoteSyncSection({
           )}
           <Input
             placeholder="user@host"
-            value={config.user && config.host ? `${config.user}@${config.host}` : ""}
+            value={
+              config.user || config.host
+                ? `${config.user ? `${config.user}@` : ""}${config.host ?? ""}`
+                : ""
+            }
             onChange={(e) => {
               const val = e.target.value;
               const at = val.indexOf("@");


### PR DESCRIPTION
This pr fixed the manual `user@host` input in the Connections remote sync flow so users can type a custom host normally.

https://github.com/user-attachments/assets/c219d12b-789e-4929-92b2-40505fcabbde

