### PR TITLE
fix(audio): use native-tls for hf-hub so corp root CAs are trusted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,10 +3830,10 @@ dependencies = [
  "http",
  "indicatif",
  "log",
+ "native-tls",
  "num_cpus",
  "rand 0.8.6",
  "reqwest 0.12.28",
- "rustls 0.23.40",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4025,7 +4025,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -7375,8 +7374,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7384,7 +7381,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.10",
@@ -7394,7 +7390,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -8063,7 +8058,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8125,7 +8120,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio-eval"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8163,7 +8158,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8176,7 +8171,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8211,7 +8206,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8263,7 +8258,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8289,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8365,7 +8360,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8383,7 +8378,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-meeting-eval"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "clap",
@@ -8395,7 +8390,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8425,7 +8420,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-rfdetr-mlx"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "image",
  "mlx-rs",
@@ -8436,7 +8431,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8494,7 +8489,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8516,7 +8511,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-team-memory"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -8525,7 +8520,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.3.348"
+version = "0.3.349"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,14 @@ edition = "2021"
 [workspace.dependencies]
 # AI
 tokenizers = "0.21.0"
+# native-tls (SChannel on Windows, Secure Transport on macOS, OpenSSL on Linux)
+# so the corp/managed root CAs in the OS trust store are honored.
+# rustls-tls only trusts webpki-roots baked into the binary, which breaks on
+# enterprise networks that MITM TLS with a Group-Policy-installed root CA
+# (e.g. ORNL → huggingface.co fails with `UnknownIssuer`, blocking the
+# whisper/parakeet/qwen3-asr model downloads).
 hf-hub = { version = "0.3.2", git = "https://github.com/neo773/hf-hub", default-features = false, features = [
-    "rustls-tls",
+    "native-tls",
     "tokio",
     "ureq",
 ] }


### PR DESCRIPTION
## Summary
- Switches the workspace `hf-hub` from `rustls-tls` to `native-tls` so model downloads honor the OS certificate store (Windows SChannel / macOS Secure Transport / Linux OpenSSL).
- Fixes whisper/parakeet/qwen3-asr/PII-redactor downloads on any enterprise network that installs a corp root CA via Group Policy for TLS interception.

## Context
Spotted via a Discord feedback log from a real enterprise user (ORNL, Windows, 2.4.285):
```
WARN screenpipe_audio::transcription::engine: whisper background download failed:
  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin:
  tls connection init failed: invalid peer certificate: UnknownIssuer
```
Downstream effect: `health_check: audio transcription backlog stalled — 25 chunks pending, oldest 2629s old` — the user's Teams meeting was captured to disk but never transcribed.

Root cause: `rustls-tls` only trusts the webpki-roots bundle baked into the binary; it ignores the Windows cert store where Group Policy installs the corp MITM proxy's root. Every other Windows app (Chrome/Edge/Teams) works fine because they use SChannel. We didn't.

Moving the model to a different CDN would not fix this — the same proxy re-signs that traffic too. The fix has to be on our side: trust the OS root store.

## Why native-tls and not rustls-native-certs
`hf-hub` only exposes `native-tls` or `rustls-tls` as features — it doesn't let us inject a custom rustls `ClientConfig` with native-cert loading. `native-tls` is already a build dep elsewhere in the workspace (`tokio-tungstenite` for Deepgram/Screenpipe Cloud realtime), so this adds no new system requirements.

Note: the workspace `reqwest` is already on `rustls` + `rustls-platform-verifier` ([Cargo.toml:44-48](https://github.com/screenpipe/screenpipe/blob/main/Cargo.toml#L44-L48)), so the rest of the app already trusts the OS roots. This PR just brings `hf-hub` in line.

## Test plan
- [x] `cargo check -p screenpipe-audio` — passes
- [x] `cargo check -p screenpipe-engine` — passes
- [ ] **Needs manual verification on a Windows machine behind a corp-style proxy with a custom root CA installed**: confirm `ggml-large-v3-turbo.bin` downloads successfully on first launch instead of erroring with `UnknownIssuer`. cc @divanshu-go @Anshgrover23  (whoever has the Windows + MITM test rig handy)
- [ ] Smoke: macOS dev build still downloads whisper on first launch (regression check; macOS uses Secure Transport via native-tls, expected to work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)