### PR TITLE
fix(screenpipe-mcp): persist HTTP sessions after initialize

### DIFF
--- a/packages/screenpipe-mcp/src/http-server.test.ts
+++ b/packages/screenpipe-mcp/src/http-server.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  buildHttpServer,
   CliError,
   isAuthorized,
   isLoopbackRequest,
@@ -176,5 +177,82 @@ describe("isAuthorized", () => {
   it("is case-sensitive on the bearer value (constant-time compare)", () => {
     // Tokens are opaque random secrets; case sensitivity is correct.
     expect(isAuthorized(lan("Bearer SECRET"), "secret")).toBe(false);
+  });
+});
+
+describe("buildHttpServer", () => {
+  it("persists initialized sessions so tools/list works on the next request", async () => {
+    const server = buildHttpServer({
+      mcpPort: 0,
+      screenpipePort: 3030,
+      host: "127.0.0.1",
+      apiKey: "secret",
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected server.address() to return a bound port");
+    }
+
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    try {
+      const initResponse = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "vitest", version: "1.0.0" },
+          },
+        }),
+      });
+
+      expect(initResponse.status).toBe(200);
+      const sessionId = initResponse.headers.get("mcp-session-id");
+      expect(sessionId).toBeTruthy();
+      await initResponse.text();
+
+      const healthResponse = await fetch(`${baseUrl}/health`);
+      expect(healthResponse.status).toBe(200);
+      expect(await healthResponse.json()).toEqual({ status: "ok", sessions: 1 });
+
+      const toolsResponse = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-session-id": sessionId!,
+          "mcp-protocol-version": "2024-11-05",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+
+      expect(toolsResponse.status).toBe(200);
+      expect(await toolsResponse.text()).toContain('"name":"search_content"');
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    }
   });
 });

--- a/packages/screenpipe-mcp/src/http-server.ts
+++ b/packages/screenpipe-mcp/src/http-server.ts
@@ -337,13 +337,15 @@ export function buildHttpServer(config: CliConfig) {
         const server = createMcpServer(fetchAPI);
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => crypto.randomUUID(),
+          onsessioninitialized: (newSessionId) => {
+            sessions.set(newSessionId, { server, transport });
+          },
+          onsessionclosed: (closedSessionId) => {
+            sessions.delete(closedSessionId);
+          },
         });
 
         await server.connect(transport);
-
-        if (transport.sessionId) {
-          sessions.set(transport.sessionId, { server, transport });
-        }
         session = { server, transport };
       }
 


### PR DESCRIPTION
## Summary
- register HTTP MCP sessions via `onsessioninitialized` instead of reading `transport.sessionId` too early
- remove the eager `sessions.set(transport.sessionId, ...)` path that runs before the SDK assigns a session id
- add a regression test covering `initialize -> /health -> tools/list`

## Root cause
`StreamableHTTPServerTransport.sessionId` is assigned by the MCP SDK while handling the `initialize` request, not immediately after `server.connect(transport)`.

The old code attempted to persist the session right after `connect()`, so `transport.sessionId` was still unset and the session map stayed empty. The next `tools/list` request came back with the returned `mcp-session-id`, but the server could not find that session and routed the request through a fresh, uninitialized transport, which returned:

```json
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Server not initialized"},"id":null}
```

This also explains why `/health` kept reporting `sessions: 0` after a successful `initialize`.

## Fix
Use the transport lifecycle hooks provided by the SDK:
- `onsessioninitialized` to register `{ server, transport }` under the real session id
- `onsessionclosed` to remove closed sessions from the map

## Regression coverage
Added an end-to-end HTTP test that:
1. starts `buildHttpServer(...)` on an ephemeral port
2. sends `initialize`
3. verifies `/health` reports `sessions: 1`
4. sends `tools/list` with the same `mcp-session-id`
5. expects `200` and `search_content` in the response

## Verification
Ran locally in `packages/screenpipe-mcp`:
- `npm install --no-package-lock`
- `npx vitest run src/http-server.test.ts`
- `npx tsc --noEmit`
- `npm run build`

Also verified the built server manually:
- `initialize` returned `200` and an `mcp-session-id`
- `/health` returned `{"status":"ok","sessions":1}`
- `tools/list` returned `200` and included `search_content`
