### PR TITLE
feat(health): expose ui_recorder status so /health answers 'is clipboard capture on?'

### DIFF
--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -17,7 +17,9 @@ use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
 use crate::server::AppState;
-use crate::ui_recorder::{tree_walker_snapshot, TreeWalkerSnapshot};
+use crate::ui_recorder::{
+    tree_walker_snapshot, ui_recorder_status_snapshot, TreeWalkerSnapshot, UiRecorderStatus,
+};
 
 /// Cached health response to avoid recomputing on every poll.
 /// Multiple WebSocket clients + HTTP polls can call /health dozens of
@@ -85,6 +87,10 @@ pub struct HealthCheckResponse {
     pub audio_pipeline: Option<AudioPipelineHealthInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accessibility: Option<TreeWalkerSnapshot>,
+    /// UI/input/clipboard recorder status. Surfaces "configured but not running"
+    /// distinctly from "off" so users can tell why ui_events stopped writing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ui_recorder: Option<UiRecorderStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pool_stats: Option<PoolHealthInfo>,
     /// True when vision capture loop is alive but DB writes have stopped (pool exhaustion).
@@ -727,6 +733,17 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
                 None
             }
         },
+        ui_recorder: {
+            let snap = ui_recorder_status_snapshot();
+            // Only attach when start_ui_recording has touched the atomics —
+            // otherwise the field is meaningless noise for users who never
+            // enabled UI capture.
+            if snap.configured || snap.events_inserted > 0 {
+                Some(snap)
+            } else {
+                None
+            }
+        },
         audio_pipeline: if !state.audio_disabled {
             let is_paused = state
                 .audio_manager
@@ -945,6 +962,7 @@ mod tests {
             pipeline: None,
             audio_pipeline: None,
             accessibility: None,
+            ui_recorder: None,
             pool_stats: None,
             vision_db_write_stalled: false,
             audio_db_write_stalled: false,

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -586,7 +586,10 @@ mod tests {
         record_ui_event_flush(3);
         let after = ui_recorder_status_snapshot();
         assert_eq!(after.events_inserted, before + 3);
-        assert!(after.last_event_at.is_some(), "successful flush stamps a timestamp");
+        assert!(
+            after.last_event_at.is_some(),
+            "successful flush stamps a timestamp"
+        );
 
         // disabled path: configured=false, running=false, no clipboard.
         set_ui_recorder_state(false, false, false);

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 use screenpipe_a11y::{ExtractionThreadPriority, UiCaptureConfig, UiRecorder};
 use screenpipe_db::{DatabaseManager, InsertUiEvent};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
@@ -170,6 +170,68 @@ pub fn tree_walker_snapshot() -> TreeWalkerSnapshot {
         .unwrap_or_default()
 }
 
+/// Point-in-time status of the UI recorder. Exposed on `/health` so users
+/// can tell whether input/clipboard capture is actually running — distinct
+/// failure modes (config off, permissions denied, recorder errored) all
+/// look the same from the DB ("ui_events stopped writing") but are very
+/// different to recover from.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, oasgen::OaSchema)]
+pub struct UiRecorderStatus {
+    /// Did the runtime config request UI recording?
+    pub configured: bool,
+    /// Did the recorder's event loop actually start? False when configured
+    /// is true but permissions were denied or `UiRecorder::start()` failed.
+    pub running: bool,
+    /// Is clipboard content capture configured? Subset of `configured`.
+    pub clipboard_capture: bool,
+    /// Lifetime count of events the recorder has flushed to the DB.
+    pub events_inserted: u64,
+    /// Wall-clock time of the most recent successful event-batch flush.
+    pub last_event_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+// Atomic-backed status so the flush_batch hot path doesn't need a mutex.
+// `last_event_at_unix` of 0 means "never written yet".
+static UI_RECORDER_CONFIGURED: AtomicBool = AtomicBool::new(false);
+static UI_RECORDER_RUNNING: AtomicBool = AtomicBool::new(false);
+static UI_RECORDER_CLIPBOARD: AtomicBool = AtomicBool::new(false);
+static UI_RECORDER_EVENTS_INSERTED: AtomicU64 = AtomicU64::new(0);
+static UI_RECORDER_LAST_EVENT_UNIX: AtomicU64 = AtomicU64::new(0);
+
+fn set_ui_recorder_state(configured: bool, running: bool, clipboard: bool) {
+    UI_RECORDER_CONFIGURED.store(configured, Ordering::Relaxed);
+    UI_RECORDER_RUNNING.store(running, Ordering::Relaxed);
+    UI_RECORDER_CLIPBOARD.store(clipboard, Ordering::Relaxed);
+}
+
+fn record_ui_event_flush(n: u64) {
+    if n == 0 {
+        return;
+    }
+    UI_RECORDER_EVENTS_INSERTED.fetch_add(n, Ordering::Relaxed);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    UI_RECORDER_LAST_EVENT_UNIX.store(now, Ordering::Relaxed);
+}
+
+/// Read the latest UI recorder status snapshot.
+pub fn ui_recorder_status_snapshot() -> UiRecorderStatus {
+    let last = UI_RECORDER_LAST_EVENT_UNIX.load(Ordering::Relaxed);
+    UiRecorderStatus {
+        configured: UI_RECORDER_CONFIGURED.load(Ordering::Relaxed),
+        running: UI_RECORDER_RUNNING.load(Ordering::Relaxed),
+        clipboard_capture: UI_RECORDER_CLIPBOARD.load(Ordering::Relaxed),
+        events_inserted: UI_RECORDER_EVENTS_INSERTED.load(Ordering::Relaxed),
+        last_event_at: if last > 0 {
+            chrono::DateTime::<chrono::Utc>::from_timestamp(last as i64, 0)
+        } else {
+            None
+        },
+    }
+}
+
 /// Handle for managing the UI recorder
 pub struct UiRecorderHandle {
     stop_flag: Arc<AtomicBool>,
@@ -226,6 +288,7 @@ pub async fn start_ui_recording(
 ) -> Result<UiRecorderHandle> {
     if !config.enabled {
         info!("UI event capture is disabled");
+        set_ui_recorder_state(false, false, false);
         return Ok(UiRecorderHandle {
             stop_flag: Arc::new(AtomicBool::new(true)),
             task_handle: None,
@@ -247,6 +310,9 @@ pub async fn start_ui_recording(
         let perms = recorder.request_permissions();
         if !perms.all_granted() {
             error!("UI capture permissions denied. UI event recording will be disabled.");
+            // configured=true, running=false makes the failure mode legible:
+            // "user asked for it, but it isn't actually running."
+            set_ui_recorder_state(true, false, config.capture_clipboard_content);
             return Ok(UiRecorderHandle {
                 stop_flag: Arc::new(AtomicBool::new(true)),
                 task_handle: None,
@@ -268,9 +334,12 @@ pub async fn start_ui_recording(
         Ok(h) => h,
         Err(e) => {
             error!("Failed to start UI recorder: {}", e);
+            set_ui_recorder_state(true, false, config.capture_clipboard_content);
             return Err(e);
         }
     };
+
+    set_ui_recorder_state(true, true, config.capture_clipboard_content);
 
     // Spawn the event processing task
     let task_handle = tokio::spawn(async move {
@@ -413,6 +482,7 @@ pub async fn start_ui_recording(
         }
 
         handle.stop();
+        UI_RECORDER_RUNNING.store(false, Ordering::Relaxed);
         info!("UI recording session ended: {}", session_id);
     });
 
@@ -439,6 +509,7 @@ async fn flush_batch(
     match db.insert_ui_events_batch(batch).await {
         Ok(inserted) => {
             debug!("Flushed {} UI events to database", inserted);
+            record_ui_event_flush(inserted as u64);
             *consecutive_failures = 0;
         }
         Err(e) => {
@@ -491,6 +562,39 @@ mod tests {
         assert!(!flag_clone.load(Ordering::Relaxed));
         handle.stop();
         assert!(flag_clone.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn ui_recorder_status_reflects_state_and_flush() {
+        // Note: globals are process-wide, but no other test in this binary
+        // touches these atomics, so this single test is race-free.
+        set_ui_recorder_state(true, true, true);
+        let snap = ui_recorder_status_snapshot();
+        assert!(snap.configured);
+        assert!(snap.running);
+        assert!(snap.clipboard_capture);
+
+        let before = snap.events_inserted;
+        record_ui_event_flush(0); // no-op
+        assert_eq!(ui_recorder_status_snapshot().events_inserted, before);
+        assert!(
+            ui_recorder_status_snapshot().last_event_at.is_none()
+                || ui_recorder_status_snapshot().last_event_at == snap.last_event_at,
+            "zero-batch flush must not bump last_event_at"
+        );
+
+        record_ui_event_flush(3);
+        let after = ui_recorder_status_snapshot();
+        assert_eq!(after.events_inserted, before + 3);
+        assert!(after.last_event_at.is_some(), "successful flush stamps a timestamp");
+
+        // disabled path: configured=false, running=false, no clipboard.
+        set_ui_recorder_state(false, false, false);
+        let off = ui_recorder_status_snapshot();
+        assert!(!off.configured && !off.running && !off.clipboard_capture);
+        // Counter and timestamp persist across state transitions — they're
+        // lifetime metrics, not per-session.
+        assert_eq!(off.events_inserted, after.events_inserted);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The `/health` endpoint reports nothing about the UI recorder, so three very different failure modes all look identical from the outside:

1. user never opted into UI capture
2. user opted in but TCC/permissions denied
3. recorder started, then died

In all three cases, `ui_events` stops getting written and `/health` says nothing about it. Today, diagnosing this requires opening sqlite3 against the DB directly and querying `ui_events` for the last-write timestamp.

This adds a `ui_recorder` field to the health response:

```json
"ui_recorder": {
  "configured": true,
  "running": false,
  "clipboard_capture": true,
  "events_inserted": 18483,
  "last_event_at": "2026-02-02T21:45:58Z"
}
```

- `configured` — runtime config asked for it
- `running` — event loop actually started (false when configured=true but perms denied / start() errored)
- `clipboard_capture` — clipboard content capture specifically (the privacy-relevant subset)
- `events_inserted` + `last_event_at` — lifetime counter + last successful flush

Backed by atomics (no mutex on the flush hot path). Field is omitted entirely from the response for users who never opted in — no noise.

## Implementation

- 5 `Atomic{Bool,U64}` statics in `ui_recorder.rs`
- `set_ui_recorder_state()` called at 3 sites in `start_ui_recording` (disabled return, perms-denied return, success path) + when the event loop exits
- `record_ui_event_flush(n)` called in `flush_batch` success branch
- `ui_recorder_status_snapshot()` reader, called from `health_check_inner`

## Test plan

- [x] `cargo test -p screenpipe-engine --lib ui_recorder` — 7/7 pass, includes new `ui_recorder_status_reflects_state_and_flush`
- [x] `cargo test -p screenpipe-engine --lib routes::health::` — 3/3 pass
- [x] `cargo clippy -p screenpipe-engine --lib --tests --no-deps -- -D warnings` — clean
- [ ] Manual: hit `/health` on a fresh build, confirm `ui_recorder` field appears with sensible values when UI capture is on
- [ ] Manual: hit `/health` with UI capture disabled, confirm field is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)