### PR TITLE
fix(ai-presets): deduplicate model IDs from API responses to prevent React key collision

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -210,7 +210,8 @@ export function AIProviderConfig({
         });
         if (resp.ok) {
           const data = await resp.json();
-          const models = (data.data || []).map((m: any) => ({
+          const models = (data.data || [])
+            .map((m: any) => ({
             id: m.id,
             name: m.name || m.id,
             free: m.free,
@@ -218,7 +219,8 @@ export function AIProviderConfig({
             recommended_for: m.recommended_for,
             warning: m.warning,
             health: m.health,
-          }));
+            }))
+            .filter((m: { id: string }, idx: number, arr: { id: string }[]) => arr.findIndex((x) => x.id === m.id) === idx);
           setPiModels(models);
         }
       } catch {
@@ -404,8 +406,9 @@ export function AIProviderConfig({
             });
             if (resp.ok) {
               const data = await resp.json();
-              if (data.data?.length > 0) {
-                setOpenAIModels(data.data);
+              const uniqueModels = (data.data as { id: string }[]).filter((m, idx, arr) => arr.findIndex((x) => x.id === m.id) === idx);
+              if (uniqueModels.length > 0) {
+                setOpenAIModels(uniqueModels);
                 setIsLoadingModels(false);
                 return;
               }

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -741,11 +741,13 @@ const AISection = ({
             modelCount = ollamaModels.length;
             setModels(ollamaModels);
           } else {
-            const apiModels = (data.data || []).map((m: any) => ({
+            const apiModels = (data.data || [])
+              .map((m: any) => ({
               id: m.id,
               name: m.id,
               provider: settingsPreset?.provider || "custom",
-            }));
+              }))
+              .filter((m: any, idx: number, arr: any[]) => arr.findIndex((x: any) => x.id === m.id) === idx);
             modelCount = apiModels.length;
             setModels(apiModels);
           }
@@ -1027,7 +1029,8 @@ const AISection = ({
                     id: m.id,
                     name: m.id,
                     provider: "openai-chatgpt",
-                  }));
+                  }))
+                  .filter((m: { id: string }, idx: number, arr: { id: string }[]) => arr.findIndex((x) => x.id === m.id) === idx);
                 console.log("[chatgpt] fetched", chatgptModels.length, "models from API");
                 if (chatgptModels.length > 0) {
                   setModels(chatgptModels);
@@ -1064,7 +1067,8 @@ const AISection = ({
             });
             if (piResp.ok) {
               const piData = await piResp.json();
-              const piModels: AIModel[] = (piData.data || []).map((m: any) => ({
+              const piModels: AIModel[] = (piData.data || [])
+                .map((m: any) => ({
                 id: m.id,
                 name: m.name || m.id,
                 provider: "screenpipe",
@@ -1079,7 +1083,8 @@ const AISection = ({
                 recommended_for: m.recommended_for,
                 warning: m.warning,
                 query_weight: m.query_weight,
-              }));
+                }))
+                .filter((m: AIModel, idx: number, arr: AIModel[]) => arr.findIndex((x) => x.id === m.id) === idx);
               if (piModels.length > 0) {
                 setModels(piModels);
                 break;


### PR DESCRIPTION
### Description:
APIs for ChatGPT, screenpipe-cloud, and OpenAI were returning duplicate model IDs, causing React to log "two children with same key" on every render — flooding the error counter via the dual console interceptors in layout.tsx and providers.tsx.

- Before: 

<img width="1506" height="968" alt="Screenshot 2026-05-20 192140" src="https://github.com/user-attachments/assets/e99c7ad5-5cfa-4f2a-831f-04f37207da61" />

<img width="1680" height="892" alt="Screenshot 2026-05-20 192204" src="https://github.com/user-attachments/assets/a7e1fc65-6b17-439f-9161-fc0563e56d28" />


- After: 



https://github.com/user-attachments/assets/fc3a1c45-6541-4115-bad7-cd5a11f57588

