### PR TITLE
ci(eval-meeting-detection): install libwayland-dev

### DIFF
--- a/.github/workflows/eval-meeting-detection.yml
+++ b/.github/workflows/eval-meeting-detection.yml
@@ -74,7 +74,8 @@ jobs:
             libssl-dev \
             cmake \
             build-essential \
-            libopenblas-dev
+            libopenblas-dev \
+            libwayland-dev
           sudo mkdir -p /usr/lib/x86_64-linux-gnu/openblas/lib
           sudo ln -sf /usr/lib/x86_64-linux-gnu/libopenblas.so /usr/lib/x86_64-linux-gnu/openblas/lib/liblibopenblas.so
           sudo ln -sf /usr/lib/x86_64-linux-gnu/libopenblas.a /usr/lib/x86_64-linux-gnu/openblas/lib/liblibopenblas.a


### PR DESCRIPTION
## Summary
Meeting Detection Eval has been failing on every PR that touches the engine — the build fails because `wayland-client.pc` isn't on the Ubuntu runner. Adding `libwayland-dev` matches what `release-cli.yml` already does for the same reason.

Pure CI infra fix. No source code change.

## Verified
- Same failure on `claude/meeting-detector-attr-needs` and `codex/meeting-detection-feedback-posthog`
- The `wayland-sys` crate is pulled in transitively through `tao → winit` on Linux
- The other eval workflow (`release-cli.yml`) already installs `libwayland-dev` for the same reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)