### PR TITLE
fix(audio): use aggregate device's nominal sample rate for process tap

### DIFF
--- a/crates/screenpipe-audio/src/core/process_tap.rs
+++ b/crates/screenpipe-audio/src/core/process_tap.rs
@@ -247,13 +247,7 @@ fn build_capture(
     let asbd = tap
         .asbd()
         .map_err(|s| anyhow!("Failed to read tap format: {:?}", s))?;
-    let sample_rate = asbd.sample_rate;
     let channels = asbd.channels_per_frame as u16;
-    info!(
-        "Process Tap: {:.0} Hz, {} ch, {} bit",
-        sample_rate, channels, asbd.bits_per_channel
-    );
-    let config = AudioStreamConfig::new(sample_rate as u32, channels);
 
     let sub_device =
         cf::DictionaryOf::with_keys_values(&[sub_keys::uid()], &[output_uid.as_type_ref()]);
@@ -285,6 +279,22 @@ fn build_capture(
     );
     let agg_device = ca::AggregateDevice::with_desc(&agg_desc)
         .map_err(|s| anyhow!("Failed to create aggregate device: {:?}", s))?;
+
+    // Use the aggregate device's nominal sample rate, not the tap's asbd.
+    // The aggregate is anchored to the output device (e.g. headphones), and its
+    // rate reflects what's actually being delivered. When the output device runs
+    // at 96kHz (common for headphone DACs), asbd may still report 48kHz, causing
+    // the recording pipeline to interpret 1.44M samples as 30s @ 48kHz when
+    // they're actually 15s @ 96kHz — produces files that play at 2x slowmo.
+    let sample_rate = agg_device
+        .nominal_sample_rate()
+        .map(|r| r as f64)
+        .unwrap_or(asbd.sample_rate);
+    info!(
+        "Process Tap: {:.0} Hz (asbd reported {:.0} Hz), {} ch, {} bit",
+        sample_rate, asbd.sample_rate, channels, asbd.bits_per_channel
+    );
+    let config = AudioStreamConfig::new(sample_rate as u32, channels);
 
     let mut ctx = Box::new(TapCallbackCtx {
         tx,


### PR DESCRIPTION
## Summary

Process tap-based system audio capture produces files at the wrong sample rate when the output device runs at anything other than 48kHz (e.g. headphone DACs at 96kHz). Result: playback is 2x slow.

## Symptom

Reproduce on macOS with output device set to 96kHz (Audio MIDI Setup → output device → Format dropdown):
1. Record any system audio with the CoreAudio Process Tap path (`use_coreaudio_tap = true`)
2. Open the resulting `.mp4` from `~/.screenpipe/data/`
3. Audio plays back at 1/2 speed regardless of player (Finder Quick Look, the screenpipe app, ffplay, etc.)

The bad metadata is baked into the file. Switching back to a 48kHz output device produces correct files going forward — without our fix, recordings made while a non-48kHz device is active are permanently broken.

## Root cause

`process_tap.rs` reads `tap.asbd().sample_rate` to configure the recording pipeline. But for the CoreAudio process tap, the `asbd` reports the **tap's nominal format** (often 48kHz), not the **aggregate device's actual delivery rate**. The aggregate device is anchored to the output device — when that output is at 96kHz, samples arrive at 96kHz.

Evidence from a real session with 96kHz headphones:
```
Process Tap: 48000 Hz, 2 ch, 32 bit
[tap_io_proc] 187.5 callbacks/s over 10s, 1024 samples/call, peak_amp=0.35068, ch=2
```
- 187.5 callbacks × 1024 interleaved samples = 192,000 samples/sec
- ÷ 2 channels = 96,000 frames/sec
- → actual rate is 96kHz, not the 48kHz asbd reports

The mislabeling cascades:
- Recording loop accumulates `48000 * 30 = 1.44M` samples thinking it's 30 seconds
- Real elapsed time: 1.44M / 96000 = **15 seconds**
- Resampler called with `(from=48000, to=16000)` ratio 1/3 produces 480K samples
- File written as "30s of 16kHz audio" but the audio content is effectively at 32kHz
- Played at the labeled 16kHz → 2× slowmo

## Fix

Query `agg_device.nominal_sample_rate()` after the aggregate device is built. That reflects the rate the IO proc will actually deliver at. Fall back to `asbd.sample_rate` if the query fails so behavior is unchanged on devices where the rate already matches.

Also widens the existing INFO log to surface the discrepancy:
```
Process Tap: 96000 Hz (asbd reported 48000 Hz), 2 ch, 32 bit
```

## Test plan

Tested locally on M2 MacBook Pro with both output configurations:
- **External Headphones @ 96kHz** (broken before): new recordings now report `96000 Hz` and play at normal speed.
- **MacBook Pro Speakers @ 48kHz** (already worked): behavior unchanged; aggregate and asbd both 48kHz, no fallback triggered.

Verified end-to-end:
1. Set output to 96kHz in Audio MIDI Setup
2. Start screenpipe with CoreAudio Process Tap enabled
3. Record system audio
4. Confirm new `~/.screenpipe/data/*output*.mp4` files play at correct speed in Finder Quick Look

## Notes

- Pure runtime correctness fix — no API changes.
- The `nominal_sample_rate()` API is from `cidre 0.13.1` already in use elsewhere.
- Existing users on 48kHz output will see no behavioral change; users on non-48kHz output get correctly-encoded recordings going forward (does not retroactively fix files already on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)