### PR TITLE
fix(chat-sidebar): `  ⋮`overlapping time label on hover

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -1380,6 +1380,9 @@ function Section({
         className={cn(
           // Light header row — avoid the "boxed section" look.
           "group/section shrink-0 px-2.5 py-1 flex items-center gap-1 rounded-sm text-left",
+          // Suppress the default macOS blue focus ring — it bleeds into the
+          // adjacent animated grid during collapse and leaves a cyan stripe.
+          "focus:outline-none",
           tone === "subtle" ? "hover:bg-muted/10" : "hover:bg-muted/15"
         )}
         aria-expanded={!collapsed}
@@ -1435,7 +1438,10 @@ function Section({
       </button>
       <div
         className={cn(
-          "grid transition-[grid-template-rows] duration-200 ease-in-out",
+          // overflow-hidden here ensures paint stays within the animated
+          // boundary and prevents the focus-ring bleed that caused the
+          // left-edge cyan stripe artifact during collapse/expand.
+          "grid overflow-hidden transition-[grid-template-rows] duration-200 ease-in-out",
           collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]"
         )}
       >
@@ -1554,7 +1560,7 @@ export function SidebarChatRow({
           <span
             className={cn(
               "absolute inset-y-0 right-0 flex items-center justify-end transition-opacity duration-150",
-              canSwapAgeForMenu && "group-hover:opacity-0",
+              canShowActions && "group-hover:opacity-0",
               menuOpen && "opacity-0"
             )}
           >


### PR DESCRIPTION
## Description:



  - Animation artifact: Clicking a section header (RECENTS, PINNED, etc.) to collapse/expand left a faint cyan/blue vertical stripe along the left edge. The native macOS focus ring on the toggle <button> was bleeding into the adjacent animated grid area during the grid-template-rows transition.

### Before

<img width="245" height="429" alt="Screenshot 2026-05-29 at 11 41 42 PM" src="https://github.com/user-attachments/assets/80946bda-e4f9-4b2e-b077-dab578a543a0" />

### After 


https://github.com/user-attachments/assets/cd9fdcb6-1a75-4033-bc57-8055c4724886




      
      
 - Hover overlap: The `⋮` action menu was appearing on top of the relative-time label (now, 1h, 3h, …) instead of replacing it. The right-signal span was only fading out on hover when canSwapAgeForMenu was true (idle rows with an age label). 


### Before


https://github.com/user-attachments/assets/88335623-8646-4535-89e9-1a963a3719f4



### After 



https://github.com/user-attachments/assets/c7792266-697e-4e94-a67e-0bd8da726ef5


Closes #3689 
