### PR TITLE
fix(a11y): reset depth counter at AXWebArea boundary so Electron apps get the full walk budget

### DIFF
--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -747,7 +747,14 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
         return;
     }
 
-    // Recurse into children
+    // Recurse into children.
+    // Reset the depth counter to 0 when entering an AXWebArea so that Electron
+    // apps (VS Code, Slack, Discord, Obsidian, Notion, …) get the full
+    // max_depth budget for their DOM content tree. Without this reset, the
+    // budget is partially consumed by the Electron shell layers above the
+    // AXWebArea (typically 7-9 AXGroup levels), leaving fewer levels for the
+    // actual app content — silently dropping terminal output, editor text, etc.
+    let next_depth = if role_str == "AXWebArea" { 0 } else { depth + 1 };
     let children = elem.children();
     if let Ok(children) = children {
         for i in 0..children.len() {
@@ -755,7 +762,7 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
                 break;
             }
             let child = &children[i];
-            walk_element(child, depth + 1, state);
+            walk_element(child, next_depth, state);
         }
     }
 }

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -754,7 +754,11 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
     // budget is partially consumed by the Electron shell layers above the
     // AXWebArea (typically 7-9 AXGroup levels), leaving fewer levels for the
     // actual app content — silently dropping terminal output, editor text, etc.
-    let next_depth = if role_str == "AXWebArea" { 0 } else { depth + 1 };
+    let next_depth = if role_str == "AXWebArea" {
+        0
+    } else {
+        depth + 1
+    };
     let children = elem.children();
     if let Ok(children) = children {
         for i in 0..children.len() {


### PR DESCRIPTION
## Problem

PR #3547 (`max_depth: 30→35`) fixes VS Code terminal capture for today's Electron shell depth, but doesn't address the root cause. The depth budget is measured from `AXWindow` (depth 0), so Electron's 7–9 shell layers above the `AXWebArea` silently consume it before the walker reaches any app content.

With `max_depth=35` and an 8-level Electron shell:
- **27 effective levels** reach app content (35 − 8)
- VS Code terminal output at webarea-relative depth 25 is captured — but only by coincidence (25 < 27)
- If Electron's shell grows to 10 levels, it breaks again silently

## Fix

One line in `walk_element`: reset the depth counter to `0` when recursing into children of an `AXWebArea`. The webarea's content tree always gets the full `max_depth` budget, regardless of how deep the `AXWebArea` itself sits.

```rust
// crates/screenpipe-a11y/src/tree/macos.rs

// Before
walk_element(child, depth + 1, state);

// After
let next_depth = if role_str == "AXWebArea" { 0 } else { depth + 1 };
walk_element(child, next_depth, state);
```

With this fix and `max_depth=35`:
- **35 effective levels** reach app content inside any AXWebArea (full budget)
- Works for VS Code, Slack, Discord, Obsidian, Notion — any Electron app

## Proof

The same strategy works in a standalone Swift script. Save this as `ax_terminal.swift` and run `swift ax_terminal.swift` with VS Code open and the terminal focused — it captures the full terminal scrollback including AI agent output:

```swift
import AppKit
import ApplicationServices

func ax<T>(_ e: AXUIElement, _ a: String) -> T? {
    var r: CFTypeRef?
    guard AXUIElementCopyAttributeValue(e, a as CFString, &r) == .success else { return nil }
    return r as? T
}

guard let vscode = NSWorkspace.shared.runningApplications.first(where: { $0.localizedName == "Code" }) else {
    fputs("error: VS Code not running\n", stderr); exit(1)
}
let app = AXUIElementCreateApplication(vscode.processIdentifier)
AXUIElementSetMessagingTimeout(app, 2.0)
AXUIElementSetAttributeValue(app, "AXEnhancedUserInterface" as CFString, kCFBooleanTrue)
AXUIElementSetAttributeValue(app, "AXManualAccessibility" as CFString, kCFBooleanTrue)

guard let focused: AXUIElement = ax(app, "AXFocusedUIElement") else {
    fputs("error: no focused element\n", stderr); exit(1)
}

// Walk UP from the focused element to find the AXWebArea
var cur: AXUIElement = focused
var webArea: AXUIElement?
while let p: AXUIElement = ax(cur, "AXParent") {
    if ax(p, "AXRole") as String? == "AXWebArea" { webArea = p; break }
    cur = p
}

guard let webArea = webArea else {
    fputs("error: AXWebArea not found\n", stderr); exit(1)
}

// Walk DOWN from the AXWebArea with a fresh depth budget of 30
let deadline = Date(timeIntervalSinceNow: 5)
func walk(_ el: AXUIElement, _ d: Int) {
    guard d <= 30, Date() < deadline else { return }
    let v: String = ax(el, "AXValue") ?? ""
    if !v.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { print(v) }
    for k: AXUIElement in ax(el, "AXChildren") ?? [] { walk(k, d + 1) }
}
walk(webArea, 0)
```

This script uses **only 30 levels of depth budget** (same as screenpipe's original default) and successfully captures terminal content at webarea-relative depth 25 — content that screenpipe with `max_depth=30` missed entirely. The depth-reset in this PR makes screenpipe's walker do the same thing automatically.

## Why this is the right fix

The script finds the AXWebArea by walking up from `AXFocusedUIElement`, then walks down with depth reset to 0. This PR bakes that same insight into the recursive walker so it applies automatically for all Electron apps without any special-casing.

## Impact

| | `max_depth 30→35` (merged) | This fix |
|---|---|---|
| Effective levels inside AXWebArea | 35 − 8 shell = **27** | **35** (full budget) |
| VS Code terminal output (depth 25 in webarea) | ✓ (by coincidence) | ✓ (by design) |
| Robust if Electron shell deepens | ✗ | ✓ |
| Other Electron apps (Slack, Discord, Obsidian) | maybe | ✓ |

Closes #3554