### PR TITLE
fix(meeting-detect): stop phantom toast on cal.com dashboard

### DIFF
--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -522,31 +522,10 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
                 ],
                 browser_title_patterns: &[],
             },
-            // Use specific phrases ("leave call", "leave meeting", "leave
-            // room", "leave studio") instead of bare "leave". The generic
-            // profile catches niche video apps via broad URL patterns, and
-            // when the AX scan walks every window of a browser (e.g. Arc)
-            // looking for call controls, a bare "leave" matches everyday
-            // page UI like Instacart's "Leave at the door" delivery
-            // option — triggering a phantom meeting. The specific phrases
-            // still cover Skype, Whereby, Riverside, RingCentral, BlueJeans,
-            // GoToMeeting, Dialpad, Around, and recent Daily.co builds.
             call_signals: vec![
                 CallSignal::RoleWithName {
                     role: "AXButton",
-                    name_contains: "leave call",
-                },
-                CallSignal::RoleWithName {
-                    role: "AXButton",
-                    name_contains: "leave meeting",
-                },
-                CallSignal::RoleWithName {
-                    role: "AXButton",
-                    name_contains: "leave room",
-                },
-                CallSignal::RoleWithName {
-                    role: "AXButton",
-                    name_contains: "leave studio",
+                    name_contains: "leave",
                 },
                 CallSignal::RoleWithName {
                     role: "AXButton",
@@ -3404,58 +3383,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_generic_profile_leave_signals_reject_ecommerce_strings() {
-        // Regression: an Instacart checkout page exposed "Leave at the door"
-        // as an AXButton, which matched the generic profile's bare
-        // `name_contains: "leave"` signal and started a phantom meeting in
-        // Arc. Tightening to specific phrases ("leave call", "leave meeting",
-        // "leave room", "leave studio") preserves legitimate detection
-        // without catching everyday e-commerce / UX strings.
-        let profile = generic_profile();
-        for innocuous in [
-            "Leave at the door",
-            "Leave a review",
-            "Leave page",
-            "Leave feedback",
-            "Leave a tip",
-        ] {
-            for signal in &profile.call_signals {
-                assert!(
-                    !check_signal_match(signal, "AXButton", Some(innocuous), None, None),
-                    "generic profile signal {signal:?} must NOT match innocuous button {innocuous:?}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_generic_profile_leave_signals_still_match_real_call_controls() {
-        // Smoke test: legitimate call-leave buttons across the niche video
-        // apps the generic profile covers must still trigger detection.
-        let profile = generic_profile();
-        for real_button in [
-            "Leave Call",
-            "Leave call",
-            "Leave Meeting",
-            "Leave Room",
-            "Leave Studio",
-            "Hang Up",
-            "Hangup",
-            "End Call",
-            "End Meeting",
-            "Disconnect",
-        ] {
-            let matched = profile
-                .call_signals
-                .iter()
-                .any(|s| check_signal_match(s, "AXButton", Some(real_button), None, None));
-            assert!(
-                matched,
-                "generic profile should still match legitimate call-leave button {real_button:?}"
-            );
-        }
-    }
 
     // ── State machine tests ────────────────────────────────────────────
 

--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -502,7 +502,12 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
                     "butter.us",
                     "livestorm.co",
                     "ping.gg",
-                    "cal.com",
+                    // Cal.com is primarily a scheduling product — its booking
+                    // dashboard (app.cal.com/event-types) and booking pages
+                    // (cal.com/{user}/{event}) aren't calls. Only Cal Video
+                    // (app.cal.com/video/{uid}) is a live meeting URL. Matching
+                    // bare "cal.com" caused false positives on the dashboard.
+                    "cal.com/video",
                     "daily.co",
                     "app.daily.co",
                     "pop.com",
@@ -517,10 +522,31 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
                 ],
                 browser_title_patterns: &[],
             },
+            // Use specific phrases ("leave call", "leave meeting", "leave
+            // room", "leave studio") instead of bare "leave". The generic
+            // profile catches niche video apps via broad URL patterns, and
+            // when the AX scan walks every window of a browser (e.g. Arc)
+            // looking for call controls, a bare "leave" matches everyday
+            // page UI like Instacart's "Leave at the door" delivery
+            // option — triggering a phantom meeting. The specific phrases
+            // still cover Skype, Whereby, Riverside, RingCentral, BlueJeans,
+            // GoToMeeting, Dialpad, Around, and recent Daily.co builds.
             call_signals: vec![
                 CallSignal::RoleWithName {
                     role: "AXButton",
-                    name_contains: "leave",
+                    name_contains: "leave call",
+                },
+                CallSignal::RoleWithName {
+                    role: "AXButton",
+                    name_contains: "leave meeting",
+                },
+                CallSignal::RoleWithName {
+                    role: "AXButton",
+                    name_contains: "leave room",
+                },
+                CallSignal::RoleWithName {
+                    role: "AXButton",
+                    name_contains: "leave studio",
                 },
                 CallSignal::RoleWithName {
                     role: "AXButton",
@@ -3314,6 +3340,119 @@ mod tests {
             assert!(
                 mute_matches.is_empty(),
                 "profile should not match standalone 'Mute' button"
+            );
+        }
+    }
+
+    /// Returns the generic-fallback profile (the one with broad URL patterns
+    /// like `daily.co`, `cal.com/video`, `pop.com`). Picks it by detecting the
+    /// distinctive `meet.jit.si` URL pattern.
+    fn generic_profile() -> MeetingDetectionProfile {
+        load_detection_profiles()
+            .into_iter()
+            .find(|p| {
+                p.app_identifiers
+                    .browser_url_patterns
+                    .contains(&"meet.jit.si")
+            })
+            .expect("generic fallback profile present")
+    }
+
+    /// Mirrors the lowercase substring match used by `has_browser_meeting_url`
+    /// and `db_find_browser_meetings`.
+    fn url_matches_any_pattern(url: &str, patterns: &[&str]) -> bool {
+        let url_lower = url.to_lowercase();
+        patterns
+            .iter()
+            .any(|p| url_lower.contains(&p.to_lowercase()))
+    }
+
+    #[test]
+    fn test_generic_profile_rejects_cal_dashboard_url() {
+        // Regression: bare `cal.com` URL pattern matched the cal.com booking
+        // dashboard, which then put Arc into the "candidate browser" set and
+        // let an unrelated tab's "Leave at the door" button fire a phantom
+        // meeting. Dashboard URLs are not calls.
+        let profile = generic_profile();
+        let patterns = profile.app_identifiers.browser_url_patterns;
+        for url in [
+            "https://app.cal.com/event-types",
+            "https://app.cal.com/bookings/upcoming",
+            "https://cal.com/louis/30min",
+            "https://cal.com/pricing",
+        ] {
+            assert!(
+                !url_matches_any_pattern(url, patterns),
+                "cal.com dashboard URL {url:?} should NOT match a meeting profile"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generic_profile_matches_cal_video_url() {
+        // The actual Cal Video URL (live meeting) must still match.
+        let profile = generic_profile();
+        let patterns = profile.app_identifiers.browser_url_patterns;
+        for url in [
+            "https://app.cal.com/video/abc123",
+            "https://app.cal.com/video/8f3e-meeting-uid",
+        ] {
+            assert!(
+                url_matches_any_pattern(url, patterns),
+                "Cal Video URL {url:?} should match the generic profile"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generic_profile_leave_signals_reject_ecommerce_strings() {
+        // Regression: an Instacart checkout page exposed "Leave at the door"
+        // as an AXButton, which matched the generic profile's bare
+        // `name_contains: "leave"` signal and started a phantom meeting in
+        // Arc. Tightening to specific phrases ("leave call", "leave meeting",
+        // "leave room", "leave studio") preserves legitimate detection
+        // without catching everyday e-commerce / UX strings.
+        let profile = generic_profile();
+        for innocuous in [
+            "Leave at the door",
+            "Leave a review",
+            "Leave page",
+            "Leave feedback",
+            "Leave a tip",
+        ] {
+            for signal in &profile.call_signals {
+                assert!(
+                    !check_signal_match(signal, "AXButton", Some(innocuous), None, None),
+                    "generic profile signal {signal:?} must NOT match innocuous button {innocuous:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_generic_profile_leave_signals_still_match_real_call_controls() {
+        // Smoke test: legitimate call-leave buttons across the niche video
+        // apps the generic profile covers must still trigger detection.
+        let profile = generic_profile();
+        for real_button in [
+            "Leave Call",
+            "Leave call",
+            "Leave Meeting",
+            "Leave Room",
+            "Leave Studio",
+            "Hang Up",
+            "Hangup",
+            "End Call",
+            "End Meeting",
+            "Disconnect",
+        ] {
+            let matched = profile
+                .call_signals
+                .iter()
+                .any(|s| check_signal_match(s, "AXButton", Some(real_button), None, None));
+            assert!(
+                matched,
+                "generic profile should still match legitimate call-leave button {real_button:?}"
             );
         }
     }


### PR DESCRIPTION
## Summary

Phantom **"meeting detected — screenpipe is saving this meeting for transcription: Arc"** toast fires while browsing Instacart in Arc. Caused by an over-broad `cal.com` URL pattern combined with the cross-window AX scan.

## Root cause

Detection has two layers. Both fired wrongly:

1. **Candidate layer** — generic profile's bare `cal.com` URL pattern matched my pinned `app.cal.com/event-types` tab in a background Arc window, putting Arc into the meeting-host candidate set. Cal.com is a scheduling product; only `cal.com/video/*` is a live call.
2. **Call-signal layer** — the candidate scan then walks every window of the browser process for call controls. The generic profile's `RoleWithName { role: "AXButton", name_contains: "leave" }` signal matched Instacart's **"Leave at the door"** delivery instruction button, satisfying `min_signals_required: 1`.

Confirmed in the live DB and log:
```
23:13:19  meeting v2: Idle -> Confirming  (app=Arc, signals=1)
23:13:25  meeting v2: Confirming -> Active (app=Arc, signals=1, browser=true)
23:13:25  meeting v2: meeting started      (id=167, app=Arc, title=None)
```
The 30s frames window contained only Instacart URLs; `StorableSidebar.json` had the pinned `app.cal.com/event-types` tab that put Arc into the candidate set.

## Fix

One line, in the generic-fallback profile (`crates/screenpipe-engine/src/meeting_detector.rs`):

- `"cal.com"` → `"cal.com/video"` — only the Cal Video subpath is a live meeting.

Other pinned tabs in the same Arc instance (`meet.google.com/landing`, `discord.com/channels/...`) can't trip the same bug because Google Meet's own profile uses strict `"leave call"`/`"end call"` matchers and Discord-in-browser requires `min_signals_required: 2`.

## What I deliberately did NOT change

Initially I also split bare `"leave"` in the generic profile into `"leave call"`/`"leave meeting"`/`"leave room"`/`"leave studio"`. Reverted — that risks silently missing apps that ship a bare "Leave" button by default (Daily.co prebuilt, Pop, Gather). The cal.com fix alone is sufficient to kill the documented false positive.

## Tests

Added 2 regression tests; all 64 `meeting_detector` tests pass:

- `test_generic_profile_rejects_cal_dashboard_url` — `app.cal.com/event-types`, `cal.com/louis/30min`, etc. must not match.
- `test_generic_profile_matches_cal_video_url` — `app.cal.com/video/abc123` still matches.

## Out of scope (follow-up)

The deeper architectural issue: `scan_process` walks **all** windows of a browser PID once any window matches a meeting URL pattern. A future PR could scope the AX scan to the matching window so a niche pinned tab can't authorize scanning every other tab in the browser — that would cover the broader class of false positives (e.g. a pinned `daily.co` tab + any other Arc page with a `"leave"`/`"end call"`/`"disconnect"` AX element).

## Test plan

- [x] `cargo test -p screenpipe-engine --lib meeting_detector` — 64 passed
- [ ] Local smoke: shop on Instacart in Arc with `app.cal.com/event-types` pinned → no toast
- [ ] Real meeting still detected: join a Cal Video / Daily / Whereby call → toast fires