### PR TITLE
Fix local media markdown links

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
@@ -66,4 +66,13 @@ describe("normalizeLocalMediaMarkdown", () => {
       "- When you were talking: ![](<\/Users/ansh/.screenpipe/data/System Audio (output)_2026-05-25_11-27-00.mp4>)",
     );
   });
+
+  it("wraps local media links that contain spaces and parentheses", () => {
+    const markdown =
+      "[play clip](/Users/ansh/.screenpipe/data/System Audio (output)_2026-05-25_11-27-00.mp4)";
+
+    expect(normalizeLocalMediaMarkdown(markdown)).toBe(
+      "[play clip](</Users/ansh/.screenpipe/data/System Audio (output)_2026-05-25_11-27-00.mp4>)",
+    );
+  });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
@@ -43,13 +43,13 @@ export function isMediaFilePath(path: string): boolean {
 
 export function normalizeLocalMediaMarkdown(text: string): string {
   return text.replace(
-    new RegExp(`!\\[([^\\]]*)\\]\\(((?:/[^\n\r]+?|[A-Z]:[\\\\/][^\n\r]+?)\\.(${MEDIA_EXTENSION_PATTERN}))\\)`, "gi"),
-    (_match, alt: string, path: string) => {
+    new RegExp(`(!?)\\[([^\\]]*)\\]\\(((?:/[^\n\r]+?|[A-Z]:[\\\\/][^\n\r]+?)\\.(${MEDIA_EXTENSION_PATTERN}))\\)`, "gi"),
+    (_match, sigil: string, alt: string, path: string) => {
       const trimmedPath = path.trim();
       if (trimmedPath.startsWith("<") && trimmedPath.endsWith(">")) {
-        return `![${alt}](${trimmedPath})`;
+        return `${sigil}[${alt}](${trimmedPath})`;
       }
-      return `![${alt}](<${trimmedPath.replace(/>/g, "%3E")}>)`;
+      return `${sigil}[${alt}](<${trimmedPath.replace(/>/g, "%3E")}>)`;
     },
   );
 }

--- a/crates/screenpipe-audio/src/utils/ffmpeg.rs
+++ b/crates/screenpipe-audio/src/utils/ffmpeg.rs
@@ -29,9 +29,9 @@ fn encode_single_audio(
     let ffmpeg_path = find_ffmpeg_path()
         .ok_or_else(|| anyhow::anyhow!("ffmpeg not found in PATH or bundled binaries — install ffmpeg (e.g. `apt install ffmpeg` / `brew install ffmpeg`) and restart"))?;
 
-    let output_path_str = output_path
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("output path is not valid UTF-8: {}", output_path.display()))?;
+    let output_path_str = output_path.to_str().ok_or_else(|| {
+        anyhow::anyhow!("output path is not valid UTF-8: {}", output_path.display())
+    })?;
 
     let mut command = screenpipe_core::ffmpeg_cmd(ffmpeg_path);
     command


### PR DESCRIPTION
## Summary

- wrap local media markdown links as well as images
- preserve existing image normalization behavior
- add a regression test for local media links with spaces and parentheses

## Changed area

- `apps/screenpipe-app-tauri/lib/utils/media-file-path.ts`
- `apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts`

## Validation

- `vet "wrap local media markdown links so chat attachments with spaces still render" --agentic --agent-harness claude`
- `node --experimental-strip-types --input-type=module <<'EOF' ... EOF`
- `git diff --check`

## Risk notes

- low risk: this only broadens the existing markdown normalization regex from image syntax to both image and link syntax
- existing image behavior stays covered and unchanged

## Skipped-test rationale

- `bunx vitest run lib/utils/media-file-path.test.ts` failed in this sandbox with `error: bun is unable to write files to tempdir: PermissionDenied`
- `bun run typecheck` failed for the same unrelated sandbox tempdir reason
