### PR TITLE
style: cargo fmt screenpipe-audio + screenpipe-engine

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -748,8 +748,11 @@ pub async fn start_device_monitor(
                     {
                         let current_enabled = audio_manager.enabled_devices().await;
                         let user_disabled = audio_manager.user_disabled_devices().await;
-                        let has_input =
-                            is_device_type_running(&device_manager, &current_enabled, DeviceType::Input);
+                        let has_input = is_device_type_running(
+                            &device_manager,
+                            &current_enabled,
+                            DeviceType::Input,
+                        );
                         // Don't try to recover if user explicitly disabled all inputs
                         let all_inputs_user_disabled = !has_input && {
                             match default_input_device() {

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -17,8 +17,7 @@ use screenpipe_audio::core::device::{
     get_cpal_device_and_config, AudioDevice, DeviceType, MACOS_OUTPUT_AUDIO_DEVICE_NAME,
 };
 use screenpipe_audio::{
-    core::device::resolve_audio_devices_for_capture,
-    meeting_detector::MeetingDetector,
+    core::device::resolve_audio_devices_for_capture, meeting_detector::MeetingDetector,
 };
 use screenpipe_core::agents::AgentExecutor;
 use screenpipe_core::find_ffmpeg_path;
@@ -736,11 +735,8 @@ async fn main() -> anyhow::Result<()> {
     let audio_devices = if config.disable_audio {
         Vec::new()
     } else {
-        resolve_audio_devices_for_capture(
-            &config.audio_devices,
-            config.use_system_default_audio,
-        )
-        .await
+        resolve_audio_devices_for_capture(&config.audio_devices, config.use_system_default_audio)
+            .await
     };
 
     if !config.disable_audio && audio_devices.is_empty() {


### PR DESCRIPTION
## Summary

Followup to [#3631](https://github.com/screenpipe/screenpipe/pull/3631) (system audio default-follow fix), which landed without running `cargo fmt`. `Clippy & Format` has been red on the last two main commits (4a111e9, e828d30). Pure whitespace.

Affected:
- `crates/screenpipe-audio/src/audio_manager/device_monitor.rs:748`
- `crates/screenpipe-engine/src/bin/screenpipe-engine.rs:17,736`

## Test plan

- [x] `cargo fmt --all -- --check` clean after this commit
- [ ] Once merged, `Clippy & Format` on the new main commit should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)