### PR TITLE
fix(audio): quiet TCC-denied retry spam + stop ffmpeg-missing panics

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -1145,6 +1145,18 @@ pub async fn start_device_monitor(
                                     warn!("device check transient error (will retry): {e}");
                                     continue;
                                 }
+                                // User denied TCC (mic / screen capture / etc.) — the 2-second
+                                // monitor loop keeps trying, so without this branch every retry
+                                // hits Sentry. SCREENPIPE-CLI-S8: 4 users × ~50 events/wk of
+                                // identical "declined TCCs" noise. Warn (not Sentry) and let
+                                // the next tick try again so we pick up the moment the user
+                                // grants permission.
+                                if e_str.contains("declined TCCs")
+                                    || e_str.contains("Screen recording permission denied")
+                                {
+                                    warn!("device check: permission not granted (will retry): {e}");
+                                    continue;
+                                }
                                 error!("device check error: {e}");
                             }
                         }

--- a/crates/screenpipe-audio/src/utils/ffmpeg.rs
+++ b/crates/screenpipe-audio/src/utils/ffmpeg.rs
@@ -20,7 +20,20 @@ fn encode_single_audio(
 ) -> anyhow::Result<()> {
     debug!("Starting FFmpeg process");
 
-    let mut command = screenpipe_core::ffmpeg_cmd(find_ffmpeg_path().unwrap());
+    // SCREENPIPE-CLI-T0 / T5: the previous `.expect("Failed to spawn FFmpeg
+    // process")` panicked the worker thread (no bundled ffmpeg on Linux,
+    // user hasn't installed it). Same for find_ffmpeg_path().unwrap(),
+    // stdin.take().expect(), wait_with_output().unwrap(), and
+    // to_str().unwrap() — none should panic the recording pipeline. Return
+    // a clear error so the caller can log and skip the chunk instead.
+    let ffmpeg_path = find_ffmpeg_path()
+        .ok_or_else(|| anyhow::anyhow!("ffmpeg not found in PATH or bundled binaries — install ffmpeg (e.g. `apt install ffmpeg` / `brew install ffmpeg`) and restart"))?;
+
+    let output_path_str = output_path
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("output path is not valid UTF-8: {}", output_path.display()))?;
+
+    let mut command = screenpipe_core::ffmpeg_cmd(ffmpeg_path);
     command
         .args([
             "-hide_banner",
@@ -46,7 +59,7 @@ fn encode_single_audio(
             "+faststart", // Optimize for web streaming
             "-f",
             "mp4",
-            output_path.to_str().unwrap(),
+            output_path_str,
         ])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -62,16 +75,23 @@ fn encode_single_audio(
     debug!("FFmpeg command: {:?}", command);
 
     #[allow(clippy::zombie_processes)]
-    let mut ffmpeg = command.spawn().expect("Failed to spawn FFmpeg process");
+    let mut ffmpeg = command
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn FFmpeg process: {e}"))?;
     debug!("FFmpeg process spawned");
-    let mut stdin = ffmpeg.stdin.take().expect("Failed to open stdin");
+    let mut stdin = ffmpeg
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("Failed to open FFmpeg stdin"))?;
 
     stdin.write_all(data)?;
 
     debug!("Dropping stdin");
     drop(stdin);
     debug!("Waiting for FFmpeg process to exit");
-    let output = ffmpeg.wait_with_output().unwrap();
+    let output = ffmpeg
+        .wait_with_output()
+        .map_err(|e| anyhow::anyhow!("FFmpeg wait failed: {e}"))?;
     let status = output.status;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## what

Two unrelated audio-engine Sentry fixes, both small.

### SCREENPIPE-CLI-S8 — TCC-denied retry-loop spam

[device_monitor.rs:1131-1148](crates/screenpipe-audio/src/audio_manager/device_monitor.rs#L1131) runs \`start_device\` every 2s. The error handler already swallows \"already running\", \"not found\", and SCK \"callback never fired\" transients, but NOT \"declined TCCs\" — so every tick on a user who hasn't granted mic/screen permission hits \`error!\` and ships to Sentry.

- **before**: 4 users × ~50 events/wk of identical \"declined TCCs\" noise on current CLI builds
- **after**: warn-and-continue, same pattern as the existing \"callback never fired\" branch — pick up the moment the user grants permission

### SCREENPIPE-CLI-T0 + CLI-T5 — ffmpeg-missing panic (Linux)

[ffmpeg.rs::encode_single_audio](crates/screenpipe-audio/src/utils/ffmpeg.rs#L65) panicked via \`.expect(\"Failed to spawn FFmpeg process\")\` when ffmpeg wasn't in PATH (Linux build doesn't bundle it). Same with \`find_ffmpeg_path().unwrap()\`, \`output_path.to_str().unwrap()\`, \`stdin.take().expect()\`, \`wait_with_output().unwrap()\` — five panic sites in 30 lines.

- **before**: missing ffmpeg → worker thread panic → audio recording dies silently
- **after**: all five return \`Result\` with anyhow context that points at the install fix (\`apt install ffmpeg\` / \`brew install ffmpeg\`)

## test plan

- [x] \`cargo check -p screenpipe-audio\` clean
- [ ] manual: deny mic permission on macOS, watch logs — should see one warn per tick, no Sentry events
- [ ] manual: \`PATH= screenpipe record\` on Linux — should error gracefully, not panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)