### PR TITLE
build(windows): fail fast on SSL.com QuotaExceededError instead of burning 5 retries

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/sign-ssl.ps1
+++ b/apps/screenpipe-app-tauri/src-tauri/sign-ssl.ps1
@@ -105,19 +105,39 @@ while (-not $signed -and $attempt -lt $maxAttempts) {
     }
 
     Push-Location $env:CODESIGNTOOL_PATH
-    & $javaFile.FullName -jar $jarFile.FullName sign `
+    # Capture stdout+stderr so we can detect SSL.com QuotaExceededError
+    # and fail fast — burning 5 retries × exponential backoff (~7.5 min)
+    # on a quota wall is pure waste; the next attempt fails the same way.
+    # Recurring concretely on build 26478881028 (2026-05-26): both Windows
+    # targets hit QuotaExceededError on every attempt. Detect the error
+    # body shape `{"error":"server_error","error_description":"code:
+    # QuotaExceededError ..."}` and exit 1 immediately so the operator
+    # sees the actual ask (top up SSL.com or wait for monthly reset)
+    # instead of a generic "5 attempts failed".
+    $signOutput = & $javaFile.FullName -jar $jarFile.FullName sign `
         "-username=$env:ESIGNER_USERNAME" `
         "-password=$env:ESIGNER_PASSWORD" `
         "-totp_secret=$env:ESIGNER_TOTP_SECRET" `
         "-credential_id=$env:ESIGNER_CREDENTIAL_ID" `
         "-input_file_path=$FilePath" `
-        "-output_dir_path=$signedDir"
+        "-output_dir_path=$signedDir" 2>&1
     $signExit = $LASTEXITCODE
     Pop-Location
+
+    # Mirror output to the build log so we keep the existing visibility.
+    $signOutput | ForEach-Object { Write-Host $_ }
 
     if ($signExit -eq 0 -and (Test-Path $signedFile)) {
         $signed = $true
         break
+    }
+
+    $signOutputText = ($signOutput | Out-String)
+    if ($signOutputText -match "QuotaExceededError") {
+        Write-Host "ERROR: SSL.com signing quota exceeded — every retry will hit the same wall."
+        Write-Host "ERROR: Top up the account at https://www.ssl.com/dashboard or wait for the monthly quota reset, then re-run this workflow."
+        Write-Host "ERROR: Failed file: $FilePath"
+        exit 1
     }
     Write-Host "WARN: sign attempt $attempt failed (exit=$signExit, signed file present=$(Test-Path $signedFile))"
 }


### PR DESCRIPTION
## Why main release-app is red on Windows

Windows release builds on commit [e828d30](https://github.com/screenpipe/screenpipe/commit/e828d30) (and every subsequent push) are failing during code signing with:

```
{"error_description":"code: QuotaExceededError - message: Quota exceeded","error":"server_error"}
```

This is the **SSL.com EV signing account hitting its monthly quota**. Every retry hits the same wall, so the current 5-attempt exponential backoff burns ~7.5 min before failing with a generic *"all attempts failed"* message — making diagnosis painful.

## What this PR does

Captures the sign tool's stdout+stderr, scans for `QuotaExceededError`, and exits 1 **immediately** with the actionable ask:

> ERROR: SSL.com signing quota exceeded — every retry will hit the same wall.
> ERROR: Top up the account at https://www.ssl.com/dashboard or wait for the monthly quota reset, then re-run this workflow.

Doesn't fix the underlying quota issue (billing action, out of band) but unblocks the **diagnosis loop**: future quota-exhaustion builds fail in ~30s instead of ~7.5 min, with a log line pointing at the actual fix.

## What still needs to happen

**Out of band**: top up SSL.com or wait for the monthly quota reset. Until that's done, no Windows release will ship — the underlying problem isn't code.

## Test plan

- [x] Logs at job [77971302000](https://github.com/screenpipe/screenpipe/actions/runs/26478881028/job/77971302000) confirm the exact error string `QuotaExceededError`
- [x] PowerShell `2>&1` capture + `-match` regex is straightforward; no behaviour change on non-quota failures (still 5 retries)
- [ ] Next Windows release after a quota top-up should pass; if SSL.com is still over quota, the new error message appears in the first 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)