### PR TITLE
Use temp path for missing config test

### DIFF
--- a/crates/screenpipe-config/src/persistence.rs
+++ b/crates/screenpipe-config/src/persistence.rs
@@ -51,12 +51,14 @@ fn dirs_next() -> Option<PathBuf> {
 mod tests {
     use super::*;
     use std::io::Write;
-    use tempfile::NamedTempFile;
+    use tempfile::{tempdir, NamedTempFile};
 
     #[test]
     fn load_missing_file_returns_default() {
-        let path = Path::new("/tmp/screenpipe-test-nonexistent-config.toml");
-        let settings = load_toml(path).unwrap();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("missing-config.toml");
+
+        let settings = load_toml(&path).unwrap();
         assert_eq!(settings, RecordingSettings::default());
     }
 


### PR DESCRIPTION
## Summary
- Replace the fixed `/tmp/screenpipe-test-nonexistent-config.toml` path with a guaranteed-absent path inside a temporary directory.
- Keeps `load_missing_file_returns_default` isolated from stale files left by local or CI runs.

## Changed area
- `crates/screenpipe-config` persistence tests.

## Validation
- `vet "make screenpipe-config missing-file persistence test use an isolated absent temp path" --agentic --agent-harness claude`
- `cargo test -p screenpipe-config load_missing_file_returns_default`
- `cargo test -p screenpipe-config`
- `git diff --check`

## Risk
- Low: test-only change; production code is unchanged.

## Skipped tests
- None.