### PR TITLE
Fix branched chat sidebar/session sync

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -880,9 +880,30 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     const branchedMessages = messages.slice(0, msgIndex + 1);
     if (branchedMessages.length === 0) return;
 
+    const { useChatStore } = await import("@/lib/stores/chat-store");
+    const store = useChatStore.getState();
+    const outgoingSid = piSessionIdRef.current;
+    if (outgoingSid && store.sessions[outgoingSid]) {
+      const outgoingKind = store.sessions[outgoingSid].kind;
+      if (outgoingKind !== "pipe-watch") {
+        store.actions.snapshotSession(outgoingSid, {
+          messages: messages as any,
+          streamingText: piStreamingTextRef.current,
+          streamingMessageId: piMessageIdRef.current,
+          contentBlocks: [...piContentBlocksRef.current],
+          isStreaming,
+          isLoading,
+        });
+      }
+    }
+
     const newId = crypto.randomUUID();
     const firstUserMsg = branchedMessages.find((m) => m.role === "user");
     const title = (firstUserMsg?.content.slice(0, 47) || "Branched Chat") + "…";
+    const createdAt = Date.now();
+    const lastUserMessageAt = [...branchedMessages]
+      .reverse()
+      .find((m) => m.role === "user")?.timestamp;
 
     const conversation: ChatConversation = {
       id: newId,
@@ -910,6 +931,7 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
           ...(m.intent ? { intent: m.intent } : {}),
           ...(m.turnIntentId ? { turnIntentId: m.turnIntentId } : {}),
           timestamp: m.timestamp,
+          ...(m.displayContent ? { displayContent: m.displayContent } : {}),
           ...(blocks?.length ? { contentBlocks: blocks } : {}),
           ...(m.images?.length ? { images: m.images } : {}),
           ...(m.model ? { model: m.model } : {}),
@@ -918,12 +940,47 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
           ...(m.steeredResponse ? { steeredResponse: true } : {}),
         };
       }),
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
+      createdAt,
+      updatedAt: createdAt,
+      ...(lastUserMessageAt ? { lastUserMessageAt } : {}),
     };
 
     await saveConversationFile(conversation);
     await refreshFileConversations();
+
+    try {
+      store.actions.upsert({
+        id: newId,
+        title: conversation.title,
+        preview: "",
+        status: "idle",
+        messageCount: conversation.messages.length,
+        createdAt: conversation.createdAt,
+        updatedAt: conversation.updatedAt,
+        pinned: false,
+        hidden: false,
+        unread: false,
+        draft: false,
+        ...(conversation.lastUserMessageAt
+          ? { lastUserMessageAt: conversation.lastUserMessageAt }
+          : {}),
+      });
+      store.actions.setMessages(newId, conversation.messages as any);
+      store.actions.setCurrent(newId);
+      store.actions.setPanelSession(newId);
+    } catch (e) {
+      console.warn("[chat] failed to sync branched conversation to store:", e);
+    }
+
+    try {
+      await emit("chat-conversation-saved", {
+        id: conversation.id,
+        title: conversation.title,
+      });
+    } catch {
+      // ignore broadcast failures; local branch save already succeeded
+    }
+    emit("chat-current-session", { id: newId });
 
     // Switch to the branched conversation
     piSessionIdRef.current = newId;

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -898,8 +898,8 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     }
 
     const newId = crypto.randomUUID();
-    const firstUserMsg = branchedMessages.find((m) => m.role === "user");
-    const title = (firstUserMsg?.content.slice(0, 47) || "Branched Chat") + "…";
+    const currentTitle = store.sessions[outgoingSid]?.title?.trim();
+    const title = currentTitle || "Branched Chat";
     const createdAt = Date.now();
     const lastUserMessageAt = [...branchedMessages]
       .reverse()


### PR DESCRIPTION
This PR fixes the `Branch in new chat` flow so branching no longer breaks sidebar state.

Before this change, branching could create a new chat but fail to fully sync chat/session state across the UI. In practice that meant:
- the source chat could disappear from the sidebar after branching
- the branched chat might not appear immediately


Before -

https://github.com/user-attachments/assets/5920c21b-4c55-4b6d-b1b7-9d97a0fc403b

After - 

https://github.com/user-attachments/assets/98b4fb4e-3383-4e4f-a9e1-cf38d05091f3

After branching:
- the original/source chat stays in the sidebar
- the branched chat becomes the active chat
- the branch title matches the current chat title instead of odd values like `a...`

