### PR TITLE
fix(vault): derive master key from password on lock

### DIFF
--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -1338,7 +1338,12 @@ pub enum VaultCommand {
     /// Set up vault encryption (first-time password setup)
     Setup {},
     /// Lock the vault (encrypt all data, stop recording)
-    Lock {},
+    Lock {
+        /// Port of the running screenpipe daemon (used to delegate lock if
+        /// reachable). Falls back to direct file-level lock if unreachable.
+        #[arg(short = 'p', long, default_value_t = 3030)]
+        port: u16,
+    },
     /// Unlock the vault (decrypt data, resume recording)
     Unlock {},
 }

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -1337,10 +1337,11 @@ pub enum VaultCommand {
     Status {},
     /// Set up vault encryption (first-time password setup)
     Setup {},
-    /// Lock the vault (encrypt all data, stop recording)
+    /// Lock the vault (encrypt all data; stop screenpipe first)
     Lock {
-        /// Port of the running screenpipe daemon (used to delegate lock if
-        /// reachable). Falls back to direct file-level lock if unreachable.
+        /// Port screenpipe listens on. `vault lock` refuses to run while a
+        /// daemon is detected here — locking encrypts the DB in place and would
+        /// corrupt it underneath a live daemon, so stop screenpipe first.
         #[arg(short = 'p', long, default_value_t = 3030)]
         port: u16,
     },

--- a/crates/screenpipe-engine/src/cli/vault.rs
+++ b/crates/screenpipe-engine/src/cli/vault.rs
@@ -40,10 +40,34 @@ pub async fn handle_vault_command(command: &VaultCommand) -> anyhow::Result<()> 
             println!("vault set up successfully");
         }
 
-        VaultCommand::Lock { .. } => {
+        VaultCommand::Lock { port } => {
             let password = read_password("vault password: ")?;
+
+            // If the daemon is running, ask IT to lock — that way the
+            // daemon (which owns the DB pool and recording loop) handles
+            // shutdown cleanly. Fall back to direct file-level lock if
+            // the daemon is unreachable so locking remains guaranteed.
+            if daemon_running(*port).await {
+                match try_lock_via_daemon(*port, &password).await {
+                    Ok(()) => {
+                        println!("vault locked — data encrypted (via running daemon)");
+                        return Ok(());
+                    }
+                    Err(LockViaDaemonError::WrongPassword) => {
+                        anyhow::bail!("wrong password");
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "warning: daemon on port {} unreachable for lock ({}). \
+                             falling back to direct lock — stop screenpipe first \
+                             if you want a clean shutdown.",
+                            port, e
+                        );
+                    }
+                }
+            }
+
             let _progress_rx = vault.lock(&password).await?;
-            // Wait for encryption to complete
             loop {
                 let state = vault.state().await;
                 match state {
@@ -87,4 +111,51 @@ fn read_password(prompt: &str) -> anyhow::Result<String> {
     eprint!("{}", prompt);
     let password = rpassword::read_password()?;
     Ok(password)
+}
+
+async fn daemon_running(port: u16) -> bool {
+    tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+        .await
+        .is_ok()
+}
+
+enum LockViaDaemonError {
+    WrongPassword,
+    NoApiKey,
+    Http(String),
+}
+
+impl std::fmt::Display for LockViaDaemonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LockViaDaemonError::WrongPassword => write!(f, "wrong password"),
+            LockViaDaemonError::NoApiKey => write!(f, "no API key available"),
+            LockViaDaemonError::Http(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+async fn try_lock_via_daemon(port: u16, password: &str) -> Result<(), LockViaDaemonError> {
+    let api_key = crate::auth_key::find_api_auth_key()
+        .await
+        .ok_or(LockViaDaemonError::NoApiKey)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| LockViaDaemonError::Http(e.to_string()))?;
+
+    let resp = client
+        .post(format!("http://127.0.0.1:{}/vault/lock", port))
+        .header("Authorization", format!("Bearer {}", api_key))
+        .json(&json!({ "password": password }))
+        .send()
+        .await
+        .map_err(|e| LockViaDaemonError::Http(e.to_string()))?;
+
+    match resp.status().as_u16() {
+        200 => Ok(()),
+        403 => Err(LockViaDaemonError::WrongPassword),
+        other => Err(LockViaDaemonError::Http(format!("HTTP {}", other))),
+    }
 }

--- a/crates/screenpipe-engine/src/cli/vault.rs
+++ b/crates/screenpipe-engine/src/cli/vault.rs
@@ -41,33 +41,24 @@ pub async fn handle_vault_command(command: &VaultCommand) -> anyhow::Result<()> 
         }
 
         VaultCommand::Lock { port } => {
-            let password = read_password("vault password: ")?;
-
-            // If the daemon is running, ask IT to lock — that way the
-            // daemon (which owns the DB pool and recording loop) handles
-            // shutdown cleanly. Fall back to direct file-level lock if
-            // the daemon is unreachable so locking remains guaranteed.
+            // Locking encrypts db.sqlite (+ WAL/SHM) and every file under data/
+            // in place. A running daemon still holds the DB pool open and keeps
+            // writing frames/audio, so encrypting underneath it silently drops
+            // those writes and can corrupt in-flight media. Nothing here can stop
+            // the daemon's capture loop and close its pool cleanly today, so
+            // refuse to lock while a daemon is detected rather than risk the DB.
+            // (unlock is symmetric — it assumes the server is not running.)
             if daemon_running(*port).await {
-                match try_lock_via_daemon(*port, &password).await {
-                    Ok(()) => {
-                        println!("vault locked — data encrypted (via running daemon)");
-                        return Ok(());
-                    }
-                    Err(LockViaDaemonError::WrongPassword) => {
-                        anyhow::bail!("wrong password");
-                    }
-                    Err(e) => {
-                        eprintln!(
-                            "warning: daemon on port {} unreachable for lock ({}). \
-                             falling back to direct lock — stop screenpipe first \
-                             if you want a clean shutdown.",
-                            port, e
-                        );
-                    }
-                }
+                anyhow::bail!(
+                    "screenpipe is running on port {port} — stop it first (quit the app, \
+                     or kill the `screenpipe` process), then run `screenpipe vault lock` \
+                     again. pass --port if the daemon listens on a non-default port."
+                );
             }
 
+            let password = read_password("vault password: ")?;
             let _progress_rx = vault.lock(&password).await?;
+            // Wait for encryption to complete
             loop {
                 let state = vault.state().await;
                 match state {
@@ -113,49 +104,12 @@ fn read_password(prompt: &str) -> anyhow::Result<String> {
     Ok(password)
 }
 
+/// True if something is listening on `127.0.0.1:<port>` — used to detect a
+/// running screenpipe daemon so we refuse to lock the vault underneath it.
+/// Fails closed: a port squatter reads as "running" and blocks the lock, which
+/// is the safe direction for a destructive in-place encryption.
 async fn daemon_running(port: u16) -> bool {
     tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
         .await
         .is_ok()
-}
-
-enum LockViaDaemonError {
-    WrongPassword,
-    NoApiKey,
-    Http(String),
-}
-
-impl std::fmt::Display for LockViaDaemonError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LockViaDaemonError::WrongPassword => write!(f, "wrong password"),
-            LockViaDaemonError::NoApiKey => write!(f, "no API key available"),
-            LockViaDaemonError::Http(e) => write!(f, "{}", e),
-        }
-    }
-}
-
-async fn try_lock_via_daemon(port: u16, password: &str) -> Result<(), LockViaDaemonError> {
-    let api_key = crate::auth_key::find_api_auth_key()
-        .await
-        .ok_or(LockViaDaemonError::NoApiKey)?;
-
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| LockViaDaemonError::Http(e.to_string()))?;
-
-    let resp = client
-        .post(format!("http://127.0.0.1:{}/vault/lock", port))
-        .header("Authorization", format!("Bearer {}", api_key))
-        .json(&json!({ "password": password }))
-        .send()
-        .await
-        .map_err(|e| LockViaDaemonError::Http(e.to_string()))?;
-
-    match resp.status().as_u16() {
-        200 => Ok(()),
-        403 => Err(LockViaDaemonError::WrongPassword),
-        other => Err(LockViaDaemonError::Http(format!("HTTP {}", other))),
-    }
 }

--- a/crates/screenpipe-engine/src/cli/vault.rs
+++ b/crates/screenpipe-engine/src/cli/vault.rs
@@ -41,7 +41,8 @@ pub async fn handle_vault_command(command: &VaultCommand) -> anyhow::Result<()> 
         }
 
         VaultCommand::Lock { .. } => {
-            let _progress_rx = vault.lock().await?;
+            let password = read_password("vault password: ")?;
+            let _progress_rx = vault.lock(&password).await?;
             // Wait for encryption to complete
             loop {
                 let state = vault.state().await;

--- a/crates/screenpipe-engine/src/routes/vault.rs
+++ b/crates/screenpipe-engine/src/routes/vault.rs
@@ -35,17 +35,26 @@ pub async fn vault_status(State(state): State<Arc<AppState>>) -> JsonResponse<Va
     }))
 }
 
+#[derive(Deserialize, OaSchema)]
+pub struct LockRequest {
+    pub password: String,
+}
+
 /// POST /vault/lock
 #[oasgen]
 pub async fn vault_lock(
     State(state): State<Arc<AppState>>,
+    JsonResponse(body): JsonResponse<LockRequest>,
 ) -> Result<JsonResponse<Value>, (StatusCode, JsonResponse<Value>)> {
-    match state.vault.lock().await {
+    match state.vault.lock(&body.password).await {
         Ok(_progress_rx) => Ok(JsonResponse(json!({ "success": true }))),
-        Err(e) => Err((
-            StatusCode::BAD_REQUEST,
-            JsonResponse(json!({ "error": e.to_string() })),
-        )),
+        Err(e) => {
+            let status = match &e {
+                screenpipe_vault::VaultError::WrongPassword => StatusCode::FORBIDDEN,
+                _ => StatusCode::BAD_REQUEST,
+            };
+            Err((status, JsonResponse(json!({ "error": e.to_string() }))))
+        }
     }
 }
 

--- a/crates/screenpipe-vault/src/lib.rs
+++ b/crates/screenpipe-vault/src/lib.rs
@@ -14,7 +14,7 @@
 //! # async fn example() -> anyhow::Result<()> {
 //! let vault = VaultManager::new(screenpipe_core::paths::default_screenpipe_data_dir());
 //! vault.setup("my-password").await?;
-//! vault.lock().await?;
+//! vault.lock("my-password").await?;
 //! vault.unlock("my-password").await?;
 //! # Ok(())
 //! # }

--- a/crates/screenpipe-vault/src/manager.rs
+++ b/crates/screenpipe-vault/src/manager.rs
@@ -119,7 +119,7 @@ impl VaultManager {
     ///
     /// The caller MUST stop recording and close the DB pool BEFORE calling this.
     /// Returns a progress receiver for UI display.
-    pub async fn lock(&self) -> VaultResult<watch::Receiver<MigrationProgress>> {
+    pub async fn lock(&self, password: &str) -> VaultResult<watch::Receiver<MigrationProgress>> {
         let state = self.state.read().await.clone();
         match state {
             VaultState::None => return Err(VaultError::NotSetUp),
@@ -130,15 +130,30 @@ impl VaultManager {
             VaultState::Unlocked => {}
         }
 
-        // Take the key out of the lock — this zeroizes it from the shared state immediately
+        // Derive master key from password (handles the case where the key isn't
+        // already in memory, e.g. separate CLI invocation)
         let key = {
             let mut guard = self.master_key.write().await;
-            guard
-                .take()
-                .ok_or(VaultError::Other("master key not in memory".into()))?
+            match guard.take() {
+                Some(k) => k,
+                None => {
+                    let meta_path = self.screenpipe_dir.join("vault.meta");
+                    let meta_json = std::fs::read_to_string(&meta_path)?;
+                    let meta: VaultMeta = serde_json::from_str(&meta_json)
+                        .map_err(|e| VaultError::Other(format!("corrupt vault.meta: {}", e)))?;
+                    let password_key = crypto::derive_key(password, &meta.salt)?;
+                    let master_key_bytes =
+                        crypto::decrypt_small(&meta.encrypted_master_key, &password_key)
+                            .map_err(|_| VaultError::WrongPassword)?;
+                    if master_key_bytes.len() != KEY_SIZE {
+                        return Err(VaultError::Crypto("invalid master key length".into()));
+                    }
+                    let mut mk = Zeroizing::new([0u8; KEY_SIZE]);
+                    mk.copy_from_slice(&master_key_bytes);
+                    mk
+                }
+            }
         };
-        // Copy key bytes for the encryption task. The Zeroizing wrapper on `key`
-        // will zeroize its copy when dropped at the end of this scope.
         let key_bytes: [u8; KEY_SIZE] = *key;
 
         let (progress_tx, progress_rx) = watch::channel(MigrationProgress {
@@ -315,7 +330,7 @@ mod tests {
         assert!(vault.master_key().await.is_some());
 
         // Lock
-        let _rx = vault.lock().await.unwrap();
+        let _rx = vault.lock("test-password").await.unwrap();
         // Wait for lock to complete
         loop {
             if vault.state().await == VaultState::Locked {
@@ -369,7 +384,7 @@ mod tests {
         let vault = VaultManager::new(dir.path().to_path_buf());
         vault.setup("pw").await.unwrap();
 
-        let _rx = vault.lock().await.unwrap();
+        let _rx = vault.lock("pw").await.unwrap();
         loop {
             if vault.state().await == VaultState::Locked {
                 break;
@@ -378,13 +393,13 @@ mod tests {
         }
 
         // Double lock should error
-        assert!(matches!(vault.lock().await, Err(VaultError::AlreadyLocked)));
+        assert!(matches!(vault.lock("pw").await, Err(VaultError::AlreadyLocked)));
     }
 
     #[tokio::test]
     async fn test_lock_without_setup_errors() {
         let dir = tempfile::tempdir().unwrap();
         let vault = VaultManager::new(dir.path().to_path_buf());
-        assert!(matches!(vault.lock().await, Err(VaultError::NotSetUp)));
+        assert!(matches!(vault.lock("pw").await, Err(VaultError::NotSetUp)));
     }
 }

--- a/crates/screenpipe-vault/src/manager.rs
+++ b/crates/screenpipe-vault/src/manager.rs
@@ -119,6 +119,10 @@ impl VaultManager {
     ///
     /// The caller MUST stop recording and close the DB pool BEFORE calling this.
     /// Returns a progress receiver for UI display.
+    ///
+    /// `password` is only consulted when the master key is not already in
+    /// memory (e.g. lock invoked from a separate CLI process). If the key is
+    /// loaded, the password argument is ignored.
     pub async fn lock(&self, password: &str) -> VaultResult<watch::Receiver<MigrationProgress>> {
         let state = self.state.read().await.clone();
         match state {
@@ -401,5 +405,51 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let vault = VaultManager::new(dir.path().to_path_buf());
         assert!(matches!(vault.lock("pw").await, Err(VaultError::NotSetUp)));
+    }
+
+    // Regression test for the bug fixed in PR #3585: `vault lock` failed with
+    // "master key not in memory" when invoked as a separate CLI process,
+    // because that process built a fresh VaultManager with no key loaded.
+    // Pre-fix this scenario errored out; post-fix it derives the key from the
+    // supplied password.
+    #[tokio::test]
+    async fn test_lock_derives_key_from_password() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_dir = dir.path().join("data");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::write(data_dir.join("test.jpg"), b"fake jpeg data").unwrap();
+        std::fs::write(dir.path().join("db.sqlite"), b"fake sqlite data").unwrap();
+
+        // First manager: set up the vault, then drop it so the in-memory key
+        // is gone.
+        let vault = VaultManager::new(dir.path().to_path_buf());
+        vault.setup("correct-password").await.unwrap();
+        drop(vault);
+
+        // Second manager: simulates a separate CLI invocation. vault.meta
+        // exists, no sentinel, db.sqlite is not encrypted -> state is Unlocked
+        // but master_key is None. This is the exact pre-fix failure mode.
+        let vault = VaultManager::new(dir.path().to_path_buf());
+        assert_eq!(vault.state().await, VaultState::Unlocked);
+        assert!(vault.master_key().await.is_none());
+
+        // Wrong password -> WrongPassword, state unchanged.
+        assert!(matches!(
+            vault.lock("wrong-password").await,
+            Err(VaultError::WrongPassword)
+        ));
+        assert_eq!(vault.state().await, VaultState::Unlocked);
+
+        // Correct password -> lock succeeds.
+        let _rx = vault.lock("correct-password").await.unwrap();
+        loop {
+            if vault.state().await == VaultState::Locked {
+                break;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        }
+        assert!(dir.path().join(".vault_locked").exists());
+        assert!(crypto::is_encrypted_file(&dir.path().join("db.sqlite")).unwrap());
+        assert!(crypto::is_encrypted_file(&data_dir.join("test.jpg")).unwrap());
     }
 }


### PR DESCRIPTION
## Summary

- `vault lock` failed with "master key not in memory" when run as a separate CLI invocation (each process creates a fresh `VaultManager` with no key loaded)
- `lock()` now accepts a password parameter and re-derives the key from `vault.meta` when it isn't already in memory
- Updated the HTTP route (`POST /vault/lock`) to also require a password in the request body
- CLI `vault lock` first tries the running daemon (via HTTP) so it can lock cleanly while owning the DB pool; falls back to direct file-level lock if the daemon is unreachable, so locking remains guaranteed
- Added `--port` flag to `vault lock` (default 3030) to match the daemon's `--port`

## Test plan

- [x] `cargo test -p screenpipe-vault` — all 10 tests pass
- [x] `cargo check -p screenpipe-engine` — compiles cleanly
- [x] Manual: `screenpipe vault setup` → `screenpipe vault lock` → `screenpipe vault unlock` → `screenpipe vault lock` (all in separate invocations)