### PR TITLE
fix: reduce Windows CPU and memory lag in timeline

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -291,7 +291,7 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 
 	// Note: audio transcript is now on-demand (opened via subtitle bar click)
 
-	const { currentDate, setCurrentDate, fetchTimeRange, hasDateBeenFetched, onWindowFocus, clearNewFramesCount, clearSentRequestForDate, clearFramesForNavigation, pendingNavigation, setPendingNavigation } =
+	const { currentDate, setCurrentDate, fetchTimeRange, hasDateBeenFetched, onWindowFocus, clearNewFramesCount, clearSentRequestForDate, clearFramesForNavigation, pendingNavigation, setPendingNavigation, loadOlderFrames, hasOlderFrames, isLoadingOlderFrames } =
 		useTimelineStore();
 
 	const { frames, isLoading, error, message, fetchNextDayData, websocket } =
@@ -448,6 +448,15 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 			}
 		});
 	}, [clearNewFramesCount]);
+
+	// Trigger backward pagination when user scrolls near the oldest loaded frame
+	useEffect(() => {
+		if (frames.length === 0 || isLoadingOlderFrames || !hasOlderFrames) return;
+		// Load more when within 50 frames of the oldest loaded
+		if (currentIndex >= frames.length - 50) {
+			loadOlderFrames();
+		}
+	}, [currentIndex, frames.length, isLoadingOlderFrames, hasOlderFrames, loadOlderFrames]);
 
 	// Listen for window focus events to refresh timeline data (debounced)
 	useEffect(() => {

--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -48,7 +48,6 @@ export interface StreamTimeSeriesResponse {
 export interface DeviceFrameResponse {
 	device_id: string;
 	frame_id: string;
-	frame: string; // base64 encoded image
 	offset_index: number;
 	fps: number;
 	metadata: DeviceMetadata;
@@ -63,6 +62,67 @@ export interface DeviceMetadata {
 	ocr_text: string;
 	timestamp: string;
 	browser_url?: string;
+}
+
+interface FrameContextResponse {
+	frame_id: number;
+	text?: string | null;
+	text_source?: string;
+}
+
+const MAX_CONTEXT_FRAMES = 5;
+
+async function fetchFullFrameText(frameId: string) {
+	const response = await localFetch(`/frames/${frameId}/context`);
+	if (!response.ok) return null;
+
+	const data = (await response.json()) as FrameContextResponse;
+	return data.text?.trim() || null;
+}
+
+async function buildScreenTextSamples(frames: StreamTimeSeriesResponse[]) {
+	const sampledFrames =
+		frames.length <= MAX_CONTEXT_FRAMES
+			? frames
+			: Array.from({ length: MAX_CONTEXT_FRAMES }, (_, index) => {
+					const frameIndex = Math.round(
+						(index * (frames.length - 1)) / (MAX_CONTEXT_FRAMES - 1),
+					);
+					return frames[frameIndex];
+				});
+
+	const selectedDevices = sampledFrames
+		.flatMap((frame) => frame.devices)
+		.filter((device) => device.frame_id);
+
+	const frameIds = Array.from(
+		new Set(selectedDevices.map((device) => String(device.frame_id))),
+	).slice(0, MAX_CONTEXT_FRAMES);
+
+	if (frameIds.length === 0) return [];
+
+	const previewByFrameId = new Map<string, string>();
+	for (const device of selectedDevices) {
+		const preview = device.metadata.ocr_text?.trim();
+		if (preview && !previewByFrameId.has(String(device.frame_id))) {
+			previewByFrameId.set(String(device.frame_id), preview);
+		}
+	}
+
+	const samples = await Promise.all(
+		frameIds.map(async (frameId) => {
+			try {
+				return await fetchFullFrameText(frameId);
+			} catch (error) {
+				console.warn("Failed to fetch full frame context:", frameId, error);
+				return null;
+			}
+		}),
+	);
+
+	return samples
+		.map((sample, index) => sample || previewByFrameId.get(frameIds[index]) || "")
+		.filter((sample) => sample.trim().length > 0);
 }
 
 export interface AudioData {
@@ -749,18 +809,9 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 			contextParts.push(`Apps: ${Array.from(apps).join(", ")}`);
 		}
 
-		// Add sample OCR text (first few frames)
-		const ocrSamples: string[] = [];
-		selectedFrames.slice(0, 3).forEach((frame) => {
-			frame.devices.forEach((device) => {
-				if (device.metadata.ocr_text && device.metadata.ocr_text.length > 0) {
-					const sample = device.metadata.ocr_text.slice(0, 200);
-					if (sample.trim()) {
-						ocrSamples.push(sample);
-					}
-				}
-			});
-		});
+		// Add full text for a few selected frames. The timeline stream keeps only
+		// OCR previews for memory safety, so hydrate full text on demand here.
+		const ocrSamples = await buildScreenTextSamples(selectedFrames);
 		if (ocrSamples.length > 0) {
 			contextParts.push(`Screen text samples:\n${ocrSamples.join("\n---\n")}`);
 		}

--- a/apps/screenpipe-app-tauri/lib/hooks/timeline-frame-merge.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/timeline-frame-merge.ts
@@ -75,7 +75,8 @@ export function mergeTimelineFrames<T extends TimelineFrameLike>({
 	incomingFrames: T[];
 	replace?: boolean;
 }): TimelineFrameMergeResult<T> {
-	const timestamps = replace ? new Set<string>() : existingTimestamps;
+	// Create a copy — never mutate the caller's Set directly (Zustand state side-effect)
+	const timestamps = replace ? new Set<string>() : new Set(existingTimestamps);
 	const newUniqueFrames: T[] = [];
 
 	for (const frame of incomingFrames) {

--- a/apps/screenpipe-app-tauri/lib/hooks/use-timeline-store.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-timeline-store.tsx
@@ -36,6 +36,9 @@ const REQUEST_TIMEOUT_MAX_MS = 60000; // Cap at 60 seconds
 const MAX_REQUEST_RETRIES = 5;
 const TIMELINE_STREAM_FRAME_LIMIT = 250;
 const MAX_TIMELINE_FRAMES_IN_MEMORY = 500;
+// During backward pagination the window temporarily expands. Trimmed back to
+// MAX_TIMELINE_FRAMES_IN_MEMORY when user returns to the live edge.
+const MAX_PAGINATION_FRAMES = 1500;
 
 // Reconnect timeout - must be tracked to prevent cascade
 let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -53,12 +56,15 @@ let currentWsId = 0;
 let cacheSaveTimer: ReturnType<typeof setTimeout> | null = null;
 const CACHE_SAVE_DEBOUNCE_MS = 2000; // Save cache 2s after last frame update
 
-function capTimelineFrames(frames: StreamTimeSeriesResponse[]) {
-	const cappedFrames =
-		frames.length > MAX_TIMELINE_FRAMES_IN_MEMORY
-			? frames.slice(0, MAX_TIMELINE_FRAMES_IN_MEMORY)
-			: frames;
+// Backward-pagination state — separate buffer so older frames don't compete
+// with the live-frame flush path.
+let olderFrameBuffer: StreamTimeSeriesResponse[] = [];
+let olderFlushTimer: ReturnType<typeof setTimeout> | null = null;
+// Timestamps older than this belong to the current pagination request.
+let olderLoadCutoffTs: string | null = null;
 
+function capTimelineFrames(frames: StreamTimeSeriesResponse[], maxFrames = MAX_TIMELINE_FRAMES_IN_MEMORY) {
+	const cappedFrames = frames.length > maxFrames ? frames.slice(0, maxFrames) : frames;
 	return {
 		frames: cappedFrames,
 		timestamps: new Set(cappedFrames.map((frame) => frame.timestamp)),
@@ -87,6 +93,10 @@ interface TimelineState {
 	// Deep link navigation — persists across component mounts
 	pendingNavigation: { timestamp: string; frameId?: string } | null;
 
+	// Backward pagination state
+	hasOlderFrames: boolean; // true while there might be more frames before the oldest loaded
+	isLoadingOlderFrames: boolean; // true while a pagination request is in-flight
+
 	// Actions
 	setPendingNavigation: (nav: { timestamp: string; frameId?: string } | null) => void;
 	setFrames: (frames: StreamTimeSeriesResponse[]) => void;
@@ -99,6 +109,8 @@ interface TimelineState {
 	fetchNextDayData: (date: Date) => void;
 	hasDateBeenFetched: (date: Date) => boolean;
 	flushFrameBuffer: () => void;
+	flushOlderFrameBuffer: () => void;
+	loadOlderFrames: () => void;
 	onWindowFocus: () => void;
 	clearNewFramesCount: () => void;
 	clearSentRequestForDate: (date: Date) => void;
@@ -122,6 +134,8 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 	hasCachedData: false,
 	pendingDateSwap: false,
 	pendingNavigation: null,
+	hasOlderFrames: true,
+	isLoadingOlderFrames: false,
 
 	setPendingNavigation: (nav) => set({ pendingNavigation: nav }),
 	setFrames: (frames) => {
@@ -181,11 +195,17 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 	// Prepare for date navigation — keep old frames visible while new ones load.
 	// Sets pendingDateSwap so flushFrameBuffer replaces frames atomically on first batch.
 	clearFramesForNavigation: () => {
-		// Clear the frame buffer too
+		// Clear all frame buffers (normal + pagination)
 		frameBuffer = [];
+		olderFrameBuffer = [];
+		olderLoadCutoffTs = null;
 		if (flushTimer) {
 			clearTimeout(flushTimer);
 			flushTimer = null;
+		}
+		if (olderFlushTimer) {
+			clearTimeout(olderFlushTimer);
+			olderFlushTimer = null;
 		}
 		// Clear request timeout so stale retries don't interfere
 		if (requestTimeoutTimer) {
@@ -309,6 +329,84 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 		});
 	},
 
+	flushOlderFrameBuffer: () => {
+		if (olderFrameBuffer.length === 0) {
+			olderLoadCutoffTs = null;
+			set({ isLoadingOlderFrames: false });
+			return;
+		}
+
+		const framesToFlush = olderFrameBuffer;
+		olderFrameBuffer = [];
+		olderLoadCutoffTs = null;
+
+		set((state) => {
+			const merged = mergeTimelineFrames({
+				existingFrames: state.frames,
+				existingTimestamps: state.frameTimestamps,
+				incomingFrames: framesToFlush,
+			});
+
+			if (!merged.changed) {
+				return {
+					isLoadingOlderFrames: false,
+					hasOlderFrames: framesToFlush.length >= TIMELINE_STREAM_FRAME_LIMIT,
+				};
+			}
+
+			// Expand cap while paginating backward — trim back to normal on live edge return
+			const capped = capTimelineFrames(merged.frames, MAX_PAGINATION_FRAMES);
+
+			return {
+				frames: capped.frames,
+				frameTimestamps: capped.timestamps,
+				isLoadingOlderFrames: false,
+				hasOlderFrames: framesToFlush.length >= TIMELINE_STREAM_FRAME_LIMIT,
+				loadingProgress: { loaded: capped.frames.length, isStreaming: true },
+			};
+		});
+	},
+
+	loadOlderFrames: () => {
+		const { frames, currentDate, websocket, isLoadingOlderFrames, hasOlderFrames, sentRequests } = get();
+		if (isLoadingOlderFrames || !hasOlderFrames || frames.length === 0) return;
+
+		// frames is sorted descending, so last item is oldest
+		const oldestFrame = frames[frames.length - 1];
+		const oldestTs = new Date(oldestFrame.timestamp);
+
+		const startTime = new Date(currentDate);
+		startTime.setHours(0, 0, 0, 0);
+
+		// Nothing older to load if oldest frame is at or before start of day
+		if (oldestTs <= startTime) {
+			set({ hasOlderFrames: false });
+			return;
+		}
+
+		// Request frames before the oldest loaded frame
+		const endTime = new Date(oldestTs.getTime() - 1);
+		const requestKey = `older_${startTime.toISOString()}_${endTime.toISOString()}`;
+
+		if (sentRequests.has(requestKey)) return;
+		if (!websocket || websocket.readyState !== WebSocket.OPEN) return;
+
+		set((state) => ({
+			isLoadingOlderFrames: true,
+			sentRequests: new Set(state.sentRequests).add(requestKey),
+		}));
+
+		olderLoadCutoffTs = endTime.toISOString();
+
+		websocket.send(JSON.stringify({
+			start_time: startTime.toISOString(),
+			end_time: endTime.toISOString(),
+			order: "descending",
+			limit: TIMELINE_STREAM_FRAME_LIMIT,
+			keep_live: true,
+		}));
+	},
+
 	connectWebSocket: () => {
 		void (async () => {
 			await ensureApiReady();
@@ -347,6 +445,12 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 			});
 			
 			frameBuffer = [];
+			olderFrameBuffer = [];
+			olderLoadCutoffTs = null;
+			if (olderFlushTimer) {
+				clearTimeout(olderFlushTimer);
+				olderFlushTimer = null;
+			}
 			requestRetryCount = 0; // Reset retry counter on reconnection
 			if (progressUpdateTimer) {
 				clearTimeout(progressUpdateTimer);
@@ -465,10 +569,32 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 					if (data.length > 0) {
 						requestRetryCount = 0;
 					}
-					// Add to buffer instead of immediate state update
-					frameBuffer.push(...data);
 
-					// Schedule flush if not already scheduled
+					// Route frames: if a backward-pagination request is in-flight, separate
+					// frames older than the pagination cutoff so they don't get evicted by
+					// the live-edge cap (capTimelineFrames keeps newest first).
+					if (olderLoadCutoffTs !== null) {
+						const cutoff = olderLoadCutoffTs;
+						const older = (data as StreamTimeSeriesResponse[]).filter(f => f.timestamp <= cutoff);
+						const newer = (data as StreamTimeSeriesResponse[]).filter(f => f.timestamp > cutoff);
+
+						if (older.length > 0) {
+							olderFrameBuffer.push(...older);
+							if (!olderFlushTimer) {
+								olderFlushTimer = setTimeout(() => {
+									olderFlushTimer = null;
+									get().flushOlderFrameBuffer();
+								}, FLUSH_INTERVAL_MS);
+							}
+						}
+						if (newer.length > 0) {
+							frameBuffer.push(...newer);
+						}
+					} else {
+						frameBuffer.push(...data);
+					}
+
+					// Schedule normal flush
 					if (!flushTimer) {
 						flushTimer = setTimeout(() => {
 							flushTimer = null;
@@ -477,11 +603,10 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 					}
 
 					// Debounce progress updates to prevent timeline flickering
-					// Only update every 500ms instead of on every message
 					if (!progressUpdateTimer) {
 						progressUpdateTimer = setTimeout(() => {
 							progressUpdateTimer = null;
-							const currentTotal = get().frames.length + frameBuffer.length;
+							const currentTotal = get().frames.length + frameBuffer.length + olderFrameBuffer.length;
 							set({
 								loadingProgress: {
 									loaded: currentTotal,
@@ -760,6 +885,14 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 		const { currentDate: oldDate } = get();
 		const oldDateStr = oldDate.toDateString();
 
+		// Discard any in-flight pagination — user is returning to live edge
+		olderFrameBuffer = [];
+		olderLoadCutoffTs = null;
+		if (olderFlushTimer) {
+			clearTimeout(olderFlushTimer);
+			olderFlushTimer = null;
+		}
+
 		set((state) => {
 			const newSentRequests = new Set<string>();
 			for (const key of state.sentRequests) {
@@ -770,12 +903,18 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 				} catch { /* keep non-matching keys */ }
 				newSentRequests.add(key);
 			}
+
+			// Trim frames back to normal cap — the expanded pagination window is
+			// no longer needed once the user returns to live.
+			const capped = capTimelineFrames(state.frames);
 			return {
+				frames: capped.frames,
+				frameTimestamps: capped.timestamps,
 				sentRequests: newSentRequests,
 				currentDate: today,
-				// Signal that position should reset to latest (index 0)
-				// by clearing pendingNavigation and setting a flag
 				pendingNavigation: null,
+				hasOlderFrames: true,
+				isLoadingOlderFrames: false,
 			};
 		});
 

--- a/apps/screenpipe-app-tauri/lib/hooks/use-timeline-store.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-timeline-store.tsx
@@ -34,7 +34,8 @@ let requestRetryCount = 0;
 const REQUEST_TIMEOUT_BASE_MS = 5000; // Initial timeout: 5 seconds
 const REQUEST_TIMEOUT_MAX_MS = 60000; // Cap at 60 seconds
 const MAX_REQUEST_RETRIES = 5;
-const TIMELINE_STREAM_FRAME_LIMIT = 2500;
+const TIMELINE_STREAM_FRAME_LIMIT = 250;
+const MAX_TIMELINE_FRAMES_IN_MEMORY = 500;
 
 // Reconnect timeout - must be tracked to prevent cascade
 let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -51,6 +52,18 @@ let currentWsId = 0;
 // Cache save debounce
 let cacheSaveTimer: ReturnType<typeof setTimeout> | null = null;
 const CACHE_SAVE_DEBOUNCE_MS = 2000; // Save cache 2s after last frame update
+
+function capTimelineFrames(frames: StreamTimeSeriesResponse[]) {
+	const cappedFrames =
+		frames.length > MAX_TIMELINE_FRAMES_IN_MEMORY
+			? frames.slice(0, MAX_TIMELINE_FRAMES_IN_MEMORY)
+			: frames;
+
+	return {
+		frames: cappedFrames,
+		timestamps: new Set(cappedFrames.map((frame) => frame.timestamp)),
+	};
+}
 
 interface TimelineState {
 	frames: StreamTimeSeriesResponse[];
@@ -111,7 +124,10 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 	pendingNavigation: null,
 
 	setPendingNavigation: (nav) => set({ pendingNavigation: nav }),
-	setFrames: (frames) => set({ frames }),
+	setFrames: (frames) => {
+		const capped = capTimelineFrames(frames);
+		set({ frames: capped.frames, frameTimestamps: capped.timestamps });
+	},
 	setIsLoading: (isLoading) => set({ isLoading }),
 	setError: (error) => set({ error }),
 	setMessage: (message) => set({ message }),
@@ -142,13 +158,13 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 				const cachedDate = new Date(cached.date);
 				const today = new Date();
 				const isToday = cachedDate.toDateString() === today.toDateString();
-				const timestamps = new Set(cached.frames.map(f => f.timestamp));
+				const capped = capTimelineFrames(cached.frames);
 				
 				// Only use cached frames if they're from today
 				// Otherwise start fresh with today's date
 				set({
-					frames: isToday ? cached.frames : [],
-					frameTimestamps: isToday ? timestamps : new Set<string>(),
+					frames: isToday ? capped.frames : [],
+					frameTimestamps: isToday ? capped.timestamps : new Set<string>(),
 					currentDate: today, // Always use today, not cached date
 					isLoading: !isToday, // Show loading if cache is stale
 					hasCachedData: isToday,
@@ -225,19 +241,21 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 				}
 				requestRetryCount = 0;
 
+				const capped = capTimelineFrames(merged.frames);
+
 				// Debounce cache save
 				if (cacheSaveTimer) clearTimeout(cacheSaveTimer);
 				cacheSaveTimer = setTimeout(() => {
 					cacheSaveTimer = null;
-					saveFramesToCache(merged.frames, state.currentDate);
+					saveFramesToCache(capped.frames, state.currentDate);
 				}, CACHE_SAVE_DEBOUNCE_MS);
 
 				return {
-					frames: merged.frames,
-					frameTimestamps: merged.timestamps,
+					frames: capped.frames,
+					frameTimestamps: capped.timestamps,
 					pendingDateSwap: false,
 					isLoading: false,
-					loadingProgress: { loaded: merged.frames.length, isStreaming: true },
+					loadingProgress: { loaded: capped.frames.length, isStreaming: true },
 					message: null,
 					error: null,
 					newFramesCount: 0,
@@ -264,21 +282,23 @@ export const useTimelineStore = create<TimelineState>((set, get) => ({
 			}
 			requestRetryCount = 0; // Reset retry count on success
 
+			const capped = capTimelineFrames(merged.frames);
+
 			// Debounce cache save - don't save on every flush
 			if (cacheSaveTimer) {
 				clearTimeout(cacheSaveTimer);
 			}
 			cacheSaveTimer = setTimeout(() => {
 				cacheSaveTimer = null;
-				saveFramesToCache(merged.frames, state.currentDate);
+				saveFramesToCache(capped.frames, state.currentDate);
 			}, CACHE_SAVE_DEBOUNCE_MS);
 
 			return {
-				frames: merged.frames,
-				frameTimestamps: merged.timestamps,
+				frames: capped.frames,
+				frameTimestamps: capped.timestamps,
 				isLoading: false,
 				loadingProgress: {
-					loaded: merged.frames.length,
+					loaded: capped.frames.length,
 					isStreaming: true
 				},
 				message: null,

--- a/crates/screenpipe-engine/src/routes/streaming.rs
+++ b/crates/screenpipe-engine/src/routes/streaming.rs
@@ -44,13 +44,18 @@ pub struct StreamFramesRequest {
     limit: Option<usize>,
 }
 
-const MAX_STREAM_FRAME_LIMIT: usize = 10_000;
-const DEFAULT_STREAM_FRAME_LIMIT: usize = MAX_STREAM_FRAME_LIMIT;
+const MAX_STREAM_FRAME_LIMIT: usize = 500;
+const DEFAULT_STREAM_FRAME_LIMIT: usize = 250;
+const MAX_STREAM_OCR_TEXT_CHARS: usize = 200;
 
 fn stream_frame_limit(requested: Option<usize>) -> usize {
     requested
         .unwrap_or(DEFAULT_STREAM_FRAME_LIMIT)
         .clamp(1, MAX_STREAM_FRAME_LIMIT)
+}
+
+fn stream_ocr_preview(text: String) -> String {
+    text.chars().take(MAX_STREAM_OCR_TEXT_CHARS).collect()
 }
 
 #[derive(Debug, Serialize)]
@@ -113,7 +118,7 @@ impl From<TimeSeriesFrame> for StreamTimeSeriesResponse {
                             file_path: device_frame.metadata.file_path,
                             app_name: device_frame.metadata.app_name,
                             window_name: device_frame.metadata.window_name,
-                            ocr_text: device_frame.metadata.ocr_text,
+                            ocr_text: stream_ocr_preview(device_frame.metadata.ocr_text),
                             browser_url: device_frame.metadata.browser_url,
                         },
                         audio: device_frame
@@ -538,7 +543,7 @@ async fn handle_stream_frames_socket(
                                         file_path: hot_frame.snapshot_path.clone(),
                                         app_name: hot_frame.app_name.clone(),
                                         window_name: hot_frame.window_name.clone(),
-                                        ocr_text: hot_frame.ocr_text_preview.clone(),
+                                        ocr_text: stream_ocr_preview(hot_frame.ocr_text_preview.clone()),
                                         browser_url: hot_frame.browser_url.clone(),
                                     },
                                     audio: audio_entries
@@ -1392,6 +1397,23 @@ mod tests {
         assert_eq!(
             stream_frame_limit(Some(MAX_STREAM_FRAME_LIMIT + 1)),
             MAX_STREAM_FRAME_LIMIT
+        );
+    }
+
+    #[test]
+    fn test_stream_ocr_preview_is_bounded() {
+        assert_eq!(stream_ocr_preview("short".to_string()), "short");
+
+        let long_text = "a".repeat(MAX_STREAM_OCR_TEXT_CHARS + 1);
+        assert_eq!(
+            stream_ocr_preview(long_text).chars().count(),
+            MAX_STREAM_OCR_TEXT_CHARS
+        );
+
+        let unicode = "😀".repeat(MAX_STREAM_OCR_TEXT_CHARS + 1);
+        assert_eq!(
+            stream_ocr_preview(unicode).chars().count(),
+            MAX_STREAM_OCR_TEXT_CHARS
         );
     }
 

--- a/crates/screenpipe-engine/src/routes/streaming.rs
+++ b/crates/screenpipe-engine/src/routes/streaming.rs
@@ -42,6 +42,10 @@ pub struct StreamFramesRequest {
     order: Order,
     #[serde(default)]
     limit: Option<usize>,
+    /// When true, preserve the current live subscription instead of overriding it.
+    /// Used by the client to paginate backward without killing the live update feed.
+    #[serde(default)]
+    keep_live: bool,
 }
 
 const MAX_STREAM_FRAME_LIMIT: usize = 500;
@@ -302,8 +306,11 @@ async fn handle_stream_frames_socket(
                             limit
                         );
 
-                        // Set live subscription flag
-                        *live_sub_clone.lock().await = Some(is_today);
+                        // Set live subscription flag — skip if the client asked to preserve
+                        // the existing live feed (backward pagination request).
+                        if !request.keep_live {
+                            *live_sub_clone.lock().await = Some(is_today);
+                        }
 
                         if is_today {
                             // Wait for cache to warm before responding (max 30s).


### PR DESCRIPTION
### Description: 


https://github.com/user-attachments/assets/10995390-3b5e-449d-8285-fa2796c080cf



- cap timeline frame streaming to smaller server/client limits
- trim OCR in timeline stream responses to lightweight previews
- cap timeline frames retained in WebView state/cache
- remove stale base64 frame field from timeline types
- hydrate full frame text on demand when sending selected timeline context to chat/pipes

## Why

On Windows, WebView2/V8 can balloon memory when the timeline loads thousands of frames with full OCR payloads. This creates a GC sawtooth pattern where memory climbs to several GB, CPU spikes during major GC, then memory drops and repeats.

This keeps the timeline payload lightweight while preserving full AI context by fetching full text only for selected frames.