### PR TITLE
fix(chat): prevent sync prompt from corrupting chat titles

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -1214,11 +1214,16 @@ function Section({
           </span>
         )}
       </button>
-      {!collapsed && (
-        <div className={bodyClassName} onScroll={onBodyScroll}>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]"
+        )}
+      >
+        <div className={cn("overflow-hidden", bodyClassName)} onScroll={collapsed ? undefined : onBodyScroll}>
           <div className="flex flex-col">{children}</div>
         </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -1324,7 +1329,7 @@ export function SidebarChatRow({
                 : "text-muted-foreground"
           )}
         >
-          {session.title || "untitled"}
+          {(session.title?.startsWith("<") ? undefined : session.title) || "untitled"}
         </span>
         <span className="ml-1 h-4 w-10 shrink-0 relative flex items-center justify-end">
           <span

--- a/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
@@ -649,7 +649,11 @@ async function persistBackgroundSession(sid: string): Promise<void> {
       }
 
       const existing = await loadConversationFile(sid);
-      const firstUserMsg = messages.find((m: any) => m.role === "user") as any;
+      // Skip injected <conversation_history> sync prompts — Pi echoes them back
+      // as user events and their first 50 chars would corrupt the title.
+      const firstUserMsg = messages.find(
+        (m: any) => m.role === "user" && !m.content?.startsWith("<conversation_history>")
+      ) as any;
       const derivedTitle: string =
         firstUserMsg?.content?.slice(0, 50) || "New Chat";
       // Prefer a previously-persisted title (user may have renamed it),


### PR DESCRIPTION
### Description:

- Before: 


<img width="396" height="202" alt="image" src="https://github.com/user-attachments/assets/b23c63f4-d196-4fc5-ab90-1e42b96e5e9d" />



- After: 



https://github.com/user-attachments/assets/58134b04-ecf1-4b2d-923f-09ffe59ae541




Fixes two issues: <conversation_history> sync prompts leaking into chat titles via a missing filter in pi-event-router, a display-layer guard for already-corrupted titles on disk, smooth CSS collapse animation for sidebar sections replacing an abrupt snap.