### PR TITLE
fix(ci): fail fast when CLI binaries are missing during npm packaging

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -563,8 +563,9 @@ jobs:
       - name: Prepare platform packages
         run: |
           # macOS ARM64
+          mkdir -p /tmp/darwin-arm64
           mkdir -p packages/cli/screenpipe-darwin-arm64/bin
-          tar -xzf artifacts/screenpipe-macos-aarch64-apple-darwin/screenpipe-*.tar.gz -C /tmp/darwin-arm64 || true
+          tar -xzf artifacts/screenpipe-macos-aarch64-apple-darwin/screenpipe-*.tar.gz -C /tmp/darwin-arm64
           cp /tmp/darwin-arm64/bin/screenpipe packages/cli/screenpipe-darwin-arm64/bin/ 2>/dev/null || \
             (cd artifacts/screenpipe-macos-aarch64-apple-darwin && tar -xzf screenpipe-*.tar.gz && cp bin/screenpipe ../../packages/cli/screenpipe-darwin-arm64/bin/)
           # Bundle mlx.metallib for Parakeet MLX GPU support
@@ -572,6 +573,7 @@ jobs:
             (cd artifacts/screenpipe-macos-aarch64-apple-darwin && cp bin/mlx.metallib ../../packages/cli/screenpipe-darwin-arm64/bin/ 2>/dev/null) || \
             echo "⚠️ mlx.metallib not found in artifact"
           chmod +x packages/cli/screenpipe-darwin-arm64/bin/screenpipe
+          test -f packages/cli/screenpipe-darwin-arm64/bin/screenpipe
 
           # macOS x64
           mkdir -p packages/cli/screenpipe-darwin-x64/bin
@@ -582,6 +584,7 @@ jobs:
           mkdir -p packages/cli/screenpipe-linux-x64/bin
           cd artifacts/screenpipe-linux-x86_64-unknown-linux-gnu && tar -xzf screenpipe-*.tar.gz && cp bin/screenpipe ../../packages/cli/screenpipe-linux-x64/bin/ && cd ../..
           chmod +x packages/cli/screenpipe-linux-x64/bin/screenpipe
+          test -f packages/cli/screenpipe-linux-x64/bin/screenpipe
 
           # Windows x64
           mkdir -p packages/cli/screenpipe-win32-x64/bin


### PR DESCRIPTION
## description

Fixes a silent failure path in the CLI npm packaging workflow.

The macOS ARM64 packaging step extracted artifacts into `/tmp/darwin-arm64` without ensuring the directory existed first. Since the extraction command used `|| true`, failures could be silently ignored, allowing npm packages to publish without bundled binaries.

This can result in published platform packages containing only `package.json`, which causes npm to strip the invalid `bin` field and breaks:

```bash
npx @screenpipe/cli-<platform>@latest record
```

Changes in this PR:

* create `/tmp/darwin-arm64` before extraction
* remove silent failure masking from the ARM64 tar extraction step
* add fail-fast `test -f` checks for macOS ARM64 and Linux x64 binaries before publish

related issue: #3542

## before

Broken npm packages could publish successfully even when the CLI binary was missing from the package contents.

## after

The workflow now fails immediately if required CLI binaries are missing during packaging.

## how to test

1. Run the `publish-npm` workflow locally or in CI
2. Verify platform package directories contain `bin/screenpipe`
3. Confirm workflow fails if extraction/copy steps do not produce the expected binary
