### PR TITLE
fix(a11y): increase default max_depth 30→35 to capture VS Code terminal

### DIFF
--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -169,7 +169,7 @@ impl Default for TreeWalkerConfig {
     fn default() -> Self {
         Self {
             walk_interval: Duration::from_secs(3),
-            max_depth: 30,
+            max_depth: 35,
             max_nodes: 5000,
             walk_timeout: Duration::from_millis(250),
             max_text_length: 50_000,


### PR DESCRIPTION
## Problem

The macOS AX walker stops at `depth >= max_depth` (default 30). VS Code's integrated terminal (`AXTextField`, description `Terminal N`) sits at **depth 30** from the AX root — exactly at the cutoff, so it is silently skipped every walk.

### Reproduction

With VS Code open and a terminal focused:

```bash
# Confirm the focused element IS the terminal
osascript -e 'tell application "System Events" to tell application process "Code" to return {role, description} of (value of attribute "AXFocusedUIElement")'
# → AXTextField, Terminal 8

# Count parent links from the element to the AX root
# (osascript script traverses AXParent 30 times before hitting nil)
# → depth = 30
```

`AXTextField` at depth 30 has a non-empty `AXValue` containing the terminal buffer. The walk condition `depth >= state.max_depth` with `max_depth = 30` means depth 30 is **never visited**.

### VS Code setup that is already correct

- `editor.accessibilitySupport = "on"` → xterm.js uses DOM renderer, not canvas
- `terminal.integrated.gpuAcceleration = "off"` → confirmed via `settings.json`

The AX tree **is** populated. screenpipe just never reaches it.

### Why 35?

- Terminal is at depth 30 → need at least 31 to fix
- 35 gives 5 levels of headroom for other deeply-nested app UIs (Electron panels, split views, etc.)
- `max_nodes = 5000` and `walk_timeout = 250ms` already guard against runaway cost — raising depth alone cannot cause unbounded walks

## Change

One line in `TreeWalkerConfig::default()`:

```rust
// crates/screenpipe-a11y/src/tree/mod.rs
max_depth: 35,  // was 30; VS Code terminal sits at exactly depth 30
```

## Affected apps

Any Electron app with deeply-nested panels (VS Code, Obsidian, Slack, Discord, Notion) will benefit. The immediate fix is VS Code's integrated terminal — the primary place developers run AI coding agents like Claude Code.