### PR TITLE
Default Pro users to Screenpipe Cloud

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -411,6 +411,27 @@ export function makeDefaultPresets(isPro: boolean): AIPreset[] {
 // ensureDefaultPreset() re-seeds with pro status once settings.user is loaded.
 const DEFAULT_CLOUD_PRESET: AIPreset = makeDefaultPresets(false)[0];
 
+const isLoggedInProUser = (user: User | null | undefined) =>
+	user?.cloud_subscribed === true && Boolean(user.token || user.id);
+
+const applyProCloudAudioDefaults = (settings: Settings): Settings => {
+	if (!isLoggedInProUser(settings.user)) return settings;
+	if ((settings as any)._proCloudAudioDefaultsAppliedV2) return settings;
+
+	if (
+		settings.audioTranscriptionEngine !== "screenpipe-cloud" ||
+		settings.meetingLiveTranscriptionProvider !== "screenpipe-cloud" ||
+		settings.meetingLiveTranscriptionEnabled !== true
+	) {
+		settings.audioTranscriptionEngine = "screenpipe-cloud";
+		settings.meetingLiveTranscriptionEnabled = true;
+		settings.meetingLiveTranscriptionProvider = "screenpipe-cloud";
+	}
+	(settings as any)._proCloudAudioDefaultsAppliedV2 = true;
+
+	return settings;
+};
+
 let DEFAULT_SETTINGS: Settings = {
 			aiPresets: makeDefaultPresets(false) as any,
 			deviceId: crypto.randomUUID(),
@@ -730,16 +751,11 @@ function createSettingsStore() {
 			needsUpdate = true;
 		}
 
-		// Post-migration: if user is a paid subscriber but still on a local engine
-		// (because migration ran before login), switch to cloud once.
-		// _cloudEngineApplied prevents overriding if user manually switches back later.
-		if (
-			settings.user?.cloud_subscribed &&
-			settings.audioTranscriptionEngine !== "screenpipe-cloud" &&
-			!(settings as any)._cloudEngineApplied
-		) {
-			settings.audioTranscriptionEngine = "screenpipe-cloud";
-			(settings as any)._cloudEngineApplied = true;
+		// Post-migration: when a logged-in Pro user is first confirmed, default
+		// both background and live transcription to Screenpipe Cloud. The marker
+		// prevents future user refreshes from overriding a manual engine choice.
+		if (isLoggedInProUser(settings.user) && !(settings as any)._proCloudAudioDefaultsAppliedV2) {
+			applyProCloudAudioDefaults(settings);
 			needsUpdate = true;
 		}
 
@@ -786,7 +802,10 @@ function createSettingsStore() {
 	const set = async (value: Partial<Settings>) => {
 		const store = await getStore();
 		const current = await get();
-		const newSettings = { ...current, ...value };
+		let newSettings = { ...current, ...value } as Settings;
+		if ("user" in value) {
+			newSettings = applyProCloudAudioDefaults(newSettings);
+		}
 		await store.set("settings", newSettings);
 		await saveAndEncrypt(store);
 	};

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -418,15 +418,12 @@ const applyProCloudAudioDefaults = (settings: Settings): Settings => {
 	if (!isLoggedInProUser(settings.user)) return settings;
 	if ((settings as any)._proCloudAudioDefaultsAppliedV2) return settings;
 
-	if (
-		settings.audioTranscriptionEngine !== "screenpipe-cloud" ||
-		settings.meetingLiveTranscriptionProvider !== "screenpipe-cloud" ||
-		settings.meetingLiveTranscriptionEnabled !== true
-	) {
+	const oldCloudEngineMigrationAlreadyRan = (settings as any)._cloudEngineApplied === true;
+	if (!oldCloudEngineMigrationAlreadyRan) {
 		settings.audioTranscriptionEngine = "screenpipe-cloud";
-		settings.meetingLiveTranscriptionEnabled = true;
-		settings.meetingLiveTranscriptionProvider = "screenpipe-cloud";
 	}
+	settings.meetingLiveTranscriptionEnabled = true;
+	settings.meetingLiveTranscriptionProvider = "screenpipe-cloud";
 	(settings as any)._proCloudAudioDefaultsAppliedV2 = true;
 
 	return settings;


### PR DESCRIPTION
### Description:

This PR updates the desktop settings flow so logged-in Pro users are defaulted to Screenpipe Cloud for both background transcription and live meeting transcription.

Previously, the Pro cloud migration only updated `audioTranscriptionEngine`, and only during settings load. That meant same-session login or user refresh could confirm `cloud_subscribed: true` without applying the cloud defaults immediately. It also left live meeting transcription on the previous provider setting.

#### Changes:
- Adds a shared Pro-user check based on subscription plus stored auth identity.
- Applies Screenpipe Cloud defaults once for logged-in Pro users.
- Sets `audioTranscriptionEngine` to `screenpipe-cloud`.
- Enables live meeting transcription.
- Sets `meetingLiveTranscriptionProvider` to `screenpipe-cloud`.
- Applies the same defaulting path when user data is updated through settings.

<img width="859" height="803" alt="image" src="https://github.com/user-attachments/assets/fecc92a3-e055-41dc-bba7-76a2501800eb" />


