### PR TITLE
fix(meetings, MCP): replace incorrect PATCH verb with PUT

### DIFF
--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -1695,7 +1695,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           };
         }
         const response = await callAPI(`/meetings/${meetingId}`, {
-          method: "PATCH",
+          method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: "Fix HTTP verb typo for /meetings/{id}"
labels: ''
assignees: ''

---

## description

Updating meetings requires PUT, not PATCH

Fixes `/meetings/{id}` endpoint (operation id `routes_meetings_get_meeting_handler`).

See crates/screenpipe-engine/src/server.rs line 626 which is also documented at docs/mintlify/docs-mintlify-mig-tmp/openapi.yaml line 889 => both specify PUT

## how to test

1. attempt to update an existing meeting with PATCH -> get HTTP 405 response
2. attempt same request with PUT -> great success

