### PR TITLE
fix(windows): unblock app updates when bundled Bun is still running

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
+++ b/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
@@ -1,8 +1,12 @@
 !macro NSIS_HOOK_PREINSTALL
-  ; Kill screenpipe processes before installation
-  nsExec::ExecToLog 'taskkill /F /IM screenpipe.exe'
-  nsExec::ExecToLog 'taskkill /F /IM screenpipe-app.exe'
-  ; Wait a moment for processes to fully terminate and release file handles
+  ; Kill screenpipe processes before installation.
+  nsExec::ExecToLog 'taskkill /F /T /IM screenpipe.exe'
+  nsExec::ExecToLog 'taskkill /F /T /IM screenpipe-app.exe'
+  ; Stop any remaining process running from this install directory, including
+  ; the bundled Bun sidecar. Use CIM ExecutablePath instead of Get-Process.Path:
+  ; reading process module paths can throw "Access to the path is denied".
+  nsExec::ExecToLog 'powershell -NoProfile -ExecutionPolicy Bypass -Command "$$root = [System.IO.Path]::GetFullPath(''$INSTDIR'').TrimEnd(''\'') + ''\''; Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) } | ForEach-Object { $$pidToStop = $$_.ProcessId; Stop-Process -Id $$pidToStop -Force -ErrorAction SilentlyContinue; Wait-Process -Id $$pidToStop -Timeout 5 -ErrorAction SilentlyContinue }"'
+  ; Wait a moment for processes to fully terminate and release file handles.
   Sleep 1000
 !macroend
 


### PR DESCRIPTION
### Description:

Fixes #3647 

Ensures the Windows installer closes Screenpipe-owned processes, including bundled Bun, before replacing app files during updates.

- Before:

<img width="610" height="446" alt="image" src="https://github.com/user-attachments/assets/ab382024-113d-4c0e-a994-de834e6d2b14" />

- After: 


https://github.com/user-attachments/assets/1fa2a859-2642-446a-a1da-e9082867df0b

