### PR TITLE
fix chat title fallback mismatch

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -65,6 +65,7 @@ import {
 import { deleteConversationFile, updateConversationFlags } from "@/lib/chat-storage";
 import { pipeSessionId } from "@/lib/events/types";
 import { commands } from "@/lib/utils/tauri";
+import { isConversationHistorySyncPrompt } from "@/lib/chat-utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -1437,7 +1438,7 @@ export function SidebarChatRow({
                 : "text-muted-foreground"
           )}
         >
-          {(session.title?.startsWith("<") ? undefined : session.title) || "untitled"}
+          {(isConversationHistorySyncPrompt(session.title) ? undefined : session.title) || "untitled"}
         </span>
         <span className="ml-1 h-4 w-10 shrink-0 relative flex items-center justify-end">
           <span

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -57,6 +57,7 @@ import {
   buildAppMentionSuggestions,
   normalizeAppTag,
   formatShortcutDisplay,
+  isConversationHistorySyncPrompt,
 } from "@/lib/chat-utils";
 import { sanitizeToolCallXml } from "@/lib/utils/sanitize-tool-call-xml";
 import { useAutoSuggestions, type Suggestion } from "@/lib/hooks/use-auto-suggestions";
@@ -2661,10 +2662,15 @@ function ChatTitleMenu({
     conversationId ? s.sessions[conversationId] : undefined
   );
   const isPinned = session?.pinned ?? false;
-  const firstUserMsg = messages.find((m) => m.role === "user");
+  const firstUserMsg = messages.find(
+    (m) => m.role === "user" && !isConversationHistorySyncPrompt(m.content)
+  );
   const derivedTitle = firstUserMsg?.content?.slice(0, 50);
   const title =
-    storeTitle && storeTitle !== "new chat" && storeTitle !== "untitled"
+    storeTitle &&
+    storeTitle !== "new chat" &&
+    storeTitle !== "untitled" &&
+    !isConversationHistorySyncPrompt(storeTitle)
       ? storeTitle
       : derivedTitle || "";
 
@@ -7737,7 +7743,7 @@ export function StandaloneChat({
                         >
                           <div className="flex-1 min-w-0">
                             <p className="text-xs font-medium truncate">
-                              {conv.title}
+                              {(isConversationHistorySyncPrompt(conv.title) ? undefined : conv.title) || "untitled"}
                             </p>
                             <p className="text-[10px] text-muted-foreground">
                               {conv.messageCount} messages
@@ -7763,7 +7769,7 @@ export function StandaloneChat({
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   setOpenConvMenuId(null);
-                                  setRenameValue(conv.title);
+                                  setRenameValue(isConversationHistorySyncPrompt(conv.title) ? "" : conv.title);
                                   setRenamingConvId(conv.id);
                                 }}
                               >

--- a/apps/screenpipe-app-tauri/lib/chat-utils.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-utils.ts
@@ -10,6 +10,10 @@ import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { commands } from "@/lib/utils/tauri";
 
+export function isConversationHistorySyncPrompt(value?: string | null): boolean {
+  return typeof value === "string" && value.startsWith("<conversation_history>");
+}
+
 // ============================================================================
 // CHAT PREFILL - Reliable cross-window event delivery
 // ============================================================================


### PR DESCRIPTION
This pr fixes chat title fallback mismatch across sidebar header.

Saw "untitled" in the chat sidebar even when the same conversation still had a visible title in the header and overlay. This makes title fallback behavior consistent across those chat surfaces.

Before - 

<img width="730" height="346" alt="Screenshot 2026-05-23 at 7 48 20 AM" src="https://github.com/user-attachments/assets/78bdfe2b-96f3-47e8-a988-484dfad499d7" />

After -

<img width="590" height="311" alt="Screenshot 2026-05-23 at 7 46 58 AM" src="https://github.com/user-attachments/assets/a0fd3cff-bd7c-44df-8561-1f54897da6ad" />
