### PR TITLE
fix(app): handle --dev argument in pre_build.js

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -776,7 +776,7 @@ await copyBunBinary();
 
 // --dev or --build
 const action = process.argv?.[2]
-if (action?.includes('--build' || action.includes('--dev'))) {
+if (action?.includes('--build') || action?.includes('--dev')) {
 	process.chdir(path.join(cwd, '..'))
 	process.env['FFMPEG_DIR'] = exports.ffmpeg
 	if (platform === 'windows') {


### PR DESCRIPTION
The current condition is a typo — the `||` is inside `includes()`:

```js
action?.includes('--build' || action.includes('--dev'))
```

Since `--build` is truthy, this short-circuits to `action?.includes('--build')`, so passing `--dev ` never enters the block