### PR TITLE
Fix recording stuck on Starting when monitorIds are stale

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -919,6 +919,10 @@ pub async fn spawn_screenpipe(
         }
         Ok(Err(e)) => {
             state.is_starting.store(false, Ordering::SeqCst);
+            state.is_starting_capture.store(false, Ordering::SeqCst);
+            if e.contains("no monitors matched") {
+                crate::health::set_recording_status(crate::health::RecordingStatus::Error);
+            }
             Err(e)
         }
         Err(_) => {

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -231,15 +231,29 @@ fn force_tray_rebuild(app: &AppHandle) -> Result<()> {
 }
 
 fn get_effective_recording_status() -> RecordingStatus {
-    let opt = OPTIMISTIC_STATUS.lock().unwrap_or_else(|e| e.into_inner());
+    let real = get_recording_status();
+    let mut opt = OPTIMISTIC_STATUS.lock().unwrap_or_else(|e| e.into_inner());
     if let Some((status, expiry)) = opt.as_ref() {
         if std::time::Instant::now() < *expiry {
+            // Don't mask a failed start — optimistic "Starting" is only useful
+            // while capture is genuinely booting, not after a terminal error.
+            if *status == RecordingStatus::Starting
+                && matches!(
+                    real,
+                    RecordingStatus::Error
+                        | RecordingStatus::Paused
+                        | RecordingStatus::Stopped
+                )
+            {
+                *opt = None;
+                drop(opt);
+                return real;
+            }
             return status.clone();
         }
     }
     drop(opt);
     // Clear expired optimistic status
-    let real = get_recording_status();
     let mut opt = OPTIMISTIC_STATUS.lock().unwrap_or_else(|e| e.into_inner());
     if let Some((ref s, _)) = *opt {
         // Clear if real status caught up or expired
@@ -670,6 +684,8 @@ fn create_dynamic_menu(
         let label = match effective_status {
             RecordingStatus::Recording => "Recording",
             RecordingStatus::Paused => "Paused — click to resume",
+            RecordingStatus::Starting => "Starting…",
+            RecordingStatus::Error => "Error — click to retry",
             _ => "Stopped — click to record",
         };
         let toggle = CheckMenuItemBuilder::with_id("toggle_recording", label)

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -187,7 +187,10 @@ impl VisionManager {
     /// Uses prefix matching (name + resolution) so that position changes after
     /// reconnect don't break the filter.
     pub fn is_monitor_allowed(&self, monitor: &screenpipe_screen::monitor::SafeMonitor) -> bool {
-        if self.stale_allowlist_fallback.load(std::sync::atomic::Ordering::Relaxed) {
+        if self
+            .stale_allowlist_fallback
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
             return true;
         }
         if self.config.use_all_monitors || self.config.monitor_ids.is_empty() {

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -97,6 +97,9 @@ pub struct VisionManager {
     /// controller report Active for all monitors, preserving the pre-feature
     /// behaviour for those users.
     focus_controller: Arc<FocusAwareController>,
+    /// Set when the user's monitor allowlist matched zero connected displays and
+    /// we fell back to recording every monitor. Clears the filter for hot-plug too.
+    stale_allowlist_fallback: Arc<AtomicBool>,
 }
 
 impl VisionManager {
@@ -145,6 +148,7 @@ impl VisionManager {
             hot_frame_cache: None,
             power_profile_rx: None,
             focus_controller,
+            stale_allowlist_fallback: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -183,6 +187,9 @@ impl VisionManager {
     /// Uses prefix matching (name + resolution) so that position changes after
     /// reconnect don't break the filter.
     pub fn is_monitor_allowed(&self, monitor: &screenpipe_screen::monitor::SafeMonitor) -> bool {
+        if self.stale_allowlist_fallback.load(std::sync::atomic::Ordering::Relaxed) {
+            return true;
+        }
         if self.config.use_all_monitors || self.config.monitor_ids.is_empty() {
             return true;
         }
@@ -234,7 +241,36 @@ impl VisionManager {
             }
         }
 
-        let task_count = self.recording_tasks.len();
+        let mut task_count = self.recording_tasks.len();
+        if task_count == 0 && total_monitors > 0 && !self.config.use_all_monitors {
+            warn!(
+                "VisionManager: allowlist {:?} matched 0/{} display(s) — \
+                 falling back to all connected monitors (stale monitor_ids?)",
+                self.config.monitor_ids, total_monitors
+            );
+            self.stale_allowlist_fallback
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            for monitor in list_monitors().await {
+                let monitor_id = monitor.id();
+                if let Err(e) = self.start_monitor(monitor_id).await {
+                    warn!(
+                        "Failed to start recording on monitor {} during stale-id fallback: {:?}",
+                        monitor_id, e
+                    );
+                }
+            }
+            task_count = self.recording_tasks.len();
+            if task_count > 0 {
+                info!(
+                    "VisionManager started via stale monitor_ids fallback ({}/{} monitor(s))",
+                    task_count, total_monitors
+                );
+                return Ok(());
+            }
+            self.stale_allowlist_fallback
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+
         if task_count == 0 {
             // Roll status back so the next .start() attempt isn't blocked by the
             // idempotency guard above.
@@ -596,41 +632,52 @@ mod tests {
         VisionManager::new(config, db, Handle::current())
     }
 
-    /// Regression: with an allowlist that matches zero physical monitors,
-    /// `start()` must return `Err` and leave status as `Stopped`, so the
-    /// outer `CaptureSession::start` stays None and the tray can retry.
-    ///
-    /// Before the fix: `start()` returned `Ok(())` silently with zero tasks,
-    /// and the outer detached spawn swallowed the no-op — leaving a "dead"
-    /// `CaptureSession` parked in `RecordingState.capture`. Every subsequent
-    /// tray click then hit the `is_some()` short-circuit in `recording.rs`.
+    /// When the allowlist is stale but physical monitors exist, fall back to
+    /// recording all connected displays instead of failing capture start.
     #[tokio::test]
-    async fn start_with_no_allowed_monitors_returns_err() {
-        // A stable_id prefix that cannot exist on any real host.
+    async fn start_with_stale_allowlist_falls_back_to_all_monitors() {
+        let monitors = list_monitors().await;
+        if monitors.is_empty() {
+            // Headless CI — nothing to fall back to.
+            return;
+        }
+
+        let stale = vec!["Display 999_9999x9999_0,0".to_string()];
+        let vm = make_vm_with_monitor_ids(stale).await;
+
+        vm.start()
+            .await
+            .expect("expected Ok via stale-id fallback when monitors exist");
+
+        assert!(
+            vm.recording_tasks.len() > 0,
+            "fallback should start at least one monitor task"
+        );
+        assert_eq!(vm.status().await, VisionManagerStatus::Running);
+
+        vm.stop().await.expect("stop after fallback start");
+    }
+
+    /// With zero physical monitors, a stale allowlist still fails cleanly.
+    #[tokio::test]
+    async fn start_with_no_connected_monitors_returns_err() {
+        let monitors = list_monitors().await;
+        if !monitors.is_empty() {
+            // Needs a headless environment — skip on dev machines with displays.
+            return;
+        }
+
         let stale = vec!["Display 999_9999x9999_0,0".to_string()];
         let vm = make_vm_with_monitor_ids(stale).await;
 
         let result = vm.start().await;
         assert!(
             result.is_err(),
-            "expected Err when allowlist matches zero monitors, got: {:?}",
+            "expected Err when no monitors are connected, got: {:?}",
             result
         );
-
-        // Status must be rolled back to Stopped so a subsequent retry
-        // (with a corrected allowlist) isn't blocked by the idempotency guard.
-        assert_eq!(
-            vm.status().await,
-            VisionManagerStatus::Stopped,
-            "status must be rolled back to Stopped on Err, otherwise retry is blocked"
-        );
-
-        // Recording tasks map must stay empty — nothing was spawned.
-        assert_eq!(
-            vm.recording_tasks.len(),
-            0,
-            "no tasks should exist after failed start"
-        );
+        assert_eq!(vm.status().await, VisionManagerStatus::Stopped);
+        assert_eq!(vm.recording_tasks.len(), 0);
     }
 
     /// Verify that stop_monitor completes promptly when the task finishes normally.


### PR DESCRIPTION
## Summary
- When saved `monitorIds` no longer match any connected display (e.g. Display 2 in settings but only Display 3 attached), VisionManager now falls back to recording all connected monitors instead of failing capture start.
- Tray menu no longer shows conflicting "Starting…" + "Stopped — click to record" after a failed start; optimistic Starting is cleared when capture fails, and toggle labels match Starting/Error states.
- Capture failures from stale monitor selection set recording status to Error so users can retry instead of appearing stuck.

## Context
User report (v2.4.285, macOS 26.1): tray stuck on "Starting…", cannot start recording. Logs showed `no monitors matched the allowed list (1 enumerated, 0 started)` 

