### PR TITLE
fix(chat): silent model switch mid-stream no longer kills active response

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -3063,6 +3063,8 @@ export function StandaloneChat({
   const [renameValue, setRenameValue] = useState("");
   const [deletingConvId, setDeletingConvId] = useState<string | null>(null);
   const [activePreset, setActivePreset] = useState<AIPreset | undefined>();
+  const pendingPresetRef = useRef<AIPreset | null>(null);
+  const isStreamingRef = useRef(false);
   const [showMentionDropdown, setShowMentionDropdown] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
   const [mentionFilter, setMentionFilter] = useState("");
@@ -3988,6 +3990,10 @@ export function StandaloneChat({
     if (storeChatIsLoading === false) setIsLoading(false);
   }, [storeChatIsStreaming, storeChatIsLoading]);
 
+  useEffect(() => {
+    isStreamingRef.current = isStreaming;
+  }, [isStreaming]);
+
   // Keep the pipe-context banner in sync with the current session.
   // When the panel switches AWAY from a pipe-watch session (user
   // clicks a chat), `activePipeExecution` would otherwise stay set
@@ -4575,6 +4581,12 @@ export function StandaloneChat({
   //
   // Called directly from the AIPresetsSelector onPresetSaved callback.
   const handlePiRestart = useCallback((preset: AIPreset) => {
+    if (isStreamingRef.current) {
+      pendingPresetRef.current = preset;
+      toast({ title: "model will switch after this response finishes" });
+      return;
+    }
+
     const providerConfig = buildProviderConfig(preset);
     if (!providerConfig) return;
 
@@ -4644,6 +4656,14 @@ export function StandaloneChat({
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settings.user?.token, setRunningConfigFromProviderConfig, restartCurrentPiSession]);
+
+  useEffect(() => {
+    if (!isStreaming && pendingPresetRef.current) {
+      const preset = pendingPresetRef.current;
+      pendingPresetRef.current = null;
+      handlePiRestart(preset);
+    }
+  }, [isStreaming, handlePiRestart]);
 
   // Listen for Pi / pipe events.
   //


### PR DESCRIPTION
### Description: 

Fixes #3545 

Model changes mid-stream now queue and apply after the response completes instead of silently killing the active session.

- before: 


https://github.com/user-attachments/assets/2c1813a8-1fee-4fc2-94d0-0ce248c41fc6



- after: 


https://github.com/user-attachments/assets/a4f7927e-b55c-415a-b852-1eee1d6c5403



### Files changed:
  - apps/screenpipe-app-tauri/components/standalone-chat.tsx — added pendingPresetRef and isStreamingRef, guarded
  handlePiRestart to park preset changes during streaming, added flush effect on stream end