### PR TITLE
fix(pipes): unify auth env var to SCREENPIPE_LOCAL_API_KEY & schedule pipe 403 error

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -645,7 +645,7 @@ Never POST, PUT, or PATCH to a connection proxy unless the user explicitly asks 
 
 # Local server auth
 
-The local screenpipe server (localhost:3030) requires a bearer token, exposed as env var SCREENPIPE_API_AUTH_KEY. Every curl to localhost:3030 must include \`-H "Authorization: Bearer $SCREENPIPE_API_AUTH_KEY"\`. Don't ask the user for a key — you already have it. On 401, retry without the header (auth is disabled on that install).
+The local screenpipe server (localhost:3030) requires a bearer token, exposed as env var SCREENPIPE_LOCAL_API_KEY. Every curl to localhost:3030 must include \`-H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY"\`. Don't ask the user for a key — you already have it. On 401, retry without the header (auth is disabled on that install).
 
 # Search rules (DB has 600k+ rows)
 
@@ -703,7 +703,7 @@ function buildConnectionsContext(
   const entries = withDesc
     .map((c) => `## ${c.name} (${c.id})\n${c.description}`)
     .join("\n\n");
-  return `\n\n# Connected integrations\n\nThe user has connected the following external services. Use the endpoints listed under each to fetch live data when relevant. All endpoints are on http://localhost:3030 and require \`-H "Authorization: Bearer $SCREENPIPE_API_AUTH_KEY"\`.\n\n${entries}`;
+  return `\n\n# Connected integrations\n\nThe user has connected the following external services. Use the endpoints listed under each to fetch live data when relevant. All endpoints are on http://localhost:3030 and require \`-H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY"\`.\n\n${entries}`;
 }
 
 interface SearchResult {
@@ -1234,11 +1234,12 @@ function friendlyToolLabel(toolCall: ToolCall): string {
       if (result) return result.label;
       // Fallback for non-API curls / arbitrary shell — strip the auth-header
       // boilerplate so the truncation surfaces the meaningful tail, not the
-      // 80-char "-H Authorization: Bearer $SCREENPIPE_API_AUTH_KEY" header.
+      // 80-char "-H Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" header.
+      // Matches both the canonical and deprecated alias name.
       const stripped = cmd
         .replace(/^\s*curl\s+/, "curl ")
         .replace(/\s-s\s+/g, " ")
-        .replace(/\s-H\s+['"]Authorization:\s*Bearer\s+\$?SCREENPIPE_API_AUTH_KEY['"]\s*/g, " ")
+        .replace(/\s-H\s+['"]Authorization:\s*Bearer\s+\$?SCREENPIPE_(LOCAL_API|API_AUTH)_KEY['"]\s*/g, " ")
         .replace(/\s-H\s+['"]Content-Type:\s*application\/json['"]\s*/g, " ")
         .replace(/\s+/g, " ")
         .trim();

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
@@ -445,7 +445,7 @@ export function buildMeetingSummarizeInstructions(
     `fallback transcript source: /search?content_type=audio for the meeting time window. audio rows use content.transcription (not content.text); content.text may be missing for audio and should not be treated as an empty transcript.`,
     `if your summary is worth saving, append it to the meeting note (and refresh the title in the same call) via:`,
     `  curl -s -X PATCH "http://localhost:3030/meetings/${meetingId}" \\`,
-    `    -H "Authorization: Bearer $SCREENPIPE_API_AUTH_KEY" \\`,
+    `    -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" \\`,
     `    -H "Content-Type: application/json" \\`,
     `    -d '{"title": "<NEW_TITLE_OR_OMIT>", "note": "<EXISTING_NOTE>\\n\\n## Summary\\n<YOUR_SUMMARY>"}'`,
     `replace <EXISTING_NOTE> with the meeting's current notes (shown above as "notes:" — empty string if none) so you don't overwrite the user's work; just append your summary under a "## Summary" heading. for the title: if the current "title:" is missing, generic ("untitled", "meeting", just the app name) or doesn't capture what actually happened, replace it with a 5-8 word plain-english title (no quotes, no "meeting about…" prefix) — otherwise omit the field so a user-set title is left alone. if there's nothing useful to summarize (empty transcript, irrelevant audio), say so out loud and skip the PATCH — don't write a placeholder.`,

--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/mcp-bridge.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/mcp-bridge.ts
@@ -14,7 +14,10 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const API_BASE = `http://localhost:${process.env.SCREENPIPE_PORT || 3030}/mcp-servers`;
-const AUTH_KEY = process.env.SCREENPIPE_API_AUTH_KEY || "";
+const AUTH_KEY =
+  process.env.SCREENPIPE_LOCAL_API_KEY ||
+  process.env.SCREENPIPE_API_AUTH_KEY || // deprecated alias, drop next release
+  "";
 
 function authHeaders(): Record<string, string> {
   return AUTH_KEY

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -1541,10 +1541,14 @@ pub async fn pi_start_inner(
         }
     }
 
-    // Pass the screenpipe API auth key so mcp-bridge.ts can authenticate
-    // its GET /mcp-servers calls (returns 403 without this).
+    // Backstop: if local_api_context_from_app couldn't resolve a key earlier
+    // (line ~1477) but the disk-backed store has one, set it here so
+    // mcp-bridge.ts can authenticate its GET /mcp-servers calls. Sets the
+    // canonical name + the deprecated alias for old pipe.md files on disk.
+    // TODO(remove next release): drop SCREENPIPE_API_AUTH_KEY alias.
     if let Some(key) = crate::store::resolved_api_auth_key() {
-        cmd.env("SCREENPIPE_API_AUTH_KEY", key);
+        cmd.env("SCREENPIPE_LOCAL_API_KEY", &key);
+        cmd.env("SCREENPIPE_API_AUTH_KEY", key); // deprecated alias
     }
 
     // Spawn process

--- a/crates/screenpipe-core/assets/extensions/mcp-bridge.ts
+++ b/crates/screenpipe-core/assets/extensions/mcp-bridge.ts
@@ -14,7 +14,10 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 const API_BASE = `http://localhost:${process.env.SCREENPIPE_PORT || 3030}/mcp-servers`;
-const AUTH_KEY = process.env.SCREENPIPE_API_AUTH_KEY || "";
+const AUTH_KEY =
+  process.env.SCREENPIPE_LOCAL_API_KEY ||
+  process.env.SCREENPIPE_API_AUTH_KEY || // deprecated alias, drop next release
+  "";
 
 function authHeaders(): Record<string, string> {
   return AUTH_KEY

--- a/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
@@ -21,7 +21,7 @@ read the screenpipe skill first so you know the meetings + search endpoints.
 
 step 1 — find the meeting that just ended:
 
-  curl -s -H "Authorization: Bearer $SCREENPIPE_API_AUTH_KEY" \
+  curl -s -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" \
     "http://localhost:3030/meetings?limit=1"
 
 the most recent row is the one that just ended. capture its `id`, `meeting_start`, `meeting_end`, `title`, `note`, `meeting_app`, and `attendees`.
@@ -31,7 +31,7 @@ step 2 — search screenpipe for what happened during this meeting and summarize
 step 3 — if your summary is worth saving, append it to the meeting note (and refresh the title in the same call) via:
 
   curl -s -X PATCH "http://localhost:3030/meetings/<MEETING_ID>" \
-    -H "Authorization: Bearer $SCREENPIPE_API_AUTH_KEY" \
+    -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" \
     -H "Content-Type: application/json" \
     -d '{"title": "<NEW_TITLE_OR_OMIT>", "note": "<EXISTING_NOTE>\n\n## Summary\n<YOUR_SUMMARY>"}'
 

--- a/crates/screenpipe-core/src/agents/bash_env.rs
+++ b/crates/screenpipe-core/src/agents/bash_env.rs
@@ -20,11 +20,12 @@
 //! wrapper is in scope for every tool invocation the agent issues. No
 //! model effort, no prompt changes, no new system-prompt lines.
 //!
-//! The wrapper falls back to `$SCREENPIPE_API_AUTH_KEY` as a second name
-//! because the app spawn path exports `SCREENPIPE_LOCAL_API_KEY` but the
-//! core pipe-executor spawn path historically exports `SCREENPIPE_API_AUTH_KEY`
-//! for the same value. Accepting both here means we don't have to migrate
-//! the env-var name in a single PR.
+//! Reads `$SCREENPIPE_LOCAL_API_KEY` only — every spawn path (Tauri chat,
+//! core pipe-executor) is now contractually required to export it.
+//! `SCREENPIPE_API_AUTH_KEY` was a historical second name from when the two
+//! spawn paths diverged; spawn paths still export it as a deprecated alias
+//! for one release so user-installed pipe.md files that hardcode the old
+//! name keep working, but new shim code reads the canonical name only.
 
 use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
@@ -59,8 +60,8 @@ pub const WRAPPER_SCRIPT: &str = r#"# screenpipe — auto-injected by pi-agent b
 unset SCREENPIPE_API_KEY
 
 _sp_auth_key() {
-  # accept either name so we don't depend on which spawn path set it
-  printf '%s' "${SCREENPIPE_LOCAL_API_KEY:-${SCREENPIPE_API_AUTH_KEY:-}}"
+  # spawn paths guarantee SCREENPIPE_LOCAL_API_KEY is set (see pi.rs).
+  printf '%s' "${SCREENPIPE_LOCAL_API_KEY:-}"
 }
 
 curl() {
@@ -188,9 +189,15 @@ mod tests {
     }
 
     #[test]
-    fn wrapper_script_contains_both_env_var_names() {
+    fn wrapper_script_reads_canonical_env_var_name() {
         assert!(WRAPPER_SCRIPT.contains("SCREENPIPE_LOCAL_API_KEY"));
-        assert!(WRAPPER_SCRIPT.contains("SCREENPIPE_API_AUTH_KEY"));
+        // The deprecated alias must NOT be referenced here — every spawn
+        // path now guarantees the canonical name is set, and reading both
+        // hides bugs where a new spawn path forgets the canonical export.
+        assert!(
+            !WRAPPER_SCRIPT.contains("SCREENPIPE_API_AUTH_KEY"),
+            "shim must read only the canonical env var name"
+        );
     }
 
     #[test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -105,8 +105,10 @@ pub struct PiExecutor {
     /// Screenpipe API base URL (default: `https://api.screenpipe.com/v1`).
     pub api_url: String,
     /// Bearer token for the *local* screenpipe-server API (localhost:3030).
-    /// Exposed to the Pi subprocess as `SCREENPIPE_API_AUTH_KEY` so bash tool
-    /// calls against the local server can authenticate. None = auth disabled.
+    /// Exposed to the Pi subprocess as `SCREENPIPE_LOCAL_API_KEY` so bash/TS
+    /// pipe code can authenticate against the local server. `SCREENPIPE_API_AUTH_KEY`
+    /// is also exported as a deprecated alias (one release) for old pipe.md
+    /// files on disk. None = auth disabled.
     pub api_auth_key: Option<String>,
 }
 
@@ -825,8 +827,14 @@ impl PiExecutor {
             }
         }
 
+        // Canonical name: SCREENPIPE_LOCAL_API_KEY. The AUTH_KEY alias is
+        // kept ONE release as a deprecated fallback for user-installed
+        // pipe.md files that hardcoded the old name (e.g. an older
+        // meeting-summary install on disk that install_builtin_pipes won't
+        // overwrite). TODO(remove next release): drop SCREENPIPE_API_AUTH_KEY.
         if let Some(ref key) = self.api_auth_key {
-            cmd.env("SCREENPIPE_API_AUTH_KEY", key);
+            cmd.env("SCREENPIPE_LOCAL_API_KEY", key);
+            cmd.env("SCREENPIPE_API_AUTH_KEY", key); // deprecated alias
         }
 
         // Auto-auth the agent's `curl localhost:3030/...` calls via a bash
@@ -943,8 +951,10 @@ impl PiExecutor {
             }
         }
 
+        // See spawn_pi above — TODO(remove next release): drop the deprecated alias.
         if let Some(ref key) = self.api_auth_key {
-            cmd.env("SCREENPIPE_API_AUTH_KEY", key);
+            cmd.env("SCREENPIPE_LOCAL_API_KEY", key);
+            cmd.env("SCREENPIPE_API_AUTH_KEY", key); // deprecated alias
         }
 
         // Auto-auth the agent's `curl localhost:3030/...` calls via a bash

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -1362,12 +1362,15 @@ impl PipeManager {
         self.api_port
     }
 
-    /// Set the local API auth key. Injected into pipe subprocesses as
-    /// `SCREENPIPE_LOCAL_API_KEY` so they can authenticate to localhost.
-    ///
-    /// Sets it as a process-level env var so child processes inherit it
-    /// automatically via cmd.spawn(). Called once during initialization
-    /// before any async tasks are spawned.
+    /// Set the local API auth key. Stored on the manager so it can be
+    /// plumbed into `render_pipe_system_prompt` (so the prompt's
+    /// "auth required" note matches reality), and also mirrored into
+    /// the process env so in-process consumers (the privacy-filter
+    /// tinfoil adapters, which read env on construction) pick it up
+    /// without a second wiring path. The pipe-subprocess env is set
+    /// directly on each child cmd in `agents/pi.rs` — it does NOT
+    /// rely on inheriting this process-level set_var.
+    /// Called once during initialization before any async tasks spawn.
     pub fn set_local_api_key(&mut self, key: Option<String>) {
         self.local_api_key = key.clone();
         if let Some(ref k) = key {
@@ -1929,6 +1932,7 @@ impl PipeManager {
             self.api_port,
             preset_prompt.as_deref(),
             self.connections_context.as_deref(),
+            self.local_api_key.as_deref(),
         );
         let prompt = self.render_prompt(&config, &body, preset_prompt.as_deref());
         let pipe_name = name.to_string();
@@ -2418,6 +2422,7 @@ impl PipeManager {
                 self.api_port,
                 preset_prompt.as_deref(),
                 self.connections_context.as_deref(),
+                self.local_api_key.as_deref(),
             );
             let prompt = self.render_prompt(&config, &body, preset_prompt.as_deref());
 
@@ -3167,7 +3172,7 @@ impl PipeManager {
         let token_registry = self.token_registry.clone();
         let extra_context = self.extra_context.clone();
         let connections_context = self.connections_context.clone();
-        let _local_api_key = self.local_api_key.clone();
+        let local_api_key = self.local_api_key.clone();
 
         let handle = tokio::spawn(async move {
             info!("pipe scheduler started (generation {})", generation);
@@ -3534,6 +3539,7 @@ impl PipeManager {
                         api_port,
                         preset_prompt.as_deref(),
                         connections_context.as_deref(),
+                        local_api_key.as_deref(),
                     );
                     let prompt = render_prompt_with_port(
                         config,
@@ -4146,6 +4152,7 @@ fn render_pipe_system_prompt(
     api_port: u16,
     system_prompt: Option<&str>,
     connections_context: Option<&str>,
+    local_api_key: Option<&str>,
 ) -> String {
     let os = std::env::consts::OS;
     let mut sys = String::new();
@@ -4156,7 +4163,10 @@ fn render_pipe_system_prompt(
         sys.push_str("\n\n");
     }
 
-    let api_auth_note = if std::env::var("SCREENPIPE_LOCAL_API_KEY").is_ok() {
+    // Pass the key explicitly instead of reading the parent's process env —
+    // the parent env is only populated via the `set_local_api_key` side-effect
+    // and may be empty when api_auth_key was resolved late or never set.
+    let api_auth_note = if local_api_key.is_some() {
         "\nAPI Authentication: REQUIRED. Add `-H \"Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY\"` to ALL curl requests to the Screenpipe API. The env var is already set in your environment.\n"
     } else {
         ""
@@ -5272,7 +5282,7 @@ mod tests {
         assert!(prompt.contains("Time range:"));
         assert!(prompt.contains("Do the work described above now."));
         // Port / body go into system prompt, not user prompt
-        let sys = render_pipe_system_prompt("body text", 3031, None, None);
+        let sys = render_pipe_system_prompt("body text", 3031, None, None, None);
         assert!(sys.contains("http://localhost:3031"));
         assert!(!sys.contains("http://localhost:3030"));
         assert!(sys.contains("body text"));
@@ -5299,7 +5309,7 @@ mod tests {
             privacy_filter: false,
             trigger: None,
         };
-        let sys = render_pipe_system_prompt("hello", 3030, None, None);
+        let sys = render_pipe_system_prompt("hello", 3030, None, None, None);
         assert!(sys.contains("http://localhost:3030"));
     }
 
@@ -5324,8 +5334,13 @@ mod tests {
             privacy_filter: false,
             trigger: None,
         };
-        let sys =
-            render_pipe_system_prompt("body text", 3030, Some("You are a helpful assistant"), None);
+        let sys = render_pipe_system_prompt(
+            "body text",
+            3030,
+            Some("You are a helpful assistant"),
+            None,
+            None,
+        );
         assert!(sys.starts_with("You are a helpful assistant\n\n"));
         assert!(sys.contains("body text"));
         assert!(sys.contains("http://localhost:3030"));
@@ -5352,16 +5367,38 @@ mod tests {
             privacy_filter: false,
             trigger: None,
         };
-        let sys = render_pipe_system_prompt("body text", 3030, None, None);
+        let sys = render_pipe_system_prompt("body text", 3030, None, None, None);
         assert!(!sys.contains("System prompt:"));
         assert!(sys.contains("body text"));
     }
 
     #[test]
     fn test_system_prompt_contains_anti_recursion_warning() {
-        let sys = render_pipe_system_prompt("task body", 3030, None, None);
+        let sys = render_pipe_system_prompt("task body", 3030, None, None, None);
         assert!(sys.contains("NEVER run `screenpipe pipe run`"));
         assert!(sys.contains("You ARE this pipe"));
+    }
+
+    #[test]
+    fn test_system_prompt_emits_auth_note_when_local_api_key_present() {
+        // Pass the key explicitly — the renderer must not depend on parent
+        // process env (which is empty in tests and was the root cause of the
+        // 403 reported by the security-requests-grc pipe in prod).
+        let sys = render_pipe_system_prompt("task body", 3030, None, None, Some("sp-test-key"));
+        assert!(
+            sys.contains("API Authentication: REQUIRED"),
+            "auth note must be emitted when local_api_key is Some"
+        );
+        assert!(sys.contains("SCREENPIPE_LOCAL_API_KEY"));
+    }
+
+    #[test]
+    fn test_system_prompt_omits_auth_note_when_no_key() {
+        let sys = render_pipe_system_prompt("task body", 3030, None, None, None);
+        assert!(
+            !sys.contains("API Authentication: REQUIRED"),
+            "auth note must not be emitted when local_api_key is None"
+        );
     }
 
     // -- PipeExecution / SchedulerState serde roundtrip ----------------------

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1147,9 +1147,10 @@ async fn main() -> anyhow::Result<()> {
     std::fs::create_dir_all(&pipes_dir).ok();
 
     let user_token = std::env::var("SCREENPIPE_API_KEY").ok();
-    let pi_executor = std::sync::Arc::new(screenpipe_core::agents::pi::PiExecutor::new(
-        user_token.clone(),
-    ));
+    let pi_executor = std::sync::Arc::new(
+        screenpipe_core::agents::pi::PiExecutor::new(user_token.clone())
+            .with_api_auth_key(config.api_auth_key.clone()),
+    );
 
     // Workflow event classifier — opt-in cloud feature. Polls recent activity
     // and emits `WorkflowEvent`s on the bus so pipes with `trigger.events`

--- a/crates/screenpipe-redact/src/adapters/tinfoil.rs
+++ b/crates/screenpipe-redact/src/adapters/tinfoil.rs
@@ -16,8 +16,9 @@
 //!
 //! 1. The explicit `api_key` on [`TinfoilConfig`] when constructed.
 //! 2. The `SCREENPIPE_PRIVACY_FILTER_API_KEY` env var.
-//! 3. The `SCREENPIPE_API_AUTH_KEY` env var (matches the convention
-//!    the rest of the codebase uses for screenpipe-cloud auth).
+//! 3. The `SCREENPIPE_LOCAL_API_KEY` env var (the local-API bearer the
+//!    rest of the codebase uses), with `SCREENPIPE_API_AUTH_KEY` honored
+//!    as a deprecated alias.
 //!
 //! If none is set, requests still go out un-authenticated — the
 //! adapter logs a warning at construction time so misconfiguration is
@@ -110,7 +111,8 @@ pub struct TinfoilConfig {
     /// `SCREENPIPE_PRIVACY_FILTER_REPO`, then [`DEFAULT_REPO`].
     pub repo: Option<String>,
     /// Bearer token for the enclave. Falls back through
-    /// `SCREENPIPE_PRIVACY_FILTER_API_KEY` and `SCREENPIPE_API_AUTH_KEY`.
+    /// `SCREENPIPE_PRIVACY_FILTER_API_KEY`, `SCREENPIPE_LOCAL_API_KEY`,
+    /// and `SCREENPIPE_API_AUTH_KEY` (deprecated alias).
     pub api_key: Option<String>,
     /// Per-request HTTP timeout. Default: 60s.
     pub timeout: Option<Duration>,
@@ -175,6 +177,7 @@ impl TinfoilRedactor {
         let api_key = cfg.api_key.or_else(|| {
             std::env::var("SCREENPIPE_PRIVACY_FILTER_API_KEY")
                 .ok()
+                .or_else(|| std::env::var("SCREENPIPE_LOCAL_API_KEY").ok())
                 .or_else(|| std::env::var("SCREENPIPE_API_AUTH_KEY").ok())
         });
 
@@ -455,6 +458,7 @@ mod tests {
     async fn no_api_key_means_no_auth() {
         // Make sure no env var is leaking in.
         std::env::remove_var("SCREENPIPE_PRIVACY_FILTER_API_KEY");
+        std::env::remove_var("SCREENPIPE_LOCAL_API_KEY");
         std::env::remove_var("SCREENPIPE_API_AUTH_KEY");
         let r = TinfoilRedactor::new(TinfoilConfig {
             enclave: Some("example.invalid".into()),

--- a/crates/screenpipe-redact/src/adapters/tinfoil_image.rs
+++ b/crates/screenpipe-redact/src/adapters/tinfoil_image.rs
@@ -80,8 +80,8 @@ pub struct TinfoilImageConfig {
     /// GitHub repo (`org/repo`) cross-checked via Sigstore. Falls back
     /// to `SCREENPIPE_PRIVACY_FILTER_REPO`, then [`DEFAULT_REPO`].
     pub repo: Option<String>,
-    /// Bearer token. Falls back to
-    /// `SCREENPIPE_PRIVACY_FILTER_API_KEY`, then `SCREENPIPE_API_AUTH_KEY`.
+    /// Bearer token. Falls back through `SCREENPIPE_PRIVACY_FILTER_API_KEY`,
+    /// `SCREENPIPE_LOCAL_API_KEY`, then `SCREENPIPE_API_AUTH_KEY` (deprecated alias).
     pub api_key: Option<String>,
     /// Per-request timeout. Default 30 s.
     pub timeout: Option<Duration>,
@@ -137,6 +137,7 @@ impl TinfoilImageRedactor {
         let api_key = cfg.api_key.or_else(|| {
             std::env::var("SCREENPIPE_PRIVACY_FILTER_API_KEY")
                 .ok()
+                .or_else(|| std::env::var("SCREENPIPE_LOCAL_API_KEY").ok())
                 .or_else(|| std::env::var("SCREENPIPE_API_AUTH_KEY").ok())
         });
 
@@ -373,6 +374,7 @@ mod tests {
     fn no_api_key_means_no_auth() {
         // Make sure no env var is leaking in.
         std::env::remove_var("SCREENPIPE_PRIVACY_FILTER_API_KEY");
+        std::env::remove_var("SCREENPIPE_LOCAL_API_KEY");
         std::env::remove_var("SCREENPIPE_API_AUTH_KEY");
         let r = TinfoilImageRedactor::new(cfg());
         assert!(!r.has_auth());


### PR DESCRIPTION
### Description:
PR #3591 unified the auth env var name to `SCREENPIPE_LOCAL_API_KEY` across all spawn paths. This PR is made on top of that.


https://github.com/user-attachments/assets/85a49c56-2723-4838-8815-4a0fcc75d827



Scheduled pipes were 403-ing against localhost:3030 because two spawn paths used different env var names for the same auth token: `SCREENPIPE_LOCAL_API_KEY` vs `SCREENPIPE_API_AUTH_KEY`. The system prompt's "API Authentication: REQUIRED" note was also silently dropped when the key resolved late, so the AI agent never knew it needed to authenticate. The CLI binary also had a gap where the auth key was never wired into the executor explicitly.

### What changed: 
All spawn paths now export SCREENPIPE_LOCAL_API_KEY as the canonical name. SCREENPIPE_API_AUTH_KEY is kept as deprecated alias for one release to avoid breaking existing user-installed pipe.md files on disk.

###Maintainer follow-up (next release): 
drop the SCREENPIPE_API_AUTH_KEY alias from all spawn paths and shims — search for TODO(remove next release) in the codebase.