### PR TITLE
Add labels to meeting and pipe chat prefills

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -16,7 +16,11 @@ import {
 import { emit, listen } from "@tauri-apps/api/event";
 import { ChatConversation } from "@/lib/hooks/use-settings";
 import { titleCreatedByAI } from "@/lib/utils/generate-title-with-preset";
-import { systemFallbackTitle, shouldAcceptTitleSource } from "@/lib/utils/chat-title";
+import {
+  deriveFallbackConversationTitle,
+  isFallbackLikeTitle,
+  shouldAcceptTitleSource,
+} from "@/lib/utils/chat-title";
 import { isInjectedTitleSourcePrompt } from "@/lib/chat-utils";
 import { commands, type AIPreset } from "@/lib/utils/tauri";
 import {
@@ -466,11 +470,11 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     const { loadConversationFile } = await import("@/lib/chat-storage");
     const existing = await loadConversationFile(convId);
 
-    // Find first real user message, skipping injected metadata
-    const firstUserMsg = msgs.find(
-      (m) => m.role === "user" && !isInjectedTitleSourcePrompt(m.content)
-    );
-    const fallbackTitle = systemFallbackTitle(firstUserMsg?.content);
+    // Find first real user message, skipping injected metadata.
+    const firstUserMsg = msgs.find((m) => (
+      m.role === "user" && !isInjectedTitleSourcePrompt(m.content)
+    ));
+    const fallbackTitle = deriveFallbackConversationTitle(firstUserMsg);
     const existingTitle = existing?.title?.trim() || null;
 
     const hasValidPreset =
@@ -478,12 +482,24 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       selectedPreset.provider &&
       selectedPreset.model?.trim();
 
-    // Title priority: user > ai > fallback
-    // Preserve existing title if it has higher priority than fallback
     const existingSource = existing?.titleSource;
-    const shouldPreserveExisting = existingSource === "user" || existingSource === "ai";
-    const title = shouldPreserveExisting && existingTitle ? existingTitle : fallbackTitle;
-    const titleSource: "user" | "ai" | "fallback" = shouldPreserveExisting && existingSource ? existingSource : "fallback";
+    const existingLooksFallback = isFallbackLikeTitle(
+      existingTitle,
+      fallbackTitle,
+      firstUserMsg?.content,
+    );
+    // Title priority: user > ai > fallback.
+    // Also preserve legacy non-fallback titles that predate titleSource.
+    const preservedTitleSource: "user" | "ai" | null =
+      existingSource === "user" || existingSource === "ai"
+        ? existingSource
+        : existingTitle && !existingLooksFallback
+          ? "user"
+          : null;
+    const title =
+      preservedTitleSource && existingTitle ? existingTitle : fallbackTitle;
+    const titleSource: "user" | "ai" | "fallback" =
+      preservedTitleSource ?? "fallback";
 
     // Start AI title generation in background (once per conversation)
     // Only generate if current title is fallback priority

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/lib/utils/meeting-format";
 import {
   buildEnrichedSummarizePrompt,
+  buildMeetingSummarizeDisplayLabel,
   buildMeetingMarkdown,
   fetchMeetingAudio,
   fetchMeetingContext,
@@ -466,6 +467,7 @@ export function NoteView({
           transcript,
           directiveOverride,
         }),
+        displayLabel: buildMeetingSummarizeDisplayLabel(fresh),
         autoSend: true,
         source: "meeting-summarize",
         useHomeChat: true,

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -272,6 +272,10 @@ follow these prompt engineering best practices (from anthropic's guide):
 after analyzing, show me the improved pipe.md and explain what you changed and why.`;
 }
 
+function buildOptimizeDisplayLabel(pipeName: string): string {
+  return `Optimize pipe: ${pipeName.trim()}`;
+}
+
 function parsePipeError(stderr: string): {
   type: "daily_limit" | "credits_exhausted" | "rate_limit" | "unknown";
   message: string;
@@ -1831,6 +1835,7 @@ export function PipesSection() {
                           navigateHomeAndPrefill({
                             context: "the user wants to optimize their pipe",
                             prompt: buildOptimizePrompt(pipe.config.name),
+                            displayLabel: buildOptimizeDisplayLabel(pipe.config.name),
                             autoSend: true,
                           });
                         }}

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -47,7 +47,7 @@ import { emit } from "@tauri-apps/api/event";
 import { useChatConversations } from "@/components/hooks/use-chat-conversations";
 import { useChatStore } from "@/lib/stores/chat-store";
 import { statusForEvent } from "@/lib/stores/pi-event-router";
-import { stripPromptPlumbing } from "@/lib/utils/chat-title";
+import { deriveFallbackConversationTitle } from "@/lib/utils/chat-title";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { usePlatform } from "@/lib/hooks/use-platform";
@@ -62,6 +62,7 @@ import {
   normalizeAppTag,
   formatShortcutDisplay,
   extractConversationHistorySyncUserText,
+  isInjectedTitleSourcePrompt,
   isConversationHistorySyncPrompt,
   type ChatLoadConversationPayload,
   shouldHandleChatLoadConversationForWindow,
@@ -2555,6 +2556,12 @@ function getMessageIntentLabel(message: Message): string | null {
   return null;
 }
 
+function isPlaceholderConversationTitle(value?: string | null): boolean {
+  if (!value) return true;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "" || normalized === "new chat" || normalized === "untitled";
+}
+
 function isSteeredAssistantMessage(message: Message): boolean {
   return message.role === "assistant" && (message.intent === "steer" || message.steeredResponse === true);
 }
@@ -2805,17 +2812,16 @@ function ChatTitleMenu({
   );
   const isPinned = session?.pinned ?? false;
   const firstUserMsg = messages.find(
-    (m) => m.role === "user" && !isConversationHistorySyncPrompt(m.content)
+    (m) => m.role === "user" && !isInjectedTitleSourcePrompt(m.content)
   );
-  const derivedTitle = firstUserMsg?.content
-    ? stripPromptPlumbing(firstUserMsg.content).slice(0, 50).trim()
+  const derivedTitle = firstUserMsg
+    ? deriveFallbackConversationTitle(firstUserMsg)
     : undefined;
   const hasMessages = messages.length > 0;
   const title =
     streamingTitle ||
     (storeTitle &&
-      storeTitle !== "new chat" &&
-      storeTitle !== "untitled" &&
+      !isPlaceholderConversationTitle(storeTitle) &&
       !isConversationHistorySyncPrompt(storeTitle)
         ? storeTitle
         : derivedTitle || (hasMessages ? "untitled" : ""));
@@ -3733,8 +3739,8 @@ export function StandaloneChat({
 
   // Listen for chat-prefill events from search modal and pipe creation
   useEffect(() => {
-    const unlisten = listen<{ context: string; prompt?: string; frameId?: number; autoSend?: boolean; source?: string; targetWindow?: string }>("chat-prefill", (event) => {
-      const { context, prompt, frameId, autoSend, source, targetWindow } = event.payload;
+    const unlisten = listen<{ context: string; prompt?: string; displayLabel?: string; frameId?: number; autoSend?: boolean; source?: string; targetWindow?: string }>("chat-prefill", (event) => {
+      const { context, prompt, displayLabel, frameId, autoSend, source, targetWindow } = event.payload;
 
       // Only process if this window is the intended target (or no target for backwards compat)
       if (targetWindow && getCurrentWindow().label !== targetWindow) return;
@@ -3781,7 +3787,7 @@ export function StandaloneChat({
             autoSendBypassRef.current = true;
             await new Promise(r => setTimeout(r, 200));
             if (sendMessageRef.current) {
-              await sendMessageRef.current(fullMessage);
+              await sendMessageRef.current(fullMessage, displayLabel);
               setInput("");
               if (inputRef.current) inputRef.current.style.height = "auto";
             }
@@ -6576,6 +6582,10 @@ export function StandaloneChat({
         });
       }
       storeState.actions.appendMessage(sidNow, newUserMessage as any);
+      const currentTitle = useChatStore.getState().sessions[sidNow]?.title;
+      if (displayLabel && isPlaceholderConversationTitle(currentTitle)) {
+        storeState.actions.patch(sidNow, { title: displayLabel });
+      }
       storeState.actions.appendMessage(sidNow, {
         id: assistantMessageId,
         role: "assistant",

--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-title-generation.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-title-generation.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  deriveFallbackConversationTitle,
   stripPromptPlumbing,
   systemFallbackTitle,
   isFallbackLikeTitle,
@@ -177,6 +178,36 @@ describe("systemFallbackTitle", () => {
     expect(systemFallbackTitle("new chat features I want")).toBe(
       "new chat features I want"
     );
+  });
+});
+
+// ─── deriveFallbackConversationTitle ───────────────────────────────────────
+
+describe("deriveFallbackConversationTitle", () => {
+  it("prefers displayContent over raw prompt text", () => {
+    expect(
+      deriveFallbackConversationTitle({
+        displayContent: "Summarize meeting: Design Review",
+        content: "search screenpipe for what happened during this meeting and summarize it",
+      })
+    ).toBe("Summarize meeting: Design Review");
+  });
+
+  it("falls back to cleaned prompt text when no displayContent exists", () => {
+    expect(
+      deriveFallbackConversationTitle({
+        content: "<role>expert</role> Create a custom screenpipe automation",
+      })
+    ).toBe("Create a custom screenpipe automation");
+  });
+
+  it("ignores blank displayContent and still derives from content", () => {
+    expect(
+      deriveFallbackConversationTitle({
+        displayContent: "   ",
+        content: "Optimize this pipe for reliability and retries",
+      })
+    ).toBe("Optimize this pipe for reliability and retries");
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
@@ -22,7 +22,12 @@ vi.mock("@/lib/chat-storage", () => ({
   saveConversationFile: vi.fn(async () => undefined),
 }));
 
-import { handlePiEvent, handleTerminated } from "../stores/pi-event-router";
+import { saveConversationFile } from "@/lib/chat-storage";
+import {
+  flushPendingSaves,
+  handlePiEvent,
+  handleTerminated,
+} from "../stores/pi-event-router";
 import { useChatStore, type SessionRecord } from "../stores/chat-store";
 import type { AgentEventEnvelope, AgentInnerEvent } from "../events/types";
 
@@ -34,6 +39,7 @@ function piEvt(sessionId: string, event: AgentInnerEvent): AgentEventEnvelope {
 }
 
 function reset() {
+  vi.clearAllMocks();
   useChatStore.setState({ sessions: {}, currentId: null, panelSessionId: null });
 }
 
@@ -275,5 +281,39 @@ describe("pi-event-router: agent_terminated", () => {
     seed("A", { status: "streaming" });
     handleTerminated({ sessionId: "A", source: "pi", exitCode: 0 });
     expect(useChatStore.getState().sessions.A.status).toBe("idle");
+  });
+
+  it("persists display labels for backgrounded chats", async () => {
+    seed("A", {
+      status: "streaming",
+      messages: [
+        {
+          id: "user-1",
+          role: "user",
+          content:
+            "search screenpipe for what happened during this meeting and summarize it",
+          displayContent: "Summarize meeting: Design Review",
+          timestamp: 1_234,
+        },
+      ],
+      messageCount: 1,
+    });
+    useChatStore.setState({ currentId: "B" });
+
+    handleTerminated({ sessionId: "A", source: "pi", exitCode: 0 });
+    await flushPendingSaves();
+
+    expect(saveConversationFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "A",
+        title: "Summarize meeting: Design Review",
+        messages: [
+          expect.objectContaining({
+            id: "user-1",
+            displayContent: "Summarize meeting: Design Review",
+          }),
+        ],
+      })
+    );
   });
 });

--- a/apps/screenpipe-app-tauri/lib/chat-utils.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-utils.ts
@@ -70,6 +70,8 @@ export function extractConversationHistorySyncUserText(value?: string | null): s
 export interface ChatPrefillData {
   context: string;
   prompt?: string;
+  /** Short user-facing label shown in chat while `prompt` remains the payload sent to Pi. */
+  displayLabel?: string;
   frameId?: number;
   autoSend?: boolean;
   source?: string;

--- a/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
@@ -61,7 +61,7 @@ import {
 } from "@/lib/chat-storage";
 import type { ChatConversation } from "@/lib/hooks/use-settings";
 import { isInjectedTitleSourcePrompt } from "@/lib/chat-utils";
-import { systemFallbackTitle } from "@/lib/utils/chat-title";
+import { deriveFallbackConversationTitle } from "@/lib/utils/chat-title";
 import { isInternalTitleSession } from "@/lib/utils/internal-session";
 import {
   useChatStore,
@@ -602,16 +602,17 @@ const saveQueue = new Map<string, Promise<void>>();
  *  saveQueue tail for each id so already-running saves finish before
  *  the window closes. Used by the close-on-quit hook in
  *  `mountPiEventRouter`. */
-async function flushPendingSaves(): Promise<void> {
+export async function flushPendingSaves(): Promise<void> {
   const sessions = useChatStore.getState().sessions;
   const ids = Object.keys(sessions).filter((id) => {
     const s = sessions[id];
     return !!s.messages && s.messages.length > 0;
   });
   await Promise.all(ids.map((id) => persistBackgroundSession(id)));
-  // Await the entire saveQueue tail so any in-flight save (queued
-  // before flush) also completes. persistBackgroundSession returns the
-  // promise it just appended, so the previous await covers the tail.
+  // Also await any queue tails that were already in-flight before this
+  // flush started, even if their sessions no longer appear in the
+  // current store snapshot.
+  await Promise.all([...saveQueue.values()]);
 }
 
 /**
@@ -658,7 +659,7 @@ async function persistBackgroundSession(sid: string): Promise<void> {
       const firstUserMsg = messages.find(
         (m: any) => m.role === "user" && !isInjectedTitleSourcePrompt(m.content)
       ) as any;
-      const derivedTitle: string = systemFallbackTitle(firstUserMsg?.content);
+      const derivedTitle: string = deriveFallbackConversationTitle(firstUserMsg);
 
       // Background saves use fallback titles; AI titles generated in foreground
       const title = existing?.title || derivedTitle;
@@ -708,6 +709,7 @@ async function persistBackgroundSession(sid: string): Promise<void> {
             ...(m.intent ? { intent: m.intent } : {}),
             ...(m.turnIntentId ? { turnIntentId: m.turnIntentId } : {}),
             timestamp: m.timestamp,
+            ...(m.displayContent ? { displayContent: m.displayContent } : {}),
             ...(blocks?.length ? { contentBlocks: blocks } : {}),
             ...(m.images?.length ? { images: m.images } : {}),
             ...(m.model ? { model: m.model } : {}),

--- a/apps/screenpipe-app-tauri/lib/utils/chat-title.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-title.ts
@@ -4,6 +4,11 @@
 
 export type ChatTitleSource = "fallback" | "ai" | "user";
 
+export interface TitleSourceMessageLike {
+  content?: string | null;
+  displayContent?: string | null;
+}
+
 const TITLE_SOURCE_RANK: Record<ChatTitleSource, number> = {
   fallback: 0,
   ai: 1,
@@ -53,6 +58,20 @@ export function systemFallbackTitle(
 }
 
 /**
+ * Derive the UI/system fallback title for a conversation from the first
+ * real user message. Prefer a short user-facing display label when present
+ * (meeting summaries, pipe actions, etc.), otherwise fall back to a cleaned
+ * slice of the raw prompt text.
+ */
+export function deriveFallbackConversationTitle(
+  firstUserMessage?: TitleSourceMessageLike | null,
+): string {
+  const displayTitle = firstUserMessage?.displayContent?.trim();
+  if (displayTitle) return displayTitle;
+  return systemFallbackTitle(firstUserMessage?.content);
+}
+
+/**
  * Check whether a title looks like a system-generated fallback (as opposed
  * to a deliberate user rename). Used to decide whether AI title generation
  * should run. This function is intentionally broad — it must recognize
@@ -80,4 +99,3 @@ export function isFallbackLikeTitle(
       : false)
   );
 }
-

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
@@ -67,6 +67,47 @@ function timestampMs(iso: string): number {
   return Number.isFinite(ms) ? ms : 0;
 }
 
+function isGenericMeetingTitle(title: string | null | undefined, meetingApp: string | null | undefined): boolean {
+  const normalizedTitle = title?.trim().toLowerCase();
+  if (!normalizedTitle) return true;
+  if (["untitled", "untitled meeting", "meeting"].includes(normalizedTitle)) {
+    return true;
+  }
+
+  const normalizedApp = meetingApp?.trim().toLowerCase();
+  if (normalizedApp && normalizedTitle === normalizedApp) {
+    return true;
+  }
+
+  return false;
+}
+
+function formatMeetingLabelTime(iso: string): string {
+  return new Date(iso)
+    .toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+    .replace(",", "");
+}
+
+export function buildMeetingSummarizeDisplayLabel(meeting: MeetingRecord): string {
+  const title = meeting.title?.trim();
+  if (!isGenericMeetingTitle(title, meeting.meeting_app) && title) {
+    return `Summarize meeting: ${title}`;
+  }
+
+  const app = meeting.meeting_app?.trim();
+  const formattedTime = formatMeetingLabelTime(meeting.meeting_start);
+  if (app && app.toLowerCase() !== "manual") {
+    return `Summarize ${app} meeting: ${formattedTime}`;
+  }
+
+  return `Summarize meeting: ${formattedTime}`;
+}
+
 function sortAudioChunks(chunks: MeetingAudioChunk[]): MeetingAudioChunk[] {
   return [...chunks].sort((a, b) => {
     const byTime = timestampMs(a.timestamp) - timestampMs(b.timestamp);


### PR DESCRIPTION
This PR adds clean UI labels for prefill-driven chats like meeting summarize and pipe optimize, while keeping the full detailed prompt sent to the assistant unchanged.

## Changes

- Added `displayLabel` to chat prefills
- Meeting summarize now uses a friendly label like `Summarize meeting: Design Review`
- Pipe optimize now uses a friendly label like `Optimize pipe: My Pipe`
- Reused existing `displayContent` for UI-facing message labels
- Unified title derivation across live UI, foreground save, and background save
- Preserved friendly labels during persistence so they survive reloads and chat switching


Before -

https://github.com/user-attachments/assets/e727069a-3421-4033-89bd-97f937cc72c5



After - 


https://github.com/user-attachments/assets/05d13006-c705-4836-90dd-1cb2938b436e

