### PR TITLE
Expose operational telemetry to user PostHog and OTLP backends

### DIFF
--- a/crates/screenpipe-engine/src/analytics.rs
+++ b/crates/screenpipe-engine/src/analytics.rs
@@ -1,6 +1,6 @@
 use once_cell::sync::Lazy;
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tracing::{debug, trace};
@@ -12,6 +12,7 @@ use tracing::warn;
 
 const POSTHOG_API_KEY: &str = "phc_z7FZXE8vmXtdTQ78LMy3j1BQWW4zP6PGDUP46rgcdnb";
 const POSTHOG_HOST: &str = "https://us.i.posthog.com";
+const OTLP_LOGS_PATH: &str = "/v1/logs";
 
 static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(false);
 
@@ -20,6 +21,22 @@ static ANALYTICS: Lazy<Analytics> = Lazy::new(Analytics::new);
 pub struct Analytics {
     client: Client,
     distinct_id: String,
+    user_posthog: Option<UserPostHogConfig>,
+    otlp: Option<OtlpConfig>,
+}
+
+#[derive(Clone, Debug)]
+struct UserPostHogConfig {
+    api_key: String,
+    host: String,
+}
+
+#[derive(Clone, Debug)]
+struct OtlpConfig {
+    logs_endpoint: String,
+    service_name: String,
+    resource_attributes: Vec<(String, String)>,
+    headers: Vec<(String, String)>,
 }
 
 impl Analytics {
@@ -29,11 +46,21 @@ impl Analytics {
         let distinct_id = env::var("SCREENPIPE_ANALYTICS_ID")
             .unwrap_or_else(|_| uuid::Uuid::new_v4().to_string());
 
-        debug!("Analytics initialized with distinct_id: {}", distinct_id);
+        let user_posthog = user_posthog_config();
+        let otlp = otlp_config();
+
+        debug!(
+            "Analytics initialized with distinct_id: {}, user_posthog: {}, otlp: {}",
+            distinct_id,
+            user_posthog.is_some(),
+            otlp.is_some()
+        );
 
         Self {
             client: Client::new(),
             distinct_id,
+            user_posthog,
+            otlp,
         }
     }
 
@@ -42,7 +69,11 @@ impl Analytics {
     }
 }
 
-/// Initialize analytics with telemetry enabled/disabled
+/// Initialize analytics with telemetry enabled/disabled.
+///
+/// Screenpipe-owned product analytics still obey the existing opt-in flag. User-configured
+/// observability sinks are controlled only by their own env vars so self-hosted operators can
+/// keep operational telemetry even when product analytics is disabled.
 pub fn init(telemetry_enabled: bool) {
     TELEMETRY_ENABLED.store(telemetry_enabled, Ordering::SeqCst);
     // Force lazy initialization
@@ -58,48 +89,271 @@ pub fn get_distinct_id() -> &'static str {
     ANALYTICS.distinct_id()
 }
 
-/// Capture an analytics event
+/// Capture an operational analytics event.
+///
+/// Existing Screenpipe PostHog telemetry is sent only when the user opted in. User-configured
+/// PostHog and OTLP sinks mirror the same operational event when their env vars are present.
 pub async fn capture_event(event: &str, properties: Value) {
-    if !TELEMETRY_ENABLED.load(Ordering::SeqCst) {
+    let screenpipe_telemetry_enabled = TELEMETRY_ENABLED.load(Ordering::SeqCst);
+    let has_user_sink = ANALYTICS.user_posthog.is_some() || ANALYTICS.otlp.is_some();
+    if !screenpipe_telemetry_enabled && !has_user_sink {
         return;
     }
 
-    let mut props = properties;
-    if let Some(obj) = props.as_object_mut() {
-        obj.insert("distinct_id".to_string(), json!(ANALYTICS.distinct_id));
-        obj.insert("$lib".to_string(), json!("screenpipe-engine"));
-        obj.insert("release".to_string(), json!(env!("CARGO_PKG_VERSION")));
-    }
+    let props = enrich_properties(properties);
 
-    let payload = json!({
-        "api_key": POSTHOG_API_KEY,
-        "event": event,
-        "properties": props,
-    });
-
-    trace!(target: "analytics", "Capturing event: {} {:?}", event, payload);
+    trace!(target: "analytics", "Capturing event: {} {:?}", event, props);
 
     let client = &ANALYTICS.client;
-    if let Err(e) = client
-        .post(format!("{}/capture/", POSTHOG_HOST))
-        .json(&payload)
-        .timeout(std::time::Duration::from_secs(5))
-        .send()
-        .await
-    {
-        debug!("failed to send analytics event: {}", e);
+
+    if screenpipe_telemetry_enabled {
+        send_posthog_event(client, POSTHOG_HOST, POSTHOG_API_KEY, event, props.clone()).await;
+    }
+
+    if let Some(config) = ANALYTICS.user_posthog.clone() {
+        send_posthog_event(client, &config.host, &config.api_key, event, props.clone()).await;
+    }
+
+    if let Some(config) = ANALYTICS.otlp.clone() {
+        send_otlp_event(client, &config, event, props).await;
     }
 }
 
 /// Capture event without blocking (fire and forget)
 pub fn capture_event_nonblocking(event: &'static str, properties: Value) {
-    if !TELEMETRY_ENABLED.load(Ordering::SeqCst) {
+    let screenpipe_telemetry_enabled = TELEMETRY_ENABLED.load(Ordering::SeqCst);
+    let has_user_sink = ANALYTICS.user_posthog.is_some() || ANALYTICS.otlp.is_some();
+    if !screenpipe_telemetry_enabled && !has_user_sink {
         return;
     }
 
     tokio::spawn(async move {
         capture_event(event, properties).await;
     });
+}
+
+fn enrich_properties(mut properties: Value) -> Value {
+    if let Some(obj) = properties.as_object_mut() {
+        obj.insert("distinct_id".to_string(), json!(ANALYTICS.distinct_id));
+        obj.insert("$lib".to_string(), json!("screenpipe-engine"));
+        obj.insert("release".to_string(), json!(env!("CARGO_PKG_VERSION")));
+    }
+    properties
+}
+
+async fn send_posthog_event(client: &Client, host: &str, api_key: &str, event: &str, props: Value) {
+    let payload = json!({
+        "api_key": api_key,
+        "event": event,
+        "properties": props,
+    });
+
+    if let Err(e) = client
+        .post(format!("{}/capture/", host.trim_end_matches('/')))
+        .json(&payload)
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+    {
+        debug!("failed to send PostHog analytics event to {}: {}", host, e);
+    }
+}
+
+async fn send_otlp_event(client: &Client, config: &OtlpConfig, event: &str, props: Value) {
+    let mut attributes = vec![
+        otlp_attribute("event.name", Value::String(event.to_string())),
+        otlp_attribute("screenpipe.signal", Value::String("event".to_string())),
+    ];
+
+    if let Some(obj) = props.as_object() {
+        for (key, value) in obj {
+            attributes.push(otlp_attribute(
+                &format!("screenpipe.{}", sanitize_attr_key(key)),
+                value.clone(),
+            ));
+        }
+    }
+
+    let payload = json!({
+        "resourceLogs": [{
+            "resource": {
+                "attributes": resource_attributes(config),
+            },
+            "scopeLogs": [{
+                "scope": {
+                    "name": "screenpipe-engine",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "logRecords": [{
+                    "timeUnixNano": unix_time_nanos(),
+                    "severityText": "INFO",
+                    "body": { "stringValue": event },
+                    "attributes": attributes,
+                }]
+            }]
+        }]
+    });
+
+    let mut req = client
+        .post(&config.logs_endpoint)
+        .json(&payload)
+        .timeout(std::time::Duration::from_secs(5));
+    for (key, value) in &config.headers {
+        req = req.header(key, value);
+    }
+
+    if let Err(e) = req.send().await {
+        debug!(
+            "failed to send OTLP analytics event to {}: {}",
+            config.logs_endpoint, e
+        );
+    }
+}
+
+fn user_posthog_config() -> Option<UserPostHogConfig> {
+    let api_key = env::var("SCREENPIPE_USER_POSTHOG_KEY")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())?;
+    let host = env::var("SCREENPIPE_USER_POSTHOG_HOST")
+        .ok()
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| POSTHOG_HOST.to_string());
+
+    Some(UserPostHogConfig { api_key, host })
+}
+
+fn otlp_config() -> Option<OtlpConfig> {
+    let logs_endpoint = env::var("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+                .ok()
+                .filter(|v| !v.trim().is_empty())
+                .map(|endpoint| format!("{}{}", endpoint.trim_end_matches('/'), OTLP_LOGS_PATH))
+        })?;
+
+    let service_name = env::var("OTEL_SERVICE_NAME")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "screenpipe".to_string());
+
+    let mut resource_attributes = parse_key_value_list(
+        &env::var("OTEL_RESOURCE_ATTRIBUTES").unwrap_or_default(),
+        ',',
+    );
+    if !resource_attributes
+        .iter()
+        .any(|(key, _)| key == "service.name")
+    {
+        resource_attributes.push(("service.name".to_string(), service_name.clone()));
+    }
+    resource_attributes.push((
+        "service.version".to_string(),
+        env!("CARGO_PKG_VERSION").to_string(),
+    ));
+
+    let headers = parse_key_value_list(
+        &env::var("OTEL_EXPORTER_OTLP_HEADERS").unwrap_or_default(),
+        ',',
+    );
+
+    Some(OtlpConfig {
+        logs_endpoint: logs_endpoint.trim().to_string(),
+        service_name,
+        resource_attributes,
+        headers,
+    })
+}
+
+fn parse_key_value_list(input: &str, separator: char) -> Vec<(String, String)> {
+    input
+        .split(separator)
+        .filter_map(|pair| {
+            let (key, value) = pair.split_once('=')?;
+            let key = key.trim();
+            if key.is_empty() {
+                return None;
+            }
+            Some((key.to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+fn resource_attributes(config: &OtlpConfig) -> Vec<Value> {
+    let mut attrs: Vec<Value> = config
+        .resource_attributes
+        .iter()
+        .map(|(key, value)| otlp_attribute(key, Value::String(value.clone())))
+        .collect();
+    attrs.push(otlp_attribute(
+        "telemetry.sdk.language",
+        Value::String("rust".to_string()),
+    ));
+    attrs.push(otlp_attribute(
+        "screenpipe.service_name",
+        Value::String(config.service_name.clone()),
+    ));
+    attrs
+}
+
+fn otlp_attribute(key: &str, value: Value) -> Value {
+    json!({
+        "key": key,
+        "value": otlp_any_value(value),
+    })
+}
+
+fn otlp_any_value(value: Value) -> Value {
+    match value {
+        Value::Bool(v) => json!({ "boolValue": v }),
+        Value::Number(n) => {
+            if let Some(v) = n.as_i64() {
+                json!({ "intValue": v.to_string() })
+            } else if let Some(v) = n.as_u64() {
+                json!({ "intValue": v.to_string() })
+            } else if let Some(v) = n.as_f64() {
+                json!({ "doubleValue": v })
+            } else {
+                json!({ "stringValue": n.to_string() })
+            }
+        }
+        Value::String(v) => json!({ "stringValue": v }),
+        Value::Array(values) => json!({
+            "arrayValue": {
+                "values": values.into_iter().map(otlp_any_value).collect::<Vec<_>>()
+            }
+        }),
+        Value::Object(obj) => json!({ "kvlistValue": { "values": otlp_kv_list(obj) } }),
+        Value::Null => json!({ "stringValue": "" }),
+    }
+}
+
+fn otlp_kv_list(obj: Map<String, Value>) -> Vec<Value> {
+    obj.into_iter()
+        .map(|(key, value)| otlp_attribute(&sanitize_attr_key(&key), value))
+        .collect()
+}
+
+fn sanitize_attr_key(key: &str) -> String {
+    key.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn unix_time_nanos() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_string())
 }
 
 /// Parse macOS version string (e.g., "14.5" or "10.15.7") into major version number

--- a/docs/mintlify/docs-mintlify-mig-tmp/docs.json
+++ b/docs/mintlify/docs-mintlify-mig-tmp/docs.json
@@ -47,7 +47,7 @@
           },
           {
             "group": "deployment",
-            "pages": ["intune-deployment"]
+            "pages": ["intune-deployment", "observability"]
           },
 
           {

--- a/docs/mintlify/docs-mintlify-mig-tmp/observability.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/observability.mdx
@@ -1,0 +1,123 @@
+---
+title: "observability"
+description: "Send screenpipe operational telemetry to your own PostHog or OpenTelemetry collector."
+---
+
+screenpipe can mirror operational telemetry from the CLI/SDK runtime to backends that you control. This is opt-in and configured with environment variables; when none of these variables are set, behavior is unchanged.
+
+## privacy boundary
+
+Only operational signals are emitted. screenpipe does **not** include recorded content, transcripts, OCR text, screenshots, audio, clipboard content, or search results in telemetry payloads.
+
+Current event families include:
+
+- API usage counters
+- vision pipeline health, including frame counts, OCR counts, queue depth, latency, and drop counters
+- audio pipeline health, including chunk counts, transcription latency, queue depth, device count, and error counters
+- pipe scheduling/run lifecycle events
+- meeting detection decisions and feedback metadata
+- environment compatibility warnings, such as unsupported macOS versions
+
+## OpenTelemetry / OTLP
+
+Set an OTLP HTTP endpoint before starting screenpipe:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4318"
+export OTEL_SERVICE_NAME="screenpipe"
+export OTEL_RESOURCE_ATTRIBUTES="deployment.environment=prod,service.namespace=desktop-ai"
+screenpipe record
+```
+
+screenpipe sends events as OTLP log records to `${OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs`. You can also set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` when your collector exposes a dedicated logs URL.
+
+Supported env vars:
+
+| env var | purpose |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP HTTP endpoint; screenpipe appends `/v1/logs`. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Explicit OTLP logs endpoint; takes precedence over the base endpoint. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated HTTP headers, for example `api-key=...`. |
+| `OTEL_SERVICE_NAME` | Service name resource attribute; defaults to `screenpipe`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Comma-separated resource attributes copied into every log record. |
+
+Custom attributes use the `screenpipe.*` namespace. For example, the `vision_pipeline_health` event includes attributes such as `screenpipe.frames_captured`, `screenpipe.ocr_queue_depth`, and `screenpipe.avg_ocr_latency_ms`.
+
+### Grafana / Tempo / Loki through the OpenTelemetry Collector
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/loki:
+    endpoint: https://loki.example.com/otlp
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/loki]
+```
+
+### Datadog through the OpenTelemetry Collector
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: datadoghq.com
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [datadog]
+```
+
+### Honeycomb through the OpenTelemetry Collector
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlphttp/honeycomb:
+    endpoint: https://api.honeycomb.io
+    headers:
+      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+      x-honeycomb-dataset: screenpipe
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/honeycomb]
+```
+
+## Native PostHog mirror
+
+If you already have PostHog and do not run an OpenTelemetry collector yet, mirror operational events directly:
+
+```bash
+export SCREENPIPE_USER_POSTHOG_KEY="phc_your_project_key"
+export SCREENPIPE_USER_POSTHOG_HOST="https://us.i.posthog.com"
+screenpipe record
+```
+
+`SCREENPIPE_USER_POSTHOG_HOST` is optional and defaults to `https://us.i.posthog.com`.
+
+Screenpipe-owned product analytics still follow the existing analytics opt-in/out setting. User-configured sinks are independent so operators can disable product analytics while keeping their own operational visibility.


### PR DESCRIPTION
### Motivation
- Allow operators to mirror CLI/SDK operational telemetry (events/metrics/errors) to their own observability backends (PostHog, OTLP collectors) without changing Screenpipe product analytics opt-in or sending recorded content.

### Description
- Extend the engine analytics pipeline to detect and configure user PostHog mirroring via `SCREENPIPE_USER_POSTHOG_KEY` and optional `SCREENPIPE_USER_POSTHOG_HOST` and send mirrored events when configured.
- Add OTLP HTTP log export support using `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and `OTEL_EXPORTER_OTLP_HEADERS` and map operational events into OTLP LogRecords with `screenpipe.*` attributes.
- Make runtime behavior additive: Screenpipe-owned PostHog/Sentry telemetry still follows the existing opt-in flag while user-configured sinks are independent so operators can enable operational visibility even when product analytics are off.
- Add documentation page with privacy boundary, environment variable reference, and example OpenTelemetry Collector configs for Grafana/Loki, Datadog, and Honeycomb, and wire the page into the docs navigation.

/fixes #3534