### PR TITLE
fix(settings): auto-start toggle now applies immediately

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -64,6 +64,26 @@ export default function GeneralSettings() {
       updateSettings(newSettings);
     }
   };
+
+  const handleAutoStartChange = async (checked: boolean) => {
+    handleSettingsChange({ autoStartEnabled: checked });
+    try {
+      await commands.setAutostart(checked);
+      toast({
+        title: checked ? "auto-start enabled" : "auto-start disabled",
+        description: checked
+          ? "screenpipe will launch when your computer starts"
+          : "screenpipe won't launch at startup",
+      });
+    } catch (e: any) {
+      handleSettingsChange({ autoStartEnabled: !checked });
+      toast({
+        title: "failed to update auto-start",
+        description: e?.toString() || "check system permissions and try again",
+        variant: "destructive",
+      });
+    }
+  };
   const enterpriseAppUpdatePolicy = normalizeEnterpriseAppUpdatePolicy(
     settings?.enterpriseAppUpdatePolicy || DEFAULT_ENTERPRISE_APP_UPDATE_POLICY
   );
@@ -129,9 +149,7 @@ export default function GeneralSettings() {
               <Switch
                 id="auto-start-toggle"
                 checked={settings?.autoStartEnabled ?? false}
-                onCheckedChange={(checked) =>
-                  handleSettingsChange({ autoStartEnabled: checked })
-                }
+                onCheckedChange={handleAutoStartChange}
                 className="ml-4"
               />
             </div>

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1443,6 +1443,14 @@ async reencryptStore() : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async setAutostart(enabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_autostart", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -3212,3 +3212,21 @@ fn dir_size(path: &std::path::Path) -> u64 {
     }
     total
 }
+
+#[tauri::command]
+#[specta::specta]
+pub fn set_autostart(app_handle: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
+    let manager = app_handle.autolaunch();
+    if enabled {
+        manager.enable().map_err(|e| e.to_string())?;
+    } else {
+        manager.disable().map_err(|e| e.to_string())?;
+    }
+    info!(
+        "autostart {}: is_enabled={}",
+        if enabled { "enabled" } else { "disabled" },
+        manager.is_enabled().unwrap_or(false)
+    );
+    Ok(())
+}

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -875,6 +875,8 @@ async fn main() {
                 hardware::get_hardware_capability,
                 // Store encryption
                 store::reencrypt_store,
+                // Autostart
+                commands::set_autostart,
             ])
             .typ::<SettingsStore>()
             .typ::<OnboardingStore>()
@@ -1217,6 +1219,7 @@ async fn main() {
             remote_sync_commands::remote_sync_scheduler_status,
             commands::set_native_theme,
             store::reencrypt_store,
+            commands::set_autostart,
         ])
         .setup(move |app| {
             //deep link register_all


### PR DESCRIPTION
### Description: 


https://github.com/user-attachments/assets/ac477f00-217e-4b26-802d-c11d88c8f85f


The **Auto-start** toggle in Settings → General was broken: toggling it only saved the preference to `~/.screenpipe/store.bin` but never called the OS registration API. The actual login-item/launch-agent was only applied on the **next app restart**, making the toggle feel broken — users who turned it off would still see screenpipe start at login, and vice versa.

### Root cause

`main.rs` called `autostart_manager.enable()/disable()` exactly once — at startup — based on the stored setting. When the toggle changed at runtime, `updateSettings({ autoStartEnabled: checked })` wrote the new value to the store JSON but there was no code path to reactively call the OS API.