### PR TITLE
Fix timeline open settings button

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -1166,7 +1166,7 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 									</p>
 
 									<button
-										onClick={() => commands.showWindow({ Home: { page: null } })}
+										onClick={() => commands.showWindow({ Home: { page: "recording" } })}
 										className="inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-full text-sm font-medium hover:bg-primary/90 transition-colors"
 									>
 										<Settings className="w-4 h-4" />


### PR DESCRIPTION
This PR route the timeline empty-state "Open settings" button to Recording settings instead of reopening Home.


https://github.com/user-attachments/assets/73cf6a52-5781-4088-a3e4-28651b0734ae

