### PR TITLE
fix(chat): drawer history reflects clear action from sidebar (#3345)

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -186,9 +186,33 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       return;
     }
 
+    // Re-open: re-fetch from disk so the drawer reflects any archive /
+    // delete actions that happened while the drawer was closed. Without
+    // this, `fileConversations` stayed at whatever the in-memory snapshot
+    // was when the drawer was last closed — so archiving every chat from
+    // the sidebar's Recents left the drawer still showing them on next
+    // open (#3345). The cross-window event listeners patch this state
+    // in-place, but rely on the listener actually being registered AND
+    // receiving every event between actions and re-open; refreshing on
+    // re-open is the cheap belt-and-suspenders guarantee.
     if (migrationDoneRef.current) {
-      setHistoryReady(true);
-      return;
+      let cancelled = false;
+      const requestId = ++historyRequestRef.current;
+      (async () => {
+        try {
+          const convs = await loadConversationMetas("");
+          if (cancelled || historyRequestRef.current !== requestId) return;
+          setFileConversations(convs);
+          lastHistoryQueryRef.current = "";
+        } catch {
+          // ignore: keep the previous snapshot rather than blanking the UI
+        } finally {
+          if (!cancelled) setHistoryReady(true);
+        }
+      })();
+      return () => {
+        cancelled = true;
+      };
     }
     migrationDoneRef.current = true;
     (async () => {


### PR DESCRIPTION
## Summary

The inline "Chat History" drawer in the chat panel kept showing archived/deleted chats after the sidebar "Recents" list had been cleared. Re-fetch from disk every time the drawer transitions from closed to open so the two surfaces stay in sync.

## Root cause

Two chat lists, two data sources:

- **Recents** (sidebar) reads live from the in-memory `chat-store` (zustand). Archiving / deleting a chat patches the store immediately — Recents updates without round-tripping disk.
- **Chat History drawer** (inline panel in `standalone-chat.tsx`) reads from `fileConversations`, a separate React state inside `useChatConversations`. It's seeded from `~/.screenpipe/chats/` on first open and kept in sync via cross-window `chat-deleted` / `chat-visibility-changed` event listeners.

When the user closed the drawer, then archived/deleted chats from the sidebar, then reopened the drawer, the open-transition `useEffect` hit the `migrationDoneRef.current` short-circuit and only flipped `historyReady = true` without re-reading the disk. The follow-up search effect bailed too because `lastHistoryQueryRef.current === ""` was already satisfied. So the drawer kept whatever in-memory snapshot it had when it was last closed — which still had the now-archived rows.

The listeners *do* patch state in-place when they receive an event, but rely on the listener being registered and the event actually firing for every action. Refreshing from disk on each re-open is the cheap belt-and-suspenders guarantee.

## What changed

`apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts`:
- When the drawer transitions from closed → open and migration has already run, re-fetch the conversation metas from disk and update `fileConversations`. Uses the existing `historyRequestRef` request-id pattern to discard stale responses if the drawer is closed mid-flight or another effect supersedes us. On error, keep the previous snapshot rather than blanking the UI.

## Test plan

- [ ] Build passes (`bun run build` under `apps/screenpipe-app-tauri/`).
- [ ] All vitest tests pass (`bunx vitest run`).
- [ ] Open the chat overlay (`/chat`).
- [ ] Create 2 conversations.
- [ ] Close the chat overlay, return to `/home`.
- [ ] Archive both conversations from the sidebar's Recents (3-dots → Archive).
- [ ] Reopen the chat overlay.
- [ ] Open the History drawer — verify it is empty (matches Recents).
- [ ] Repeat with Delete instead of Archive — drawer should also be empty.
- [ ] With drawer open, archive a chat from the sidebar in the same window — drawer still updates (regression check on the existing listener path).

Fixes #3345

🤖 Generated with [Claude Code](https://claude.com/claude-code)