### PR TITLE
fix(capture): recover vision capture after a locked-screen startup

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
@@ -129,6 +129,15 @@ impl CaptureSession {
                         "VisionManager initial start failed ({e}); monitor watcher \
                          will retry on screen-unlock / display reconfiguration"
                     );
+                    // Surface the real state to the tray/health rather than
+                    // letting the caller log "started successfully" and report
+                    // healthy while vision is actually down (https://github.com/screenpipe/screenpipe/issues/3702
+                    // review note). `Starting` reads as "recovering" — the
+                    // health poll promotes it to Recording once the watcher's
+                    // retry succeeds and frames start landing.
+                    crate::health::set_recording_status(
+                        crate::health::RecordingStatus::Starting,
+                    );
                 }
             }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
@@ -96,20 +96,47 @@ impl CaptureSession {
                 None
             };
 
-            // Await VisionManager::start inline so its Err can propagate back to
-            // start_capture. Previously this was inside a detached `tokio::spawn`,
-            // which returned the outer `Ok(Self)` before the spawn even ran — so
-            // a silent failure (e.g. stale allowlist matching zero monitors) left
-            // a "dead" CaptureSession parked in RecordingState.capture and every
-            // subsequent tray click short-circuited on is_some().
-            vision_manager.start().await.map_err(|e| {
-                error!("Failed to start VisionManager: {:?}", e);
-                format!("Failed to start VisionManager: {e}")
-            })?;
-            info!("VisionManager started successfully");
+            // Attempt the initial VisionManager::start inline.
+            //
+            // History of this call site:
+            //   1. Originally `start()` ran inside a detached `tokio::spawn`,
+            //      which returned the outer `Ok(Self)` before the spawn even
+            //      ran — so a silent failure left a "dead" CaptureSession parked
+            //      in RecordingState.capture and every tray click short-circuited
+            //      on is_some().
+            //   2. We then `?`-propagated the error so the failure surfaced. But
+            //      that early-return meant the monitor watcher below — the ONLY
+            //      thing that retries `start()` on unlock / display-reconfig —
+            //      never got spawned. A transient "0 monitors enumerated because
+            //      the screen was locked at startup" (common right after an
+            //      auto-update restart) then killed capture *permanently*: the
+            //      recorder sat dead until the user manually restarted the app.
+            //      See issue https://github.com/screenpipe/screenpipe/issues/3702.
+            //
+            // Fix: treat a failed initial `start()` as RECOVERABLE. We always
+            // spawn the monitor watcher; its retry loop wakes on screen-unlock
+            // and display-reconfiguration and re-invokes `start()` until monitors
+            // appear. Only a hard failure (which `start()` does not currently
+            // return — it rolls status back to Stopped on the stale/empty case)
+            // would warrant aborting the session.
+            match vision_manager.start().await {
+                Ok(()) => info!("VisionManager started successfully"),
+                Err(e) => {
+                    // Do NOT abort the capture session. The monitor watcher
+                    // spawned below will retry start() on unlock / topology
+                    // change and recover automatically.
+                    warn!(
+                        "VisionManager initial start failed ({e}); monitor watcher \
+                         will retry on screen-unlock / display reconfiguration"
+                    );
+                }
+            }
 
             // Long-running parts (monitor watcher + shutdown handler) stay in the
-            // spawn — they're fire-and-forget by design.
+            // spawn — they're fire-and-forget by design. This MUST be spawned
+            // even when the initial start() failed, because the watcher's retry
+            // loop is what recovers capture after a locked-screen / no-monitor
+            // startup (issue https://github.com/screenpipe/screenpipe/issues/3702).
             let vm_spawn = vision_manager.clone();
             tokio::spawn(async move {
                 let mut shutdown_rx = shutdown_rx;

--- a/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
@@ -96,56 +96,19 @@ impl CaptureSession {
                 None
             };
 
-            // Attempt the initial VisionManager::start inline.
-            //
-            // History of this call site:
-            //   1. Originally `start()` ran inside a detached `tokio::spawn`,
-            //      which returned the outer `Ok(Self)` before the spawn even
-            //      ran — so a silent failure left a "dead" CaptureSession parked
-            //      in RecordingState.capture and every tray click short-circuited
-            //      on is_some().
-            //   2. We then `?`-propagated the error so the failure surfaced. But
-            //      that early-return meant the monitor watcher below — the ONLY
-            //      thing that retries `start()` on unlock / display-reconfig —
-            //      never got spawned. A transient "0 monitors enumerated because
-            //      the screen was locked at startup" (common right after an
-            //      auto-update restart) then killed capture *permanently*: the
-            //      recorder sat dead until the user manually restarted the app.
-            //      See issue https://github.com/screenpipe/screenpipe/issues/3702.
-            //
-            // Fix: treat a failed initial `start()` as RECOVERABLE. We always
-            // spawn the monitor watcher; its retry loop wakes on screen-unlock
-            // and display-reconfiguration and re-invokes `start()` until monitors
-            // appear. Only a hard failure (which `start()` does not currently
-            // return — it rolls status back to Stopped on the stale/empty case)
-            // would warrant aborting the session.
+            // A failed initial start() (e.g. 0 monitors while screen is locked at boot)
+            // is recoverable — the monitor watcher below retries on unlock/topology change.
+            // Don't propagate the error; keep the session alive so the watcher can run.
             match vision_manager.start().await {
                 Ok(()) => info!("VisionManager started successfully"),
                 Err(e) => {
-                    // Do NOT abort the capture session. The monitor watcher
-                    // spawned below will retry start() on unlock / topology
-                    // change and recover automatically.
-                    warn!(
-                        "VisionManager initial start failed ({e}); monitor watcher \
-                         will retry on screen-unlock / display reconfiguration"
-                    );
-                    // Surface the real state to the tray/health rather than
-                    // letting the caller log "started successfully" and report
-                    // healthy while vision is actually down (https://github.com/screenpipe/screenpipe/issues/3702
-                    // review note). `Starting` reads as "recovering" — the
-                    // health poll promotes it to Recording once the watcher's
-                    // retry succeeds and frames start landing.
-                    crate::health::set_recording_status(
-                        crate::health::RecordingStatus::Starting,
-                    );
+                    warn!("VisionManager initial start failed ({e}); monitor watcher will retry");
+                    crate::health::set_recording_status(crate::health::RecordingStatus::Starting);
                 }
             }
 
             // Long-running parts (monitor watcher + shutdown handler) stay in the
-            // spawn — they're fire-and-forget by design. This MUST be spawned
-            // even when the initial start() failed, because the watcher's retry
-            // loop is what recovers capture after a locked-screen / no-monitor
-            // startup (issue https://github.com/screenpipe/screenpipe/issues/3702).
+            // spawn — they're fire-and-forget by design.
             let vm_spawn = vision_manager.clone();
             tokio::spawn(async move {
                 let mut shutdown_rx = shutdown_rx;

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -925,12 +925,6 @@ pub async fn spawn_screenpipe(
         Ok(Err(e)) => {
             state.is_starting.store(false, Ordering::SeqCst);
             state.is_starting_capture.store(false, Ordering::SeqCst);
-            // NOTE (https://github.com/screenpipe/screenpipe/issues/3702): as of the locked-screen recovery fix, a transient
-            // "no monitors matched" no longer fails CaptureSession::start — the
-            // session is created and the monitor watcher retries start() on
-            // unlock. This branch now only fires for genuinely fatal capture
-            // failures, but we keep the Error status mapping as a safety net in
-            // case some other path resurfaces the stale-allowlist string.
             if e.contains("no monitors matched") {
                 crate::health::set_recording_status(crate::health::RecordingStatus::Error);
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -925,6 +925,12 @@ pub async fn spawn_screenpipe(
         Ok(Err(e)) => {
             state.is_starting.store(false, Ordering::SeqCst);
             state.is_starting_capture.store(false, Ordering::SeqCst);
+            // NOTE (https://github.com/screenpipe/screenpipe/issues/3702): as of the locked-screen recovery fix, a transient
+            // "no monitors matched" no longer fails CaptureSession::start — the
+            // session is created and the monitor watcher retries start() on
+            // unlock. This branch now only fires for genuinely fatal capture
+            // failures, but we keep the Error status mapping as a safety net in
+            // case some other path resurfaces the stale-allowlist string.
             if e.contains("no monitors matched") {
                 crate::health::set_recording_status(crate::health::RecordingStatus::Error);
             }

--- a/crates/screenpipe-engine/src/sleep_monitor.rs
+++ b/crates/screenpipe-engine/src/sleep_monitor.rs
@@ -26,7 +26,6 @@ use tracing::{debug, error, info, warn};
 use crate::analytics::capture_event_nonblocking;
 #[cfg(target_os = "macos")]
 use serde_json::json;
-#[cfg(target_os = "macos")]
 use tokio::sync::Notify;
 
 /// Tracks whether the system is currently in a "post-wake" state
@@ -772,6 +771,35 @@ mod tests {
             .await
             .expect("parked waiter should be woken by unlock notify")
             .expect("waiter task should not panic");
+    }
+
+    /// Mirrors the monitor watcher's stale-permit drain (https://github.com/screenpipe/screenpipe/issues/3702
+    /// review note): a permit buffered by an unlock that fired while the watcher
+    /// was NOT parked must be drained with a zero-timeout poll, so the
+    /// subsequent "wait for a fresh unlock" does not return instantly.
+    #[tokio::test]
+    async fn test_stale_permit_drain_then_block() {
+        let notify = std::sync::Arc::new(Notify::const_new());
+
+        // Simulate a stale permit buffered while no waiter was parked.
+        notify.notify_one();
+
+        // Drain step: timeout(0, notified()) consumes the buffered permit.
+        let drained =
+            tokio::time::timeout(std::time::Duration::from_millis(0), notify.notified()).await;
+        assert!(
+            drained.is_ok(),
+            "zero-timeout poll should consume the buffered stale permit"
+        );
+
+        // Now a fresh wait must actually block (no stale permit left), so a
+        // short timeout elapses with Err rather than returning Ok instantly.
+        let fresh =
+            tokio::time::timeout(std::time::Duration::from_millis(30), notify.notified()).await;
+        assert!(
+            fresh.is_err(),
+            "after draining, the next wait must block until a real unlock"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/screenpipe-engine/src/sleep_monitor.rs
+++ b/crates/screenpipe-engine/src/sleep_monitor.rs
@@ -50,6 +50,25 @@ static SCREEN_IS_LOCKED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static DISPLAY_RECONFIG_NOTIFY: Notify = Notify::const_new();
 
+/// Fired when the screen transitions from locked → unlocked
+/// (`com.apple.screenIsUnlocked`, or the CGSession safety-net poll catching a
+/// missed notification). Lets subsystems that couldn't enumerate monitors while
+/// the screen was locked retry immediately on unlock instead of waiting for the
+/// next timer tick. Uses the same `notify_one` single-consumer semantics as
+/// `DISPLAY_RECONFIG_NOTIFY`: at most one pending permit is buffered when no
+/// waiter is parked, so the next `.notified().await` returns immediately.
+///
+/// This is the recovery signal for issue https://github.com/screenpipe/screenpipe/issues/3702: an auto-update restart while the
+/// screen is locked enumerates 0 monitors, VisionManager start() fails, and the
+/// monitor watcher must re-run start() on unlock to bring capture back.
+static SCREEN_UNLOCK_NOTIFY: Notify = Notify::const_new();
+
+/// Handle to the screen-unlock notify. Await `.notified()` on it to be woken the
+/// next time the screen transitions from locked to unlocked.
+pub fn screen_unlock_notify() -> &'static Notify {
+    &SCREEN_UNLOCK_NOTIFY
+}
+
 /// Set to `true` once `CGDisplayRegisterReconfigurationCallback` has been
 /// registered successfully. If registration fails (rare CG error path),
 /// callers should fall back to shorter polling instead of relying on the
@@ -280,6 +299,11 @@ pub fn start_sleep_monitor() {
                 // the capture loop recreates them with fresh frames.
                 #[cfg(target_os = "macos")]
                 screenpipe_screen::stream_invalidation::request();
+                // Wake any subsystem that aborted while the screen was locked
+                // (e.g. the monitor watcher after a 0-monitor start failure on a
+                // locked-screen auto-update restart — issue https://github.com/screenpipe/screenpipe/issues/3702) so it can
+                // retry monitor enumeration immediately.
+                SCREEN_UNLOCK_NOTIFY.notify_one();
             }
         }
 
@@ -341,6 +365,10 @@ pub fn start_sleep_monitor() {
                 info!("Screen unlocked (CGSession safety-net poll)");
                 #[cfg(target_os = "macos")]
                 screenpipe_screen::stream_invalidation::request();
+                // Safety-net for the unlock recovery signal (issue https://github.com/screenpipe/screenpipe/issues/3702): if the
+                // CFNotificationCenter unlock notification was dropped, this poll
+                // still wakes waiters within ~5s.
+                SCREEN_UNLOCK_NOTIFY.notify_one();
             }
         }
     });
@@ -523,6 +551,9 @@ fn on_did_wake(handle: &tokio::runtime::Handle) {
             info!("Screen unlocked after wake (CGSession safety-net cleared SCREEN_IS_LOCKED)");
             #[cfg(target_os = "macos")]
             screenpipe_screen::stream_invalidation::request();
+            // Recovery signal for issue https://github.com/screenpipe/screenpipe/issues/3702 — wake the monitor watcher so it
+            // retries enumeration now that displays are available post-wake.
+            SCREEN_UNLOCK_NOTIFY.notify_one();
         }
 
         // Resume DB write queue now that the system is stable.
@@ -713,6 +744,33 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_millis(50), waiter)
             .await
             .expect("parked waiter should be woken by notify_one")
+            .expect("waiter task should not panic");
+    }
+
+    /// The screen-unlock recovery signal (https://github.com/screenpipe/screenpipe/issues/3702) must be observable through the
+    /// public `screen_unlock_notify()` handle and follow `notify_one`
+    /// buffer-or-wake semantics, so the monitor watcher's retry `select!` is
+    /// guaranteed to wake on unlock.
+    #[tokio::test]
+    async fn test_screen_unlock_notify_wakes_waiter() {
+        // Case 1: a notify issued before a waiter parks must be buffered and
+        // consumed immediately by the next `.notified()`.
+        screen_unlock_notify().notify_one();
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            screen_unlock_notify().notified(),
+        )
+        .await
+        .expect("buffered unlock permit should be consumed immediately");
+
+        // Case 2: a parked waiter must be woken by a subsequent notify.
+        let waiter = tokio::spawn(async { screen_unlock_notify().notified().await });
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        screen_unlock_notify().notify_one();
+        tokio::time::timeout(std::time::Duration::from_millis(50), waiter)
+            .await
+            .expect("parked waiter should be woken by unlock notify")
             .expect("waiter task should not panic");
     }
 

--- a/crates/screenpipe-engine/src/sleep_monitor.rs
+++ b/crates/screenpipe-engine/src/sleep_monitor.rs
@@ -49,21 +49,11 @@ static SCREEN_IS_LOCKED: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static DISPLAY_RECONFIG_NOTIFY: Notify = Notify::const_new();
 
-/// Fired when the screen transitions from locked → unlocked
-/// (`com.apple.screenIsUnlocked`, or the CGSession safety-net poll catching a
-/// missed notification). Lets subsystems that couldn't enumerate monitors while
-/// the screen was locked retry immediately on unlock instead of waiting for the
-/// next timer tick. Uses the same `notify_one` single-consumer semantics as
-/// `DISPLAY_RECONFIG_NOTIFY`: at most one pending permit is buffered when no
-/// waiter is parked, so the next `.notified().await` returns immediately.
-///
-/// This is the recovery signal for issue https://github.com/screenpipe/screenpipe/issues/3702: an auto-update restart while the
-/// screen is locked enumerates 0 monitors, VisionManager start() fails, and the
-/// monitor watcher must re-run start() on unlock to bring capture back.
+/// Fired on every locked → unlocked transition. Lets the monitor watcher retry
+/// start() immediately rather than waiting for the next poll tick.
+/// Same notify_one single-consumer semantics as DISPLAY_RECONFIG_NOTIFY.
 static SCREEN_UNLOCK_NOTIFY: Notify = Notify::const_new();
 
-/// Handle to the screen-unlock notify. Await `.notified()` on it to be woken the
-/// next time the screen transitions from locked to unlocked.
 pub fn screen_unlock_notify() -> &'static Notify {
     &SCREEN_UNLOCK_NOTIFY
 }
@@ -298,10 +288,6 @@ pub fn start_sleep_monitor() {
                 // the capture loop recreates them with fresh frames.
                 #[cfg(target_os = "macos")]
                 screenpipe_screen::stream_invalidation::request();
-                // Wake any subsystem that aborted while the screen was locked
-                // (e.g. the monitor watcher after a 0-monitor start failure on a
-                // locked-screen auto-update restart — issue https://github.com/screenpipe/screenpipe/issues/3702) so it can
-                // retry monitor enumeration immediately.
                 SCREEN_UNLOCK_NOTIFY.notify_one();
             }
         }
@@ -364,9 +350,6 @@ pub fn start_sleep_monitor() {
                 info!("Screen unlocked (CGSession safety-net poll)");
                 #[cfg(target_os = "macos")]
                 screenpipe_screen::stream_invalidation::request();
-                // Safety-net for the unlock recovery signal (issue https://github.com/screenpipe/screenpipe/issues/3702): if the
-                // CFNotificationCenter unlock notification was dropped, this poll
-                // still wakes waiters within ~5s.
                 SCREEN_UNLOCK_NOTIFY.notify_one();
             }
         }
@@ -550,8 +533,6 @@ fn on_did_wake(handle: &tokio::runtime::Handle) {
             info!("Screen unlocked after wake (CGSession safety-net cleared SCREEN_IS_LOCKED)");
             #[cfg(target_os = "macos")]
             screenpipe_screen::stream_invalidation::request();
-            // Recovery signal for issue https://github.com/screenpipe/screenpipe/issues/3702 — wake the monitor watcher so it
-            // retries enumeration now that displays are available post-wake.
             SCREEN_UNLOCK_NOTIFY.notify_one();
         }
 
@@ -746,60 +727,42 @@ mod tests {
             .expect("waiter task should not panic");
     }
 
-    /// The screen-unlock recovery signal (https://github.com/screenpipe/screenpipe/issues/3702) must be observable through the
-    /// public `screen_unlock_notify()` handle and follow `notify_one`
-    /// buffer-or-wake semantics, so the monitor watcher's retry `select!` is
-    /// guaranteed to wake on unlock.
     #[tokio::test]
     async fn test_screen_unlock_notify_wakes_waiter() {
-        // Case 1: a notify issued before a waiter parks must be buffered and
-        // consumed immediately by the next `.notified()`.
+        // buffered permit resolves immediately
         screen_unlock_notify().notify_one();
         tokio::time::timeout(
             std::time::Duration::from_millis(50),
             screen_unlock_notify().notified(),
         )
         .await
-        .expect("buffered unlock permit should be consumed immediately");
+        .expect("buffered permit should resolve immediately");
 
-        // Case 2: a parked waiter must be woken by a subsequent notify.
+        // parked waiter woken by subsequent notify
         let waiter = tokio::spawn(async { screen_unlock_notify().notified().await });
         tokio::task::yield_now().await;
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         screen_unlock_notify().notify_one();
         tokio::time::timeout(std::time::Duration::from_millis(50), waiter)
             .await
-            .expect("parked waiter should be woken by unlock notify")
+            .expect("parked waiter should wake")
             .expect("waiter task should not panic");
     }
 
-    /// Mirrors the monitor watcher's stale-permit drain (https://github.com/screenpipe/screenpipe/issues/3702
-    /// review note): a permit buffered by an unlock that fired while the watcher
-    /// was NOT parked must be drained with a zero-timeout poll, so the
-    /// subsequent "wait for a fresh unlock" does not return instantly.
     #[tokio::test]
     async fn test_stale_permit_drain_then_block() {
         let notify = std::sync::Arc::new(Notify::const_new());
-
-        // Simulate a stale permit buffered while no waiter was parked.
         notify.notify_one();
 
-        // Drain step: timeout(0, notified()) consumes the buffered permit.
+        // timeout(0) drains the buffered permit without blocking
         let drained =
             tokio::time::timeout(std::time::Duration::from_millis(0), notify.notified()).await;
-        assert!(
-            drained.is_ok(),
-            "zero-timeout poll should consume the buffered stale permit"
-        );
+        assert!(drained.is_ok(), "should consume the buffered permit");
 
-        // Now a fresh wait must actually block (no stale permit left), so a
-        // short timeout elapses with Err rather than returning Ok instantly.
+        // no permit left — next wait must block
         let fresh =
             tokio::time::timeout(std::time::Duration::from_millis(30), notify.notified()).await;
-        assert!(
-            fresh.is_err(),
-            "after draining, the next wait must block until a real unlock"
-        );
+        assert!(fresh.is_err(), "should block after drain");
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -196,11 +196,29 @@ pub async fn start_monitor_watcher(
                 #[cfg(target_os = "macos")]
                 {
                     let unlock = crate::sleep_monitor::screen_unlock_notify();
-                    tokio::select! {
-                        _ = tokio::time::sleep(Duration::from_secs(5)) => {}
-                        _ = unlock.notified() => {
-                            info!("screen unlocked — retrying VisionManager start immediately");
-                        }
+                    // Drain any permit buffered by an unlock that fired while we
+                    // were Running (and thus not parked here). Without this drain,
+                    // a stale permit makes the wait below return instantly the
+                    // first time we enter recovery and logs "screen unlocked"
+                    // without an unlock having just happened
+                    // (https://github.com/screenpipe/screenpipe/issues/3702 review note).
+                    //
+                    // `timeout(0, notified())` polls the `notified()` future
+                    // exactly once: if a permit was buffered it is consumed and
+                    // the future resolves `Ok`; otherwise it elapses `Err`. Either
+                    // way the stale permit is gone and we don't block.
+                    let _ =
+                        tokio::time::timeout(Duration::from_millis(0), unlock.notified()).await;
+
+                    // Now wait for a *fresh* unlock (or the 5s backstop).
+                    let woke_on_unlock = tokio::time::timeout(
+                        Duration::from_secs(5),
+                        unlock.notified(),
+                    )
+                    .await
+                    .is_ok();
+                    if woke_on_unlock {
+                        info!("screen unlocked — retrying VisionManager start immediately");
                     }
                 }
                 #[cfg(not(target_os = "macos"))]

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -183,8 +183,27 @@ pub async fn start_monitor_watcher(
             }
 
             // ── Normal monitor polling ──────────────────────────────────────
-            // If stopped (e.g. no monitors after undock/wake), retry start()
+            // If stopped (e.g. no monitors after undock/wake, or a 0-monitor
+            // start failure because the screen was locked at an auto-update
+            // restart — issue https://github.com/screenpipe/screenpipe/issues/3702), retry start().
+            //
+            // Recovery wakeup (Option B for https://github.com/screenpipe/screenpipe/issues/3702): instead of a blind 5s sleep,
+            // race a short timer against the screen-unlock signal. When the user
+            // unlocks, displays become enumerable again and we retry *immediately*
+            // rather than waiting up to 5s. On non-macOS the unlock notify never
+            // fires, so the timer alone drives retries.
             if vision_manager.status().await != VisionManagerStatus::Running {
+                #[cfg(target_os = "macos")]
+                {
+                    let unlock = crate::sleep_monitor::screen_unlock_notify();
+                    tokio::select! {
+                        _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                        _ = unlock.notified() => {
+                            info!("screen unlocked — retrying VisionManager start immediately");
+                        }
+                    }
+                }
+                #[cfg(not(target_os = "macos"))]
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 match vision_manager.start().await {
                     Ok(()) => {

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -183,41 +183,19 @@ pub async fn start_monitor_watcher(
             }
 
             // ── Normal monitor polling ──────────────────────────────────────
-            // If stopped (e.g. no monitors after undock/wake, or a 0-monitor
-            // start failure because the screen was locked at an auto-update
-            // restart — issue https://github.com/screenpipe/screenpipe/issues/3702), retry start().
-            //
-            // Recovery wakeup (Option B for https://github.com/screenpipe/screenpipe/issues/3702): instead of a blind 5s sleep,
-            // race a short timer against the screen-unlock signal. When the user
-            // unlocks, displays become enumerable again and we retry *immediately*
-            // rather than waiting up to 5s. On non-macOS the unlock notify never
-            // fires, so the timer alone drives retries.
+            // If stopped (e.g. no monitors after undock/wake), retry start().
             if vision_manager.status().await != VisionManagerStatus::Running {
                 #[cfg(target_os = "macos")]
                 {
                     let unlock = crate::sleep_monitor::screen_unlock_notify();
-                    // Drain any permit buffered by an unlock that fired while we
-                    // were Running (and thus not parked here). Without this drain,
-                    // a stale permit makes the wait below return instantly the
-                    // first time we enter recovery and logs "screen unlocked"
-                    // without an unlock having just happened
-                    // (https://github.com/screenpipe/screenpipe/issues/3702 review note).
-                    //
-                    // `timeout(0, notified())` polls the `notified()` future
-                    // exactly once: if a permit was buffered it is consumed and
-                    // the future resolves `Ok`; otherwise it elapses `Err`. Either
-                    // way the stale permit is gone and we don't block.
-                    let _ =
-                        tokio::time::timeout(Duration::from_millis(0), unlock.notified()).await;
-
-                    // Now wait for a *fresh* unlock (or the 5s backstop).
-                    let woke_on_unlock = tokio::time::timeout(
-                        Duration::from_secs(5),
-                        unlock.notified(),
-                    )
-                    .await
-                    .is_ok();
-                    if woke_on_unlock {
+                    // Drain any permit buffered while we were Running so we don't
+                    // wake instantly on a stale signal.
+                    let _ = tokio::time::timeout(Duration::from_millis(0), unlock.notified()).await;
+                    // Race unlock against the 5s backstop.
+                    if tokio::time::timeout(Duration::from_secs(5), unlock.notified())
+                        .await
+                        .is_ok()
+                    {
                         info!("screen unlocked — retrying VisionManager start immediately");
                     }
                 }


### PR DESCRIPTION


## Description

After an auto-update restart while the screen is **locked**, macOS enumerates 0 monitors. `VisionManager::start()` fails, and the capture session was permanently dead until a manual app restart — even after the user unlocked. The app window stayed open and looked alive, but `:3030` was unreachable and nothing was recorded overnight.

This PR fixes that by making the initial start failure **recoverable**:

1. **Spawn the monitor watcher unconditionally.** The capture session is created even when initial `start()` fails. The watcher's existing retry loop brings capture back once displays are enumerable.
2. **Wake the retry immediately on unlock.** A new `SCREEN_UNLOCK_NOTIFY` signal fires on the locked → unlocked transition. The watcher races this against the 5s backstop, so capture resumes as soon as the user unlocks instead of waiting up to 5s.
3. **Drain stale unlock permits.** `SCREEN_UNLOCK_NOTIFY` can buffer a permit while capture is already `Running`. On the next recovery entry that stale permit would wake the retry loop instantly with a misleading log. A zero-timeout drain (`timeout(0, notified())`) clears it before waiting for a fresh signal.
4. **Honest tray/health status during recovery.** With the initial failure now swallowed, the tray would have read healthy while vision was actually down. `RecordingStatus::Starting` is set on the failure path; the health poll promotes it to `Recording` once frames land.

Fixes #3702.



## Root cause

### 1. Zero monitors while the screen is locked

On macOS, display enumeration returns 0 monitors when the screen is locked at process startup. The auto-update restart happened at `00:07` while the machine was locked overnight:

```
00:08:15  INFO  sleep_monitor:   Screen is locked at startup — setting SCREEN_IS_LOCKED
00:08:14  WARN  vision_manager:  no monitors matched the allowed list (0 enumerated, 0 started)
00:08:14 ERROR  capture_session: Failed to start VisionManager: no monitors matched ...
00:08:14 ERROR  recording:       Failed to start capture session
```

### 2. The `?` returned before the watcher was ever spawned

```rust
// capture_session.rs — before this fix
vision_manager.start().await.map_err(|e| { ... })?;  // returns early
info!("VisionManager started successfully");

tokio::spawn(async move {                             // never reached
    start_monitor_watcher(vm_spawn, audio_manager).await ...
});
```

The only component that retries `start()` on unlock / topology change is `start_monitor_watcher`. Because the `?` returned before the spawn, the retry loop never ran. The transient "0 monitors" condition became permanent.

This was a regression: the start was originally inside a detached `tokio::spawn` that returned `Ok(Self)` before running (silent dead session). That was fixed by propagating the error — but propagation killed the watcher-spawn path.

### Log proof

Across the entire ~11-hour window:

| Event | Count |
|---|---|
| `Starting VisionManager` | 6 |
| `no monitors matched` | 19 |
| `Monitor watcher started` | **0** |
| `VisionManager started successfully` | **0** |

The remaining log shows only 5-minute update checks and repeated `failed to store tags ... (localhost:3030/raw_sql)` — the server was unreachable on `:3030` the entire time.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Auto-update restart while screen locked | Capture dead permanently until manual restart | Recovers automatically on unlock |
| Unlock after 0-monitor start | Never retried | Retries immediately |
| Undock / wake with no monitors | Recovered if watcher had previously started | Recovers reliably |
| Genuinely fatal failure | Session aborted | Session aborted (unchanged) |
| Non-macOS | 5s poll retry | 5s poll retry (unchanged) |

---

## Testing

**Manual (macOS):**
1. Lock the screen (`Cmd+Ctrl+Q`).
2. Trigger a recorder restart while locked.
3. Confirm log shows `no monitors matched` **and** `Monitor watcher started`.
4. Unlock — confirm `screen unlocked — retrying VisionManager start immediately`, then `VisionManager recovered`, and `:3030` responds.


