### PR TITLE
Hide copy and more actions while assistant reply is streaming

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -8185,6 +8185,12 @@ export function StandaloneChat({
               const canEditMessage = message.role === "user" && !isSteerUserMessage && !isLoading;
               const canShowMessageActions = !item.showActionsWhenExpandedBy ||
                 expandedSteerWorkIds.has(item.showActionsWhenExpandedBy);
+              const isActiveStreamingAssistantMessage =
+                message.role === "assistant" &&
+                (isLoading || isStreaming) &&
+                message.id === activeSourceFooterMessageId;
+              const shouldShowMessageActionBar =
+                canShowMessageActions && !isActiveStreamingAssistantMessage;
               const nextAssistant = visibleMessages
                 .slice(messageIndex + 1)
                 .find((candidate) => candidate.role === "assistant");
@@ -8342,7 +8348,7 @@ export function StandaloneChat({
                 )}
               </div>
               )}
-              {!hideSupersededSteerBody && canShowMessageActions ? (
+              {!hideSupersededSteerBody && shouldShowMessageActionBar ? (
                 <>
                 {/* Action buttons - appear on hover, outside the message box */}
                 {editingMessageId !== message.id && (


### PR DESCRIPTION
This PR hides assistant message actions like Copy and More options while that assistant reply is still streaming.

### Changes

- detect when a message is the active streaming assistant message
- hide the message action bar for that message while streaming is in progress
- keep existing actions unchanged for completed assistant replies and user messages


After - 


https://github.com/user-attachments/assets/34cc95e6-42a2-4c57-a13e-0d064143f61c



Before - 

https://github.com/user-attachments/assets/a8c1148e-0a37-47c1-aa82-a8cdde9639e9

