### PR TITLE
fix: Screenpipe Cloud chat image forwarding

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -72,25 +72,11 @@ async fn fetch_models_from_gateway(
                 .unwrap_or("standard");
             let reasoning = intelligence == "highest" || intelligence == "high";
 
-            // Determine input modalities from best_for/tags
-            let best_for = m.get("best_for").and_then(|v| v.as_array());
-            let has_vision = best_for
-                .map(|arr| {
-                    arr.iter()
-                        .any(|v| v.as_str().is_some_and(|s| s.contains("vision")))
-                })
-                .unwrap_or(false);
-            let input = if has_vision {
-                json!(["text", "image"])
-            } else {
-                json!(["text"])
-            };
-
             json!({
                 "id": id,
                 "name": name,
                 "reasoning": reasoning,
-                "input": input,
+                "input": ["text", "image"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
                 "contextWindow": ctx,
                 "maxTokens": 32000,


### PR DESCRIPTION
### Description:

<img width="1918" height="1078" alt="Screenshot 2026-05-20 191551" src="https://github.com/user-attachments/assets/e2902f02-450f-4abd-ac0d-bbf6ccbb0876" />

Fixes #3463 
This fixes desktop chat image forwarding for Screenpipe Cloud models.

Pi was marking cloud models as text-only unless `/v1/models` had `best_for` containing `vision`. Some cloud models do not expose vision that way, so Pi replaced attached images with text placeholders before the request reached Screenpipe Cloud.