### PR TITLE
fix desktop login url

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -1377,7 +1377,7 @@ pub async fn open_login_window(app_handle: tauri::AppHandle) -> Result<(), Strin
         use tauri_plugin_opener::OpenerExt;
         app_handle
             .opener()
-            .open_url("https://screenpi.pe/login", None::<&str>)
+            .open_url("https://screenpipe.com/login", None::<&str>)
             .map_err(|e| e.to_string())?;
         return Ok(());
     }
@@ -1398,7 +1398,7 @@ pub async fn open_login_window(app_handle: tauri::AppHandle) -> Result<(), Strin
 
         let app_for_nav = app_handle.clone();
 
-        const LOGIN_URL: &str = "https://screenpi.pe/login";
+        const LOGIN_URL: &str = "https://screenpipe.com/login";
         let mut builder = WebviewWindowBuilder::new(
             &app_handle,
             label,


### PR DESCRIPTION
## Summary
- Updates the desktop login window URL from `https://screenpi.pe/login` to `https://screenpipe.com/login`.
- Applies the same canonical login URL to both the external-browser fallback and the embedded login webview path.

## Why
The desktop app still pointed login flows at the old `screenpi.pe` domain. This caused the below state for users
<img width="1220" height="827" alt="Screenshot 2026-05-25 at 2 00 36 PM" src="https://github.com/user-attachments/assets/f838f489-563c-49d3-abf8-fc6d9262e882" />



