### PR TITLE
fix(chat): surface real reason behind 'failed to read media file: unknown error'

### DIFF
--- a/apps/screenpipe-app-tauri/components/share-logs-button.tsx
+++ b/apps/screenpipe-app-tauri/components/share-logs-button.tsx
@@ -258,7 +258,14 @@ export const ShareLogsButton = ({
           mergedVideoPath,
           signedUrlVideo
         );
-        if (videoResult.status !== "ok") throw new Error("Failed to upload video");
+        if (videoResult.status !== "ok") {
+          // Surface the Rust-side reason (e.g. "Upload failed with status: 403
+          // body: SignedURLExpired", "Failed to read file: …") so the toast
+          // shows something we can act on instead of a generic string.
+          throw new Error(
+            `failed to upload video: ${videoResult.error || "unknown error"}`,
+          );
+        }
       }
 
       const os = osPlatform();

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1939,7 +1939,10 @@ function MarkdownBlock({ text, isUser }: { text: string; isUser: boolean }) {
           );
         },
         a({ href, children, ...props }) {
-          const isMediaLink = href?.toLowerCase().match(/\.(mp4|mp3|wav|webm)$/);
+          // Require at least one path char before the extension so a bare
+          // ".mp4" / ".wav" (sometimes emitted by the model as a placeholder)
+          // doesn't get rendered as a VideoComponent that then 404s.
+          const isMediaLink = href?.toLowerCase().match(/.\.(mp4|mp3|wav|webm)$/);
           if (isMediaLink && href) {
             return <VideoComponent filePath={href} className="my-2" />;
           }
@@ -1992,7 +1995,7 @@ function MarkdownBlock({ text, isUser }: { text: string; isUser: boolean }) {
         },
         img({ src, alt, ...props }) {
           if (!src) return null;
-          if (src.toLowerCase().endsWith(".mp4")) {
+          if (src.length > 4 && src.toLowerCase().endsWith(".mp4")) {
             return <VideoComponent filePath={src} className="my-2" />;
           }
           // try asset protocol for local paths, fall back to http serve
@@ -2032,7 +2035,8 @@ function MarkdownBlock({ text, isUser }: { text: string; isUser: boolean }) {
         },
         code({ className, children, ...props }) {
           const content = String(children).replace(/\n$/, "");
-          const isMedia = content.trim().toLowerCase().match(/\.(mp4|mp3|wav|webm)$/);
+          // Same bare-extension guard as the `a` and `img` renderers above.
+          const isMedia = content.trim().toLowerCase().match(/.\.(mp4|mp3|wav|webm)$/);
           const match = /language-(\w+)/.exec(className || "");
           const language = match?.[1] || "";
           const isCodeBlock = className?.includes("language-");

--- a/apps/screenpipe-app-tauri/lib/actions/video-actions.ts
+++ b/apps/screenpipe-app-tauri/lib/actions/video-actions.ts
@@ -10,10 +10,19 @@ export async function getMediaFile(
 
 		return result;
 	} catch (error) {
-		console.error("failed to read media file:", error);
-		throw new Error(
-			`failed to read media file: ${error instanceof Error ? error.message : "unknown error"}`,
-		);
+		// Tauri rejects `invoke` with the raw Err(String) payload, not an Error
+		// instance — so an `instanceof Error` check used to discard the real
+		// reason and surface "unknown error" to the user. Hugo's "Failed to load
+		// media: failed to read media file: unknown error" feedback was actually
+		// "File does not exist: <path>" upstream.
+		const message =
+			error instanceof Error
+				? error.message
+				: typeof error === "string"
+					? error
+					: JSON.stringify(error);
+		console.error("failed to read media file:", message);
+		throw new Error(`failed to read media file: ${message}`);
 	}
 }
 


### PR DESCRIPTION
## Summary

Three small diagnostic fixes from a Windows 10 user feedback round on `2.4.260` — all of the user's chat / upload errors were being shown as generic strings while the real reasons sat in the discarded payload.

- **`video-actions.ts`** — Tauri rejects `invoke` with the raw `Err(String)` from Rust, not an `Error` instance, so `error instanceof Error ? error.message : "unknown error"` always took the false branch and rendered "unknown error". User-visible report: `Failed to load media: failed to read media file: unknown error` — the actual Rust message was `File does not exist: <path>`. Now preserves the string.
- **`share-logs-button.tsx`** — `commands.uploadFileToS3` returns `Result<bool, string>` and the `.error` field carries the underlying reason (S3 body, signed-URL-expired, file-not-found, etc.); we discarded it and threw a generic `Failed to upload video`. Now propagates `videoResult.error`.
- **`standalone-chat.tsx`** — `isMedia` regex `/\.(mp4|mp3|wav|webm)$/` matched bare `".mp4"` / `".wav"` strings (verified: `'.mp4'.match(...)` returns a match), so a model emitting a bare extension as a code block / markdown link rendered a `<VideoComponent filePath=".mp4">` that then hit `File does not exist: .mp4`. Now requires at least one char before the extension dot.

Together these stop hiding the real failure mode the next time a user reports a chat playback or feedback-form bug.

## Test plan

- [ ] in-app chat: click an audio chunk whose file has been deleted by reconciliation — toast now shows `File does not exist: <path>` instead of `unknown error`
- [ ] in-app help form: click `recording 5m` + `send logs & feedback` with an expired or invalid signed-url scenario — toast surfaces the S3/reqwest body
- [ ] paste a markdown chat message containing a `.mp4` bare code block — no `<VideoComponent>` is rendered for it
- [ ] normal media playback (paths like `/foo.mp4`, `C:\path\file.mp4`) still works — confirmed via regex unit run (`.mp4` => no match, `a.mp4` / `C:\…\file.mp4` => MATCH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)