### PR TITLE
Fix chat local file links

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/markdown-viewer-link.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/markdown-viewer-link.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/lib/utils/tauri", () => ({
 
 import {
   openScreenpipeViewerLink,
+  rewriteLocalMarkdownLinksForChat,
   screenpipeViewerPathFromHref,
 } from "@/components/markdown";
 
@@ -110,5 +111,30 @@ describe("openScreenpipeViewerLink", () => {
     await expect(
       openScreenpipeViewerLink("screenpipe://view?path=/tmp/x.jpg"),
     ).rejects.toThrow("viewer window crashed");
+  });
+});
+
+describe("rewriteLocalMarkdownLinksForChat", () => {
+  it("rewrites local document links to viewer deeplinks", () => {
+    expect(
+      rewriteLocalMarkdownLinksForChat("[doc](file:///Users/me/test%20note.md)"),
+    ).toBe(
+      "[doc](screenpipe://view?path=%2FUsers%2Fme%2Ftest%20note.md)",
+    );
+  });
+
+  it("leaves image markdown untouched so paths with parentheses still render", () => {
+    const input = "![img](/Users/me/test (1).png)";
+    expect(rewriteLocalMarkdownLinksForChat(input)).toBe(input);
+  });
+
+  it("keeps local media links as local paths so recordings still render inline", () => {
+    expect(
+      rewriteLocalMarkdownLinksForChat(
+        "[clip](file:///Users/me/System%20Audio%20(output)_2026-05-25_11-27-00.mp4)",
+      ),
+    ).toBe(
+      "[clip](</Users/me/System Audio (output)_2026-05-25_11-27-00.mp4>)",
+    );
   });
 });

--- a/apps/screenpipe-app-tauri/components/markdown.tsx
+++ b/apps/screenpipe-app-tauri/components/markdown.tsx
@@ -6,7 +6,7 @@ import ReactMarkdown, { defaultUrlTransform, Options } from 'react-markdown'
 import { commands } from "@/lib/utils/tauri";
 import { MediaComponent } from "@/components/rewind/media";
 import { getApiBaseUrl } from "@/lib/api";
-import { isMediaFilePath, normalizeLocalMediaMarkdown } from "@/lib/utils/media-file-path";
+import { isMediaFilePath, normalizeLocalMediaMarkdown, normalizeMediaFilePath } from "@/lib/utils/media-file-path";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
 export function createScreenpipeUrlTransform(allowedHosts: readonly string[]) {
@@ -51,6 +51,79 @@ export async function openScreenpipeViewerLink(href: string): Promise<boolean> {
     throw new Error(result.error);
   }
   return true;
+}
+
+function unwrapMarkdownUrl(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+export function resolveLocalPathFromMarkdownUrl(url: string): string | null {
+  const raw = unwrapMarkdownUrl(url);
+  if (!raw || raw.startsWith("screenpipe://")) {
+    return null;
+  }
+
+  const urlWithoutFragment = raw.split("#", 1)[0] ?? raw;
+
+  let candidate = urlWithoutFragment;
+  let wasFileUri = false;
+
+  if (/^file:\/\//i.test(candidate)) {
+    wasFileUri = true;
+    const withoutScheme = candidate.replace(/^file:\/\//i, "");
+    candidate = `/${withoutScheme.replace(/^\/+/, "")}`;
+  }
+
+  try {
+    candidate = decodeURIComponent(candidate);
+  } catch {
+    // Keep the original string when the markdown contains malformed escapes.
+  }
+
+  if (/^\/[A-Za-z]:[\\/]/.test(candidate)) {
+    candidate = candidate.slice(1);
+  }
+
+  if (candidate.startsWith("/") && (wasFileUri || !candidate.startsWith("//"))) {
+    return candidate;
+  }
+
+  if (/^[A-Za-z]:[\\/]/.test(candidate)) {
+    return candidate;
+  }
+
+  return null;
+}
+
+function wrapPathForMarkdown(path: string): string {
+  return `<${path.replace(/>/g, "%3E")}>`;
+}
+
+export function rewriteLocalMarkdownLinksForChat(text: string): string {
+  return text.replace(
+    /(!?)\[([^\]\n]+)\]\((<[^>\n]+>|[^)\n]+)\)/g,
+    (match, sigil: string, label: string, rawUrl: string) => {
+      const localPath = resolveLocalPathFromMarkdownUrl(rawUrl);
+      if (!localPath) {
+        return match;
+      }
+
+      if (sigil === "!") {
+        return `${sigil}[${label}](${wrapPathForMarkdown(localPath)})`;
+      }
+
+      const normalizedMediaPath = normalizeMediaFilePath(localPath);
+      if (isMediaFilePath(normalizedMediaPath)) {
+        return `[${label}](${wrapPathForMarkdown(normalizedMediaPath)})`;
+      }
+
+      return `[${label}](screenpipe://view?path=${encodeURIComponent(localPath)})`;
+    },
+  );
 }
 
 type MarkdownComponents = NonNullable<Options["components"]>;

--- a/apps/screenpipe-app-tauri/components/markdown.tsx
+++ b/apps/screenpipe-app-tauri/components/markdown.tsx
@@ -103,17 +103,29 @@ function wrapPathForMarkdown(path: string): string {
   return `<${path.replace(/>/g, "%3E")}>`;
 }
 
-export function rewriteLocalMarkdownLinksForChat(text: string): string {
+function rewriteLocalMediaLinksForChat(text: string): string {
   return text.replace(
+    /(!?)\[([^\]]*)\]\(((?:file:\/\/\/?[^\n\r]+?|\/[^\n\r]+?|[A-Z]:[\\/][^\n\r]+?)\.(mp4|mp3|wav|webm|ogg|m4a))\)/gi,
+    (_match, sigil: string, label: string, rawPath: string) => {
+      const localPath =
+        resolveLocalPathFromMarkdownUrl(rawPath) ?? normalizeMediaFilePath(rawPath.trim());
+      const normalizedPath = normalizeMediaFilePath(localPath);
+      return `${sigil}[${label}](${wrapPathForMarkdown(normalizedPath)})`;
+    },
+  );
+}
+
+export function rewriteLocalMarkdownLinksForChat(text: string): string {
+  return rewriteLocalMediaLinksForChat(text).replace(
     /(!?)\[([^\]\n]+)\]\((<[^>\n]+>|[^)\n]+)\)/g,
     (match, sigil: string, label: string, rawUrl: string) => {
-      const localPath = resolveLocalPathFromMarkdownUrl(rawUrl);
-      if (!localPath) {
+      if (sigil === "!") {
         return match;
       }
 
-      if (sigil === "!") {
-        return `${sigil}[${label}](${wrapPathForMarkdown(localPath)})`;
+      const localPath = resolveLocalPathFromMarkdownUrl(rawUrl);
+      if (!localPath) {
+        return match;
       }
 
       const normalizedMediaPath = normalizeMediaFilePath(localPath);

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -31,6 +31,7 @@ import {
   MemoizedReactMarkdown,
   chatUrlTransform,
   openScreenpipeViewerLink,
+  rewriteLocalMarkdownLinksForChat,
 } from "@/components/markdown";
 import { AIPresetsSelector } from "@/components/rewind/ai-presets-selector";
 import { AIPreset, PiQueuedPrompt } from "@/lib/utils/tauri";
@@ -2036,7 +2037,9 @@ function MarkdownBlock({ text, isUser }: { text: string; isUser: boolean }) {
   // Assistant messages occasionally contain raw tool-call XML the model emitted
   // as text — rewrite it to a fenced code block so rehypeRaw doesn't collapse
   // the unknown tags and bleed the args into the prose. See sanitize-tool-call-xml.ts.
-  const renderText = isUser ? text : sanitizeToolCallXml(text);
+  const renderText = rewriteLocalMarkdownLinksForChat(
+    isUser ? text : sanitizeToolCallXml(text),
+  );
   return (
     <MemoizedReactMarkdown
       className={cn(


### PR DESCRIPTION
This PR fixes local file links in chat so they’re actually usable.


### Before

- chat could show raw markdown like file instead of rendering a clickable link
- file:///... links could end up with an empty or unusable target
- some absolute local paths with spaces could render as plain text instead of links
- local media links were easy to break when the filename had spaces or parentheses



https://github.com/user-attachments/assets/9202d6eb-0966-4e60-9a8d-96feccb76351



### After

- local document links in chat are rewritten to Screenpipe viewer links and open correctly
- file:///... document links now work in chat
- absolute local paths with spaces/parentheses are handled properly
- local media links keep their media behavior instead of being treated like document links
- image/media markdown with parentheses is preserved instead of being mangled


https://github.com/user-attachments/assets/63a71ba5-403b-4915-922c-60ddb70a3cf0


