### PR TITLE
fix(chat): render local file:// links as clickable

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/markdown-viewer-link.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/markdown-viewer-link.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/utils/tauri", () => ({
 import {
   openScreenpipeViewerLink,
   screenpipeViewerPathFromHref,
+  createScreenpipeUrlTransform,
 } from "@/components/markdown";
 
 describe("screenpipeViewerPathFromHref", () => {
@@ -110,5 +111,41 @@ describe("openScreenpipeViewerLink", () => {
     await expect(
       openScreenpipeViewerLink("screenpipe://view?path=/tmp/x.jpg"),
     ).rejects.toThrow("viewer window crashed");
+  });
+});
+
+describe("createScreenpipeUrlTransform — file:// handling", () => {
+  // Regression for defaultUrlTransform strips file:// URLs entirely,
+  // rendering local file links as plain text. The transform must pass them
+  // through so the a-component click handler can open them via Tauri shell.
+
+  it("passes file:// URLs through unchanged", () => {
+    const transform = createScreenpipeUrlTransform(["view"]);
+    const url = "file:///Users/me/screenpipe/data/frame_123.jpg";
+    expect(transform(url)).toBe(url);
+  });
+
+  it("passes Windows-style file:// URLs through unchanged", () => {
+    const transform = createScreenpipeUrlTransform(["view"]);
+    const url = "file:///C:/Users/me/screenpipe/data/frame.mp4";
+    expect(transform(url)).toBe(url);
+  });
+
+  it("still strips javascript: URLs", () => {
+    const transform = createScreenpipeUrlTransform(["view"]);
+    expect(transform("javascript:alert(1)")).toBe("");
+  });
+
+  it("still allows screenpipe:// URLs for allowed hosts", () => {
+    const transform = createScreenpipeUrlTransform(["view"]);
+    const url = "screenpipe://view?path=/tmp/frame.jpg";
+    expect(transform(url)).toBe(url);
+  });
+
+  it("still blocks screenpipe:// URLs for disallowed hosts", () => {
+    const transform = createScreenpipeUrlTransform(["view"]);
+    // "timeline" not in allowed set — should fall through to defaultUrlTransform
+    // which strips unknown protocols.
+    expect(transform("screenpipe://timeline?timestamp=2026-05-25T00:00:00Z")).toBe("");
   });
 });

--- a/apps/screenpipe-app-tauri/components/markdown.tsx
+++ b/apps/screenpipe-app-tauri/components/markdown.tsx
@@ -18,6 +18,12 @@ export function createScreenpipeUrlTransform(allowedHosts: readonly string[]) {
       if (parsed.protocol === "screenpipe:" && allowed.has(parsed.host)) {
         return url;
       }
+      // Allow local file links through — click handling is done in the
+      // a-component via Tauri's shell.open so the browser never navigates
+      // to a file:// URL directly.
+      if (parsed.protocol === "file:") {
+        return url;
+      }
     } catch {
       // Fall back to react-markdown's default sanitizer for malformed URLs.
     }

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -2125,6 +2125,42 @@ function MarkdownBlock({ text, isUser }: { text: string; isUser: boolean }) {
             );
           }
 
+          // Local file links — open via Tauri shell so the OS handles the
+          // file type (finder, explorer, default app). The URL transform in
+          // markdown.tsx lets file:// through; without this click handler
+          // the anchor would be a dead href="#" in the Tauri webview.
+          if (href?.startsWith("file://")) {
+            const handleFileLinkClick = async (
+              e: React.MouseEvent<HTMLAnchorElement>,
+            ) => {
+              e.preventDefault();
+              try {
+                // Strip file:// prefix — openViewerWindow expects a raw fs path
+                const path = decodeURIComponent(
+                  href.replace(/^file:\/\/\//, "/").replace(/^file:\/\//, "")
+                );
+                // On Windows, leading slash must be removed: /C:/Users/... → C:/Users/...
+                const fsPath = path.startsWith("/") && path[2] === ":" ? path.slice(1) : path;
+                const result = await commands.openViewerWindow(fsPath);
+                if (result.status === "error") {
+                  console.error("failed to open local file:", result.error);
+                }
+              } catch (error) {
+                console.error("failed to open local file:", error);
+              }
+            };
+            return (
+              <a
+                href="#"
+                onClick={handleFileLinkClick}
+                className="underline underline-offset-2 text-blue-500 hover:text-blue-400 cursor-pointer inline"
+                {...props}
+              >
+                {children}
+             </a>
+            );
+          }
+
           return (
             <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2" {...props}>
               {children}


### PR DESCRIPTION
## description
Local file links (`[text](file:///path/to/file)`) were not rendering as 
clickable links in chat — `react-markdown`'s `defaultUrlTransform` strips 
`file://` URLs by design, so the href was silently dropped and the link 
appeared as plain text.

Two changes fix this:
1. `markdown.tsx` — `createScreenpipeUrlTransform` now passes `file://` 
   URLs through instead of handing them to `defaultUrlTransform`
2. `standalone-chat.tsx` — added a `file://` branch in the `a` component 
   that opens the file in screenpipe's viewer via `commands.openViewerWindow`, 
   since `tauri-plugin-shell`'s `openUrl` rejects `file://` by its regex policy

Also adds regression tests for the `file://` URL transform behaviour in 
`markdown-viewer-link.test.ts`.

related issue: #3635

## before
<img width="1295" height="693" alt="b" src="https://github.com/user-attachments/assets/85378b32-76b0-4814-a14c-caeb7a05b8ed" />


## after
<img width="1483" height="940" alt="aaa" src="https://github.com/user-attachments/assets/eff4bc41-c692-48c7-b65e-85e3460ccca3" />


## how to test
1. In chat, send: `please respond with exactly this markdown and nothing else: [open file](file:///C:/Users/USER/OneDrive/Documents/screenpipe-test.txt)`
2. Before fix: link renders as plain/underlined text with no click action
3. After fix: link renders as blue clickable text — clicking opens the file in screenpipe's built-in viewer

