### PR TITLE
fix(owned-browser): hide native webview when panel closes

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -504,7 +504,10 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
-    if (!panelOpen) return;
+    if (!panelOpen) {
+      invoke("owned_browser_hide").catch(() => {});
+      return;
+    }
     const el = placeholderRef.current;
     if (!el) return;
     schedulePushBounds();


### PR DESCRIPTION


https://github.com/user-attachments/assets/227bfce0-0a50-4a69-aaab-d3643813c64a

### Description: 

- Before: 


https://github.com/user-attachments/assets/11404b40-e0e1-4c18-b9be-173b4aaa05d6



- After: 



Native WebView2 child stayed floating on top when switching to Help/Settings/Memories because `owned_browser_hide` was never called during the `panelOpen → false` transition. Fixed by hiding explicitly in the bounds-tracking effect when `panelOpen` is false.