### PR TITLE
feat(audio): opt-in macOS VoiceProcessingIO for default microphone

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -2922,7 +2922,35 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
         </Card>
         )}
 
-        {/* CoreAudio System Audio (macOS 14.4+ only; default on) */}
+        {/* macOS microphone AEC (VoiceProcessingIO on default input) */}
+        {!settings.disableAudio && isMacOS && (
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Mic className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">
+                    Microphone echo cancellation
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Use Apple VoiceProcessingIO on the default microphone
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="macosInputVpioEnabled"
+                checked={Boolean(settings.macosInputVpioEnabled ?? false)}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({ macosInputVpioEnabled: checked }, true)
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+        )}
+
+        {/* CoreAudio System Audio (macOS 14.4+ only) */}
         {!settings.disableAudio && coreaudioTapAvailable && (
         <Card className="border-border bg-card">
           <CardContent className="px-3 py-2.5">

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -254,6 +254,8 @@ export type Settings = SettingsStore & {
 	experimentalCoreaudioSystemAudio?: boolean;
 	/** Experimental: request Windows WASAPI microphone AEC when supported. */
 	windowsInputAecEnabled?: boolean;
+	/** Experimental: request Apple VoiceProcessingIO AEC on the default macOS microphone. */
+	macosInputVpioEnabled?: boolean;
 	/** Continue recording audio when the screen is locked (default: false) */
 	recordWhileLocked?: boolean;
 	/** Auto-delete local data older than retention days (free alternative to cloud archive) */
@@ -537,6 +539,7 @@ let DEFAULT_SETTINGS: Settings = {
 			disableClipboardCapture: false,
 			experimentalCoreaudioSystemAudio: false,
 			windowsInputAecEnabled: false,
+			macosInputVpioEnabled: false,
 			recordWhileLocked: false,
 			localRetentionEnabled: false,
 			localRetentionDays: 14,

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1661,6 +1661,11 @@ experimentalCoreaudioSystemAudio?: boolean;
  */
 windowsInputAecEnabled?: boolean; 
 /**
+ * Experimental: request Apple VoiceProcessingIO (AEC) on the default macOS microphone.
+ * Ignored on non-macOS platforms. Only the system default input uses VPIO; other devices use HAL.
+ */
+macosInputVpioEnabled?: boolean; 
+/**
  * Duration of each audio chunk in seconds before transcription.
  * Stored as i32 to match existing store.bin schema (cast to u64 by engine).
  */

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -18,11 +18,11 @@ serde_json = "1.0"
 oasgen = { workspace = true }
 
 # Cross-platform audio capture.
-# Use the divanshu-go Windows AEC fork so Windows microphone AEC can be
-# wired through screenpipe's capture path. Cargo.lock pins the resolved
-# commit; update the cpal guard in .github/workflows/ci.yml whenever this
-# dependency is intentionally advanced.
-cpal = { git = "https://github.com/divanshu-go/cpal.git", branch = "windows-aec" }
+# Fork: macOS VoiceProcessingIO (AEC) + Windows WASAPI AEC. Cargo.lock pins the
+# resolved commit; update the cpal guard in .github/workflows/ci.yml whenever
+# this dependency is intentionally advanced. After screenpipe/cpal#3 merges,
+# point at https://github.com/screenpipe/cpal on main.
+cpal = { git = "https://github.com/divanshu-go/cpal.git", branch = "fix/macos-voice-processing-io" }
 
 # Wav encoding
 hound = "3.5"

--- a/crates/screenpipe-audio/src/audio_manager/builder.rs
+++ b/crates/screenpipe-audio/src/audio_manager/builder.rs
@@ -67,6 +67,8 @@ pub struct AudioManagerOptions {
     pub experimental_coreaudio_system_audio: bool,
     /// Experimental: request Windows WASAPI microphone AEC when the endpoint supports it.
     pub windows_input_aec_enabled: bool,
+    /// Use Apple VoiceProcessingIO on the default macOS microphone when supported.
+    pub macos_input_vpio_enabled: bool,
     /// Controls when local Whisper transcription runs.
     /// `Realtime` = immediate (default), `Batch` = accumulate longer chunks for quality.
     pub transcription_mode: TranscriptionMode,
@@ -113,6 +115,7 @@ impl Default for AudioManagerOptions {
             use_system_default_audio: true,
             experimental_coreaudio_system_audio: false,
             windows_input_aec_enabled: false,
+            macos_input_vpio_enabled: false,
             transcription_mode: TranscriptionMode::default(),
             meeting_detector: None,
             meeting_streaming: MeetingStreamingConfig::default(),
@@ -215,6 +218,11 @@ impl AudioManagerBuilder {
 
     pub fn windows_input_aec_enabled(mut self, enabled: bool) -> Self {
         self.options.windows_input_aec_enabled = enabled;
+        self
+    }
+
+    pub fn macos_input_vpio_enabled(mut self, enabled: bool) -> Self {
+        self.options.macos_input_vpio_enabled = enabled;
         self
     }
 

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -152,8 +152,17 @@ impl AudioManager {
         let device_manager = DeviceManager::new(
             options.experimental_coreaudio_system_audio,
             options.windows_input_aec_enabled,
+            options.macos_input_vpio_enabled,
         )
         .await?;
+        if options.windows_input_aec_enabled {
+            info!("screenpipe-audio: Windows WASAPI microphone AEC enabled in settings");
+        }
+        if options.macos_input_vpio_enabled {
+            info!(
+                "screenpipe-audio: macOS VoiceProcessingIO (AEC) enabled in settings (default input only)"
+            );
+        }
         let segmentation_manager = Arc::new(SegmentationManager::new(options.is_disabled).await?);
         let status = RwLock::new(AudioManagerStatus::Stopped);
         let vad_engine: Arc<Mutex<Box<dyn VadEngine + Send>>> = if options.is_disabled {
@@ -249,6 +258,7 @@ impl AudioManager {
         self.device_manager.configure_backend_flags(
             options.experimental_coreaudio_system_audio,
             options.windows_input_aec_enabled,
+            options.macos_input_vpio_enabled,
         );
         *self.meeting_detector.write().await = options.meeting_detector.clone();
         *self.options.write().await = options;

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -17,7 +17,7 @@ use std::sync::mpsc;
 use std::sync::Arc;
 use tokio::sync::{broadcast, oneshot};
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 
 #[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
 use crate::utils::audio::audio_to_mono;
@@ -129,6 +129,7 @@ impl AudioStream {
         is_running: Arc<AtomicBool>,
         #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] use_coreaudio_tap: bool,
         #[cfg_attr(not(target_os = "windows"), allow(unused_variables))] windows_input_aec: bool,
+        #[cfg_attr(not(target_os = "macos"), allow(unused_variables))] macos_input_vpio: bool,
     ) -> Result<Self> {
         let (tx, _) = broadcast::channel::<Vec<f32>>(1000);
         let tx_clone = tx.clone();
@@ -189,6 +190,7 @@ impl AudioStream {
                                 &is_disconnected,
                                 &stream_control_tx,
                                 windows_input_aec,
+                                macos_input_vpio,
                             )
                             .await?
                         }
@@ -207,6 +209,7 @@ impl AudioStream {
                     &is_disconnected,
                     &stream_control_tx,
                     windows_input_aec,
+                    macos_input_vpio,
                 )
                 .await?
             }
@@ -233,12 +236,31 @@ impl AudioStream {
         is_disconnected: &Arc<AtomicBool>,
         stream_control_tx: &mpsc::Sender<StreamControl>,
         windows_input_aec: bool,
+        macos_input_vpio: bool,
     ) -> Result<(AudioStreamConfig, tokio::task::JoinHandle<()>)> {
         let (cpal_audio_device, config) = get_cpal_device_and_config(device).await?;
         let audio_config = AudioStreamConfig::from(&config);
         let channels = config.channels();
         let is_running_weak = Arc::downgrade(is_running);
         let input_aec = windows_input_aec && device.device_type == super::device::DeviceType::Input;
+        let input_vpio = macos_input_vpio
+            && device.device_type == super::device::DeviceType::Input
+            && is_default_input_device(device);
+
+        #[cfg(target_os = "macos")]
+        {
+            if macos_input_vpio && input_vpio {
+                info!(
+                    device = %device,
+                    "screenpipe-audio: enabling VoiceProcessingIO (AEC) on default microphone"
+                );
+            } else if macos_input_vpio && device.device_type == super::device::DeviceType::Input {
+                info!(
+                    device = %device,
+                    "screenpipe-audio: macOS VPIO requested but using HAL (only system default input supports VoiceProcessingIO)"
+                );
+            }
+        }
 
         let thread = Self::spawn_audio_thread(
             cpal_audio_device,
@@ -250,6 +272,7 @@ impl AudioStream {
             is_disconnected.clone(),
             stream_control_tx.clone(),
             input_aec,
+            input_vpio,
         )
         .await?;
         Ok((audio_config, thread))
@@ -267,8 +290,13 @@ impl AudioStream {
         is_disconnected: Arc<AtomicBool>,
         stream_control_tx: mpsc::Sender<StreamControl>,
         windows_input_aec: bool,
+        macos_input_vpio: bool,
     ) -> Result<tokio::task::JoinHandle<()>> {
         let device_name = device.name()?;
+        #[cfg(target_os = "macos")]
+        let use_vpio = macos_input_vpio;
+        #[cfg(target_os = "windows")]
+        let use_aec = windows_input_aec;
 
         Ok(tokio::task::spawn_blocking(move || {
             // Primary attempt: the "best" config get_cpal_device_and_config
@@ -293,6 +321,7 @@ impl AudioStream {
                 tx.clone(),
                 primary_cb,
                 windows_input_aec,
+                macos_input_vpio,
             ) {
                 Ok(s) => Some(s),
                 Err(primary_err) if is_wasapi_unsupported_format(&primary_err) => {
@@ -316,6 +345,7 @@ impl AudioStream {
                                 tx,
                                 fallback_cb,
                                 windows_input_aec,
+                                macos_input_vpio,
                             ) {
                                 Ok(s) => Some(s),
                                 Err(fallback_err) => {
@@ -346,6 +376,21 @@ impl AudioStream {
                 if let Err(e) = stream.play() {
                     error!("failed to play stream for {}: {}", device_name, e);
                     return;
+                }
+
+                #[cfg(target_os = "macos")]
+                if use_vpio {
+                    info!(
+                        device = %device_name,
+                        "screenpipe-audio: VoiceProcessingIO microphone capture running (AEC initialized)"
+                    );
+                }
+                #[cfg(target_os = "windows")]
+                if use_aec {
+                    info!(
+                        device = %device_name,
+                        "screenpipe-audio: WASAPI microphone capture running with AEC enabled"
+                    );
                 }
 
                 if let Ok(StreamControl::Stop { response, mode }) = stream_control_rx.recv() {
@@ -588,10 +633,11 @@ fn build_input_stream(
     tx: broadcast::Sender<Vec<f32>>,
     error_callback: impl FnMut(CpalError) + Send + 'static,
     windows_input_aec: bool,
+    macos_input_vpio: bool,
 ) -> Result<cpal::Stream> {
     let stream_config = cpal_stream_config(config, windows_input_aec);
     match config.sample_format() {
-        cpal::SampleFormat::F32 => build_cpal_input_stream::<f32, _, _>(
+        cpal::SampleFormat::F32 => build_cpal_input_stream_for_platform::<f32, _, _>(
             device,
             &stream_config,
             move |data: &[f32], _: &_| {
@@ -599,8 +645,9 @@ fn build_input_stream(
                 let _ = tx.send(mono);
             },
             error_callback,
+            macos_input_vpio,
         ),
-        cpal::SampleFormat::I16 => build_cpal_input_stream::<i16, _, _>(
+        cpal::SampleFormat::I16 => build_cpal_input_stream_for_platform::<i16, _, _>(
             device,
             &stream_config,
             move |data: &[i16], _: &_| {
@@ -609,8 +656,9 @@ fn build_input_stream(
                 let _ = tx.send(mono);
             },
             error_callback,
+            macos_input_vpio,
         ),
-        cpal::SampleFormat::I32 => build_cpal_input_stream::<i32, _, _>(
+        cpal::SampleFormat::I32 => build_cpal_input_stream_for_platform::<i32, _, _>(
             device,
             &stream_config,
             move |data: &[i32], _: &_| {
@@ -622,8 +670,9 @@ fn build_input_stream(
                 let _ = tx.send(mono);
             },
             error_callback,
+            macos_input_vpio,
         ),
-        cpal::SampleFormat::I8 => build_cpal_input_stream::<i8, _, _>(
+        cpal::SampleFormat::I8 => build_cpal_input_stream_for_platform::<i8, _, _>(
             device,
             &stream_config,
             move |data: &[i8], _: &_| {
@@ -632,11 +681,64 @@ fn build_input_stream(
                 let _ = tx.send(mono);
             },
             error_callback,
+            macos_input_vpio,
         ),
         _ => Err(anyhow!(
             "unsupported sample format: {}",
             config.sample_format()
         )),
+    }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
+fn is_default_input_device(device: &AudioDevice) -> bool {
+    use super::device::{default_input_device, DeviceType};
+
+    if device.device_type != DeviceType::Input {
+        return false;
+    }
+
+    default_input_device()
+        .map(|default_device| default_device == *device)
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_voice_processing_config(enabled: bool) -> Option<cpal::MacosVoiceProcessingInputConfig> {
+    if enabled {
+        Some(cpal::MacosVoiceProcessingInputConfig::screenpipe_aec())
+    } else {
+        None
+    }
+}
+
+#[cfg(not(all(target_os = "linux", feature = "pulseaudio")))]
+fn build_cpal_input_stream_for_platform<T, D, E>(
+    device: &cpal::Device,
+    stream_config: &cpal::StreamConfig,
+    data_callback: D,
+    error_callback: E,
+    macos_input_vpio: bool,
+) -> Result<cpal::Stream>
+where
+    T: cpal::SizedSample,
+    D: FnMut(&[T], &cpal::InputCallbackInfo) + Send + 'static,
+    E: FnMut(CpalError) + Send + 'static,
+{
+    #[cfg(target_os = "macos")]
+    {
+        return build_cpal_input_stream(
+            device,
+            stream_config,
+            data_callback,
+            error_callback,
+            macos_voice_processing_config(macos_input_vpio),
+        );
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = macos_input_vpio;
+        build_cpal_input_stream(device, stream_config, data_callback, error_callback)
     }
 }
 
@@ -649,6 +751,7 @@ fn build_cpal_input_stream<T, D, E>(
     stream_config: &cpal::StreamConfig,
     data_callback: D,
     error_callback: E,
+    voice_processing: Option<cpal::MacosVoiceProcessingInputConfig>,
 ) -> Result<cpal::Stream>
 where
     T: cpal::SizedSample,
@@ -656,7 +759,13 @@ where
     E: FnMut(CpalError) + Send + 'static,
 {
     device
-        .build_input_stream(stream_config, data_callback, error_callback, None, None)
+        .build_input_stream(
+            stream_config,
+            data_callback,
+            error_callback,
+            None,
+            voice_processing,
+        )
         .map_err(|e| anyhow!(e))
 }
 

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -238,9 +238,7 @@ impl AudioStream {
         windows_input_aec: bool,
         macos_input_vpio: bool,
     ) -> Result<(AudioStreamConfig, tokio::task::JoinHandle<()>)> {
-        let (cpal_audio_device, config) = get_cpal_device_and_config(device).await?;
-        let audio_config = AudioStreamConfig::from(&config);
-        let channels = config.channels();
+        let (cpal_audio_device, mut config) = get_cpal_device_and_config(device).await?;
         let is_running_weak = Arc::downgrade(is_running);
         let input_aec = windows_input_aec && device.device_type == super::device::DeviceType::Input;
         let input_vpio = macos_input_vpio
@@ -250,9 +248,33 @@ impl AudioStream {
         #[cfg(target_os = "macos")]
         {
             if macos_input_vpio && input_vpio {
+                let original_rate = config.sample_rate().0;
                 info!(
                     device = %device,
                     "screenpipe-audio: enabling VoiceProcessingIO (AEC) on default microphone"
+                );
+                config = cpal_audio_device.default_input_config().map_err(|e| {
+                    anyhow!(
+                        "could not get default input config for VoiceProcessingIO on {}: {}",
+                        device,
+                        e
+                    )
+                })?;
+                let vpio_rate = config.sample_rate().0;
+                if vpio_rate != original_rate {
+                    info!(
+                        device = %device,
+                        original_rate,
+                        vpio_rate,
+                        "screenpipe-audio: VPIO config rate differs from originally-picked config; \
+                         using hardware native rate"
+                    );
+                }
+                info!(
+                    device = %device,
+                    sample_rate = vpio_rate,
+                    channels = config.channels(),
+                    "screenpipe-audio: using default input config for VoiceProcessingIO"
                 );
             } else if macos_input_vpio && device.device_type == super::device::DeviceType::Input {
                 info!(
@@ -261,6 +283,9 @@ impl AudioStream {
                 );
             }
         }
+
+        let audio_config = AudioStreamConfig::from(&config);
+        let channels = config.channels();
 
         let thread = Self::spawn_audio_thread(
             cpal_audio_device,
@@ -361,6 +386,41 @@ impl AudioStream {
                             error!(
                                 "could not get default_input_config for {}: {} (primary: {})",
                                 device_name, e, primary_err
+                            );
+                            None
+                        }
+                    }
+                }
+                #[cfg(target_os = "macos")]
+                Err(primary_err) if macos_input_vpio => {
+                    warn!(
+                        device = %device_name,
+                        rate = config.sample_rate().0,
+                        channels = channels,
+                        format = ?config.sample_format(),
+                        "VoiceProcessingIO stream creation failed ({}); retrying with HAL (VPIO disabled)",
+                        primary_err,
+                    );
+                    let fallback_cb = create_error_callback(
+                        device_name.clone(),
+                        is_running_weak,
+                        is_disconnected,
+                        stream_control_tx,
+                    );
+                    match build_input_stream(
+                        &device,
+                        &config,
+                        channels,
+                        tx,
+                        fallback_cb,
+                        windows_input_aec,
+                        false,
+                    ) {
+                        Ok(s) => Some(s),
+                        Err(fallback_err) => {
+                            error!(
+                                "HAL fallback also failed for {} after VPIO error: {} (VPIO error: {})",
+                                device_name, fallback_err, primary_err
                             );
                             None
                         }

--- a/crates/screenpipe-audio/src/device/device_manager.rs
+++ b/crates/screenpipe-audio/src/device/device_manager.rs
@@ -20,10 +20,16 @@ pub struct DeviceManager {
     use_coreaudio_tap: AtomicBool,
     /// When true, Windows WASAPI input streams request endpoint AEC.
     windows_input_aec: AtomicBool,
+    /// When true, the default macOS microphone uses VoiceProcessingIO (AEC).
+    macos_input_vpio: AtomicBool,
 }
 
 impl DeviceManager {
-    pub async fn new(use_coreaudio_tap: bool, windows_input_aec: bool) -> Result<Self> {
+    pub async fn new(
+        use_coreaudio_tap: bool,
+        windows_input_aec: bool,
+        macos_input_vpio: bool,
+    ) -> Result<Self> {
         let streams = Arc::new(DashMap::new());
         let states = Arc::new(DashMap::new());
 
@@ -32,14 +38,22 @@ impl DeviceManager {
             states,
             use_coreaudio_tap: AtomicBool::new(use_coreaudio_tap),
             windows_input_aec: AtomicBool::new(windows_input_aec),
+            macos_input_vpio: AtomicBool::new(macos_input_vpio),
         })
     }
 
-    pub fn configure_backend_flags(&self, use_coreaudio_tap: bool, windows_input_aec: bool) {
+    pub fn configure_backend_flags(
+        &self,
+        use_coreaudio_tap: bool,
+        windows_input_aec: bool,
+        macos_input_vpio: bool,
+    ) {
         self.use_coreaudio_tap
             .store(use_coreaudio_tap, Ordering::Relaxed);
         self.windows_input_aec
             .store(windows_input_aec, Ordering::Relaxed);
+        self.macos_input_vpio
+            .store(macos_input_vpio, Ordering::Relaxed);
     }
 
     pub async fn devices(&self) -> Vec<AudioDevice> {
@@ -61,6 +75,7 @@ impl DeviceManager {
             is_running.clone(),
             self.use_coreaudio_tap.load(Ordering::Relaxed),
             self.windows_input_aec.load(Ordering::Relaxed),
+            self.macos_input_vpio.load(Ordering::Relaxed),
         )
         .await
         {

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -104,6 +104,11 @@ pub struct RecordingSettings {
     #[serde(rename = "windowsInputAecEnabled", default)]
     pub windows_input_aec_enabled: bool,
 
+    /// Experimental: request Apple VoiceProcessingIO (AEC) on the default macOS microphone.
+    /// Ignored on non-macOS platforms. Only the system default input uses VPIO; other devices use HAL.
+    #[serde(rename = "macosInputVpioEnabled", default)]
+    pub macos_input_vpio_enabled: bool,
+
     /// Duration of each audio chunk in seconds before transcription.
     /// Stored as i32 to match existing store.bin schema (cast to u64 by engine).
     #[serde(rename = "audioChunkDuration")]
@@ -466,6 +471,7 @@ impl Default for RecordingSettings {
             use_system_default_audio: true,
             experimental_coreaudio_system_audio: false,
             windows_input_aec_enabled: false,
+            macos_input_vpio_enabled: false,
             audio_chunk_duration: 30,
             deepgram_api_key: String::new(),
             filter_music: false,

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -309,6 +309,11 @@ pub struct RecordArgs {
     #[arg(long, default_value_t = false)]
     pub windows_input_aec_enabled: bool,
 
+    /// [experimental, macOS] Request VoiceProcessingIO AEC on the default microphone.
+    /// Ignored on non-macOS platforms and non-default input devices.
+    #[arg(long, default_value_t = false)]
+    pub macos_input_vpio_enabled: bool,
+
     /// Data directory. Default to $HOME/.screenpipe
     #[arg(long, value_hint = ValueHint::DirPath)]
     pub data_dir: Option<String>,
@@ -557,6 +562,7 @@ pub struct RecordArgSources {
     pub use_system_default_audio: bool,
     pub experimental_coreaudio_system_audio: bool,
     pub windows_input_aec_enabled: bool,
+    pub macos_input_vpio_enabled: bool,
     pub audio_transcription_engine: bool,
     pub monitor_id: bool,
     pub use_all_monitors: bool,
@@ -600,6 +606,7 @@ impl RecordArgSources {
                 "experimental_coreaudio_system_audio",
             ),
             windows_input_aec_enabled: from_command_line(record, "windows_input_aec_enabled"),
+            macos_input_vpio_enabled: from_command_line(record, "macos_input_vpio_enabled"),
             audio_transcription_engine: from_command_line(record, "audio_transcription_engine"),
             monitor_id: from_command_line(record, "monitor_id"),
             use_all_monitors: from_command_line(record, "use_all_monitors"),
@@ -635,6 +642,7 @@ impl RecordArgSources {
             || self.use_system_default_audio
             || self.experimental_coreaudio_system_audio
             || self.windows_input_aec_enabled
+            || self.macos_input_vpio_enabled
             || self.audio_transcription_engine
             || self.monitor_id
             || self.use_all_monitors
@@ -718,6 +726,7 @@ impl RecordArgs {
             use_system_default_audio: self.use_system_default_audio,
             experimental_coreaudio_system_audio: self.experimental_coreaudio_system_audio,
             windows_input_aec_enabled: self.windows_input_aec_enabled,
+            macos_input_vpio_enabled: self.macos_input_vpio_enabled,
             monitor_ids: self.monitor_id.iter().map(|id| id.to_string()).collect(),
             // Explicit `--monitor-id` implies opting out of `--use-all-monitors`.
             // `use_all_monitors` has `default_value_t = true`, so without this
@@ -915,6 +924,9 @@ impl RecordArgs {
         }
         if sources.windows_input_aec_enabled {
             settings.windows_input_aec_enabled = self.windows_input_aec_enabled;
+        }
+        if sources.macos_input_vpio_enabled {
+            settings.macos_input_vpio_enabled = self.macos_input_vpio_enabled;
         }
         if sources.audio_transcription_engine {
             settings.audio_transcription_engine =

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -61,6 +61,8 @@ pub struct RecordingConfig {
     pub experimental_coreaudio_system_audio: bool,
     /// Experimental: request Windows WASAPI microphone AEC when supported.
     pub windows_input_aec_enabled: bool,
+    /// Use Apple VoiceProcessingIO on the default macOS microphone when supported.
+    pub macos_input_vpio_enabled: bool,
     pub monitor_ids: Vec<String>,
     pub use_all_monitors: bool,
 
@@ -243,6 +245,7 @@ impl RecordingConfig {
             use_system_default_audio: settings.use_system_default_audio,
             experimental_coreaudio_system_audio: settings.experimental_coreaudio_system_audio,
             windows_input_aec_enabled: settings.windows_input_aec_enabled,
+            macos_input_vpio_enabled: settings.macos_input_vpio_enabled,
             monitor_ids: settings.monitor_ids.clone(),
             use_all_monitors: settings.use_all_monitors,
             ignored_windows: settings.ignored_windows.clone(),
@@ -369,6 +372,7 @@ impl RecordingConfig {
             .use_system_default_audio(self.use_system_default_audio)
             .experimental_coreaudio_system_audio(self.experimental_coreaudio_system_audio)
             .windows_input_aec_enabled(self.windows_input_aec_enabled)
+            .macos_input_vpio_enabled(self.macos_input_vpio_enabled)
             .deepgram_config(self.deepgram_config.clone())
             .output_path(output_path)
             .use_pii_removal(self.use_pii_removal)


### PR DESCRIPTION


## Summary

Adds a Screenpipe setting and CLI flag to request Apple VoiceProcessingIO (VPIO) acoustic echo cancellation on the default macOS microphone, parallel to the existing Windows WASAPI `windowsInputAecEnabled` path.

This is intended for desktop meeting capture on macOS:

- **microphone / default input**: optional VPIO AEC to reduce speaker/output echo in the local mic lane (system default device only)
- **system / output audio**: captured separately as before (CoreAudio tap and other output paths unchanged)

The flag is off by default. Non-default input devices keep the HAL capture path.

## Details

- Adds `--macos-input-vpio-enabled` to the CLI.

- Adds a macOS-only desktop settings toggle: **Microphone echo cancellation**.

- On macOS, applies `MacosVoiceProcessingInputConfig::screenpipe_aec()` only when the flag is on and the device is the system default input.


Closes #3432

Ref: https://github.com/screenpipe/cpal/pull/3


<img width="1117" height="781" alt="image" src="https://github.com/user-attachments/assets/96571c4a-f953-480d-bd23-4f85086c18bc" />

