### PR TITLE
fix(windows): link ui-events to frames on content-dedup skip, expand timeline popover clickability

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
@@ -24,17 +24,19 @@ function formatUiEvent(ev: UiEventSummary): { icon: string; label: string } | nu
 	const truncate = (s: string, max = 40) => s.length > max ? s.slice(0, max) + "\u2026" : s;
 	switch (ev.event_type) {
 		case "text":
-			return ev.text_content
-				? { icon: "\u2328", label: `typed "${truncate(ev.text_content)}"` }
-				: null;
+			return { icon: "\u2328", label: ev.text_content ? `typed "${truncate(ev.text_content)}"` : "typed" };
 		case "clipboard":
-			return ev.text_content
-				? { icon: "\ud83d\udccb", label: `copied "${truncate(ev.text_content)}"` }
-				: null;
+			return { icon: "\ud83d\udccb", label: ev.text_content ? `copied "${truncate(ev.text_content)}"` : "copied" };
 		case "click":
 			return { icon: "\ud83d\uddb1", label: `clicked "${truncate(ev.text_content || "element")}"` };
 		case "app_switch":
 			return { icon: "\u21d4", label: `switched to ${ev.app_name || "app"}` };
+		case "key":
+			return { icon: "\u2303", label: ev.text_content ? `pressed ${truncate(ev.text_content)}` : "key press" };
+		case "scroll":
+			return { icon: "\u21f3", label: `scrolled${ev.window_title ? ` in ${truncate(ev.window_title)}` : ""}` };
+		case "window_focus":
+			return { icon: "\ud83d\udd32", label: `focused ${ev.window_title ? truncate(ev.window_title) : ev.app_name || "window"}` };
 		default:
 			return null;
 	}

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -1491,6 +1491,12 @@ export const TimelineSlider = ({
 								dir="rtl"
 								style={{
 									// borderLeft removed — caused visible white lines between groups
+									cursor: "pointer",
+								}}
+								onClick={(e) => {
+									const rect = e.currentTarget.getBoundingClientRect();
+									setPopoverAnchor({ x: rect.left + rect.width / 2, y: rect.top });
+									setActivePopoverGroup(activePopoverGroup === groupIndex ? null : groupIndex);
 								}}
 							>
 								{/* Vertical stacked icons - favicons for browser groups, app icons otherwise */}

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -937,9 +937,7 @@ pub async fn event_driven_capture_loop(
                             // so link them to that frame — semantically correct
                             // and prevents the correlation_ids from expiring unmatched.
                             if !correlation_ids.is_empty() {
-                                if let (Some(ref linker), Some(fid)) =
-                                    (&linker_tx, last_frame_id)
-                                {
+                                if let (Some(ref linker), Some(fid)) = (&linker_tx, last_frame_id) {
                                     let _ = linker.try_send(
                                         crate::frame_linker_actor::LinkerMessage::FrameCaptured(
                                             crate::frame_linker::FrameCaptured {

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -348,6 +348,10 @@ pub async fn event_driven_capture_loop(
 
     // Track content hash for dedup across captures
     let mut last_content_hash: Option<i64> = None;
+    // Last frame_id that was successfully written to the DB. Used to link
+    // events to a frame even when content-dedup skips the capture — the
+    // screen looks the same, so reusing the last frame is semantically correct.
+    let mut last_frame_id: Option<i64> = None;
     // Track last successful DB write time — dedup is bypassed after 30s
     // to guarantee the timeline always has periodic entries
     let mut last_db_write = Instant::now();
@@ -403,6 +407,7 @@ pub async fn event_driven_capture_loop(
                 }
                 if let Some(ref result) = output.result {
                     last_content_hash = result.content_hash;
+                    last_frame_id = Some(result.frame_id);
                     last_db_write = Instant::now();
                     // Update elements cache for this device (first frame = anchor)
                     if let Some(hash) = result.content_hash {
@@ -859,6 +864,7 @@ pub async fn event_driven_capture_loop(
                         if let Some(ref result) = output.result {
                             // Full capture — update hash, metrics, cache
                             last_content_hash = result.content_hash;
+                            last_frame_id = Some(result.frame_id);
                             last_db_write = Instant::now();
 
                             // Update elements cache: only when we inserted new elements
@@ -925,6 +931,30 @@ pub async fn event_driven_capture_loop(
                                 monitor_id,
                                 trigger.as_str()
                             );
+                            // Even though the frame was deduped, the events that
+                            // triggered this capture still need a frame_id. The
+                            // screen looks identical to the last captured frame,
+                            // so link them to that frame — semantically correct
+                            // and prevents the correlation_ids from expiring unmatched.
+                            if !correlation_ids.is_empty() {
+                                if let (Some(ref linker), Some(fid)) =
+                                    (&linker_tx, last_frame_id)
+                                {
+                                    let _ = linker.try_send(
+                                        crate::frame_linker_actor::LinkerMessage::FrameCaptured(
+                                            crate::frame_linker::FrameCaptured {
+                                                frame_id: fid,
+                                                correlation_ids: std::mem::take(
+                                                    &mut correlation_ids,
+                                                ),
+                                            },
+                                        ),
+                                    );
+                                } else {
+                                    // No frame ever captured yet — just drop the ids.
+                                    correlation_ids.clear();
+                                }
+                            }
                         }
                     }
                     Ok(Err(e)) => {

--- a/crates/screenpipe-engine/src/frame_linker_actor.rs
+++ b/crates/screenpipe-engine/src/frame_linker_actor.rs
@@ -217,7 +217,6 @@ async fn apply_update(db: &Arc<DatabaseManager>, row_id: i64, frame_id: i64) {
         }
     }
 }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/screenpipe-engine/src/frame_linker_actor.rs
+++ b/crates/screenpipe-engine/src/frame_linker_actor.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 use screenpipe_db::DatabaseManager;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::frame_linker::{
     CorrelationId, EventPersisted, FrameCaptured, FrameLinker, FrameLinkerConfig,
@@ -110,17 +110,53 @@ pub fn spawn_frame_linker(
                             break;
                         }
                         Some(LinkerMessage::EventPersisted(e)) => {
+                            let corr_id = e.correlation_id;
+                            let row_id = e.row_id;
+                            debug!(corr_id, row_id, "frame_linker: event persisted");
                             if let Some(update) =
                                 linker.on_event_persisted(e, Instant::now())
                             {
                                 PAIRS_EMITTED.fetch_add(1, Ordering::Relaxed);
+                                info!(
+                                    corr_id,
+                                    row_id = update.row_id,
+                                    frame_id = update.frame_id,
+                                    "frame_linker: paired event→frame (frame arrived first)"
+                                );
                                 apply_update(&db, update.row_id, update.frame_id).await;
+                            } else {
+                                let (pe, pf) = linker.pending_len();
+                                debug!(
+                                    corr_id,
+                                    row_id,
+                                    pending_events = pe,
+                                    pending_frames = pf,
+                                    "frame_linker: event stashed, waiting for frame"
+                                );
                             }
                         }
                         Some(LinkerMessage::FrameCaptured(c)) => {
+                            let frame_id = c.frame_id;
+                            let n_corr = c.correlation_ids.len();
+                            debug!(frame_id, n_corr, "frame_linker: frame captured");
                             let updates = linker.on_frame_captured(c, Instant::now());
                             if !updates.is_empty() {
                                 PAIRS_EMITTED.fetch_add(updates.len() as u64, Ordering::Relaxed);
+                                info!(
+                                    frame_id,
+                                    paired = updates.len(),
+                                    still_pending = n_corr - updates.len(),
+                                    "frame_linker: paired frame→events (events arrived first)"
+                                );
+                            } else {
+                                let (pe, pf) = linker.pending_len();
+                                debug!(
+                                    frame_id,
+                                    n_corr,
+                                    pending_events = pe,
+                                    pending_frames = pf,
+                                    "frame_linker: frame stashed, waiting for event rows"
+                                );
                             }
                             for update in updates {
                                 apply_update(&db, update.row_id, update.frame_id).await;
@@ -130,12 +166,29 @@ pub fn spawn_frame_linker(
                 }
                 _ = tick.tick() => {
                     let evicted = linker.tick(Instant::now());
+                    let (pe, pf) = linker.pending_len();
+                    let total_pairs = PAIRS_EMITTED.load(Ordering::Relaxed);
+                    let total_evicted = EVICTED_TTL.load(Ordering::Relaxed) + evicted as u64;
+                    let total_failed = UPDATES_FAILED.load(Ordering::Relaxed);
                     if evicted > 0 {
                         EVICTED_TTL.fetch_add(evicted as u64, Ordering::Relaxed);
-                        let (e, f) = linker.pending_len();
+                        warn!(
+                            evicted,
+                            pending_events = pe,
+                            pending_frames = pf,
+                            total_pairs,
+                            total_evicted,
+                            total_failed,
+                            "frame_linker: stale entries expired without pairing (frame or event never arrived)"
+                        );
+                    } else {
                         debug!(
-                            "frame linker evicted {} stale entries (pending: {} events, {} frames)",
-                            evicted, e, f
+                            pending_events = pe,
+                            pending_frames = pf,
+                            total_pairs,
+                            total_evicted,
+                            total_failed,
+                            "frame_linker: tick"
                         );
                     }
                 }
@@ -145,16 +198,23 @@ pub fn spawn_frame_linker(
 }
 
 async fn apply_update(db: &Arc<DatabaseManager>, row_id: i64, frame_id: i64) {
-    if let Err(e) = db.update_ui_event_frame_id(row_id, frame_id).await {
+    match db.update_ui_event_frame_id(row_id, frame_id).await {
+        Ok(_) => {
+            debug!(row_id, frame_id, "frame_linker: ui_events.frame_id updated");
+        }
+        Err(e) => {
         UPDATES_FAILED.fetch_add(1, Ordering::Relaxed);
         // A failed UPDATE is recoverable in principle (the row stays
         // NULL) but very rare in practice — log and move on. We don't
         // retry because the linker has no memory of dispatched updates;
         // a retry would have to re-pair from scratch.
         warn!(
-            "frame linker UPDATE failed (row_id={}, frame_id={}): {}",
-            row_id, frame_id, e
+                row_id,
+                frame_id,
+                error = %e,
+                "frame_linker: UPDATE ui_events.frame_id failed"
         );
+    }
     }
 }
 

--- a/crates/screenpipe-engine/src/frame_linker_actor.rs
+++ b/crates/screenpipe-engine/src/frame_linker_actor.rs
@@ -203,19 +203,20 @@ async fn apply_update(db: &Arc<DatabaseManager>, row_id: i64, frame_id: i64) {
             debug!(row_id, frame_id, "frame_linker: ui_events.frame_id updated");
         }
         Err(e) => {
-        UPDATES_FAILED.fetch_add(1, Ordering::Relaxed);
-        // A failed UPDATE is recoverable in principle (the row stays
-        // NULL) but very rare in practice — log and move on. We don't
-        // retry because the linker has no memory of dispatched updates;
-        // a retry would have to re-pair from scratch.
-        warn!(
+            UPDATES_FAILED.fetch_add(1, Ordering::Relaxed);
+            // A failed UPDATE is recoverable in principle (the row stays
+            // NULL) but very rare in practice — log and move on. We don't
+            // retry because the linker has no memory of dispatched updates;
+            // a retry would have to re-pair from scratch.
+            warn!(
                 row_id,
                 frame_id,
                 error = %e,
                 "frame_linker: UPDATE ui_events.frame_id failed"
-        );
+            );
+        }
     }
-    }
+}
 }
 
 #[cfg(test)]


### PR DESCRIPTION


### Description:

### Before: 

- Not event Capturing due to deduplication of frames.

<img width="908" height="413" alt="Screenshot 2026-05-22 004138" src="https://github.com/user-attachments/assets/c4a808d4-722c-4c58-bb8a-8d65fd9b2d32" />

- No popover is coming.

<img width="1919" height="1079" alt="Screenshot 2026-05-22 010457" src="https://github.com/user-attachments/assets/e5c0e8fe-9ed4-4b4d-acfb-578870d2df40" />



### After: 

- Ui events occuring resolved deduplication issue.

<img width="899" height="183" alt="Screenshot 2026-05-22 010556" src="https://github.com/user-attachments/assets/c1efbd62-3422-44dc-a2b1-78f25551c945" />

- Demonstration video:


https://github.com/user-attachments/assets/0ed91fea-5a4e-4139-b27b-2f83d1810c1a


Fixes frame-event linking on Windows where content deduplication was silently dropping 74% of correlation IDs, and fixes the timeline popover being unclickable on narrow segments.

### Files changed:

- crates/screenpipe-engine/src/event_driven_capture.rs — track last_frame_id; reuse it when dedup skips a capture instead of dropping correlation IDs
- crates/screenpipe-engine/src/frame_linker_actor.rs — add info! logs for successful pairings and warn! logs for evictions with running totals
- apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx — make entire group container clickable, not just the icon (which was gated behind groupWidth > 30)
- apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx — handle key, scroll, window_focus event types in formatUiEvent (were silently filtered as null)