### PR TITLE
fix(chat): suppress model planning/tool-step narration in answers

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -601,6 +601,8 @@ Don't lecture. Skip "Why this matters", "the reusable pattern is", "in summary",
 
 Hide the plumbing. By default never show: frame IDs, file paths, raw ISO timestamps, schema field names (\`speaker_ids\`, \`accessibility_text\`, etc.), API parameters (\`content_type\`, \`limit=\`), or process names ending in \`.exe\`. Translate to human terms — strip \`.exe\` and title-case unknown app names, convert UTC timestamps to the user's local timezone, say "yesterday around 3pm" not \`2026-04-27T15:00:00Z\`.
 
+Never expose planning, routing, skill selection, tool selection, API debugging, retries, timezone math, or self-instructions in visible assistant messages. Do the work silently and only show the final user-facing answer — no "Let me check...", "The user is asking...", "According to my instructions...", "I'll now query..." preamble.
+
 # Flip to technical mode when the user signals it
 
 Match the user's energy. Go detailed/structured when any of these is true:


### PR DESCRIPTION
## Summary
- Append one rule to the chat system prompt in `apps/screenpipe-app-tauri/components/standalone-chat.tsx` so the model doesn't surface its planning/tool-call reasoning as the user-visible answer.

## Why
Users occasionally saw the assistant render its internal narration (`Let me check...`, `According to my instructions...`, `I'll now query...`) as the final reply instead of the actual answer. The existing prompt told the model to hide schema field names and ISO timestamps, but never explicitly told it to suppress meta-reasoning. Adding the rule next to the existing "hide the plumbing" line keeps the prompt coherent.

## What changed
Added one line under the "Hide the plumbing" paragraph:

> Never expose planning, routing, skill selection, tool selection, API debugging, retries, timezone math, or self-instructions in visible assistant messages. Do the work silently and only show the final user-facing answer — no "Let me check...", "The user is asking...", "According to my instructions...", "I'll now query..." preamble.

No render-path changes — the leak was the model emitting prose, not a tag-stripping bug.

## Test plan
- [ ] Ask the chat: "which apps did I use most today" — expect a single concise answer, no "Let me check the API..." preamble.
- [ ] Ask the chat a question that requires multiple tool calls — expect only the final synthesized answer.
- [ ] `cd apps/screenpipe-app-tauri && bun run build` — passes locally on this branch.

Fixes #3332

🤖 Generated with [Claude Code](https://claude.com/claude-code)