### PR TITLE
Fix pointer cursor for assistant-message markdown links

### DIFF
--- a/apps/screenpipe-app-tauri/app/globals.css
+++ b/apps/screenpipe-app-tauri/app/globals.css
@@ -303,6 +303,11 @@
     background-color: rgba(59, 130, 246, 0.35) !important;
   }
 
+  .prose a,
+  .prose a * {
+    cursor: pointer !important;
+  }
+
   /* Allow video/audio controls to work normally */
   video, audio {
     -webkit-user-drag: auto !important;


### PR DESCRIPTION
This pr fix the cursor shown for clickable links inside assistant message markdown.

Before -

https://github.com/user-attachments/assets/45b6f78e-f4f9-47fe-ab9d-836375ad7194


After -


https://github.com/user-attachments/assets/1209f8a0-96f3-4d99-b657-59ea32be0ada

