### PR TITLE
fix(windows): drop em-dashes from sign-ssl.ps1 quota path (PowerShell 5.1 breaks UTF-8 without BOM)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/sign-ssl.ps1
+++ b/apps/screenpipe-app-tauri/src-tauri/sign-ssl.ps1
@@ -134,7 +134,13 @@ while (-not $signed -and $attempt -lt $maxAttempts) {
 
     $signOutputText = ($signOutput | Out-String)
     if ($signOutputText -match "QuotaExceededError") {
-        Write-Host "ERROR: SSL.com signing quota exceeded — every retry will hit the same wall."
+        # ASCII only in this block: sign-ssl.ps1 is read by PowerShell 5.1
+        # on Windows runners with no BOM and an ANSI codepage. UTF-8
+        # multi-byte chars (em-dash, smart-quotes) mangle and break the
+        # parser at the first non-ASCII byte; the reported line number
+        # ends up far below the actual offending character. Stick to
+        # `-` and straight quotes here.
+        Write-Host "ERROR: SSL.com signing quota exceeded - every retry will hit the same wall."
         Write-Host "ERROR: Top up the account at https://www.ssl.com/dashboard or wait for the monthly quota reset, then re-run this workflow."
         Write-Host "ERROR: Failed file: $FilePath"
         exit 1


### PR DESCRIPTION
## Why Windows release is still red after quota top-up

PR [#3637](https://github.com/screenpipe/screenpipe/pull/3637) added a `QuotaExceededError` fast-fail block to `sign-ssl.ps1` with **em-dashes** (`—`, U+2014) in the error messages. Windows runners use PowerShell 5.1, which reads `.ps1` files with the system ANSI codepage when there's no BOM (the file has none). The em-dash is multi-byte UTF-8; ANSI tokenization mangles it and the parser throws:

```
At sign-ssl.ps1:142 char:67
+ ... ite-Host "WARN: sign attempt $attempt failed (exit=$signExit, signed  ...
+                                                                 ~
Missing argument in parameter list.
```

The reported line (142) is **misleading** — the actual offending character is at line 137 (em-dash). PowerShell's error recovery from the bad byte propagates forward.

Net effect: the just-topped-up SSL.com quota was never tested because the script wouldn't even load. The sign step exits 1 before talking to SSL.com.

## Fix

- Replace `—` with `-` in the new error messages.
- Add a comment at the block explaining the ASCII-only constraint so the next refactor doesn't re-introduce it.

Tested locally: `grep -n '[^[:print:][:space:]]' sign-ssl.ps1` returns nothing (no non-ASCII chars remain).

## Test plan

- [x] No non-ASCII bytes in the script (`grep` clean)
- [ ] Next Windows release picks up the fix and either (a) signs successfully against the newly-topped-up quota, or (b) hits the QuotaExceededError path in 30s with the actionable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)