### PR TITLE
fix(defaults): power-mode Auto by default; readable chat-load errors

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/intercom-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/intercom-chat.tsx
@@ -42,6 +42,17 @@ function stripHtml(html: string): string {
   return div.textContent || div.innerText || "";
 }
 
+// WebKit returns `TypeError: Load failed` when the chat backend is unreachable,
+// which surfaces as the opaque "Load failed (screenpi.pe)" line. Swap any
+// connection-style failure for an actionable message; pass others through.
+function describeChatError(e: unknown): string {
+  const msg = (e instanceof Error ? e.message : String(e)) || "";
+  if (/load failed|failed to fetch|networkerror|network request failed/i.test(msg)) {
+    return "chat is temporarily unreachable — please try again in a moment, or email louis@screenpi.pe";
+  }
+  return msg || "failed to send message";
+}
+
 export function IntercomChat() {
   const { settings } = useSettings();
   const [messages, setMessages] = useState<Message[]>([]);
@@ -149,7 +160,7 @@ export function IntercomChat() {
         ]);
       }
     } catch (err: any) {
-      setError(err.message || "failed to send message");
+      setError(describeChatError(err));
       setInput(body);
     } finally {
       setSending(false);

--- a/crates/screenpipe-engine/src/power/profile.rs
+++ b/crates/screenpipe-engine/src/power/profile.rs
@@ -16,9 +16,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Default)]
 pub enum PowerMode {
     /// Automatically switch based on battery state.
+    #[default]
     Auto,
     /// Always use full performance (ignore battery).
-    #[default]
     Performance,
     /// Always use battery saver (even on AC).
     BatterySaver,


### PR DESCRIPTION
## Summary
Two default flips triggered by a frustrated paying customer (battery drain on battery + opaque \"Load failed (screenpi.pe)\" in the in-app chat panel).

- **Power mode default → `Auto`** ([profile.rs](crates/screenpipe-engine/src/power/profile.rs)). Was `Performance`, which meant new users got full-blast capture on battery until they found Settings → Power Mode. Existing users with a persisted `powerMode` value are unaffected ([server_core.rs:284](apps/screenpipe-app-tauri/src-tauri/src/server_core.rs) only falls back to the Default when the field is absent in the settings store).
- **Intercom-chat error mapping** ([intercom-chat.tsx](apps/screenpipe-app-tauri/components/settings/intercom-chat.tsx)). WebKit's raw `TypeError: Load failed` surfaces as the opaque \"Load failed (screenpi.pe)\" string. Wrap the catch to show an actionable message pointing at louis@screenpi.pe. Doesn't fix the underlying screenpi.pe/api/intercom outage — that's a server-side investigation — but stops the panel looking broken when the proxy hiccups.

## Out of scope (worth follow-up PRs)
- **Local retention defaulting to enabled.** Currently `enabled: false` so the DB grows unbounded → \"errors all over the place after 4 days\" reports. Fix requires startup wiring (not just a Default flip — the loop only spawns via `/retention/configure`), plus a UX call about deleting users' old media on upgrade.
- **Audio shortcut UX**: two separate shortcuts (`startAudioShortcut` + `stopAudioShortcut`) instead of one toggle, and silent failure when the OS rejects a combo. Worth a redesign.
- **screenpi.pe/api/intercom outage** — likely Vercel/Clerk/CORS issue in the website repo, not this app.

## Test plan
- [x] `cargo check -p screenpipe-engine` passes
- [x] Manual read of [profile.rs](crates/screenpipe-engine/src/power/profile.rs) confirms tests still match (they pass `PowerMode::Auto` explicitly; only `PowerMode::default()` semantics change)
- [ ] On a clean install, verify the Settings → Power Mode panel shows \"Auto\" as the active selection on first boot
- [ ] Unplug laptop, confirm profile drops from Performance → Balanced/Saver within ~5s (poll interval)
- [ ] Open Settings → Help → Live chat with backend offline, confirm the error reads \"chat is temporarily unreachable — please try again in a moment, or email louis@screenpi.pe\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)