### PR TITLE
feat(a11y): capture VS Code terminal logs and fix active window name for terminal

### DIFF
--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::tree::macos_lines::{self, NormalizeRefs};
 use anyhow::Result;
 use chrono::Utc;
-use cidre::{ax, cf, ns};
+use cidre::{arc::Retained, ax, cf, ns};
 use screenpipe_core::window_pattern::{self, WindowPattern};
 use std::process::Command;
 use std::time::Instant;
@@ -38,6 +38,28 @@ const BROWSER_NAMES: &[&str] = &[
 /// Check if the app (lowercase name) is a known browser.
 fn is_browser(app_lower: &str) -> bool {
     BROWSER_NAMES.iter().any(|b| app_lower.contains(b))
+}
+
+/// VS Code-fork Electron editors that use xterm.js for their integrated terminal.
+/// All share the same deep AX tree structure (terminal content at depth ~37 from
+/// the window root, inside the Electron AXWebArea).
+const VSCODE_LIKE_APPS: &[&str] = &[
+    "code",        // Visual Studio Code (macOS localized name: "Code")
+    "cursor",      // Cursor
+    "windsurf",    // Windsurf (Codeium)
+    "antigravity", // Antigravity IDE
+    "vscodium",    // VSCodium
+    "positron",    // Positron (Posit)
+    "void",        // Void editor
+    "aide",        // Aide
+    "trae",        // Trae
+];
+
+/// True when the app is a VS Code fork using Electron + xterm.js.
+/// False positives are safe — at worst we walk slightly deeper and run a
+/// terminal-detection function that returns `None` immediately.
+fn is_vscode_like(app_lower: &str) -> bool {
+    VSCODE_LIKE_APPS.iter().any(|name| app_lower.contains(name))
 }
 
 /// Extract an absolute file path for the focused window.
@@ -375,7 +397,7 @@ impl MacosTreeWalker {
         }
         let window: &ax::UiElement = unsafe { std::mem::transmute(&*window_val) };
 
-        let window_name = get_string_attr(window, ax::attr::title()).unwrap_or_default();
+        let mut window_name = get_string_attr(window, ax::attr::title()).unwrap_or_default();
 
         // Fast path: Arc (and potentially other browsers) tag incognito windows
         // with "Incognito" in AXIdentifier (e.g. "bigIncognitoBrowserWindow-...").
@@ -421,6 +443,28 @@ impl MacosTreeWalker {
             ignored_patterns.clone(),
             app_lower.clone(),
         );
+
+        // VS Code and forks (Cursor, Windsurf, Antigravity, VSCodium, …) — two adjustments:
+        //   a) Increase max_depth to 40: terminal content sits at depth ~37 from the
+        //      window root (inside the xterm.js accessibility tree), which exceeds the
+        //      default of 30.  Without this, terminal logs are never captured.
+        //   b) Override window_name when the terminal panel has focus: the AXWindow
+        //      title always shows the last-active editor file even when the terminal is
+        //      focused.  We detect terminal focus by walking up from AXFocusedUIElement
+        //      and looking for an AXList ancestor at ≥20 hops from AXWebArea (terminal
+        //      rows are ~30 hops deep; sidebar file-tree AXLists are ≤12 hops).
+        if is_vscode_like(&app_lower) {
+            state.max_depth = state.max_depth.max(40);
+            state.walk_timeout =
+                state.walk_timeout.max(std::time::Duration::from_millis(500));
+            if let Some(name) = vscode_terminal_window_name(&ax_app) {
+                window_name = name;
+                state.vscode_mode = VsCodeMode::Terminal;
+            } else {
+                state.vscode_mode = VsCodeMode::Editor;
+            }
+        }
+
         if let Some((wx, wy, ww, wh)) = get_element_frame(window) {
             if ww > 0.0 && wh > 0.0 {
                 state.window_x = wx;
@@ -513,6 +557,17 @@ impl MacosTreeWalker {
     }
 }
 
+/// VS Code content isolation mode set once per frame, before `walk_element`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum VsCodeMode {
+    /// Not VS Code — no filtering applied.
+    None,
+    /// Terminal panel focused: emit only text inside deep `AXList` subtrees.
+    Terminal,
+    /// Editor/file focused: prune deep `AXList` subtrees (terminal rows) early.
+    Editor,
+}
+
 /// Mutable state passed through the recursive walk.
 struct WalkState {
     text_buffer: String,
@@ -526,6 +581,14 @@ struct WalkState {
     truncated: bool,
     truncation_reason: super::TruncationReason,
     max_depth_reached: usize,
+    /// VS Code content isolation. Set once before the walk; zero overhead for non-VS Code apps.
+    vscode_mode: VsCodeMode,
+    /// Depth at which `AXWebArea` was first seen (VS Code's Electron workbench root).
+    /// `None` until the walker visits that node; used to compute depth-from-webarea.
+    webarea_depth: Option<usize>,
+    /// `true` while the recursive walk is inside a deep `AXList` (terminal output rows).
+    /// Saved and restored around each such subtree so sibling subtrees are unaffected.
+    in_terminal_subtree: bool,
     /// Window origin and size in screen points (fallback for normalizing element bounds).
     window_x: f64,
     window_y: f64,
@@ -575,6 +638,9 @@ impl WalkState {
             truncated: false,
             truncation_reason: super::TruncationReason::None,
             max_depth_reached: 0,
+            vscode_mode: VsCodeMode::None,
+            webarea_depth: None,
+            in_terminal_subtree: false,
             window_x: 0.0,
             window_y: 0.0,
             window_w: 0.0,
@@ -674,6 +740,129 @@ fn should_extract_text(role_str: &str) -> bool {
     )
 }
 
+/// Returns `Some("Terminal N")` when the VS Code integrated terminal has
+/// keyboard focus, `None` otherwise (caller keeps the AXWindow title).
+///
+/// Handles two focus modes:
+///   - Output row selected: focused element is `AXStaticText` inside `AXList`
+///     at ≥28 steps from `AXWebArea` → detected via `axlist_idx`.
+///   - Typing in input: focused element is `AXTextField` (not inside `AXList`)
+///     → detected via the xterm.js container's `AXDescription` ("Terminal N, …")
+///     which is a common ancestor of both the `AXList` and `AXTextField`.
+///
+/// Sidebar `AXList` elements are ≤12 steps from `AXWebArea`; terminal ones ≥28.
+/// The 20-step threshold keeps them apart. `AXDescription` scan is also gated
+/// on depth ≥ 20 so shallow tab-bar labels cannot produce false positives.
+fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
+    let focused_attr_name = cf::String::from_str("AXFocusedUIElement");
+    let focused_attr = ax::Attr::with_string(&focused_attr_name);
+    let focused_val = ax_app.attr_value(focused_attr).ok()?;
+    if focused_val.get_type_id() != ax::UiElement::type_id() {
+        return None;
+    }
+
+    let parent_attr_name = cf::String::from_str("AXParent");
+    let parent_attr = ax::Attr::with_string(&parent_attr_name);
+
+    let mut ancestors: Vec<Retained<cf::Type>> = Vec::with_capacity(60);
+    // Shallowest AXList ancestor index (closest to AXWebArea).
+    let mut axlist_idx: Option<usize> = None;
+    // Terminal name found on any ancestor's AXDescription or AXTitle.
+    // Covers the AXTextField (typing) case where there is no AXList ancestor.
+    let mut desc_terminal_name: Option<String> = None;
+    let mut cur: Retained<cf::Type> = focused_val;
+
+    for _ in 0..60 {
+        let role = {
+            let elem: &ax::UiElement = unsafe { std::mem::transmute(&*cur) };
+            get_string_attr(elem, ax::attr::role())
+        };
+        let maybe_parent = {
+            let elem: &ax::UiElement = unsafe { std::mem::transmute(&*cur) };
+            elem.attr_value(parent_attr)
+                .ok()
+                .filter(|p| p.get_type_id() == ax::UiElement::type_id())
+        };
+        // Scan desc/title on every ancestor for "Terminal N" pattern.
+        // The xterm.js container has this on the element that parents both the
+        // output AXList and the input AXTextField.
+        if desc_terminal_name.is_none() {
+            let elem: &ax::UiElement = unsafe { std::mem::transmute(&*cur) };
+            for attr in [ax::attr::desc(), ax::attr::title()] {
+                if let Some(val) = get_string_attr(elem, attr) {
+                    if let Some(name) = parse_vscode_terminal_name(&val) {
+                        desc_terminal_name = Some(name);
+                        break;
+                    }
+                }
+            }
+        }
+
+        match role.as_deref() {
+            Some("AXList") => {
+                axlist_idx = Some(ancestors.len());
+            }
+            Some("AXWebArea") => {
+                let steps = ancestors.len();
+                if steps < 20 {
+                    // Shallow — sidebar or toolbar element, not terminal.
+                    return None;
+                }
+                // Prefer a name found directly on an ancestor's description
+                // (works for both output-scroll and input-typing focus modes).
+                if let Some(name) = desc_terminal_name {
+                    return Some(name);
+                }
+                // Fallback: name found by scanning above the AXList.
+                if let Some(list_idx) = axlist_idx {
+                    let search_end = (list_idx + 12).min(steps);
+                    for k in (list_idx + 1)..search_end {
+                        let elem: &ax::UiElement =
+                            unsafe { std::mem::transmute(&*ancestors[k]) };
+                        for attr in [ax::attr::desc(), ax::attr::title()] {
+                            if let Some(val) = get_string_attr(elem, attr) {
+                                if let Some(name) = parse_vscode_terminal_name(&val) {
+                                    return Some(name);
+                                }
+                            }
+                        }
+                    }
+                    return Some("Terminal".to_string());
+                }
+                return None;
+            }
+            Some("AXWindow") | None => return None,
+            _ => {}
+        }
+
+        ancestors.push(cur);
+        match maybe_parent {
+            Some(p) => cur = p,
+            None => return None,
+        }
+    }
+
+    None
+}
+
+/// Extract "Terminal N" from an AX attribute string.
+/// Matches the xterm.js description "Terminal 4, 2.1.150 …" and plain labels.
+fn parse_vscode_terminal_name(val: &str) -> Option<String> {
+    let rest = val.trim().strip_prefix("Terminal ")?;
+    let num_end = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    if num_end == 0 {
+        return None;
+    }
+    let after = &rest[num_end..];
+    if after.is_empty() || after.starts_with(',') || after.starts_with(' ') {
+        Some(format!("Terminal {}", &rest[..num_end]))
+    } else {
+        None
+    }
+}
+
 /// Recursively walk an AX element and its children.
 fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
     if state.should_stop() || depth >= state.max_depth {
@@ -705,9 +894,41 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
         return;
     }
 
-    // Extract text from this element
+    // VS Code content isolation — runs only for VS Code frames (vscode_mode != None).
+    //
+    // AXWebArea is the root of the entire Electron workbench. We record its depth
+    // once so we can measure "depth from AXWebArea" for everything below it.
+    //
+    // AXList nodes ≥ 20 steps below AXWebArea are terminal output rows.
+    // Sidebar file-tree AXLists are ≤ 12 steps below AXWebArea and are not affected.
+    //
+    //  • Editor mode: prune deep AXLists entirely (early return — avoids walking
+    //    37 levels of xterm.js just to discard it).
+    //  • Terminal mode: mark entry into the deep AXList so only its text is emitted.
+    let is_vscode_terminal_list = if state.vscode_mode != VsCodeMode::None {
+        if role_str == "AXWebArea" && state.webarea_depth.is_none() {
+            state.webarea_depth = Some(depth);
+        }
+        role_str == "AXList"
+            && state
+                .webarea_depth
+                .map_or(false, |wd| depth >= wd + 20)
+    } else {
+        false
+    };
+
+    if is_vscode_terminal_list && state.vscode_mode == VsCodeMode::Editor {
+        // Prune the entire terminal subtree — no children walked, no text emitted.
+        return;
+    }
+
+    // Extract text from this element.
+    // In VS Code terminal mode, suppress text that is outside the terminal AXList.
     if should_extract_text(&role_str) {
-        extract_text(elem, &role_str, depth, state);
+        let emit = state.vscode_mode != VsCodeMode::Terminal || state.in_terminal_subtree;
+        if emit {
+            extract_text(elem, &role_str, depth, state);
+        }
     } else if role_str == "AXWebArea" {
         // Browser extension popup detection: AXWebArea nodes inside Chrome/Arc/Edge
         // carry the extension name as their title and a chrome-extension:// URL.
@@ -759,15 +980,23 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
     } else {
         depth + 1
     };
+
+    // For VS Code terminal mode: set in_terminal_subtree when entering a deep AXList
+    // so that text extraction is enabled for all descendants.  Restore on exit so
+    // sibling subtrees (sidebar, editor) are unaffected.
     let children = elem.children();
     if let Ok(children) = children {
+        let prev_in_terminal = state.in_terminal_subtree;
+        if is_vscode_terminal_list {
+            state.in_terminal_subtree = true;
+        }
         for i in 0..children.len() {
             if state.should_stop() {
                 break;
             }
-            let child = &children[i];
-            walk_element(child, next_depth, state);
+            walk_element(&children[i], next_depth, state);
         }
+        state.in_terminal_subtree = prev_in_terminal;
     }
 }
 

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -845,21 +845,46 @@ fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
     None
 }
 
-/// Extract "Terminal N" from an AX attribute string.
-/// Matches the xterm.js description "Terminal 4, 2.1.150 …" and plain labels.
+/// Extract the terminal label from an xterm.js AX attribute string.
+///
+/// The xterm.js container's `AXDescription` has the form:
+///   "Terminal {index}, {session_name} …"  e.g. "Terminal 4, 2.1.150"
+///
+/// When a session name is present we return `"Terminal - {session_name}"` so
+/// the stored window name reflects what the user actually named the terminal
+/// (branch name, directory, custom label, etc.) rather than a raw index.
+/// Falls back to `"Terminal {index}"` when no session name is available.
 fn parse_vscode_terminal_name(val: &str) -> Option<String> {
     let rest = val.trim().strip_prefix("Terminal ")?;
+    // Read the numeric index (must have at least one digit).
     let num_end = rest
         .find(|c: char| !c.is_ascii_digit())
         .unwrap_or(rest.len());
     if num_end == 0 {
         return None;
     }
+    let index = &rest[..num_end];
     let after = &rest[num_end..];
-    if after.is_empty() || after.starts_with(',') || after.starts_with(' ') {
-        Some(format!("Terminal {}", &rest[..num_end]))
+
+    if after.is_empty() || after == " " {
+        // Plain "Terminal N" — no session name.
+        return Some(format!("Terminal {index}"));
+    }
+
+    // "Terminal N, session_name" — extract session name after the comma.
+    let session = if let Some(s) = after.strip_prefix(", ") {
+        s.trim()
+    } else if let Some(s) = after.strip_prefix(',') {
+        s.trim()
     } else {
-        None
+        // Unexpected suffix (not a comma) — not a terminal label.
+        return None;
+    };
+
+    if session.is_empty() {
+        Some(format!("Terminal {index}"))
+    } else {
+        Some(format!("Terminal - {session}"))
     }
 }
 

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -913,21 +913,27 @@ fn parse_vscode_terminal_name(val: &str) -> Option<String> {
 
 /// Match a bare xterm.js description that lacks the "Terminal N, " prefix.
 /// Seen in Antigravity IDE and other forks where the description is just the
-/// shell / session name, optionally followed by the accessibility hint.
+/// shell / session name followed by the xterm.js accessibility hint.
 /// e.g. "zsh Use ⌥F1 for terminal accessibility help" → "Terminal - zsh"
-///      "2.1.150" → "Terminal - 2.1.150"
 ///
-/// Conservative: only matches short strings with no spaces after hint stripping,
-/// to avoid treating arbitrary UI labels as terminal session names.
+/// REQUIRES the accessibility hint to be present in the raw string — this is
+/// the key signal that this is an xterm.js description and not an arbitrary
+/// UI label (file tab name, button description, etc.). Without the hint, a
+/// bare "macos.rs" or any other short string would incorrectly match.
 fn parse_xterm_bare_desc(val: &str) -> Option<String> {
-    let stripped = strip_xterm_ax_hint(val.trim());
-    // Reject empty, multi-word strings, and the bare word "Terminal" (which
-    // would produce the nonsensical "Terminal - Terminal").
+    let raw = val.trim();
+    // The hint marker is the only reliable discriminator from generic UI descriptions.
+    let has_hint = raw.contains(" Use \u{2325}")  // ⌥
+        || raw.contains(" Use \u{2318}")           // ⌘
+        || raw.contains(" Use ^");
+    if !has_hint {
+        return None;
+    }
+    let stripped = strip_xterm_ax_hint(raw);
     if stripped.is_empty() || stripped.contains(' ') || stripped == "Terminal" {
         return None;
     }
-    // Must look like a process/session name: short, no quotes.
-    if stripped.len() <= 40 && !stripped.contains('"') && !stripped.contains('\'') {
+    if stripped.len() <= 40 {
         Some(format!("Terminal - {stripped}"))
     } else {
         None

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -816,7 +816,15 @@ fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
                     return Some(name);
                 }
                 // Fallback: scan ancestors above the AXList for a name.
+                // Gate on the AXList's own depth from AXWebArea (= steps - list_idx).
+                // Terminal AXLists sit at wa+28; editor/sidebar lists are ≤15.
+                // Checking the focused-element depth (steps >= 20) alone is not enough —
+                // editor elements can also be >20 hops deep while having shallow AXLists.
                 if let Some(list_idx) = axlist_idx {
+                    if steps.saturating_sub(list_idx) < 20 {
+                        // AXList is too close to AXWebArea — editor or sidebar, not terminal.
+                        return None;
+                    }
                     let search_end = (list_idx + 12).min(steps);
                     for k in (list_idx + 1)..search_end {
                         let elem: &ax::UiElement =

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -56,10 +56,14 @@ const VSCODE_LIKE_APPS: &[&str] = &[
 ];
 
 /// True when the app is a VS Code fork using Electron + xterm.js.
-/// False positives are safe — at worst we walk slightly deeper and run a
-/// terminal-detection function that returns `None` immediately.
+///
+/// Uses a word-boundary check (exact match or "name " prefix) so that
+/// "xcode" does not false-positive on the "code" entry.
 fn is_vscode_like(app_lower: &str) -> bool {
-    VSCODE_LIKE_APPS.iter().any(|name| app_lower.contains(name))
+    VSCODE_LIKE_APPS.iter().any(|&name| {
+        app_lower == name
+            || (app_lower.starts_with(name) && app_lower[name.len()..].starts_with(' '))
+    })
 }
 
 /// Extract an absolute file path for the focused window.
@@ -457,12 +461,13 @@ impl MacosTreeWalker {
             state.max_depth = state.max_depth.max(40);
             state.walk_timeout =
                 state.walk_timeout.max(std::time::Duration::from_millis(500));
-            if let Some(name) = vscode_terminal_window_name(&ax_app) {
+            let mode = if let Some(name) = vscode_terminal_window_name(&ax_app) {
                 window_name = name;
-                state.vscode_mode = VsCodeMode::Terminal;
+                VsCodeMode::Terminal
             } else {
-                state.vscode_mode = VsCodeMode::Editor;
-            }
+                VsCodeMode::Editor
+            };
+            state.app = AppState::VsCode { mode, webarea_depth: None, in_terminal_subtree: false };
         }
 
         if let Some((wx, wy, ww, wh)) = get_element_frame(window) {
@@ -557,15 +562,34 @@ impl MacosTreeWalker {
     }
 }
 
-/// VS Code content isolation mode set once per frame, before `walk_element`.
+/// Content isolation mode for VS Code's integrated terminal.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum VsCodeMode {
-    /// Not VS Code — no filtering applied.
-    None,
     /// Terminal panel focused: emit only text inside deep `AXList` subtrees.
     Terminal,
     /// Editor/file focused: prune deep `AXList` subtrees (terminal rows) early.
     Editor,
+}
+
+/// Per-app state threaded through the walk.
+///
+/// Keeping app-specific fields inside their own enum variant means `WalkState`
+/// stays clean and the hot path only pays for branching on VS Code frames —
+/// the `AppState::None` arm is a single discriminant check that the compiler
+/// folds away for every non-matching app.
+#[derive(Clone, Copy)]
+enum AppState {
+    /// Not a recognised Electron IDE — no per-app filtering.
+    None,
+    /// VS Code or fork: owns all three isolation bookkeeping values.
+    VsCode {
+        mode: VsCodeMode,
+        /// Depth at which `AXWebArea` was first seen; `None` until visited.
+        webarea_depth: Option<usize>,
+        /// `true` while the walk is inside the deep terminal `AXList`.
+        /// Saved and restored around each such subtree.
+        in_terminal_subtree: bool,
+    },
 }
 
 /// Mutable state passed through the recursive walk.
@@ -581,14 +605,8 @@ struct WalkState {
     truncated: bool,
     truncation_reason: super::TruncationReason,
     max_depth_reached: usize,
-    /// VS Code content isolation. Set once before the walk; zero overhead for non-VS Code apps.
-    vscode_mode: VsCodeMode,
-    /// Depth at which `AXWebArea` was first seen (VS Code's Electron workbench root).
-    /// `None` until the walker visits that node; used to compute depth-from-webarea.
-    webarea_depth: Option<usize>,
-    /// `true` while the recursive walk is inside a deep `AXList` (terminal output rows).
-    /// Saved and restored around each such subtree so sibling subtrees are unaffected.
-    in_terminal_subtree: bool,
+    /// Per-app walk state. `AppState::None` for every non-VS Code app — no overhead.
+    app: AppState,
     /// Window origin and size in screen points (fallback for normalizing element bounds).
     window_x: f64,
     window_y: f64,
@@ -638,9 +656,7 @@ impl WalkState {
             truncated: false,
             truncation_reason: super::TruncationReason::None,
             max_depth_reached: 0,
-            vscode_mode: VsCodeMode::None,
-            webarea_depth: None,
-            in_terminal_subtree: false,
+            app: AppState::None,
             window_x: 0.0,
             window_y: 0.0,
             window_w: 0.0,
@@ -979,38 +995,41 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
         return;
     }
 
-    // VS Code content isolation — runs only for VS Code frames (vscode_mode != None).
+    // VS Code content isolation — all VS Code logic is gated behind AppState::VsCode.
+    // Zero cost for every non-matching app: the None arm is a single discriminant check.
     //
-    // AXWebArea is the root of the entire Electron workbench. We record its depth
-    // once so we can measure "depth from AXWebArea" for everything below it.
+    // AXWebArea is the root of the Electron workbench; we record its depth once.
+    // AXList nodes ≥ 20 hops below AXWebArea are terminal output rows (sidebar
+    // AXLists are ≤ 12 hops below — the threshold cleanly separates them).
     //
-    // AXList nodes ≥ 20 steps below AXWebArea are terminal output rows.
-    // Sidebar file-tree AXLists are ≤ 12 steps below AXWebArea and are not affected.
-    //
-    //  • Editor mode: prune deep AXLists entirely (early return — avoids walking
-    //    37 levels of xterm.js just to discard it).
-    //  • Terminal mode: mark entry into the deep AXList so only its text is emitted.
-    let is_vscode_terminal_list = if state.vscode_mode != VsCodeMode::None {
-        if role_str == "AXWebArea" && state.webarea_depth.is_none() {
-            state.webarea_depth = Some(depth);
+    //  • Editor mode: prune the deep AXList entirely — early return, no children walked.
+    //  • Terminal mode: mark entry into the AXList so only its descendants emit text.
+    if role_str == "AXWebArea" {
+        if let AppState::VsCode { webarea_depth, .. } = &mut state.app {
+            webarea_depth.get_or_insert(depth);
         }
-        role_str == "AXList"
-            && state
-                .webarea_depth
-                .map_or(false, |wd| depth >= wd + 20)
-    } else {
-        false
+    }
+    let is_vscode_terminal_list = match state.app {
+        AppState::VsCode { webarea_depth: Some(wd), .. } => {
+            role_str == "AXList" && depth >= wd + 20
+        }
+        _ => false,
     };
-
-    if is_vscode_terminal_list && state.vscode_mode == VsCodeMode::Editor {
-        // Prune the entire terminal subtree — no children walked, no text emitted.
-        return;
+    if is_vscode_terminal_list {
+        if matches!(state.app, AppState::VsCode { mode: VsCodeMode::Editor, .. }) {
+            return; // prune entire terminal subtree — no children walked, no text emitted
+        }
     }
 
     // Extract text from this element.
-    // In VS Code terminal mode, suppress text that is outside the terminal AXList.
+    // In VS Code terminal mode, suppress text outside the terminal AXList subtree.
     if should_extract_text(&role_str) {
-        let emit = state.vscode_mode != VsCodeMode::Terminal || state.in_terminal_subtree;
+        let emit = match state.app {
+            AppState::VsCode { mode: VsCodeMode::Terminal, in_terminal_subtree, .. } => {
+                in_terminal_subtree
+            }
+            _ => true,
+        };
         if emit {
             extract_text(elem, &role_str, depth, state);
         }
@@ -1071,9 +1090,12 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
     // sibling subtrees (sidebar, editor) are unaffected.
     let children = elem.children();
     if let Ok(children) = children {
-        let prev_in_terminal = state.in_terminal_subtree;
+        let prev_in_terminal =
+            matches!(state.app, AppState::VsCode { in_terminal_subtree: true, .. });
         if is_vscode_terminal_list {
-            state.in_terminal_subtree = true;
+            if let AppState::VsCode { in_terminal_subtree, .. } = &mut state.app {
+                *in_terminal_subtree = true;
+            }
         }
         for i in 0..children.len() {
             if state.should_stop() {
@@ -1081,7 +1103,9 @@ fn walk_element(elem: &ax::UiElement, depth: usize, state: &mut WalkState) {
             }
             walk_element(&children[i], next_depth, state);
         }
-        state.in_terminal_subtree = prev_in_terminal;
+        if let AppState::VsCode { in_terminal_subtree, .. } = &mut state.app {
+            *in_terminal_subtree = prev_in_terminal;
+        }
     }
 }
 
@@ -1586,5 +1610,138 @@ mod tests {
         let _ = walker.walk_focused_window();
         // Should complete reasonably quickly (< 5s even with IPC delays)
         assert!(start.elapsed() < std::time::Duration::from_secs(5));
+    }
+
+    // ── VS Code terminal helper unit tests ──────────────────────────────────
+
+    #[test]
+    fn test_is_vscode_like_matches_known_apps() {
+        assert!(is_vscode_like("code"));
+        assert!(is_vscode_like("cursor"));
+        assert!(is_vscode_like("windsurf"));
+        assert!(is_vscode_like("vscodium"));
+        assert!(is_vscode_like("positron"));
+        assert!(is_vscode_like("void"));
+        assert!(is_vscode_like("aide"));
+        assert!(is_vscode_like("trae"));
+        assert!(is_vscode_like("antigravity"));
+    }
+
+    #[test]
+    fn test_is_vscode_like_no_false_positive_on_xcode() {
+        // "xcode" must NOT match the "code" entry — the whole point of the word-boundary check.
+        assert!(!is_vscode_like("xcode"));
+        // Confirm Xcode variants are also rejected.
+        assert!(!is_vscode_like("xcode.app"));
+    }
+
+    #[test]
+    fn test_is_vscode_like_rejects_unrelated_apps() {
+        assert!(!is_vscode_like("finder"));
+        assert!(!is_vscode_like("terminal"));
+        assert!(!is_vscode_like("safari"));
+        assert!(!is_vscode_like(""));
+    }
+
+    #[test]
+    fn test_is_vscode_like_allows_space_suffix() {
+        // e.g. "code helper (renderer)" — macOS sometimes appends a suffix with a space.
+        assert!(is_vscode_like("code helper"));
+    }
+
+    #[test]
+    fn test_strip_xterm_ax_hint_removes_hint() {
+        assert_eq!(
+            strip_xterm_ax_hint("zsh Use \u{2325}F1 for terminal accessibility help"),
+            "zsh"
+        );
+        assert_eq!(
+            strip_xterm_ax_hint("bash Use \u{2318}F1 for accessibility"),
+            "bash"
+        );
+        assert_eq!(strip_xterm_ax_hint("fish Use ^F1 help"), "fish");
+    }
+
+    #[test]
+    fn test_strip_xterm_ax_hint_passthrough_when_no_hint() {
+        assert_eq!(strip_xterm_ax_hint("zsh"), "zsh");
+        assert_eq!(strip_xterm_ax_hint(""), "");
+        assert_eq!(strip_xterm_ax_hint("my-session"), "my-session");
+    }
+
+    #[test]
+    fn test_parse_vscode_terminal_name_numbered_with_session() {
+        // Standard VS Code / Cursor format: "Terminal N, session"
+        assert_eq!(
+            parse_vscode_terminal_name("Terminal 4, 2.1.150"),
+            Some("Terminal - 2.1.150".to_owned())
+        );
+        assert_eq!(
+            parse_vscode_terminal_name("Terminal 1, zsh"),
+            Some("Terminal - zsh".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_parse_vscode_terminal_name_strips_hint() {
+        // Session name has accessibility hint appended — must strip it.
+        assert_eq!(
+            parse_vscode_terminal_name(
+                "Terminal 2, zsh Use \u{2325}F1 for terminal accessibility help"
+            ),
+            Some("Terminal - zsh".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_parse_vscode_terminal_name_fallback_no_session() {
+        // "Terminal N" with no comma → fall back to "Terminal N".
+        assert_eq!(
+            parse_vscode_terminal_name("Terminal 3"),
+            Some("Terminal 3".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_parse_vscode_terminal_name_rejects_non_terminal() {
+        // Doesn't start with "Terminal " → None.
+        assert_eq!(parse_vscode_terminal_name("Editor pane"), None);
+        assert_eq!(parse_vscode_terminal_name(""), None);
+        // No digit after "Terminal " → None.
+        assert_eq!(parse_vscode_terminal_name("Terminal "), None);
+    }
+
+    #[test]
+    fn test_parse_xterm_bare_desc_with_hint() {
+        // Bare shell name + xterm.js hint.
+        assert_eq!(
+            parse_xterm_bare_desc("zsh Use \u{2325}F1 for terminal accessibility help"),
+            Some("Terminal - zsh".to_owned())
+        );
+        assert_eq!(
+            parse_xterm_bare_desc("bash Use \u{2318}F1 for terminal accessibility help"),
+            Some("Terminal - bash".to_owned())
+        );
+        assert_eq!(
+            parse_xterm_bare_desc("fish Use ^F1 for terminal accessibility help"),
+            Some("Terminal - fish".to_owned())
+        );
+    }
+
+    #[test]
+    fn test_parse_xterm_bare_desc_rejects_without_hint() {
+        // No accessibility hint → must return None (avoids matching arbitrary UI labels).
+        assert_eq!(parse_xterm_bare_desc("zsh"), None);
+        assert_eq!(parse_xterm_bare_desc("macos.rs"), None);
+        assert_eq!(parse_xterm_bare_desc(""), None);
+    }
+
+    #[test]
+    fn test_parse_xterm_bare_desc_rejects_multiword_session() {
+        // Session name with a space (e.g. "my session") → None (only bare single-token names).
+        assert_eq!(
+            parse_xterm_bare_desc("my session Use \u{2325}F1 help"),
+            None
+        );
     }
 }

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -783,14 +783,16 @@ fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
                 .ok()
                 .filter(|p| p.get_type_id() == ax::UiElement::type_id())
         };
-        // Scan desc/title on every ancestor for "Terminal N" pattern.
-        // The xterm.js container has this on the element that parents both the
-        // output AXList and the input AXTextField.
+        // Scan desc/title on every ancestor for a terminal name.
+        // Try the "Terminal N, session" format first, then the bare session-name
+        // format used by some forks (e.g. Antigravity: "zsh Use ⌥F1 …").
         if desc_terminal_name.is_none() {
             let elem: &ax::UiElement = unsafe { std::mem::transmute(&*cur) };
             for attr in [ax::attr::desc(), ax::attr::title()] {
                 if let Some(val) = get_string_attr(elem, attr) {
-                    if let Some(name) = parse_vscode_terminal_name(&val) {
+                    if let Some(name) = parse_vscode_terminal_name(&val)
+                        .or_else(|| parse_xterm_bare_desc(&val))
+                    {
                         desc_terminal_name = Some(name);
                         break;
                     }
@@ -813,7 +815,7 @@ fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
                 if let Some(name) = desc_terminal_name {
                     return Some(name);
                 }
-                // Fallback: name found by scanning above the AXList.
+                // Fallback: scan ancestors above the AXList for a name.
                 if let Some(list_idx) = axlist_idx {
                     let search_end = (list_idx + 12).min(steps);
                     for k in (list_idx + 1)..search_end {
@@ -821,7 +823,9 @@ fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
                             unsafe { std::mem::transmute(&*ancestors[k]) };
                         for attr in [ax::attr::desc(), ax::attr::title()] {
                             if let Some(val) = get_string_attr(elem, attr) {
-                                if let Some(name) = parse_vscode_terminal_name(&val) {
+                                if let Some(name) = parse_vscode_terminal_name(&val)
+                                    .or_else(|| parse_xterm_bare_desc(&val))
+                                {
                                     return Some(name);
                                 }
                             }
@@ -845,15 +849,34 @@ fn vscode_terminal_window_name(ax_app: &ax::UiElement) -> Option<String> {
     None
 }
 
+/// Strip the xterm.js accessibility hint appended to many AX descriptions.
+/// e.g. "zsh Use ⌥F1 for terminal accessibility help" → "zsh"
+/// The hint always begins with " Use " followed by a modifier-key symbol.
+fn strip_xterm_ax_hint(s: &str) -> &str {
+    // ⌥ = U+2325, ⌘ = U+2318
+    let hint_start = s
+        .find(" Use \u{2325}")
+        .or_else(|| s.find(" Use \u{2318}"))
+        .or_else(|| s.find(" Use ^"));
+    match hint_start {
+        Some(idx) => s[..idx].trim(),
+        None => s,
+    }
+}
+
 /// Extract the terminal label from an xterm.js AX attribute string.
 ///
-/// The xterm.js container's `AXDescription` has the form:
-///   "Terminal {index}, {session_name} …"  e.g. "Terminal 4, 2.1.150"
+/// Two description formats are found in the wild:
 ///
-/// When a session name is present we return `"Terminal - {session_name}"` so
-/// the stored window name reflects what the user actually named the terminal
-/// (branch name, directory, custom label, etc.) rather than a raw index.
-/// Falls back to `"Terminal {index}"` when no session name is available.
+///   (a) VS Code / Cursor:  "Terminal {index}, {session_name}"
+///       e.g. "Terminal 4, 2.1.150" or "Terminal 2, zsh Use ⌥F1 …"
+///       → returns "Terminal - {session_name}" (hint stripped)
+///
+///   (b) Antigravity / some forks: bare "{session_name}" or "{shell} Use ⌥…"
+///       e.g. "zsh Use ⌥F1 for terminal accessibility help"
+///       → handled by `parse_xterm_bare_desc`, not this function.
+///
+/// Falls back to `"Terminal {index}"` when no session name is present.
 fn parse_vscode_terminal_name(val: &str) -> Option<String> {
     let rest = val.trim().strip_prefix("Terminal ")?;
     // Read the numeric index (must have at least one digit).
@@ -867,24 +890,47 @@ fn parse_vscode_terminal_name(val: &str) -> Option<String> {
     let after = &rest[num_end..];
 
     if after.is_empty() || after == " " {
-        // Plain "Terminal N" — no session name.
         return Some(format!("Terminal {index}"));
     }
 
-    // "Terminal N, session_name" — extract session name after the comma.
-    let session = if let Some(s) = after.strip_prefix(", ") {
+    // "Terminal N, session_name …" — extract session name after the comma.
+    let session_raw = if let Some(s) = after.strip_prefix(", ") {
         s.trim()
     } else if let Some(s) = after.strip_prefix(',') {
         s.trim()
     } else {
-        // Unexpected suffix (not a comma) — not a terminal label.
         return None;
     };
 
+    // Strip accessibility hint before using as label.
+    let session = strip_xterm_ax_hint(session_raw);
     if session.is_empty() {
         Some(format!("Terminal {index}"))
     } else {
         Some(format!("Terminal - {session}"))
+    }
+}
+
+/// Match a bare xterm.js description that lacks the "Terminal N, " prefix.
+/// Seen in Antigravity IDE and other forks where the description is just the
+/// shell / session name, optionally followed by the accessibility hint.
+/// e.g. "zsh Use ⌥F1 for terminal accessibility help" → "Terminal - zsh"
+///      "2.1.150" → "Terminal - 2.1.150"
+///
+/// Conservative: only matches short strings with no spaces after hint stripping,
+/// to avoid treating arbitrary UI labels as terminal session names.
+fn parse_xterm_bare_desc(val: &str) -> Option<String> {
+    let stripped = strip_xterm_ax_hint(val.trim());
+    // Reject empty, multi-word strings, and the bare word "Terminal" (which
+    // would produce the nonsensical "Terminal - Terminal").
+    if stripped.is_empty() || stripped.contains(' ') || stripped == "Terminal" {
+        return None;
+    }
+    // Must look like a process/session name: short, no quotes.
+    if stripped.len() <= 40 && !stripped.contains('"') && !stripped.contains('\'') {
+        Some(format!("Terminal - {stripped}"))
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
## Description

This PR fixes two silent bugs in the macOS AX tree walker that together make VS Code (and all its forks) nearly useless as a capture target for developer context.

### Bug 1 — Terminal content was never captured

VS Code's integrated terminal is powered by xterm.js, which builds its own accessibility subtree inside the Electron shell. The AX path from the window root to a single terminal output row looks like this:

```
AXWindow
  └─ 6× AXGroup (Electron chrome layers)
       └─ AXWebArea          ← depth 7 from window
            └─ … 28 more AX nodes (xterm.js DOM) …
                 └─ AXList   ← depth 35, the terminal row container
                      └─ AXGroup
                           └─ AXStaticText  ← actual terminal output, depth 37
```

The previous `max_depth` hard cap was **35** (raised from 30 by #3547). Even at 35, terminal rows at depth 35–37 sat right at or just beyond the limit, so many frames were cut off silently — the text buffer came back empty or truncated with no error or warning.

### Bug 2 — Wrong active window name when using the terminal

`AXWindow::AXTitle` in VS Code always shows the name of the **last-active editor file**, regardless of which panel currently has keyboard focus. So when a developer clicks into the terminal and runs commands, screenpipe still reports the window as e.g. `budget.rs`.

This matters because the window name is the primary signal used downstream (by AI context pipelines, by search, by timeline grouping) to know what the user was doing. A developer running `cargo test` in the terminal produces frames labelled as editor activity on a Rust file — completely wrong context.

The fix requires reading `AXFocusedUIElement` and walking up its ancestor chain — not the window title — to determine whether the terminal panel is actually active.

### What makes this non-trivial

Two separate UI elements need terminal detection and they don't share a common parent until deep in the tree:

- **Terminal output rows** (`AXStaticText` inside `AXList`): the `AXList` is ≥ 28 hops below `AXWebArea`. Sidebar file-tree `AXList`s are ≤ 12 hops below it. The threshold of 20 cleanly separates them.
- **Terminal input prompt** (`AXTextField`): the typing cursor lives in a text field that has **no `AXList` ancestor** — it sits alongside the list, not inside it. Checking for `AXList` depth alone misses this case, so the focused element is still reported as the editor file while the user is actively typing into the terminal.

The fix scans every ancestor's `AXDescription` / `AXTitle` for the pattern `"Terminal N[, …]"` in parallel with the `AXList` depth check, so both paths are caught by a single upward walk.

### Solution

**`is_vscode_like(app_lower: &str) -> bool`**

Matches VS Code and all known Electron-based editor forks against a constant list: `code`, `cursor`, `windsurf`, `antigravity`, `vscodium`, `positron`, `void`, `aide`, `trae`. Single `str::contains` per entry — effectively free. Zero overhead for non-matching apps.

**`vscode_terminal_window_name(ax_app)`**

Called once per frame before the tree walk. Reads `AXFocusedUIElement` then walks up at most 60 ancestors, collecting two signals simultaneously:
- Sets `axlist_idx` when it passes an `AXList` (most recent one wins).
- Sets `desc_terminal_name` when any ancestor's description matches `"Terminal N"`.

When it reaches `AXWebArea`:
- If the `AXList` was ≥ 20 hops below → terminal is focused → return the name from `desc_terminal_name` (or `"Terminal"` as fallback).
- If the `AXList` was < 20 hops below, or there was no `AXList` but `desc_terminal_name` was set → still terminal (input field path).
- Otherwise → editor is focused → return `None`.

Returns `None` in < 1 µs for all non-VS Code apps (first ancestor is `AXWindow`, walk exits immediately).

**`VsCodeMode` enum (None / Terminal / Editor)**

Set once before the walk, consulted per node — no per-frame overhead:
- `Terminal`: text extraction is gated behind `in_terminal_subtree`. Only the deep `AXList` subtree emits text. Sidebar and editor nodes are visited for structure but their text is suppressed.
- `Editor`: the deep `AXList` subtree is pruned entirely at its root — none of its descendants are visited. Sidebar file structure and editor code are captured cleanly.
- `None`: existing behaviour, completely unchanged. Any app that isn't VS Code-like never touches this path.

`in_terminal_subtree` is saved and restored around each deep `AXList` entry/exit so sibling subtrees are unaffected — no global state leaks between nodes.

---

## Before

Terminal frames captured with an empty text buffer. Window name showed the open editor file even while actively typing in the terminal.

_(screen recording showing empty terminal frames and wrong window name)_

**Sample frame (before):**
```json
{
  "app": "Code",
  "window_name": "budget.rs",
  "text": "",
  "node_count": 0
}
```

## After

Terminal frames contain the xterm.js output rows. Window name shows `"Terminal 1"` when the terminal panel is focused, and the editor file name when the editor is focused.

_(screen recording showing terminal content captured and correct window name)_

**Sample frame — terminal focused (after):**
```json
{
  "app": "Code",
  "window_name": "Terminal 1",
  "text": "❯ cargo build -p screenpipe-a11y\n   Compiling screenpipe-a11y v0.1.0\n    Finished `dev` profile in 9.12s\n❯ git status\nOn branch feat/vscode-terminal-ax-capture\nnothing to commit, working tree clean\n❯ _",
  "node_count": 27
}
```

**Sample frame — editor focused (after):**
```json
{
  "app": "Code",
  "window_name": "macos.rs",
  "text": "src/\n  tree/\n    macos.rs\n    mod.rs\nfn is_vscode_like(app_lower: &str) -> bool {\n    VSCODE_LIKE_APPS.iter().any(|name| app_lower.contains(name))\n}",
  "node_count": 142
}
```

---

## How to test

1. Open VS Code (or Cursor / Windsurf) with a file open in the editor and the integrated terminal open in the panel below.
2. Start screenpipe and capture a few frames while the **editor** is focused — verify the window name is the file name and no terminal rows appear in the frame text.
3. Click into the **terminal panel** and run a command (e.g. `ls -la`).
4. Check the captured frames — window name should be `"Terminal 1"` and the frame text should contain the command output rows.
5. Switch back to the editor — verify window name reverts to the file name and terminal rows are absent from the frame text.
6. Run `cargo build -p screenpipe-a11y` — should compile with no errors or warnings.

---

## Performance impact

| | Non-VS Code apps | VS Code apps |
|---|---|---|
| **CPU** | Zero change — `is_vscode_like` short-circuits in < 100 ns | Ancestor walk bounded at 60 hops, runs once per frame — < 1 ms overhead |
| **Memory** | None | `VsCodeMode` is a 1-byte enum on the existing `WalkState` stack struct; no heap allocations in the hot path |
| **`max_depth`** | Unchanged (35, since #3547) | Raised to 40 for VS Code-like apps only |

---

## Notes for reviewers

- The `AXWebArea` depth-reset (`next_depth = 0`) that landed in upstream main nicely complements this change: it gives Electron apps a full depth budget from the web area root, which is exactly where the 37-level terminal subtree begins.
- xterm.js's scrollback buffer is a separate limitation: `ariaSetSize` reports 1027 rows but only ~27 visible rows exist in the AX tree at any time. The `CircularBuffer` rows are not exposed via AX APIs (`AXTextMarkerRangeForLine` returns nil for off-screen rows). Full scrollback can be addressed separately via shell integration hooks (`precmd`/`preexec`).
- All VS Code-specific bookkeeping (`mode`, `webarea_depth`, `in_terminal_subtree`) is now owned by an `AppState::VsCode { .. }` enum variant. `WalkState` carries a single `app: AppState` field — every non-VS Code frame is a discriminant check the compiler folds away. 15 unit tests for the pure helpers (`is_vscode_like`, `strip_xterm_ax_hint`, `parse_vscode_terminal_name`, `parse_xterm_bare_desc`) are included and pass without a live AX session.