### PR TITLE
feat(a11y/windows): coalesce WM_MOUSEWHEEL ticks into 500ms scroll events

### DIFF
--- a/crates/screenpipe-a11y/src/platform/windows.rs
+++ b/crates/screenpipe-a11y/src/platform/windows.rs
@@ -489,10 +489,9 @@ fn run_native_hooks(
                         // SCROLL_AGGREGATION_WINDOW_MS has elapsed without a new wheel
                         // tick.  The 100ms SetTimer above bounds worst-case latency to
                         // ~600ms.
-                        let needs_idle_flush = s
-                            .scroll_aggregator
-                            .as_ref()
-                            .is_some_and(|agg| agg.last_scroll.elapsed().as_millis() >= SCROLL_AGGREGATION_WINDOW_MS);
+                        let needs_idle_flush = s.scroll_aggregator.as_ref().is_some_and(|agg| {
+                            agg.last_scroll.elapsed().as_millis() >= SCROLL_AGGREGATION_WINDOW_MS
+                        });
                         if needs_idle_flush {
                             if let Some(agg) = s.scroll_aggregator.take() {
                                 emit_aggregated_scroll(&s.tx, agg);

--- a/crates/screenpipe-a11y/src/platform/windows.rs
+++ b/crates/screenpipe-a11y/src/platform/windows.rs
@@ -326,6 +326,24 @@ struct PendingClipboard {
     window_title: Option<String>,
 }
 
+/// Consecutive `WM_MOUSEWHEEL` ticks within this window are coalesced into a
+/// single `Scroll` event (summed `delta_y`). Wheel ticks fire far more often
+/// than clicks, so one event per tick floods `ui_events` with little added
+/// signal (measured: 1121 scroll vs. 15 click events in a 2-min session).
+/// Coalescing preserves total scroll distance while cutting row count ~10x.
+const SCROLL_AGGREGATION_WINDOW_MS: u128 = 500;
+
+/// In-flight scroll aggregation state (None when not currently scrolling).
+struct ScrollAggregator {
+    last_scroll: Instant,
+    accumulated_delta: i32,
+    coords: (i32, i32),
+    app_name: Option<String>,
+    window_title: Option<String>,
+    start_timestamp: chrono::DateTime<Utc>,
+    start_relative_ms: u64,
+}
+
 struct HookState {
     tx: Sender<UiEvent>,
     start: Instant,
@@ -344,6 +362,33 @@ struct HookState {
     /// Updated unconditionally at the top of mouse_hook_proc / keyboard_hook_proc so the UIA
     /// worker can defer tree captures while the user is actively typing/clicking/scrolling.
     last_input_at_ms: Arc<AtomicU64>,
+    /// In-flight scroll aggregator (None = not currently scrolling).
+    scroll_aggregator: Option<ScrollAggregator>,
+}
+
+/// Emit the accumulated scroll as a single `Scroll` event. `delta_y` is summed
+/// as i32 while aggregating and clamped to i16 (the wire type) on emit; real
+/// tick sums stay well within range.
+fn emit_aggregated_scroll(tx: &Sender<UiEvent>, agg: ScrollAggregator) {
+    let event = UiEvent {
+        id: None,
+        timestamp: agg.start_timestamp,
+        relative_ms: agg.start_relative_ms,
+        data: EventData::Scroll {
+            x: agg.coords.0,
+            y: agg.coords.1,
+            delta_x: 0,
+            delta_y: agg
+                .accumulated_delta
+                .clamp(i16::MIN as i32, i16::MAX as i32) as i16,
+        },
+        app_name: agg.app_name,
+        window_title: agg.window_title,
+        browser_url: None,
+        element: None,
+        frame_id: None,
+    };
+    let _ = tx.try_send(event);
 }
 
 // Thread-local storage for hook state
@@ -387,6 +432,7 @@ fn run_native_hooks(
             focused_element,
             pending_clipboard: Vec::new(),
             last_input_at_ms,
+            scroll_aggregator: None,
         }));
     });
 
@@ -491,10 +537,14 @@ fn run_native_hooks(
             }
         });
 
-        // Final text buffer flush
+        // Final flush on shutdown: text buffer + any in-flight scroll aggregation,
+        // so input buffered when recording stops isn't dropped.
         HOOK_STATE.with(|state| {
             if let Some(ref mut s) = *state.borrow_mut() {
                 flush_text_buffer(s);
+                if let Some(agg) = s.scroll_aggregator.take() {
+                    emit_aggregated_scroll(&s.tx, agg);
+                }
             }
         });
     }
@@ -760,6 +810,15 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
                     return;
                 }
 
+                // Flush any in-flight scroll aggregation when a non-scroll mouse
+                // event arrives (e.g. a click right after scrolling), so the
+                // buffered scroll doesn't sit until the next wheel tick or timeout.
+                if msg != WM_MOUSEWHEEL {
+                    if let Some(agg) = s.scroll_aggregator.take() {
+                        emit_aggregated_scroll(&s.tx, agg);
+                    }
+                }
+
                 match msg {
                     WM_LBUTTONDOWN | WM_RBUTTONDOWN | WM_MBUTTONDOWN | WM_XBUTTONDOWN => {
                         // Record activity
@@ -824,25 +883,38 @@ unsafe extern "system" fn mouse_hook_proc(code: i32, wparam: WPARAM, lparam: LPA
 
                         if s.config.capture_scroll {
                             // High word of mouseData contains wheel delta
-                            let delta = (mouse_struct.mouseData >> 16) as i16;
+                            let delta = (mouse_struct.mouseData >> 16) as i16 as i32;
+                            let now = Instant::now();
 
-                            let event = UiEvent {
-                                id: None,
-                                timestamp,
-                                relative_ms: t,
-                                data: EventData::Scroll {
-                                    x,
-                                    y,
-                                    delta_x: 0,
-                                    delta_y: delta,
-                                },
-                                app_name,
-                                window_title,
-                                browser_url: None,
-                                element: None,
-                                frame_id: None,
-                            };
-                            let _ = s.tx.try_send(event);
+                            // Coalesce consecutive ticks within the aggregation window
+                            // into one event; otherwise flush the previous run and
+                            // start a fresh one seeded with this tick.
+                            let within_window = matches!(
+                                &s.scroll_aggregator,
+                                Some(agg) if now.duration_since(agg.last_scroll).as_millis() < SCROLL_AGGREGATION_WINDOW_MS
+                            );
+
+                            if within_window {
+                                if let Some(agg) = s.scroll_aggregator.as_mut() {
+                                    agg.accumulated_delta =
+                                        agg.accumulated_delta.saturating_add(delta);
+                                    agg.last_scroll = now;
+                                    agg.coords = (x, y);
+                                }
+                            } else {
+                                if let Some(agg) = s.scroll_aggregator.take() {
+                                    emit_aggregated_scroll(&s.tx, agg);
+                                }
+                                s.scroll_aggregator = Some(ScrollAggregator {
+                                    last_scroll: now,
+                                    accumulated_delta: delta,
+                                    coords: (x, y),
+                                    app_name,
+                                    window_title,
+                                    start_timestamp: timestamp,
+                                    start_relative_ms: t,
+                                });
+                            }
                         }
                     }
 
@@ -1517,6 +1589,7 @@ mod tests {
             focused_element: Arc::new(parking_lot::Mutex::new(None)),
             pending_clipboard: Vec::new(),
             last_input_at_ms: Arc::new(AtomicU64::new(0)),
+            scroll_aggregator: None,
         }
     }
 

--- a/crates/screenpipe-a11y/src/platform/windows.rs
+++ b/crates/screenpipe-a11y/src/platform/windows.rs
@@ -330,7 +330,8 @@ struct PendingClipboard {
 /// single `Scroll` event (summed `delta_y`). Wheel ticks fire far more often
 /// than clicks, so one event per tick floods `ui_events` with little added
 /// signal (measured: 1121 scroll vs. 15 click events in a 2-min session).
-/// Coalescing preserves total scroll distance while cutting row count ~10x.
+/// Coalescing preserves total scroll distance while cutting row count ~86x
+/// (measured: 1121 → 13 events in a 2-min session).
 const SCROLL_AGGREGATION_WINDOW_MS: u128 = 500;
 
 /// In-flight scroll aggregation state (None when not currently scrolling).
@@ -481,6 +482,20 @@ fn run_native_hooks(
                         if let Some(last_time) = s.last_text_time {
                             if last_time.elapsed().as_millis() as u64 >= s.config.text_timeout_ms {
                                 flush_text_buffer(s);
+                            }
+                        }
+
+                        // Idle-flush: emit any in-flight scroll aggregation once
+                        // SCROLL_AGGREGATION_WINDOW_MS has elapsed without a new wheel
+                        // tick.  The 100ms SetTimer above bounds worst-case latency to
+                        // ~600ms.
+                        let needs_idle_flush = s
+                            .scroll_aggregator
+                            .as_ref()
+                            .is_some_and(|agg| agg.last_scroll.elapsed().as_millis() >= SCROLL_AGGREGATION_WINDOW_MS);
+                        if needs_idle_flush {
+                            if let Some(agg) = s.scroll_aggregator.take() {
+                                emit_aggregated_scroll(&s.tx, agg);
                             }
                         }
 


### PR DESCRIPTION
## What

When `capture_scroll` is enabled, the Windows mouse hook emits one `Scroll` `UiEvent` per `WM_MOUSEWHEEL` tick. Wheel ticks fire far more often than clicks, flooding `ui_events` with rows that carry little extra signal.

Measured on a real 2-min session (Windows, `capture_scroll` on): **scroll 1121 events** vs. click 15 (~70x).

This PR coalesces consecutive wheel ticks within a 500ms window into a single `Scroll` event with summed `delta_y`. Same session: scroll rows **1121 → 13 (~99%)**, largest aggregated run `delta_y = -14880` (~124 ticks). `delta_y` accumulates as `i32`, clamped to the `i16` wire type on emit; real 500ms runs stay well within range.

The in-flight aggregator is flushed so nothing is lost:
- a non-scroll mouse event arrives (e.g. a click right after scrolling)
- the 500ms window expires and a new tick starts a fresh run
- **recording shuts down** (hook message loop exits)

## Why split / behavior note

Originally bundled in #3437; per review this is a separate concern (scroll *event volume*, gated by `capture_scroll`), split out here with its own benchmark and the shutdown-flush fix flagged in that review.

**This changes scroll-event volume/granularity for installs with `capture_scroll` enabled** — fewer rows, summed delta, vs. one event per tick. `capture_scroll`'s default is unchanged (still off).

## Scope

Windows only. macOS emits one `Scroll` per wheel tick too and shares this volume characteristic, but I only have a Windows environment to measure and test on, so I've scoped the PR to where I have data. The same pattern can be applied to the macOS/Linux paths by someone who can verify it there.

## Testing

- `cargo check -p screenpipe-a11y --tests --lib` — clean
- `cargo fmt --all -- --check` — clean
