### PR TITLE
fix(build): bump Windows ffmpeg + openblas download timeout to 120s

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -651,7 +651,7 @@ if (platform == 'windows') {
 			const arm64Url = asset.browser_download_url
 			const arm64Filename = asset.name
 			console.log(`ffmpeg ARM64: ${arm64Url}`)
-			await downloadFile(arm64Url, arm64Filename, { retries: 10 })
+			await downloadFile(arm64Url, arm64Filename, { retries: 10, timeoutMs: 120000 })
 			await $`${sevenZ} x ${arm64Filename}`
 			// tordona 7z extracts to a single folder; move its contents to ffmpeg (or rename if single top-level dir)
 			const entries = await fs.readdir(cwd, { withFileTypes: true })
@@ -667,7 +667,7 @@ if (platform == 'windows') {
 			}
 			await fs.rm(path.join(cwd, arm64Filename), { force: true }).catch(() => {})
 		} else {
-			await downloadFile(config.windows.ffmpegUrl, `${config.windows.ffmpegName}.7z`, { retries: 10 })
+			await downloadFile(config.windows.ffmpegUrl, `${config.windows.ffmpegName}.7z`, { retries: 10, timeoutMs: 120000 })
 			await $`${sevenZ} x ${config.windows.ffmpegName}.7z`
 			await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 			await $`rm -rf ${config.windows.ffmpegName}.7z`

--- a/apps/screenpipe-app-tauri/scripts/setup_openblas.js
+++ b/apps/screenpipe-app-tauri/scripts/setup_openblas.js
@@ -33,11 +33,11 @@ export async function setupOpenBlas({ cwd, winArch }) {
 
 	if (!(await fs.exists(path.join(cwd, config.openblasRealname)))) {
 		if (winArch === 'arm64') {
-			await downloadFile(config.windows.openblasUrlArm64, `${config.windows.openblasNameArm64}.zip`, { retries: 5 })
+			await downloadFile(config.windows.openblasUrlArm64, `${config.windows.openblasNameArm64}.zip`, { retries: 5, timeoutMs: 120000 })
 			await $`${sevenZ} x ${config.windows.openblasNameArm64}.zip -o${config.openblasRealname} -y`
 			await fs.rm(path.join(cwd, `${config.windows.openblasNameArm64}.zip`), { force: true })
 		} else {
-			await downloadFile(config.windows.openblasUrl, `${config.windows.openblasName}.zip`, { retries: 5 })
+			await downloadFile(config.windows.openblasUrl, `${config.windows.openblasName}.zip`, { retries: 5, timeoutMs: 120000 })
 			await $`${sevenZ} x ${config.windows.openblasName}.zip -o${config.openblasRealname} -y`
 			await fs.rm(path.join(cwd, `${config.windows.openblasName}.zip`), { force: true })
 		}


### PR DESCRIPTION
Follow-up to #3643 per the review nit:

> Windows ffmpeg/openblas callers (`setup_openblas.js:36,40`, `pre_build.js:620,636`) still use the 30s default. The macOS bun caller already bumps to 120s. If GitHub CDN ever stalls on Windows runners, those will hit the same wall with even tighter budget. Bump to `timeoutMs: 120000` in a follow-up PR.

## Change

Four one-line edits — pass `timeoutMs: 120000` to `downloadFile` in the Windows ffmpeg and openblas branches:

- [`scripts/pre_build.js`](https://github.com/screenpipe/screenpipe/blob/main/screenpipe-app-tauri/scripts/pre_build.js) — Windows ffmpeg arm64 + x64
- [`scripts/setup_openblas.js`](https://github.com/screenpipe/screenpipe/blob/main/screenpipe-app-tauri/scripts/setup_openblas.js) — Windows openblas arm64 + x64

Brings them in line with the macOS bun caller that already passes the same value. `downloadFile`'s signature already supports `timeoutMs` (default 30000); no new code path. Per-attempt 120s × {10,5} retries × exponential backoff stays well inside the workflow's 180-min ceiling.

## Test plan

- [x] `node --check` clean on both files (syntax verified locally)
- [x] Diff is exactly 4 one-line additions inside the existing Windows branches
- [ ] (reviewer) Windows runner build still succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)