### PR TITLE
domain: prep canonical switch to screenpipe.com (phase 1, desktop website links)

### DIFF
--- a/apps/screenpipe-app-tauri/app/settings/page.tsx
+++ b/apps/screenpipe-app-tauri/app/settings/page.tsx
@@ -68,7 +68,7 @@ function ReferralSection() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [sending, setSending] = useState(false);
   const referralCode = settings.user?.id ? `REF-${settings.user.id.slice(0, 8).toUpperCase()}` : "";
-  const referralLink = referralCode ? `https://screenpi.pe/?ref=${referralCode}` : "";
+  const referralLink = referralCode ? `https://screenpipe.com/?ref=${referralCode}` : "";
 
   const handleCopy = async () => {
     if (!referralLink) return;

--- a/apps/screenpipe-app-tauri/components/changelog-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/changelog-dialog.tsx
@@ -117,7 +117,7 @@ export const ChangelogDialog: React.FC = () => {
         <div className="px-6 pt-6 pb-4 border-b border-border flex items-center justify-between">
           <h1 className="text-xl font-semibold">changelog</h1>
           <a
-            href="https://screenpi.pe/changelog"
+            href="https://screenpipe.com/changelog"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -200,12 +200,12 @@ export const ChangelogDialog: React.FC = () => {
             <div className="text-sm text-muted-foreground font-mono">
               couldn&apos;t reach the changelog. try again later or visit{" "}
               <a
-                href="https://screenpi.pe/changelog"
+                href="https://screenpipe.com/changelog"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline hover:text-foreground"
               >
-                screenpi.pe/changelog
+                screenpipe.com/changelog
               </a>
             </div>
           )}

--- a/apps/screenpipe-app-tauri/components/login-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/login-dialog.tsx
@@ -19,7 +19,7 @@ export function LoginDialog() {
         <DialogHeader>
           <DialogTitle>login required</DialogTitle>
           <DialogDescription>
-            please login to continue. you will be redirected to screenpi.pe
+            please login to continue. you will be redirected to screenpipe.com
           </DialogDescription>
         </DialogHeader>
         <div className="flex justify-end">

--- a/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
@@ -628,12 +628,12 @@ export default function ConnectApps({ handleNextSlide }: ConnectAppsProps) {
       if (data.url) {
         await openUrl(data.url);
       } else {
-        await openUrl("https://screenpi.pe/billing");
+        await openUrl("https://screenpipe.com/billing");
         return;
       }
     } catch (error) {
       console.error("failed to start onboarding checkout:", error);
-      await openUrl("https://screenpi.pe/billing");
+      await openUrl("https://screenpipe.com/billing");
       return;
     }
 

--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -992,7 +992,7 @@ if the input is sparse, just describe what little you have warmly. don't apologi
             stays on your machine ·{" "}
             <button
               type="button"
-              onClick={() => openUrl("https://screenpi.pe/security")}
+              onClick={() => openUrl("https://screenpipe.com/security")}
               className="underline hover:text-muted-foreground transition-colors"
             >
               how it works ↗

--- a/apps/screenpipe-app-tauri/components/post-install-connections-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/post-install-connections-modal.tsx
@@ -245,7 +245,7 @@ export function PostInstallConnectionsModal({
                             <Lock className="h-3 w-3" />pro required
                           </Button>
                           <button
-                            onClick={() => openUrl("https://screenpi.pe/onboarding")}
+                            onClick={() => openUrl("https://screenpipe.com/onboarding")}
                             className="text-[10px] text-muted-foreground hover:text-foreground underline"
                           >
                             upgrade to pro to connect

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -210,7 +210,7 @@ export function AccountSection() {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => openUrl("https://screenpi.pe/account")}
+                onClick={() => openUrl("https://screenpipe.com/account")}
               >
                 <UserCog className="w-4 h-4 mr-1.5" />
                 manage
@@ -256,7 +256,7 @@ export function AccountSection() {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => openUrl("https://screenpi.pe/billing")}
+                onClick={() => openUrl("https://screenpipe.com/billing")}
               >
                 <CreditCard className="w-3.5 h-3.5 mr-1.5" />
                 Billing <ExternalLinkIcon className="w-3.5 h-3.5 ml-1.5" />

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1703,7 +1703,7 @@ function OAuthPanel({
               <Lock className="h-3 w-3" />pro required
             </Button>
             <button
-              onClick={() => openUrl("https://screenpi.pe/onboarding")}
+              onClick={() => openUrl("https://screenpipe.com/onboarding")}
               className="text-[10px] text-muted-foreground hover:text-foreground underline"
             >
               upgrade to pro to connect

--- a/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
@@ -92,10 +92,10 @@ export function FeedbackSection() {
               </div>
             </div>
             <button
-              onClick={() => open("https://screenpi.pe/ideas")}
+              onClick={() => open("https://screenpipe.com/ideas")}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors duration-150"
             >
-              screenpi.pe/ideas →
+              screenpipe.com/ideas →
             </button>
           </div>
         </div>
@@ -146,10 +146,10 @@ export function FeedbackSection() {
               </div>
             </div>
             <button
-              onClick={() => open("https://screenpi.pe/changelog")}
+              onClick={() => open("https://screenpipe.com/changelog")}
               className="text-xs text-muted-foreground hover:text-foreground transition-colors duration-150"
             >
-              screenpi.pe/changelog →
+              screenpipe.com/changelog →
             </button>
           </div>
         </div>

--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -110,7 +110,7 @@ export default function GeneralSettings() {
 
     const path = isEnterprise ? "/enterprise" : "/account/versions";
     if (isEnterprise) params.set("tab", "builds");
-    const url = `https://screenpi.pe${path}?${params.toString()}`;
+    const url = `https://screenpipe.com${path}?${params.toString()}`;
 
     try {
       await openUrl(url);

--- a/apps/screenpipe-app-tauri/components/settings/gmail-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/gmail-card.tsx
@@ -157,7 +157,7 @@ export function GmailCard() {
                   <Lock className="h-3 w-3" />pro required
                 </Button>
                 <button
-                  onClick={() => openUrl("https://screenpi.pe/onboarding")}
+                  onClick={() => openUrl("https://screenpipe.com/onboarding")}
                   className="text-[10px] text-muted-foreground hover:text-foreground underline"
                 >
                   upgrade to pro to connect

--- a/apps/screenpipe-app-tauri/components/settings/google-docs-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/google-docs-card.tsx
@@ -145,7 +145,7 @@ export function GoogleDocsCard() {
                   <Lock className="h-3 w-3" />pro required
                 </Button>
                 <button
-                  onClick={() => openUrl("https://screenpi.pe/onboarding")}
+                  onClick={() => openUrl("https://screenpipe.com/onboarding")}
                   className="text-[10px] text-muted-foreground hover:text-foreground underline"
                 >
                   upgrade to pro to connect

--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -1863,9 +1863,9 @@ export function RecordingSettings() {
           }),
         });
         const data = await response.json();
-        openUrl(data.url || "https://screenpi.pe/billing");
+        openUrl(data.url || "https://screenpipe.com/billing");
       } catch {
-        openUrl("https://screenpi.pe/billing");
+        openUrl("https://screenpipe.com/billing");
       }
       // Revert back to previous value in the Select component
       return;
@@ -2255,7 +2255,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                         size="sm"
                         className="h-7 px-2 text-xs"
                         data-testid="audio-engine-fallback-upgrade"
-                        onClick={() => openUrl("https://screenpi.pe/billing")}
+                        onClick={() => openUrl("https://screenpipe.com/billing")}
                       >
                         Upgrade
                       </Button>

--- a/apps/screenpipe-app-tauri/components/settings/sync-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/sync-settings.tsx
@@ -262,7 +262,7 @@ function SyncOnboarding({ onSubscribe, onRefresh, isLoading, isRefreshing, isLog
               variant="outline"
               onClick={async () => {
                 const { open } = await import("@tauri-apps/plugin-shell");
-                await open("https://screenpi.pe/login");
+                await open("https://screenpipe.com/login");
               }}
             >
               Log in to continue

--- a/apps/screenpipe-app-tauri/components/settings/team-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/team-section.tsx
@@ -186,8 +186,9 @@ export function TeamSection() {
       let claimToken: string | null = null;
       let base64Key: string | null = null;
 
-      // Handle web URL format: https://screenpi.pe/join/TOKEN#key=BASE64
-      const webMatch = input.match(/screenpi\.pe\/join\/([^#?]+)/);
+      // Handle web URL format: https://screenpipe.com/join/TOKEN#key=BASE64
+      // (also accept legacy https://screenpi.pe/join/... links)
+      const webMatch = input.match(/(?:screenpipe\.com|screenpi\.pe)\/join\/([^#?]+)/);
       if (webMatch) {
         inviteToken = webMatch[1];
         const hash = input.split("#")[1] || "";
@@ -505,7 +506,7 @@ export function TeamSection() {
           {showJoinInput ? (
             <div className="flex gap-2">
               <Input
-                placeholder="paste invite link (https://screenpi.pe/join/... or screenpipe://...)"
+                placeholder="paste invite link (https://screenpipe.com/join/... or screenpipe://...)"
                 value={inviteInput}
                 onChange={(e) => setInviteInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && handleJoinFromLink()}

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -7368,7 +7368,7 @@ export function StandaloneChat({
                   onClick={() => {
                     if (!isPro) {
                       setAppFilterOpen(false);
-                      openUrl("https://screenpi.pe/onboarding");
+                      openUrl("https://screenpipe.com/onboarding");
                       return;
                     }
                     updateSettings({ piPrivacyFilter: !privacyOn });

--- a/apps/screenpipe-app-tauri/lib/auth-guard.tsx
+++ b/apps/screenpipe-app-tauri/lib/auth-guard.tsx
@@ -18,10 +18,10 @@ let lastToastTime = 0;
 function openLogin() {
   // dynamic import to avoid SSR/test crashes from tauri plugins
   import("@tauri-apps/plugin-shell").then(({ open }) => {
-    open("https://screenpi.pe/login");
+    open("https://screenpipe.com/login");
   }).catch(() => {
     // fallback: window.open works in tauri webview
-    window.open("https://screenpi.pe/login", "_blank");
+    window.open("https://screenpipe.com/login", "_blank");
   });
 }
 

--- a/apps/screenpipe-app-tauri/lib/hooks/use-team.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-team.ts
@@ -140,7 +140,7 @@ export function useTeam() {
       }
       const tokenData = await tokenRes.json();
       const base64Key = await exportTeamKey(key);
-      return `https://screenpi.pe/join/${tokenData.invite_token}#key=${encodeURIComponent(base64Key)}`;
+      return `https://screenpipe.com/join/${tokenData.invite_token}#key=${encodeURIComponent(base64Key)}`;
     },
     [headers]
   );


### PR DESCRIPTION
## Summary

Updates desktop app/CLI links that open the website in a browser, from `screenpi.pe` to `screenpipe.com`. API calls (`/api/*`, `api.screenpi.pe`), updater URLs (`/api/app-update/*`), the `louis@screenpi.pe` email, `docs.screenpi.pe`, and all Rust code stay on `.pe` — those move in Phase 2.

**DO NOT MERGE** until:
1. The companion `screenpipe/website` PR is merged AND deployed
2. The Clerk primary domain swap to `screenpipe.com` is done

Merging early would point the desktop app at a domain that isn't yet authoritative for login/billing — bricking those flows for users on the new build.

## What changed (website-facing browser links only)

- `apps/screenpipe-app-tauri/app/settings/page.tsx` — referral link displayed/copied/emailed
- `apps/screenpipe-app-tauri/components/changelog-dialog.tsx` — "view all changelog" link + fallback text
- `apps/screenpipe-app-tauri/components/login-dialog.tsx` — "you will be redirected to ..." copy
- `apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx` — `/billing` fallbacks after checkout
- `apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx` — `/security` "how it works" link
- `apps/screenpipe-app-tauri/components/onboarding/read-content.tsx` — `/welcome` page URL + display text
- `apps/screenpipe-app-tauri/components/post-install-connections-modal.tsx` — `/onboarding` upgrade link
- `apps/screenpipe-app-tauri/components/settings/account-section.tsx` — `/account`, `/billing` buttons
- `apps/screenpipe-app-tauri/components/settings/connections-section.tsx` — `/onboarding` upgrade link
- `apps/screenpipe-app-tauri/components/settings/feedback-section.tsx` — `/ideas`, `/changelog` links + display text
- `apps/screenpipe-app-tauri/components/settings/general-settings.tsx` — `/enterprise` / `/account/versions`
- `apps/screenpipe-app-tauri/components/settings/gmail-card.tsx` — `/onboarding` upgrade link
- `apps/screenpipe-app-tauri/components/settings/google-docs-card.tsx` — `/onboarding` upgrade link
- `apps/screenpipe-app-tauri/components/settings/recording-settings.tsx` — `/billing` fallbacks + upgrade
- `apps/screenpipe-app-tauri/components/settings/sync-settings.tsx` — `/login` button
- `apps/screenpipe-app-tauri/components/settings/team-section.tsx` — invite-link placeholder + regex (now accepts BOTH domains for backward-compat with unexpired pre-switch links)
- `apps/screenpipe-app-tauri/components/standalone-chat.tsx` — `/onboarding` upgrade link
- `apps/screenpipe-app-tauri/lib/auth-guard.tsx` — `/login` redirect (both primary + fallback)
- `apps/screenpipe-app-tauri/lib/hooks/use-team.ts` — new invite link generation

## What deliberately stayed on `screenpi.pe` (out of scope for Phase 1)

- All `/api/*` calls (cloud-sync checkout, team API, referral API, license validate, intercom, logs, enterprise heartbeat/policy, etc.) — those depend on backend routing/cloudflare config
- Updater URLs (`/api/app-update/*`) — release manifest is served from `.pe`
- `api.screenpi.pe` proxy/inference endpoints
- `docs.screenpi.pe` (separate subdomain rollover)
- `louis@screenpi.pe` email (Google Workspace stays on `.pe`)
- All Rust (`crates/`, `src-tauri/src/*.rs`) — risks the 5 release platforms; will be Phase 2 with proper testing
- ai-gateway worker URLs in `packages/ai-gateway/` — separate Cloudflare Worker deploy
- Test fixtures referencing `screenpi.pe/demo` URLs (testing URL-parsing logic, not real opens)

## Test plan

- [ ] Build verified: `bunx next build` in `apps/screenpipe-app-tauri/` compiled cleanly (15/15 routes, no webpack errors)
- [ ] Vitest: all 250 tests pass
- [ ] Bun tests: all 177 tests pass
- [ ] After companion website PR + Clerk swap, launch app and click through:
  - Settings → Account → "manage" → opens `screenpipe.com/account`
  - Settings → Account → "Billing" → opens `screenpipe.com/billing`
  - Settings → Sync → "Log in to continue" → opens `screenpipe.com/login`
  - Settings → Recording → upgrade flow → opens `screenpipe.com/billing`
  - Settings → Feedback → "screenpipe.com/ideas" + "screenpipe.com/changelog" → open correctly
  - Settings → Team → generate invite link → contains `screenpipe.com/join/...`
  - Settings → Team → paste legacy `screenpi.pe/join/...` link → still parses
  - Onboarding → "how it works" → opens `screenpipe.com/security`
  - Onboarding → read-content → opens `screenpipe.com/welcome`
  - Standalone chat → privacy filter pro gate → opens `screenpipe.com/onboarding`
  - Each Gmail/Google Docs/connection card upgrade button → opens `screenpipe.com/onboarding`
  - Changelog dialog → "view all" → opens `screenpipe.com/changelog`
  - Settings page → referral link → contains `screenpipe.com/?ref=...`
  - Login dialog → copy reads "redirected to screenpipe.com"
  - Auth guard → session expiry → sign-in toast → opens `screenpipe.com/login`