### PR TITLE
Harden system-default audio enrollment and recovery liveness

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/builder.rs
+++ b/crates/screenpipe-audio/src/audio_manager/builder.rs
@@ -24,6 +24,46 @@ use crate::{
 
 use crate::audio_manager::AudioManager;
 
+/// When following system defaults, ensure both input and output types appear in
+/// `enabled_devices`. Skips enrolling the current default for a type the user
+/// has explicitly muted via tray/API (`user_disabled_devices`).
+pub(crate) async fn ensure_system_default_device_types(
+    options: &mut AudioManagerOptions,
+    user_disabled: &HashSet<String>,
+) {
+    if options.is_disabled || !options.use_system_default_audio {
+        return;
+    }
+
+    let has_output = options.enabled_devices.iter().any(|name| {
+        parse_audio_device(name)
+            .map(|d| d.device_type == DeviceType::Output)
+            .unwrap_or(false)
+    });
+    if !has_output {
+        if let Ok(output) = default_output_device().await {
+            let name = output.to_string();
+            if !user_disabled.contains(&name) {
+                options.enabled_devices.insert(name);
+            }
+        }
+    }
+
+    let has_input = options.enabled_devices.iter().any(|name| {
+        parse_audio_device(name)
+            .map(|d| d.device_type == DeviceType::Input)
+            .unwrap_or(false)
+    });
+    if !has_input {
+        if let Ok(input) = default_input_device() {
+            let name = input.to_string();
+            if !user_disabled.contains(&name) {
+                options.enabled_devices.insert(name);
+            }
+        }
+    }
+}
+
 /// Controls when Whisper transcription runs.
 #[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum TranscriptionMode {
@@ -283,28 +323,7 @@ impl AudioManagerBuilder {
             options.enabled_devices = HashSet::from_iter(devices);
         }
 
-        if !options.is_disabled && options.use_system_default_audio {
-            let has_output = options.enabled_devices.iter().any(|name| {
-                parse_audio_device(name)
-                    .map(|d| d.device_type == DeviceType::Output)
-                    .unwrap_or(false)
-            });
-            if !has_output {
-                if let Ok(output) = default_output_device().await {
-                    options.enabled_devices.insert(output.to_string());
-                }
-            }
-            let has_input = options.enabled_devices.iter().any(|name| {
-                parse_audio_device(name)
-                    .map(|d| d.device_type == DeviceType::Input)
-                    .unwrap_or(false)
-            });
-            if !has_input {
-                if let Ok(input) = default_input_device() {
-                    options.enabled_devices.insert(input.to_string());
-                }
-            }
-        }
+        ensure_system_default_device_types(options, &HashSet::new()).await;
 
         Ok(options.clone())
     }

--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -13,7 +13,9 @@ use tokio::{sync::Mutex, task::JoinHandle, time::sleep};
 use tracing::{debug, error, info, warn};
 
 use crate::{
-    core::device::{default_input_device, default_output_device, parse_audio_device, DeviceType},
+    core::device::{
+        default_input_device, default_output_device, parse_audio_device, AudioDevice, DeviceType,
+    },
     device::device_manager::DeviceManager,
 };
 
@@ -28,6 +30,21 @@ fn is_legacy_display_output(device_name: &str) -> bool {
     device_name.contains("Display") && device_name.contains("(output)")
 }
 
+/// True when the device has an open stream that has not latched `is_disconnected`.
+///
+/// `DeviceManager::is_running` flips true when the record pipeline attaches — before
+/// the first audio frame — so we also require a live stream handle. Streams that
+/// failed to open never get inserted; streams that died (timeout, zero-fill hijack)
+/// set `is_disconnected` and are treated as not running so recovery can retry.
+fn is_device_actively_streaming(device_manager: &DeviceManager, device: &AudioDevice) -> bool {
+    if !device_manager.is_running(device) {
+        return false;
+    }
+    device_manager
+        .stream(device)
+        .is_some_and(|stream| !stream.is_disconnected())
+}
+
 /// True when an enabled device of `device_type` is actively recording.
 /// `enabled_devices` alone is not enough — a failed startup leaves the name
 /// enrolled but no stream running, which previously blocked output recovery.
@@ -40,7 +57,7 @@ fn is_device_type_running(
         parse_audio_device(name)
             .ok()
             .filter(|d| d.device_type == device_type)
-            .is_some_and(|d| device_manager.is_running(&d))
+            .is_some_and(|d| is_device_actively_streaming(device_manager, &d))
     })
 }
 
@@ -472,7 +489,7 @@ pub async fn start_device_monitor(
                             let current = audio_manager.enabled_devices().await;
                             let has_correct_input = parse_audio_device(&default_input_name)
                                 .ok()
-                                .is_some_and(|d| device_manager.is_running(&d));
+                                .is_some_and(|d| is_device_actively_streaming(&device_manager, &d));
 
                             if !has_correct_input {
                                 info!(
@@ -512,7 +529,7 @@ pub async fn start_device_monitor(
                             let current = audio_manager.enabled_devices().await;
                             let has_correct_output = parse_audio_device(&default_output_name)
                                 .ok()
-                                .is_some_and(|d| device_manager.is_running(&d));
+                                .is_some_and(|d| is_device_actively_streaming(&device_manager, &d));
 
                             if !has_correct_output {
                                 info!(

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -261,6 +261,11 @@ impl AudioManager {
             options.macos_input_vpio_enabled,
         );
         *self.meeting_detector.write().await = options.meeting_detector.clone();
+
+        let user_disabled = self.user_disabled_devices.read().await.clone();
+        let mut options = options;
+        super::builder::ensure_system_default_device_types(&mut options, &user_disabled).await;
+
         *self.options.write().await = options;
         *self.engine.write().await = None;
         Ok(())

--- a/crates/screenpipe-audio/src/core/device.rs
+++ b/crates/screenpipe-audio/src/core/device.rs
@@ -786,6 +786,14 @@ pub async fn resolve_audio_devices_for_capture(
         if let Ok(output) = default_output_device().await {
             devices.push(output.to_string());
         }
+        if devices.is_empty() {
+            tracing::warn!(
+                "resolve_audio_devices_for_capture: no default input or output found \
+                 (use_system_default_audio={}, configured={:?})",
+                use_system_default_audio,
+                configured
+            );
+        }
         return devices;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #3631 addressing pre-merge review:

- **user_disabled_devices gate**: `ensure_system_default_device_types()` now runs in `apply_options` with the live muted-device set, so capture reconfigure does not re-enroll tray-muted defaults. Initial boot still uses an empty set (nothing muted yet).
- **Recovery liveness**: `is_device_type_running()` now requires an open stream with `!is_disconnected`, not just `DeviceManager::is_running` (which flips true when the record pipeline attaches, before first frame). Dead/hijacked streams trigger recovery again.
- **Empty resolve warn**: `resolve_audio_devices_for_capture` logs when both default input and output are missing.

## Notes

**Muted devices:** With `useSystemDefaultAudio: true`, the settings UI hides per-device toggles — users mute via tray → `pause_device` → `user_disabled_devices`. Recovery paths already checked this; enrollment now does too.

**is_running semantics:** Flag is set in `AudioManager::start_device` when `record_device` spawns; stream liveness is tracked separately via `AudioStream::is_disconnected` (set on timeout / zero-fill hijack). Stale handle cleanup still runs as a backstop.


