### PR TITLE
Add labels for auto-sent chat entry points

### DIFF
--- a/apps/screenpipe-app-tauri/components/notification-bell.tsx
+++ b/apps/screenpipe-app-tauri/components/notification-bell.tsx
@@ -67,6 +67,13 @@ async function openNotificationLink(href: string) {
   await open(raw);
 }
 
+function buildNotificationDisplayLabel(title: string): string {
+  const normalized = title.replace(/\s+/g, " ").trim();
+  if (!normalized) return "Ask AI about notification";
+  const compact = normalized.length > 60 ? `${normalized.slice(0, 57).trimEnd()}...` : normalized;
+  return `Ask AI about: ${compact}`;
+}
+
 export function NotificationBell() {
   const [history, setHistory] = useState<NotificationEntry[]>([]);
   const [open, setOpen] = useState(false);
@@ -313,6 +320,7 @@ export function NotificationBell() {
                           showChatWithPrefill({
                             context: `notification from ${entry.pipe_name || "screenpipe"}:\n\n**${entry.title}**\n${entry.body}`,
                             prompt: `tell me more about this: "${entry.title}"`,
+                            displayLabel: buildNotificationDisplayLabel(entry.title),
                             autoSend: true,
                             source: `notification-bell-${entry.id}`,
                           });

--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -183,6 +183,16 @@ function navigateHomeAndPrefill(data: ChatPrefillData): void {
   window.location.href = url.toString();
 }
 
+function buildForkPipeDisplayLabel(pipeTitle: string): string {
+  const title = pipeTitle.trim();
+  return title ? `Fork pipe: ${title}` : "Fork pipe";
+}
+
+function buildPublishPipeDisplayLabel(pipeName: string): string {
+  const name = pipeName.trim();
+  return name ? `Publish pipe: ${name}` : "Publish pipe";
+}
+
 
 
 function formatCount(n: number): string {
@@ -1109,6 +1119,7 @@ ${pipeSource}
 
 IMPORTANT: first read the screenpipe skill file to understand how pipes work, then ask the user how they want to customize/improve this pipe for their specific needs. do NOT auto-send or auto-create — have a conversation first to understand what they want to change.`,
                     prompt: `i want to fork the "${pipe.title}" pipe and adapt it to my needs. here is the original pipe.md:\n\n${pipeSource}`,
+                    displayLabel: buildForkPipeDisplayLabel(pipe.title),
                     autoSend: true,
                   });
                 }}
@@ -1511,6 +1522,7 @@ STEP 5: PUBLISH (only after user says yes)
 - include Authorization header with Bearer token from settings (read settings first to get user.token)
 - tell the user the result`,
       prompt: `help me publish my pipe "${pipeName}" to the store. make it generic and ready for anyone to use.`,
+      displayLabel: buildPublishPipeDisplayLabel(pipeName),
       autoSend: true,
     });
   };

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -175,6 +175,13 @@ function navigateHomeAndPrefill(data: ChatPrefillData): void {
   window.location.href = url.toString();
 }
 
+function buildCreatePipeDisplayLabel(prompt: string): string {
+  const normalized = prompt.replace(/\s+/g, " ").trim();
+  if (!normalized) return "Create pipe";
+  const compact = normalized.length > 60 ? `${normalized.slice(0, 57).trimEnd()}...` : normalized;
+  return `Create pipe: ${compact}`;
+}
+
 /** Convert a raw schedule string to a short human-readable label. */
 function humanizeSchedule(schedule: string | undefined): string {
   if (!schedule || schedule === "manual") return "manual";
@@ -2767,6 +2774,7 @@ export function PipesSection() {
           navigateHomeAndPrefill({
             context: PIPE_CREATION_PROMPT,
             prompt: value,
+            displayLabel: buildCreatePipeDisplayLabel(value),
             autoSend: true,
           });
         }}

--- a/apps/screenpipe-app-tauri/components/settings/speakers-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/speakers-section.tsx
@@ -86,6 +86,10 @@ function getLatestSampleTime(speaker: Speaker): number {
   return Math.max(...samples.map((s) => s.timestamp || 0));
 }
 
+function buildOrganizeSpeakersDisplayLabel(): string {
+  return "Organize speakers";
+}
+
 function AudioClip({
   path,
   startTime,
@@ -1178,6 +1182,7 @@ export function SpeakersSection() {
               context: `here are my current speakers:\n${speakerSummary}\n\nYou have access to the screenpipe API to manage speakers:\n- POST /speakers/update {id, name} to rename\n- POST /speakers/merge {speaker_to_keep_id, speaker_to_merge_id} to merge duplicates\n- POST /speakers/delete {speaker_id} to delete\n- POST /speakers/hallucination {speaker_id} to mark false detections`,
               prompt:
                 "look at my speakers and help me organize them. find likely duplicates to merge, suggest better names for vague ones, and flag any that look like false detections. make the changes directly via the API.",
+              displayLabel: buildOrganizeSpeakersDisplayLabel(),
               autoSend: true,
               source: "speakers-organize",
               useHomeChat: true,


### PR DESCRIPTION
This PR adds user-facing display labels to a few auto-sent chat entry points so chat bubbles and titles no longer show raw hidden prompt/context content.

<img width="1135" height="649" alt="image" src="https://github.com/user-attachments/assets/3d15bf61-9035-4f08-a3b6-d1a6f2a5ea2d" />


<img width="1135" height="649" alt="image" src="https://github.com/user-attachments/assets/6bff8858-6c4e-4f21-ac04-6792620262a7" />


<img width="1135" height="649" alt="image" src="https://github.com/user-attachments/assets/c2c59bff-058b-45da-80e8-cc54d0c13222" />

<img width="1135" height="649" alt="image" src="https://github.com/user-attachments/assets/bd97774e-629d-4b61-86b9-cca50436e9ba" />


<img width="1135" height="649" alt="image" src="https://github.com/user-attachments/assets/26f0095b-8063-4109-8c13-db257a98ace4" />
