### PR TITLE
Fix desktop app missing system audio when following system defaults.

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use screenpipe_audio::audio_manager::builder::AudioManagerOptions;
+use screenpipe_audio::core::device::resolve_audio_devices_for_capture;
 use screenpipe_audio::core::engine::AudioTranscriptionEngine;
 use screenpipe_audio::meeting_detector::MeetingDetector;
 use screenpipe_audio::transcription::deepgram::{
@@ -322,8 +323,18 @@ async fn reconfigure_audio_manager(
             None
         };
 
+    let audio_devices = if config.disable_audio {
+        Vec::new()
+    } else {
+        resolve_audio_devices_for_capture(
+            &config.audio_devices,
+            config.use_system_default_audio,
+        )
+        .await
+    };
+
     let mut audio_manager_builder = config
-        .to_audio_manager_builder(server.data_path.clone(), config.audio_devices.clone())
+        .to_audio_manager_builder(server.data_path.clone(), audio_devices)
         .transcription_mode(config.transcription_mode.clone())
         .openai_compatible_config(openai_compatible_config);
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
@@ -12,9 +12,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use screenpipe_audio::core::device::{
-    default_input_device, default_output_device, parse_audio_device,
-};
+use screenpipe_audio::core::device::resolve_audio_devices_for_capture;
 use screenpipe_audio::core::engine::AudioTranscriptionEngine;
 use screenpipe_audio::transcription::stt::{
     OpenAICompatibleConfig, DEFAULT_OPENAI_COMPATIBLE_ENDPOINT, DEFAULT_OPENAI_COMPATIBLE_MODEL,
@@ -191,25 +189,17 @@ impl ServerCore {
         info!("Database initialized at {}", db_path);
 
         // --- Audio devices + manager (built but NOT started) ---
-        let mut audio_devices = Vec::new();
-        if !config.disable_audio {
-            if config.audio_devices.is_empty() {
-                if let Ok(input) = default_input_device() {
-                    audio_devices.push(input.to_string());
-                }
-                if let Ok(output) = default_output_device().await {
-                    audio_devices.push(output.to_string());
-                }
-            } else {
-                for d in &config.audio_devices {
-                    if let Ok(device) = parse_audio_device(d) {
-                        audio_devices.push(device.to_string());
-                    }
-                }
-            }
-            if audio_devices.is_empty() {
-                warn!("No audio devices available");
-            }
+        let audio_devices = if config.disable_audio {
+            Vec::new()
+        } else {
+            resolve_audio_devices_for_capture(
+                &config.audio_devices,
+                config.use_system_default_audio,
+            )
+            .await
+        };
+        if !config.disable_audio && audio_devices.is_empty() {
+            warn!("No audio devices available");
         }
 
         let openai_compatible_config =

--- a/crates/screenpipe-audio/src/audio_manager/builder.rs
+++ b/crates/screenpipe-audio/src/audio_manager/builder.rs
@@ -284,7 +284,6 @@ impl AudioManagerBuilder {
         }
 
         if !options.is_disabled && options.use_system_default_audio {
-            use crate::core::device::{parse_audio_device, DeviceType};
             let has_output = options.enabled_devices.iter().any(|name| {
                 parse_audio_device(name)
                     .map(|d| d.device_type == DeviceType::Output)

--- a/crates/screenpipe-audio/src/audio_manager/builder.rs
+++ b/crates/screenpipe-audio/src/audio_manager/builder.rs
@@ -11,7 +11,7 @@ use screenpipe_db::DatabaseManager;
 
 use crate::{
     core::{
-        device::{default_input_device, default_output_device},
+        device::{default_input_device, default_output_device, parse_audio_device, DeviceType},
         engine::AudioTranscriptionEngine,
     },
     meeting_detector::MeetingDetector,
@@ -281,6 +281,30 @@ impl AudioManagerBuilder {
                 );
             }
             options.enabled_devices = HashSet::from_iter(devices);
+        }
+
+        if !options.is_disabled && options.use_system_default_audio {
+            use crate::core::device::{parse_audio_device, DeviceType};
+            let has_output = options.enabled_devices.iter().any(|name| {
+                parse_audio_device(name)
+                    .map(|d| d.device_type == DeviceType::Output)
+                    .unwrap_or(false)
+            });
+            if !has_output {
+                if let Ok(output) = default_output_device().await {
+                    options.enabled_devices.insert(output.to_string());
+                }
+            }
+            let has_input = options.enabled_devices.iter().any(|name| {
+                parse_audio_device(name)
+                    .map(|d| d.device_type == DeviceType::Input)
+                    .unwrap_or(false)
+            });
+            if !has_input {
+                if let Ok(input) = default_input_device() {
+                    options.enabled_devices.insert(input.to_string());
+                }
+            }
         }
 
         Ok(options.clone())

--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -28,6 +28,22 @@ fn is_legacy_display_output(device_name: &str) -> bool {
     device_name.contains("Display") && device_name.contains("(output)")
 }
 
+/// True when an enabled device of `device_type` is actively recording.
+/// `enabled_devices` alone is not enough — a failed startup leaves the name
+/// enrolled but no stream running, which previously blocked output recovery.
+fn is_device_type_running(
+    device_manager: &DeviceManager,
+    enabled: &HashSet<String>,
+    device_type: DeviceType,
+) -> bool {
+    enabled.iter().any(|name| {
+        parse_audio_device(name)
+            .ok()
+            .filter(|d| d.device_type == device_type)
+            .is_some_and(|d| device_manager.is_running(&d))
+    })
+}
+
 use super::{AudioManager, AudioManagerStatus};
 
 /// Exponential backoff for output device recovery.
@@ -454,7 +470,9 @@ pub async fn start_device_monitor(
                         if let Ok(default_input) = default_input_device() {
                             let default_input_name = default_input.to_string();
                             let current = audio_manager.enabled_devices().await;
-                            let has_correct_input = current.contains(&default_input_name);
+                            let has_correct_input = parse_audio_device(&default_input_name)
+                                .ok()
+                                .is_some_and(|d| device_manager.is_running(&d));
 
                             if !has_correct_input {
                                 info!(
@@ -492,7 +510,9 @@ pub async fn start_device_monitor(
                         if let Ok(default_output) = default_output_device().await {
                             let default_output_name = default_output.to_string();
                             let current = audio_manager.enabled_devices().await;
-                            let has_correct_output = current.contains(&default_output_name);
+                            let has_correct_output = parse_audio_device(&default_output_name)
+                                .ok()
+                                .is_some_and(|d| device_manager.is_running(&d));
 
                             if !has_correct_output {
                                 info!(
@@ -728,11 +748,8 @@ pub async fn start_device_monitor(
                     {
                         let current_enabled = audio_manager.enabled_devices().await;
                         let user_disabled = audio_manager.user_disabled_devices().await;
-                        let has_input = current_enabled.iter().any(|name| {
-                            parse_audio_device(name)
-                                .map(|d| d.device_type == DeviceType::Input)
-                                .unwrap_or(false)
-                        });
+                        let has_input =
+                            is_device_type_running(&device_manager, &current_enabled, DeviceType::Input);
                         // Don't try to recover if user explicitly disabled all inputs
                         let all_inputs_user_disabled = !has_input && {
                             match default_input_device() {
@@ -807,11 +824,11 @@ pub async fn start_device_monitor(
                     {
                         let current_enabled = audio_manager.enabled_devices().await;
                         let user_disabled = audio_manager.user_disabled_devices().await;
-                        let has_output = current_enabled.iter().any(|name| {
-                            parse_audio_device(name)
-                                .map(|d| d.device_type == DeviceType::Output)
-                                .unwrap_or(false)
-                        });
+                        let has_output = is_device_type_running(
+                            &device_manager,
+                            &current_enabled,
+                            DeviceType::Output,
+                        );
                         // Don't try to recover if user explicitly disabled output
                         let output_user_disabled = !has_output && {
                             match default_output_device().await {

--- a/crates/screenpipe-audio/src/core/device.rs
+++ b/crates/screenpipe-audio/src/core/device.rs
@@ -759,6 +759,51 @@ pub async fn default_output_device() -> Result<AudioDevice> {
     }
 }
 
+/// Whether capture should ignore pinned device names and follow system defaults.
+pub fn should_resolve_to_system_default_audio(
+    configured: &[String],
+    use_system_default_audio: bool,
+) -> bool {
+    configured.is_empty()
+        || use_system_default_audio
+        || (configured.len() == 1 && configured[0].trim().eq_ignore_ascii_case("default"))
+}
+
+/// Resolve the audio device list used when starting or reconfiguring capture.
+///
+/// Matches the CLI engine behavior: when following system defaults (empty list,
+/// bare `"default"` sentinel, or `use_system_default_audio`), always enroll the
+/// current default input and output. Otherwise parse explicit device names.
+pub async fn resolve_audio_devices_for_capture(
+    configured: &[String],
+    use_system_default_audio: bool,
+) -> Vec<String> {
+    if should_resolve_to_system_default_audio(configured, use_system_default_audio) {
+        let mut devices = Vec::new();
+        if let Ok(input) = default_input_device() {
+            devices.push(input.to_string());
+        }
+        if let Ok(output) = default_output_device().await {
+            devices.push(output.to_string());
+        }
+        return devices;
+    }
+
+    let mut audio_devices = Vec::new();
+    for d in configured {
+        if d.trim().eq_ignore_ascii_case("default") {
+            continue;
+        }
+        match parse_audio_device(d) {
+            Ok(device) => audio_devices.push(device.to_string()),
+            Err(e) => {
+                tracing::warn!("skipping unparseable audio device '{}': {}", d, e);
+            }
+        }
+    }
+    audio_devices
+}
+
 /// Returns the Windows "Default Communications Device" (output) if it differs
 /// from the multimedia/console default. MS Teams, Zoom, etc. route call audio
 /// to the eCommunications endpoint, which is often a USB headset while the
@@ -840,5 +885,39 @@ mod windows_com_audio {
         }
 
         Ok(Some(name))
+    }
+}
+
+#[cfg(test)]
+mod resolve_audio_tests {
+    use super::should_resolve_to_system_default_audio;
+
+    #[test]
+    fn empty_config_uses_system_defaults() {
+        assert!(should_resolve_to_system_default_audio(&[], false));
+    }
+
+    #[test]
+    fn default_sentinel_uses_system_defaults() {
+        assert!(should_resolve_to_system_default_audio(
+            &["default".to_string()],
+            false
+        ));
+    }
+
+    #[test]
+    fn follow_system_default_flag_overrides_pinned_names() {
+        assert!(should_resolve_to_system_default_audio(
+            &["MacBook Pro Microphone (input)".to_string()],
+            true
+        ));
+    }
+
+    #[test]
+    fn pinned_devices_only_when_not_following_system_default() {
+        assert!(!should_resolve_to_system_default_audio(
+            &["MacBook Pro Microphone (input)".to_string()],
+            false
+        ));
     }
 }

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -17,7 +17,7 @@ use screenpipe_audio::core::device::{
     get_cpal_device_and_config, AudioDevice, DeviceType, MACOS_OUTPUT_AUDIO_DEVICE_NAME,
 };
 use screenpipe_audio::{
-    core::device::{default_input_device, default_output_device, parse_audio_device},
+    core::device::resolve_audio_devices_for_capture,
     meeting_detector::MeetingDetector,
 };
 use screenpipe_core::agents::AgentExecutor;
@@ -733,33 +733,18 @@ async fn main() -> anyhow::Result<()> {
         list_monitors().await
     };
 
-    let mut audio_devices = Vec::new();
+    let audio_devices = if config.disable_audio {
+        Vec::new()
+    } else {
+        resolve_audio_devices_for_capture(
+            &config.audio_devices,
+            config.use_system_default_audio,
+        )
+        .await
+    };
 
-    if !config.disable_audio {
-        if config.audio_devices.is_empty()
-            || config.use_system_default_audio
-            || config.audio_devices == vec!["default".to_string()]
-        {
-            // Use default devices
-            if let Ok(input_device) = default_input_device() {
-                audio_devices.push(input_device.to_string());
-            }
-            if let Ok(output_device) = default_output_device().await {
-                audio_devices.push(output_device.to_string());
-            }
-        } else {
-            // Use specified devices
-            for d in &config.audio_devices {
-                match parse_audio_device(d) {
-                    Ok(device) => audio_devices.push(device.to_string()),
-                    Err(e) => warn!("skipping unparseable audio device '{}': {}", d, e),
-                }
-            }
-        }
-
-        if audio_devices.is_empty() {
-            warn!("no audio devices available.");
-        }
+    if !config.disable_audio && audio_devices.is_empty() {
+        warn!("no audio devices available.");
     }
 
     let audio_devices_clone = audio_devices.clone();


### PR DESCRIPTION

# Description

Aligns Tauri audio startup and reconfiguration with the CLI engine’s default-device resolution. Fixes a regression where follow-system-default users could run with mic only and no system audio, and fixes output recovery silently skipping when System Audio was configured but never actually recording.

# Why

Consumer users on macOS (e.g. Zoom + AirPods) reported zero participant audio and sparse mic capture. Logs showed only the default input device recording; `System Audio (output)` never started. The CLI engine already resolved `audioDevices: ["default"]` and `useSystemDefaultAudio: true` to both input and output. The Tauri desktop path did not—it attempted to parse the bare `"default"` sentinel, dropped it, and often enrolled mic only. Separately, device recovery treated a name in `enabled_devices` as proof output was running, so a failed System Audio startup was never retried.

# What this does

Introduces `resolve_audio_devices_for_capture()` in `screenpipe-audio` and uses it in `server_core`, `capture_session`, and `screenpipe-engine` so desktop and CLI share the same rules: empty list, `"default"`, or `use_system_default_audio` → current default input plus default output (System Audio on macOS).

Updates the device monitor to decide input/output presence from `device_manager.is_running()`, not merely membership in `enabled_devices`. Initial sync uses the same check.

When `use_system_default_audio` is set, `AudioManagerBuilder` ensures both input and output types are enrolled even if persisted settings list only one.


<img width="1470" height="910" alt="Screenshot 2026-05-27 at 1 22 25 AM" src="https://github.com/user-attachments/assets/f79483a6-8394-4b44-bfa8-65a9cf908a6a" />


