### PR TITLE
fix(audio,timeline): stop device_monitor 'default' spam; restore day-picker

### DIFF
--- a/apps/screenpipe-app-tauri/lib/actions/has-frames-date.ts
+++ b/apps/screenpipe-app-tauri/lib/actions/has-frames-date.ts
@@ -37,6 +37,9 @@ export async function listDaysWithFrames(): Promise<Set<string>> {
 		// audio_chunks has no timestamp column itself; the recording time
 		// lives on audio_transcriptions, which is what the timeline UI also
 		// uses to render the audio track.
+		// LIMIT is required by the /raw_sql validator; bound it to the max so
+		// future heavy users with many recording days don't get clipped.
+		// One row per local-calendar day, so 10000 = ~27 years of headroom.
 		const query = `
 			SELECT DISTINCT DATE(timestamp, 'localtime') AS day FROM (
 				SELECT timestamp FROM frames WHERE timestamp IS NOT NULL
@@ -44,6 +47,7 @@ export async function listDaysWithFrames(): Promise<Set<string>> {
 				SELECT timestamp FROM audio_transcriptions WHERE timestamp IS NOT NULL
 			)
 			ORDER BY day
+			LIMIT 10000
 		`;
 		const response = await localFetch("/raw_sql", {
 			method: "POST",

--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -194,8 +194,9 @@ pub async fn start_device_monitor(
         // started different devices from saved config.
         let mut needs_initial_sync = true;
 
-        // One-time migration flag for legacy "Display N (output)" device names
-        #[cfg(target_os = "macos")]
+        // One-time migration flag: on first loop iteration, scrub the bare
+        // "default" sentinel (all platforms) and migrate legacy "Display N
+        // (output)" names to "System Audio (output)" (macOS only).
         let mut legacy_migrated = false;
 
         loop {

--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -227,20 +227,27 @@ pub async fn start_device_monitor(
                 }
                 let enabled_devices = audio_manager.enabled_devices().await;
 
-                // Scrub unparseable legacy entries from `enabled_devices` once
-                // per session. Without this, names like bare "default" (persisted
-                // from older versions before the (input)/(output) suffix
-                // convention) cause the monitor below to log an ERROR every
-                // poll forever.
+                // Scrub the legacy bare "default" sentinel from `enabled_devices`
+                // once per session. Older versions persisted "default" to mean
+                // "follow the system default device"; today that's represented
+                // by the `use_system_default_audio` flag, and modern
+                // `start_device` only ever inserts names with an (input)/(output)
+                // suffix. The stray entry has no behavioral effect (recording
+                // proceeds on the resolved devices) but caused the monitor below
+                // to ERROR every poll forever.
+                //
+                // Narrowed to the literal sentinel so that an unplugged real
+                // device persisted under a bare name doesn't get silently
+                // dropped from the user's enabled set.
                 if !legacy_migrated {
-                    let unparseable: Vec<String> = enabled_devices
+                    let sentinels: Vec<String> = enabled_devices
                         .iter()
-                        .filter(|name| parse_audio_device(name).is_err())
+                        .filter(|name| name.trim().eq_ignore_ascii_case("default"))
                         .cloned()
                         .collect();
-                    for name in &unparseable {
+                    for name in &sentinels {
                         info!(
-                            "[DEVICE_RECOVERY] dropping unparseable legacy enabled-device entry '{}'",
+                            "[DEVICE_RECOVERY] dropping legacy '{}' sentinel from enabled_devices (use_system_default_audio supersedes it)",
                             name
                         );
                         audio_manager.forget_device(name).await;

--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -227,6 +227,27 @@ pub async fn start_device_monitor(
                 }
                 let enabled_devices = audio_manager.enabled_devices().await;
 
+                // Scrub unparseable legacy entries from `enabled_devices` once
+                // per session. Without this, names like bare "default" (persisted
+                // from older versions before the (input)/(output) suffix
+                // convention) cause the monitor below to log an ERROR every
+                // poll forever.
+                if !legacy_migrated {
+                    let unparseable: Vec<String> = enabled_devices
+                        .iter()
+                        .filter(|name| parse_audio_device(name).is_err())
+                        .cloned()
+                        .collect();
+                    for name in &unparseable {
+                        info!(
+                            "[DEVICE_RECOVERY] dropping unparseable legacy enabled-device entry '{}'",
+                            name
+                        );
+                        audio_manager.forget_device(name).await;
+                    }
+                }
+                let enabled_devices = audio_manager.enabled_devices().await;
+
                 // Migrate legacy "Display N (output)" device names to "System Audio (output)".
                 // This handles upgrades from versions that tracked per-display output devices.
                 #[cfg(target_os = "macos")]
@@ -253,6 +274,12 @@ pub async fn start_device_monitor(
                             let _ = audio_manager.start_device(&device).await;
                         }
                     }
+                }
+                // Non-macOS platforms still need to flip the flag so the scrub
+                // above runs exactly once.
+                #[cfg(not(target_os = "macos"))]
+                {
+                    legacy_migrated = true;
                 }
 
                 // Handle "Follow System Default" mode
@@ -867,7 +894,7 @@ pub async fn start_device_monitor(
                     let device = match parse_audio_device(&device_name) {
                         Ok(device) => device,
                         Err(e) => {
-                            error!("Device name {} invalid: {}", device_name, e);
+                            debug!("Device name {} invalid: {}", device_name, e);
                             continue;
                         }
                     };
@@ -909,7 +936,7 @@ pub async fn start_device_monitor(
                     let device = match parse_audio_device(device_name) {
                         Ok(device) => device,
                         Err(e) => {
-                            error!("Device name {} invalid: {}", device_name, e);
+                            debug!("Device name {} invalid: {}", device_name, e);
                             continue;
                         }
                     };

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -1040,9 +1040,10 @@ impl AudioManager {
         self.options.read().await.enabled_devices.clone()
     }
 
-    /// Drop a name from `enabled_devices` without trying to parse it.
-    /// Used to scrub legacy/unparseable names (e.g. bare "default" persisted
-    /// from older versions) so the monitor stops re-trying them every poll.
+    /// Drop a name from `enabled_devices` without trying to parse it or stop
+    /// a running stream. Used to scrub legacy sentinel entries (e.g. bare
+    /// "default" from older versions) that have no corresponding parseable
+    /// device and would otherwise stay in the set forever.
     pub async fn forget_device(&self, device_name: &str) {
         self.options
             .write()

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -1040,6 +1040,17 @@ impl AudioManager {
         self.options.read().await.enabled_devices.clone()
     }
 
+    /// Drop a name from `enabled_devices` without trying to parse it.
+    /// Used to scrub legacy/unparseable names (e.g. bare "default" persisted
+    /// from older versions) so the monitor stops re-trying them every poll.
+    pub async fn forget_device(&self, device_name: &str) {
+        self.options
+            .write()
+            .await
+            .enabled_devices
+            .remove(device_name);
+    }
+
     /// Stop all SCK-based (Output) audio devices for DRM pause.
     /// Input (microphone) devices are left running. Unlike `stop_device()`,
     /// this does NOT remove devices from `enabled_devices` since DRM pause


### PR DESCRIPTION
## Summary

Two unrelated bugs surfaced in a user feedback log (v2.4.247):

- **`device_monitor` log spam**: 572 identical ERRORs in 33 min (one every ~2s) — `Device name default invalid: Device type (input/output) not specified...`. Caused by a legacy bare `"default"` entry in `enabled_devices`, persisted from before the `(input)/(output)` suffix convention. The monitor re-tries it every poll forever.
  - Add `AudioManager::forget_device(name)` that drops a name from `enabled_devices` without trying to parse it.
  - On monitor startup, scrub any entry where `parse_audio_device` returns `Err` (one INFO line per dropped entry).
  - Downgrade the hot-path `error!` to `debug!` so any future regression doesn't pollute logs.

- **Timeline calendar broken (`listDaysWithFrames` → HTTP 400)**: the day-picker's `UNION ALL` SELECT had no `LIMIT`, which the `/raw_sql` validator now rejects:
  > `Query rejected: SELECT without LIMIT. Add 'LIMIT n' (max 10000)...`
  - Added `LIMIT 10000` to the outer SELECT (1 row per local-calendar day → ~27 years of headroom).

## Test plan

- [x] `cargo check -p screenpipe-audio` clean
- [x] `cargo check -p screenpipe-engine` clean
- [x] `bunx next build` clean in `apps/screenpipe-app-tauri/`
- [ ] Manually verify timeline day-picker opens without 400s in the webview console
- [ ] Verify no `device_monitor` ERROR spam on a fresh start with a stale `default` entry (or any unparseable name) in saved config

🤖 Generated with [Claude Code](https://claude.com/claude-code)