### PR TITLE
feat(capture): expose capture_on_keystroke + capture_on_clipboard via CLI

### DIFF
--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -193,6 +193,24 @@ pub struct RecordingSettings {
     #[serde(rename = "minCaptureIntervalMs", default)]
     pub min_capture_interval_ms: Option<u64>,
 
+    /// Override `EventDrivenCaptureConfig::capture_on_keystroke`.
+    /// None = engine default (false). When true, non-printable key events
+    /// (Arrow / Enter / Tab / Esc, modifier combos like Ctrl+S) fire a paired
+    /// capture so `ui_events.frame_id` is populated for the originating row.
+    /// Off by default — fast typing can generate a storm of captures even
+    /// with the 200ms `min_capture_interval_ms` debounce.
+    #[serde(rename = "captureOnKeystroke", default)]
+    pub capture_on_keystroke: Option<bool>,
+
+    /// Override `EventDrivenCaptureConfig::capture_on_clipboard`.
+    /// None = engine default (false). When true, clipboard changes fire a
+    /// paired capture so `ui_events.frame_id` is populated for the
+    /// clipboard row. Off by default — adds 50-150ms of blocking work per
+    /// Ctrl+C/X/V (more with OCR fallback) which can cause visible HID lag
+    /// on some USB devices.
+    #[serde(rename = "captureOnClipboard", default)]
+    pub capture_on_clipboard: Option<bool>,
+
     /// Prioritize mouse/keyboard input latency over a11y event completeness.
     /// Opt-in master switch for the three coordinated optimizations defined on
     /// `UiCaptureConfig.prioritize_input_latency`.
@@ -464,6 +482,8 @@ impl Default for RecordingSettings {
             visual_check_interval_ms: None,
             visual_change_threshold: None,
             min_capture_interval_ms: None,
+            capture_on_keystroke: None,
+            capture_on_clipboard: None,
             prioritize_input_latency: false,
             extraction_thread_priority: default_extraction_thread_priority(),
             pause_extraction_on_input_ms: default_pause_extraction_on_input_ms(),

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -428,6 +428,22 @@ pub struct RecordArgs {
     #[arg(long)]
     pub min_capture_interval_ms: Option<u64>,
 
+    /// Mitsukeru fork: override `EventDrivenCaptureConfig::capture_on_keystroke`.
+    /// When true, non-printable key events (Arrow/Enter/Tab/Esc, modifier
+    /// combos like Ctrl+S) fire a paired capture so `ui_events.frame_id`
+    /// is populated for the originating row. Off by default — fast typing
+    /// can flood the pipeline even with the min-capture-interval debounce.
+    #[arg(long)]
+    pub capture_on_keystroke: Option<bool>,
+
+    /// Mitsukeru fork: override `EventDrivenCaptureConfig::capture_on_clipboard`.
+    /// When true, clipboard changes fire a paired capture so the clipboard
+    /// row's `frame_id` is linked. Off by default — adds 50-150ms of
+    /// blocking work per Ctrl+C/X/V (more with OCR fallback) which can
+    /// cause visible HID input lag on some USB devices.
+    #[arg(long)]
+    pub capture_on_clipboard: Option<bool>,
+
     /// Prioritize mouse/keyboard input latency over a11y event metadata completeness.
     /// When enabled, three opt-in optimizations are activated together:
     ///   1. mouse/keyboard hook locks switch to try_lock (contended → app_name/window=None)
@@ -724,6 +740,8 @@ impl RecordArgs {
             visual_check_interval_ms: self.visual_check_interval_ms,
             visual_change_threshold: self.visual_change_threshold,
             min_capture_interval_ms: self.min_capture_interval_ms,
+            capture_on_keystroke: self.capture_on_keystroke,
+            capture_on_clipboard: self.capture_on_clipboard,
             prioritize_input_latency: self.prioritize_input_latency,
             extraction_thread_priority: self.extraction_thread_priority.clone(),
             pause_extraction_on_input_ms: self.pause_extraction_on_input_ms,

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -151,6 +151,12 @@ pub struct RecordingConfig {
     pub visual_check_interval_ms: Option<u64>,
     pub visual_change_threshold: Option<f64>,
     pub min_capture_interval_ms: Option<u64>,
+    /// Override `EventDrivenCaptureConfig::capture_on_keystroke`.
+    /// None = engine default (false). See `RecordingSettings.capture_on_keystroke`.
+    pub capture_on_keystroke: Option<bool>,
+    /// Override `EventDrivenCaptureConfig::capture_on_clipboard`.
+    /// None = engine default (false). See `RecordingSettings.capture_on_clipboard`.
+    pub capture_on_clipboard: Option<bool>,
 
     /// Prioritize input latency over a11y event completeness.
     /// See `RecordingSettings.prioritize_input_latency` for details.
@@ -303,6 +309,8 @@ impl RecordingConfig {
             visual_check_interval_ms: settings.visual_check_interval_ms,
             visual_change_threshold: settings.visual_change_threshold,
             min_capture_interval_ms: settings.min_capture_interval_ms,
+            capture_on_keystroke: settings.capture_on_keystroke,
+            capture_on_clipboard: settings.capture_on_clipboard,
             prioritize_input_latency: settings.prioritize_input_latency,
             extraction_thread_priority: settings.extraction_thread_priority.clone(),
             pause_extraction_on_input_ms: settings.pause_extraction_on_input_ms,
@@ -394,6 +402,8 @@ impl RecordingConfig {
             visual_check_interval_ms: self.visual_check_interval_ms,
             visual_change_threshold: self.visual_change_threshold,
             min_capture_interval_ms: self.min_capture_interval_ms,
+            capture_on_keystroke: self.capture_on_keystroke,
+            capture_on_clipboard: self.capture_on_clipboard,
         }
     }
 }

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -52,6 +52,12 @@ pub struct VisionManagerConfig {
     pub visual_check_interval_ms: Option<u64>,
     pub visual_change_threshold: Option<f64>,
     pub min_capture_interval_ms: Option<u64>,
+    /// Override `EventDrivenCaptureConfig::capture_on_keystroke`.
+    /// None = engine default (false). PowerProfile does not touch this.
+    pub capture_on_keystroke: Option<bool>,
+    /// Override `EventDrivenCaptureConfig::capture_on_clipboard`.
+    /// None = engine default (false). PowerProfile does not touch this.
+    pub capture_on_clipboard: Option<bool>,
 }
 
 /// Status of the VisionManager
@@ -399,6 +405,12 @@ impl VisionManager {
         if let Some(v) = self.config.min_capture_interval_ms {
             capture_config.min_capture_interval_ms = v;
         }
+        if let Some(v) = self.config.capture_on_keystroke {
+            capture_config.capture_on_keystroke = v;
+        }
+        if let Some(v) = self.config.capture_on_clipboard {
+            capture_config.capture_on_clipboard = v;
+        }
 
         // Subscribe to the shared broadcast channel so UI events reach this monitor
         let trigger_rx = self.trigger_tx.subscribe();
@@ -565,6 +577,8 @@ mod tests {
             visual_check_interval_ms: None,
             visual_change_threshold: None,
             min_capture_interval_ms: None,
+            capture_on_keystroke: None,
+            capture_on_clipboard: None,
         };
         VisionManager::new(config, db, Handle::current())
     }


### PR DESCRIPTION
## Summary
- Exposes two existing `EventDrivenCaptureConfig` knobs as CLI flags + persisted settings, so customers can opt into capture-on-keystroke / capture-on-clipboard without a rebuild.
- Wires the standard Mitsukeru-fork plumbing: `cli/mod.rs` → `RecordingSettings` (screenpipe-config) → `RecordingConfig` → `VisionManagerConfig` → applied as override on `EventDrivenCaptureConfig`.
- Both default to `None` (engine default `false`) — zero behavior change for existing deployments.

## Why
Today these triggers are hardcoded off:
- `capture_on_keystroke: false` — non-printable key events (Arrow/Enter/Tab/Esc, Ctrl+S, …) never fire a paired capture, so `ui_events.frame_id` stays NULL for `UiEventType::Key` rows even though the recorder already mints a correlation_id and broadcasts the trigger ([ui_recorder.rs:814](https://github.com/screenpipe/screenpipe/blob/claude/youthful-meitner-5228d1/crates/screenpipe-engine/src/ui_recorder.rs#L814)). The `reduce_drained_triggers` reducer drops the trigger + corr_id when the gate is closed.
- `capture_on_clipboard: false` — same story, but for clipboard rows.

The frame-linker already handles both: as soon as the gate is open, the corr_id rides through the reducer, the capture fires, and `UPDATE ui_events SET frame_id = ?` lands via the existing actor.

Flipping the flag for a deployment costs:
- **keystroke**: ~10-20× more captures during heavy typing (debounce caps at ~5/s via `min_capture_interval_ms`). With a11y-primary capture (OCR skipped on most frames) the per-capture cost is dominated by the AX tree walk, not OCR.
- **clipboard**: 50-150ms blocking work per Ctrl+C/X/V (more with OCR fallback), can cause visible HID input lag on some USB devices. Already documented in [event_driven_capture.rs:179-187](https://github.com/screenpipe/screenpipe/blob/claude/youthful-meitner-5228d1/crates/screenpipe-engine/src/event_driven_capture.rs#L179-L187).

Off-by-default is the right global posture; this just makes the customer-facing knob accessible.

## SDK scope (intentional)
- **`packages/cli/screenpipe/` (npm wrapper)** — no code change. It's `spawnSync(bin, process.argv.slice(2))`; new CLI args flow through automatically. Use via `bunx screenpipe --capture-on-keystroke true`.
- **`ee/sdk` Recorder SDK (JS + Swift)** — intentionally NOT touched. It's a separate product that writes MP4s via NAPI bindings — no `EventDrivenCaptureConfig`, no `ui_events`, no frame_id linkage. Adding `captureOnKeystroke?: boolean` to `RecorderOptions` would be misleading dead code.

If we later want the Recorder SDK (or any HTTP runtime-config endpoint) to grow daemon-capture knobs, that's a separate, bigger change.

## Files changed
- `crates/screenpipe-config/src/recording.rs` — 2 new `Option<bool>` fields on `RecordingSettings` + Default impl entries. Serde rename to `captureOnKeystroke` / `captureOnClipboard` (camelCase) for store.bin compatibility.
- `crates/screenpipe-engine/src/cli/mod.rs` — 2 new `#[arg(long)] Option<bool>` clap args + wire to `RecordingSettings`.
- `crates/screenpipe-engine/src/recording_config.rs` — fields on internal `RecordingConfig` + plumbing through both `from_settings` and `to_vision_manager_config`.
- `crates/screenpipe-engine/src/vision_manager/manager.rs` — fields on `VisionManagerConfig` + 2 `if let Some(v)` overrides applied to `EventDrivenCaptureConfig` alongside the existing `visual_check_interval_ms` block. Test fixture updated.

## Test plan
- [x] `cargo build -p screenpipe-config -p screenpipe-engine` — clean
- [x] `cargo test -p screenpipe-config --lib` — 26 pass (including JSON round-trip that exercises the new Default fields)
- [x] `cargo test -p screenpipe-engine --lib event_driven` — 19 pass (KeyPress/Clipboard reducer gates still behave correctly)
- [x] `cargo test -p screenpipe-engine --lib` — 458 pass, 1 unrelated `sleep_monitor::test_recently_woke_flag` flake (passes in isolation, no relation to capture config)
- [ ] Smoke: `bunx screenpipe --capture-on-keystroke true --capture-on-clipboard true` on a dev box, type for 30s, query `SELECT COUNT(*) FROM ui_events WHERE event_type = 'key' AND frame_id IS NOT NULL` and confirm > 0
- [ ] Verify desktop app `tauri.ts` regenerates with the new `captureOnKeystroke?: boolean | null` field on next build (specta auto-generation; no manual edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)