### PR TITLE
perf(macos): CPU baseline + spike-flattening cluster (7 tunings)

### DIFF
--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -521,7 +521,6 @@ struct WalkState {
     max_depth: usize,
     max_nodes: usize,
     walk_timeout: std::time::Duration,
-    element_timeout_secs: f32,
     start: Instant,
     truncated: bool,
     truncation_reason: super::TruncationReason,
@@ -570,7 +569,6 @@ impl WalkState {
             max_depth: config.max_depth,
             max_nodes: config.effective_max_nodes(),
             walk_timeout: config.effective_walk_timeout(),
-            element_timeout_secs: config.element_timeout_secs,
             start,
             truncated: false,
             truncation_reason: super::TruncationReason::None,
@@ -691,8 +689,10 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
         std::thread::yield_now();
     }
 
-    // Set a per-element timeout to prevent IPC hangs
-    let _ = elem.set_messaging_timeout_secs(state.element_timeout_secs);
+    // Per-element timeout is unnecessary: AXUIElementSetMessagingTimeout
+    // (called once on the app root at walk start) is inherited by every
+    // child UIElement returned via the messaging protocol. Removing the
+    // per-element call eliminates ~node_count AX IPC roundtrips per walk.
 
     // Get the role
     let role_str = match elem.role() {
@@ -772,19 +772,27 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
 }
 
 /// Extract text attributes from an element, append to the buffer, and collect a structured node.
+///
+/// Bounds (AXPosition + AXSize, 2 AX IPC calls) are fetched lazily only after
+/// text is confirmed — for elements with no text the 2 IPCs are skipped
+/// entirely. See is_on_screen() (issue #2436) for why we keep the raw frame.
 fn extract_text(elem: &ax::UiElement, role_str: &str, depth: usize, state: &mut WalkState) {
-    // Read element bounds once (used for all text extraction paths). The
-    // raw screen-absolute frame is also passed to is_on_screen() so we
-    // know whether the captured screenshot actually shows this element —
-    // see issue #2436 for the search-hits-off-screen-text bug this fixes.
-    let frame = get_element_frame(elem);
-    let bounds = frame.and_then(|(x, y, w, h)| normalize_bounds(x, y, w, h, state));
-    let on_screen = frame.and_then(|(x, y, w, h)| is_on_screen(x, y, w, h, state));
+    let mut frame_cache: Option<Option<(f64, f64, f64, f64)>> = None;
+    let mut resolve_bounds =
+        |elem: &ax::UiElement,
+         state: &WalkState|
+         -> (Option<super::NodeBounds>, Option<bool>) {
+            let frame = *frame_cache.get_or_insert_with(|| get_element_frame(elem));
+            let bounds = frame.and_then(|(x, y, w, h)| normalize_bounds(x, y, w, h, state));
+            let on_screen = frame.and_then(|(x, y, w, h)| is_on_screen(x, y, w, h, state));
+            (bounds, on_screen)
+        };
 
     // For text fields / text areas, prefer value (the actual content)
     if role_str == "AXTextField" || role_str == "AXTextArea" || role_str == "AXComboBox" {
         if let Some(val) = get_string_attr(elem, ax::attr::value()) {
             if !val.is_empty() {
+                let (bounds, on_screen) = resolve_bounds(elem, state);
                 append_text(&mut state.text_buffer, &val);
                 let trimmed = val.trim().to_string();
                 let mut node = AccessibilityTreeNode::new(
@@ -811,6 +819,7 @@ fn extract_text(elem: &ax::UiElement, role_str: &str, depth: usize, state: &mut 
     if role_str == "AXStaticText" {
         if let Some(val) = get_string_attr(elem, ax::attr::value()) {
             if !val.is_empty() {
+                let (bounds, on_screen) = resolve_bounds(elem, state);
                 append_text(&mut state.text_buffer, &val);
                 let trimmed = val.trim().to_string();
                 let mut node = AccessibilityTreeNode::new(
@@ -831,6 +840,7 @@ fn extract_text(elem: &ax::UiElement, role_str: &str, depth: usize, state: &mut 
     // Fall back to title
     if let Some(title) = get_string_attr(elem, ax::attr::title()) {
         if !title.is_empty() {
+            let (bounds, on_screen) = resolve_bounds(elem, state);
             append_text(&mut state.text_buffer, &title);
             let mut node = AccessibilityTreeNode::new(
                 role_str.to_string(),
@@ -848,6 +858,7 @@ fn extract_text(elem: &ax::UiElement, role_str: &str, depth: usize, state: &mut 
     // Fall back to description
     if let Some(desc) = get_string_attr(elem, ax::attr::desc()) {
         if !desc.is_empty() {
+            let (bounds, on_screen) = resolve_bounds(elem, state);
             append_text(&mut state.text_buffer, &desc);
             let mut node = AccessibilityTreeNode::new(
                 role_str.to_string(),

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -521,6 +521,7 @@ struct WalkState {
     max_depth: usize,
     max_nodes: usize,
     walk_timeout: std::time::Duration,
+    element_timeout_secs: f32,
     start: Instant,
     truncated: bool,
     truncation_reason: super::TruncationReason,
@@ -569,6 +570,7 @@ impl WalkState {
             max_depth: config.max_depth,
             max_nodes: config.effective_max_nodes(),
             walk_timeout: config.effective_walk_timeout(),
+            element_timeout_secs: config.element_timeout_secs,
             start,
             truncated: false,
             truncation_reason: super::TruncationReason::None,
@@ -689,10 +691,12 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
         std::thread::yield_now();
     }
 
-    // Per-element timeout is unnecessary: AXUIElementSetMessagingTimeout
-    // (called once on the app root at walk start) is inherited by every
-    // child UIElement returned via the messaging protocol. Removing the
-    // per-element call eliminates ~node_count AX IPC roundtrips per walk.
+    // Set a per-element timeout to prevent IPC hangs.
+    // Per Apple's AXUIElement.h: the timeout is per-element (only the
+    // system-wide element propagates globally). Without this, a single
+    // unresponsive element can block for up to the default 6s before
+    // returning, far longer than walk_timeout's check between elements.
+    let _ = elem.set_messaging_timeout_secs(state.element_timeout_secs);
 
     // Get the role
     let role_str = match elem.role() {

--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -453,7 +453,13 @@ impl Default for TreeWalkerConfig {
     fn default() -> Self {
         Self {
             walk_interval: Duration::from_secs(3),
-            max_depth: 35,
+            // Lowered 35 -> 28 after the AXWebArea depth-reset
+            // (crates/screenpipe-a11y/src/tree/macos.rs walk_element) made the
+            // pre-#3547 absolute-depth headroom redundant for Electron apps —
+            // 25 levels of webarea-relative budget still catches the VS Code
+            // terminal (which sits at relative depth 25) with 3 levels of
+            // headroom. Trims walker work on deep native AX trees.
+            max_depth: 28,
             max_nodes: 5000,
             walk_timeout: Duration::from_millis(250),
             max_text_length: 50_000,
@@ -467,7 +473,11 @@ impl Default for TreeWalkerConfig {
             ignore_incognito_windows: true,
             max_nodes_override: None,
             walk_timeout_override: None,
-            enable_line_bounds: true,
+            // Disabled by default — per-line geometry capture fires
+            // parameterized AX calls on every multi-line AXTextArea /
+            // AXStaticText. Only opt in when consumers actively need
+            // line-level highlighting on screenshots.
+            enable_line_bounds: false,
             line_bounds_max_calls_per_node: 30,
             line_bounds_max_calls_per_frame: 300,
             line_bounds_time_budget: Duration::from_millis(400),
@@ -583,7 +593,7 @@ mod tests {
     fn test_default_config() {
         let config = TreeWalkerConfig::default();
         assert_eq!(config.walk_interval, Duration::from_secs(3));
-        assert_eq!(config.max_depth, 35);
+        assert_eq!(config.max_depth, 28);
         assert_eq!(config.max_nodes, 5000);
         assert_eq!(config.walk_timeout, Duration::from_millis(250));
         assert_eq!(config.max_text_length, 50_000);

--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -453,13 +453,7 @@ impl Default for TreeWalkerConfig {
     fn default() -> Self {
         Self {
             walk_interval: Duration::from_secs(3),
-            // Lowered 35 -> 28 after the AXWebArea depth-reset
-            // (crates/screenpipe-a11y/src/tree/macos.rs walk_element) made the
-            // pre-#3547 absolute-depth headroom redundant for Electron apps —
-            // 25 levels of webarea-relative budget still catches the VS Code
-            // terminal (which sits at relative depth 25) with 3 levels of
-            // headroom. Trims walker work on deep native AX trees.
-            max_depth: 28,
+            max_depth: 35,
             max_nodes: 5000,
             walk_timeout: Duration::from_millis(250),
             max_text_length: 50_000,
@@ -473,11 +467,7 @@ impl Default for TreeWalkerConfig {
             ignore_incognito_windows: true,
             max_nodes_override: None,
             walk_timeout_override: None,
-            // Disabled by default — per-line geometry capture fires
-            // parameterized AX calls on every multi-line AXTextArea /
-            // AXStaticText. Only opt in when consumers actively need
-            // line-level highlighting on screenshots.
-            enable_line_bounds: false,
+            enable_line_bounds: true,
             line_bounds_max_calls_per_node: 30,
             line_bounds_max_calls_per_frame: 300,
             line_bounds_time_budget: Duration::from_millis(400),
@@ -593,7 +583,7 @@ mod tests {
     fn test_default_config() {
         let config = TreeWalkerConfig::default();
         assert_eq!(config.walk_interval, Duration::from_secs(3));
-        assert_eq!(config.max_depth, 28);
+        assert_eq!(config.max_depth, 35);
         assert_eq!(config.max_nodes, 5000);
         assert_eq!(config.walk_timeout, Duration::from_millis(250));
         assert_eq!(config.max_text_length, 50_000);

--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -349,8 +349,16 @@ pub async fn start_device_monitor(
         // (output)" names to "System Audio (output)" (macOS only).
         let mut legacy_migrated = false;
 
+        // Active poll cadence. The loop body short-circuits when audio is not
+        // Running, so we stretch the sleep in that state to avoid burning CPU
+        // polling a paused subsystem. Failure-retry paths keep their own
+        // backoff and aren't affected.
+        const POLL_INTERVAL_ACTIVE: Duration = Duration::from_secs(2);
+        const POLL_INTERVAL_IDLE: Duration = Duration::from_secs(10);
+
         loop {
-            if audio_manager.status().await == AudioManagerStatus::Running {
+            let manager_running = audio_manager.status().await == AudioManagerStatus::Running;
+            if manager_running {
                 // Check if sleep/wake or display reconfiguration requested
                 // audio stream invalidation. Force-cycle all running devices
                 // to recover from silent CoreAudio stream failures.
@@ -1165,7 +1173,12 @@ pub async fn start_device_monitor(
                 )
                 .await;
             }
-            sleep(Duration::from_secs(2)).await;
+            let interval = if manager_running {
+                POLL_INTERVAL_ACTIVE
+            } else {
+                POLL_INTERVAL_IDLE
+            };
+            sleep(interval).await;
         }
     }));
     Ok(())

--- a/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
+++ b/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
@@ -26,7 +26,10 @@ const BACKFILL_MIN_INTERVAL: Duration = Duration::from_secs(30);
 const BACKFILL_MAX_CHUNKS_PER_PASS: usize = 12;
 const RECONCILIATION_LOOKBACK_HOURS: i64 = 24 * 7;
 const RECONCILIATION_FRESHNESS_DELAY_SECS: i64 = 10 * 60;
-const RECONCILIATION_CHUNKS_PER_SWEEP: i64 = 50;
+// Dropped from 50 -> 15 to flatten the 80%+ CPU spikes observed every 120s
+// in 10-min sample profiles. With the 120s scheduler this still clears
+// ~450 chunks/hour — far above the typical capture rate per device.
+const RECONCILIATION_CHUNKS_PER_SWEEP: i64 = 15;
 
 use crate::core::engine::AudioTranscriptionEngine;
 use crate::metrics::AudioPipelineMetrics;
@@ -167,8 +170,9 @@ pub async fn reconcile_untranscribed(
     let now = chrono::Utc::now();
     let since = now - chrono::Duration::hours(RECONCILIATION_LOOKBACK_HOURS);
     let older_than = now - chrono::Duration::seconds(RECONCILIATION_FRESHNESS_DELAY_SECS);
-    // Limit to 50 chunks per sweep to avoid prolonged CPU spikes.
-    // With 120s between sweeps this still clears ~1500 chunks/hour.
+    // Bounded per-sweep batch to avoid prolonged CPU spikes.
+    // With 120s between sweeps this still clears
+    // RECONCILIATION_CHUNKS_PER_SWEEP * 30 chunks/hour.
     let chunks = match db
         .get_reconciliation_candidate_chunks(since, older_than, RECONCILIATION_CHUNKS_PER_SWEEP)
         .await

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -155,7 +155,10 @@ impl Default for UiRecorderConfig {
             enable_tree_walker: true,
             tree_walk_interval_ms: 3000,
             record_input_events: true,
-            prioritize_input_latency: false,
+            // Default ON so the BelowNormal QoS + pause-on-input gate are
+            // actually honored — otherwise the AX walker can run while the
+            // user is typing/clicking, which is exactly when CPU lag is felt.
+            prioritize_input_latency: true,
             extraction_thread_priority: ExtractionThreadPriority::BelowNormal,
             pause_extraction_on_input_ms: 150,
         }


### PR DESCRIPTION
## Summary

4 small CPU-perf changes, narrowed after an audit found 3 of the original 7 had real downsides (see commit 1407b5403). Profile context: 10-min `sample` on the live macOS app (`sample $PID 600`) showed avg 18.9% CPU, baseline ~10-15%, periodic spikes to 78-84% at the 120s reconciliation cadence.

## Changes

1. **`prioritize_input_latency` default `false` → `true`** ([ui_recorder.rs](https://github.com/screenpipe/screenpipe/blob/perf/macos-cpu-cluster/crates/screenpipe-engine/src/ui_recorder.rs#L155-L163))
   ⚠️ **macOS no-op.** Grepping the codebase, this flag is only read in `windows_uia.rs` + `windows.rs` (`apply_extraction_thread_priority`). There is no macOS handler. **Windows users get** the BelowNormal QoS + 150ms pause-on-input gate; macOS users get nothing. Including for Windows benefit + so future macOS wiring respects the default.

2. **`RECONCILIATION_CHUNKS_PER_SWEEP` 50 → 15** ([reconciliation.rs](https://github.com/screenpipe/screenpipe/blob/perf/macos-cpu-cluster/crates/screenpipe-audio/src/audio_manager/reconciliation.rs#L25-L32))
   Direct fix for the 78-84% spikes at the 120s cadence. With the 120s scheduler this still clears ~450 chunks/hour, above typical capture rate per device. Tradeoff: 3× slower backlog drain after long downtime.

3. **`device_monitor` adaptive poll (2s active / 10s idle)** ([device_monitor.rs](https://github.com/screenpipe/screenpipe/blob/perf/macos-cpu-cluster/crates/screenpipe-audio/src/audio_manager/device_monitor.rs))
   The loop body short-circuits when audio manager status != Running, so the 2s poll was pure waste in that state. Failure-retry paths keep their own backoff. Tradeoff: up to 10s delay refreshing device list on Paused → Running transition without a full restart.

4. **Lazy `get_element_frame` in `extract_text`** ([tree/macos.rs](https://github.com/screenpipe/screenpipe/blob/perf/macos-cpu-cluster/crates/screenpipe-a11y/src/tree/macos.rs))
   Previously fetched AXPosition + AXSize (2 AX IPCs) up-front; now uses a lazy `frame_cache` that runs only when text is actually found. Elements that fall through all 4 text paths skip both IPCs.

## Reverted from initial PR (commit 1407b5403)

- **`max_depth` 35 → 28**: only measured against the VS Code terminal case (#3555 commit msg). Slack/Discord/Notion/Obsidian unmeasured → risk of silent content drop. Restored to 35.
- **`enable_line_bounds` default false**: zero UI exposure means flipping default = silent UX regression for search-result highlighting (issue #2436), with no way for users to opt back in without editing source. Restored to true. Future PR can add UI toggle.
- **Per-element `set_messaging_timeout_secs` removal**: Apple's AXUIElement.h confirms the timeout is per-element (only `sys_wide` propagates globally). Without the per-element call, a single hanging UIElement could block for the 6s system default. Restored.

## Deferred to follow-up PRs

- AX batching via `AXUIElementCopyMultipleAttributeValues` — needs cidre wrapper first. Biggest single CPU win remaining.
- Event-driven walker (`AXValueChangedNotification`) — replaces 3s polling with content-change notifications.
- Adaptive `max_depth` per app type — needs per-Electron-app measurement first.
- `sys_wide.set_messaging_timeout_secs` once at process start — would let us remove per-element call safely.
- UI toggle for `enable_line_bounds` — needed before we can disable it by default.

## Cross-platform

Of the 4 retained changes:
- #1 affects **Windows only** (macOS doesn't honor the flag)
- #2, #3 are **cross-platform** (audio path is shared)
- #4 is **macOS only** (Windows already batches via UIA CacheRequest)

## Verification

- `cargo check` clean across `screenpipe-a11y`, `screenpipe-audio`, `screenpipe-engine`
- `cargo test -p screenpipe-audio --lib` → 143 pass
- `cargo test -p screenpipe-engine --lib` → 475 pass + 1 pre-existing flake (`sleep_monitor::test_recently_woke_flag` — global static races under parallel runs; reproduces on `origin/main`)
- `cargo test -p screenpipe-a11y --lib` → 169 pass + 3 pre-existing flakes (`test_get_clipboard_*` — race on shared macOS pasteboard; reproduces on `origin/main`)
- 10-min CPU profile recipe at [CONTRIBUTING.md#profiling-cpu](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#profiling-cpu) (commit 503b1e702) for re-measurement after merge

## Test plan

- [ ] Capture fresh 10-min profile on the merged build, confirm spike envelope drops from 78-84% → ~30%
- [ ] Confirm meeting summary capture still works (relies on AXTextArea/AXStaticText extraction)
- [ ] On Windows: confirm walker yields under typing/clicking with prioritize_input_latency default true
- [ ] Hot-plug USB headset during recording, confirm picked up within 2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)