### PR TITLE
chore: pin git dependencies to locked revisions in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "accessibility"
 version = "0.3.0"
-source = "git+https://github.com/eiz/accessibility.git?branch=master#173e898d4a52ee0afe0224ecb458d324057856e7"
+source = "git+https://github.com/eiz/accessibility.git?rev=173e898d4a52ee0afe0224ecb458d324057856e7#173e898d4a52ee0afe0224ecb458d324057856e7"
 dependencies = [
  "accessibility-sys",
  "cocoa",
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "accessibility-sys"
 version = "0.2.0"
-source = "git+https://github.com/eiz/accessibility.git?branch=master#173e898d4a52ee0afe0224ecb458d324057856e7"
+source = "git+https://github.com/eiz/accessibility.git?rev=173e898d4a52ee0afe0224ecb458d324057856e7#173e898d4a52ee0afe0224ecb458d324057856e7"
 dependencies = [
  "core-foundation-sys",
 ]
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "antirez-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/divanshu-go/audiopipe.git?branch=main#2fd5c360651157a5df504394066e509ad4d1bdc9"
+source = "git+https://github.com/divanshu-go/audiopipe.git?rev=2fd5c360651157a5df504394066e509ad4d1bdc9#2fd5c360651157a5df504394066e509ad4d1bdc9"
 dependencies = [
  "cc",
 ]
@@ -644,7 +644,7 @@ dependencies = [
 [[package]]
 name = "audiopipe"
 version = "0.2.0"
-source = "git+https://github.com/divanshu-go/audiopipe.git?branch=main#2fd5c360651157a5df504394066e509ad4d1bdc9"
+source = "git+https://github.com/divanshu-go/audiopipe.git?rev=2fd5c360651157a5df504394066e509ad4d1bdc9#2fd5c360651157a5df504394066e509ad4d1bdc9"
 dependencies = [
  "antirez-asr-sys",
  "half",
@@ -1429,6 +1429,18 @@ dependencies = [
 [[package]]
 name = "cidre"
 version = "0.15.1"
+source = "git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a#8481f3f0dc7dd39bb5be80d9424bfac0cad3801a"
+dependencies = [
+ "cc",
+ "cidre-macros 0.5.0",
+ "half",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "cidre"
+version = "0.15.1"
 source = "git+https://github.com/yury/cidre.git#8481f3f0dc7dd39bb5be80d9424bfac0cad3801a"
 dependencies = [
  "cc",
@@ -1795,10 +1807,10 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/screenpipe/cpal.git?branch=main#99f7c0f175217b5e47e4e454acbc02089d1fdd29"
+source = "git+https://github.com/screenpipe/cpal.git?rev=99f7c0f175217b5e47e4e454acbc02089d1fdd29#99f7c0f175217b5e47e4e454acbc02089d1fdd29"
 dependencies = [
  "alsa",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git)",
  "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
@@ -2997,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg-sidecar"
 version = "2.5.0"
-source = "git+https://github.com/nathanbabcock/ffmpeg-sidecar?branch=main#b0f48a514235d1278d860f4a0af66aa9d6e1618d"
+source = "git+https://github.com/nathanbabcock/ffmpeg-sidecar?rev=b0f48a514235d1278d860f4a0af66aa9d6e1618d#b0f48a514235d1278d860f4a0af66aa9d6e1618d"
 dependencies = [
  "anyhow",
  "tar",
@@ -3823,7 +3835,7 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 [[package]]
 name = "hf-hub"
 version = "0.3.2"
-source = "git+https://github.com/neo773/hf-hub#437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760"
+source = "git+https://github.com/neo773/hf-hub?rev=437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760#437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760"
 dependencies = [
  "dirs 5.0.1",
  "futures",
@@ -7042,7 +7054,7 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 [[package]]
 name = "qwen3-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/divanshu-go/audiopipe.git?branch=main#2fd5c360651157a5df504394066e509ad4d1bdc9"
+source = "git+https://github.com/divanshu-go/audiopipe.git?rev=2fd5c360651157a5df504394066e509ad4d1bdc9#2fd5c360651157a5df504394066e509ad4d1bdc9"
 dependencies = [
  "cc",
  "cmake",
@@ -7884,7 +7896,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rusty-tesseract"
 version = "1.1.10"
-source = "git+https://github.com/screenpipe/rusty-tesseract.git?branch=main#08346c1de08d122c7121425abc79081c30dbf778"
+source = "git+https://github.com/screenpipe/rusty-tesseract.git?rev=08346c1de08d122c7121425abc79081c30dbf778#08346c1de08d122c7121425abc79081c30dbf778"
 dependencies = [
  "dirs 5.0.1",
  "image",
@@ -7991,9 +8003,9 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs#b7f48a1236b2339350baa1375a805c7ce32f88df"
+source = "git+https://github.com/screenpipe/sck-rs?rev=b7f48a1236b2339350baa1375a805c7ce32f88df#b7f48a1236b2339350baa1375a805c7ce32f88df"
 dependencies = [
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git)",
  "image",
  "once_cell",
  "thiserror 1.0.69",
@@ -8065,7 +8077,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "chrono",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",
  "clap",
  "cpal",
  "criterion",
@@ -8295,7 +8307,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "chrono",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",
  "clap",
  "colored",
  "console-subscriber",
@@ -8442,7 +8454,7 @@ dependencies = [
  "atspi-proxies",
  "base64 0.22.1",
  "chrono",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",
  "core-foundation 0.10.1",
  "core-graphics",
  "criterion",
@@ -10022,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "tinfoil"
 version = "0.1.0"
-source = "git+https://github.com/tinfoilsh/tinfoil-rs#82143d767b540195dea265df0b01c4b4fc93c424"
+source = "git+https://github.com/tinfoilsh/tinfoil-rs?rev=82143d767b540195dea265df0b01c4b4fc93c424#82143d767b540195dea265df0b01c4b4fc93c424"
 dependencies = [
  "async-openai",
  "async-stream",
@@ -10906,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "vad-rs"
 version = "0.2.0"
-source = "git+https://github.com/divanshu-go/vad-rs-1.git?branch=main#b14b26ec7093f5398ef6658020259cd7c130ea6c"
+source = "git+https://github.com/divanshu-go/vad-rs-1.git?rev=b14b26ec7093f5398ef6658020259cd7c130ea6c#b14b26ec7093f5398ef6658020259cd7c130ea6c"
 dependencies = [
  "eyre",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 [workspace.dependencies]
 # AI
 tokenizers = "0.21.0"
-hf-hub = { version = "0.3.2", git = "https://github.com/neo773/hf-hub", default-features = false, features = [
+hf-hub = { version = "0.3.2", git = "https://github.com/neo773/hf-hub", rev = "437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760", default-features = false, features = [
     "native-tls",
     "tokio",
     "ureq",
@@ -51,7 +51,7 @@ reqwest-middleware = "0.4.1"
 
 [patch.crates-io]
 # enables chinese mirror (hf is banned in china) and rustls-tls
-hf-hub = { git = "https://github.com/neo773/hf-hub" }
+hf-hub = { git = "https://github.com/neo773/hf-hub", rev = "437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760" }
 
 [profile.release]
 codegen-units = 1

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -10835,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs#b7f48a1236b2339350baa1375a805c7ce32f88df"
+source = "git+https://github.com/screenpipe/sck-rs?branch=main#b7f48a1236b2339350baa1375a805c7ce32f88df"
 dependencies = [
  "cidre 0.15.1",
  "image 0.25.10",
@@ -10885,7 +10885,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.4.297"
+version = "2.4.298"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 [[package]]
 name = "accessibility"
 version = "0.3.0"
-source = "git+https://github.com/eiz/accessibility.git?branch=master#173e898d4a52ee0afe0224ecb458d324057856e7"
+source = "git+https://github.com/eiz/accessibility.git?rev=173e898d4a52ee0afe0224ecb458d324057856e7#173e898d4a52ee0afe0224ecb458d324057856e7"
 dependencies = [
  "accessibility-sys",
  "cocoa 0.26.1",
@@ -40,7 +40,7 @@ dependencies = [
 [[package]]
 name = "accessibility-sys"
 version = "0.2.0"
-source = "git+https://github.com/eiz/accessibility.git?branch=master#173e898d4a52ee0afe0224ecb458d324057856e7"
+source = "git+https://github.com/eiz/accessibility.git?rev=173e898d4a52ee0afe0224ecb458d324057856e7#173e898d4a52ee0afe0224ecb458d324057856e7"
 dependencies = [
  "core-foundation-sys 0.8.7",
 ]
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "antirez-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/divanshu-go/audiopipe.git?branch=main#2fd5c360651157a5df504394066e509ad4d1bdc9"
+source = "git+https://github.com/divanshu-go/audiopipe.git?rev=2fd5c360651157a5df504394066e509ad4d1bdc9#2fd5c360651157a5df504394066e509ad4d1bdc9"
 dependencies = [
  "cc",
 ]
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "audiopipe"
 version = "0.2.0"
-source = "git+https://github.com/divanshu-go/audiopipe.git?branch=main#2fd5c360651157a5df504394066e509ad4d1bdc9"
+source = "git+https://github.com/divanshu-go/audiopipe.git?rev=2fd5c360651157a5df504394066e509ad4d1bdc9#2fd5c360651157a5df504394066e509ad4d1bdc9"
 dependencies = [
  "antirez-asr-sys",
  "half",
@@ -1983,6 +1983,18 @@ dependencies = [
 [[package]]
 name = "cidre"
 version = "0.15.1"
+source = "git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a#8481f3f0dc7dd39bb5be80d9424bfac0cad3801a"
+dependencies = [
+ "cc",
+ "cidre-macros 0.5.0",
+ "half",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "cidre"
+version = "0.15.1"
 source = "git+https://github.com/yury/cidre.git#7049fbfbb92a5b3ed034d3c3162e2fccf3dd5f3e"
 dependencies = [
  "cc",
@@ -2506,10 +2518,10 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/screenpipe/cpal.git?branch=main#99f7c0f175217b5e47e4e454acbc02089d1fdd29"
+source = "git+https://github.com/screenpipe/cpal.git?rev=99f7c0f175217b5e47e4e454acbc02089d1fdd29#99f7c0f175217b5e47e4e454acbc02089d1fdd29"
 dependencies = [
  "alsa",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git)",
  "core-foundation-sys 0.8.7",
  "coreaudio-rs",
  "dasp_sample",
@@ -4011,7 +4023,7 @@ dependencies = [
 [[package]]
 name = "ffmpeg-sidecar"
 version = "2.5.0"
-source = "git+https://github.com/nathanbabcock/ffmpeg-sidecar?branch=main#b0f48a514235d1278d860f4a0af66aa9d6e1618d"
+source = "git+https://github.com/nathanbabcock/ffmpeg-sidecar?rev=b0f48a514235d1278d860f4a0af66aa9d6e1618d#b0f48a514235d1278d860f4a0af66aa9d6e1618d"
 dependencies = [
  "anyhow",
  "tar",
@@ -4074,7 +4086,7 @@ dependencies = [
 [[package]]
 name = "fix-path-env"
 version = "0.0.0"
-source = "git+https://github.com/tauri-apps/fix-path-env-rs#c4c45d503ea115a839aae718d02f79e7c7f0f673"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs?rev=c4c45d503ea115a839aae718d02f79e7c7f0f673#c4c45d503ea115a839aae718d02f79e7c7f0f673"
 dependencies = [
  "home",
  "strip-ansi-escapes",
@@ -5337,7 +5349,7 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 [[package]]
 name = "hf-hub"
 version = "0.3.2"
-source = "git+https://github.com/neo773/hf-hub#437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760"
+source = "git+https://github.com/neo773/hf-hub?rev=437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760#437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760"
 dependencies = [
  "dirs 5.0.1",
  "futures",
@@ -9656,7 +9668,7 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 [[package]]
 name = "qwen3-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/divanshu-go/audiopipe.git?branch=main#2fd5c360651157a5df504394066e509ad4d1bdc9"
+source = "git+https://github.com/divanshu-go/audiopipe.git?rev=2fd5c360651157a5df504394066e509ad4d1bdc9#2fd5c360651157a5df504394066e509ad4d1bdc9"
 dependencies = [
  "cc",
  "cmake",
@@ -10659,7 +10671,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 [[package]]
 name = "rusty-tesseract"
 version = "1.1.10"
-source = "git+https://github.com/screenpipe/rusty-tesseract.git?branch=main#08346c1de08d122c7121425abc79081c30dbf778"
+source = "git+https://github.com/screenpipe/rusty-tesseract.git?rev=08346c1de08d122c7121425abc79081c30dbf778#08346c1de08d122c7121425abc79081c30dbf778"
 dependencies = [
  "dirs 5.0.1",
  "image 0.25.10",
@@ -10835,9 +10847,9 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?branch=main#b7f48a1236b2339350baa1375a805c7ce32f88df"
+source = "git+https://github.com/screenpipe/sck-rs?rev=b7f48a1236b2339350baa1375a805c7ce32f88df#b7f48a1236b2339350baa1375a805c7ce32f88df"
 dependencies = [
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git)",
  "image 0.25.10",
  "once_cell",
  "thiserror 1.0.69",
@@ -11019,7 +11031,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "chrono",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",
  "clap",
  "cpal",
  "crossbeam",
@@ -11219,7 +11231,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "chrono",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",
  "clap",
  "colored",
  "crossbeam",
@@ -11344,7 +11356,7 @@ dependencies = [
  "atspi-proxies",
  "base64 0.22.1",
  "chrono",
- "cidre 0.15.1",
+ "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",
  "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "image 0.25.10",
@@ -13454,7 +13466,7 @@ dependencies = [
 [[package]]
 name = "tauri-nspanel"
 version = "2.0.1"
-source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v2#18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a"
+source = "git+https://github.com/ahkohd/tauri-nspanel?rev=18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a#18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a"
 dependencies = [
  "bitflags 2.11.0",
  "block",
@@ -14163,7 +14175,7 @@ dependencies = [
 [[package]]
 name = "tinfoil"
 version = "0.1.0"
-source = "git+https://github.com/tinfoilsh/tinfoil-rs#82143d767b540195dea265df0b01c4b4fc93c424"
+source = "git+https://github.com/tinfoilsh/tinfoil-rs?rev=82143d767b540195dea265df0b01c4b4fc93c424#82143d767b540195dea265df0b01c4b4fc93c424"
 dependencies = [
  "async-openai",
  "async-stream",
@@ -15235,7 +15247,7 @@ dependencies = [
 [[package]]
 name = "vad-rs"
 version = "0.2.0"
-source = "git+https://github.com/divanshu-go/vad-rs-1.git?branch=main#b14b26ec7093f5398ef6658020259cd7c130ea6c"
+source = "git+https://github.com/divanshu-go/vad-rs-1.git?rev=b14b26ec7093f5398ef6658020259cd7c130ea6c#b14b26ec7093f5398ef6658020259cd7c130ea6c"
 dependencies = [
  "eyre",
  "ndarray",
@@ -16017,7 +16029,7 @@ dependencies = [
 [[package]]
 name = "windows-icons"
 version = "0.1.1"
-source = "git+https://github.com/tribhuwan-kumar/windows-icons.git#4dcd086b36bed286181cb87636ad6eb058ab7684"
+source = "git+https://github.com/tribhuwan-kumar/windows-icons.git?rev=4dcd086b36bed286181cb87636ad6eb058ab7684#4dcd086b36bed286181cb87636ad6eb058ab7684"
 dependencies = [
  "base64 0.22.1",
  "image 0.25.10",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -93,7 +93,7 @@ arboard = "3.4"
 sysinfo = "=0.29.0"
 
 # hakc
-fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
 
 # server
 axum = "0.6.0" # or your current version
@@ -191,7 +191,7 @@ objc2 = { version = "0.6", features = ["relax-sign-encoding"] }
 # bunch of hack for permissions
 core-graphics-helmer-fork = "0.24.0"
 nokhwa-bindings-macos = { git = "https://github.com/CapSoftware/nokhwa", rev = "0d3d1f30a78b" }
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v2" }
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a" }
 # Owned-browser cookie inheritance (see src/owned_browser_cookies.rs):
 # read Arc/Chrome's `Cookies` SQLite, pull the AES-128 key from the
 # macOS Keychain (`Arc Safe Storage`), AES-CBC decrypt each
@@ -210,7 +210,7 @@ sha1 = "0.10"
 winreg = "0.52.0"
 lazy_static = "1.5.0"
 image = "0.25.5"
-windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git" }
+windows-icons = { git = "https://github.com/tribhuwan-kumar/windows-icons.git", rev = "4dcd086b36bed286181cb87636ad6eb058ab7684" }
 base64 = "0.22.1"
 aes-gcm = "0.10"
 rusqlite = { version = "0.29.0", features = ["bundled"] }

--- a/crates/screenpipe-audio-eval/Cargo.toml
+++ b/crates/screenpipe-audio-eval/Cargo.toml
@@ -44,7 +44,7 @@ screenpipe-db = { path = "../screenpipe-db" }
 # the engine. Without this, `TranscriptionEngine::new` returns
 # `Disabled` while audiopipe's background download thread runs and the
 # eval silently emits empty hypotheses.
-audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", branch = "main", default-features = false, features = ["parakeet"] }
+audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", rev = "2fd5c360651157a5df504394066e509ad4d1bdc9", default-features = false, features = ["parakeet"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -19,7 +19,7 @@ oasgen = { workspace = true }
 
 # Cross-platform audio capture. Tracks screenpipe/cpal main, which carries
 # the Windows WASAPI AEC and macOS VoiceProcessingIO patches.
-cpal = { git = "https://github.com/screenpipe/cpal.git", branch = "main" }
+cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "99f7c0f175217b5e47e4e454acbc02089d1fdd29" }
 
 # Wav encoding
 hound = "3.5"
@@ -36,7 +36,7 @@ chrono = { version = "0.4.31", features = ["serde"] }
 # Local Embeddings + STT
 # Using fork of vad-rs with Silero VAD v5/v6 support
 # v5/v6: 3x faster, 6000+ languages, better accuracy
-vad-rs = { git = "https://github.com/divanshu-go/vad-rs-1.git", branch="main", default-features = false }
+vad-rs = { git = "https://github.com/divanshu-go/vad-rs-1.git", rev = "b14b26ec7093f5398ef6658020259cd7c130ea6c", default-features = false }
 anyhow = "1.0.86"
 hf-hub = { workspace = true }
 # https://github.com/pdeljanov/Symphonia/tree/master?tab=readme-ov-file#optimizations
@@ -82,7 +82,7 @@ ort = { version = "=2.0.0-rc.10", default-features = false, features = ["ndarray
 ort-sys = { version = "=2.0.0-rc.10", default-features = false }
 knf-rs = "0.3.2"
 futures = "0.3.31"
-audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", branch = "main", default-features = false, features = ["qwen3-asr-antirez-blas", "parakeet"], optional = true }
+audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", rev = "2fd5c360651157a5df504394066e509ad4d1bdc9", default-features = false, features = ["qwen3-asr-antirez-blas", "parakeet"], optional = true }
 mlx-rs = { version = "0.25", optional = true }
 bytes = { version = "1.9.0", features = ["serde"] }
 rand = "0.9.0"
@@ -122,7 +122,7 @@ samplerate = { version = "0.2.4" }
 libsamplerate-sys = "0.1.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { git = "https://github.com/yury/cidre.git" }
+cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a" }
 once_cell = "1.17.1"
 objc = "0.2.7"
 ort = { version = "=2.0.0-rc.10", features = ["download-binaries"] }

--- a/crates/screenpipe-core/Cargo.toml
+++ b/crates/screenpipe-core/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 which = "6.0.1"
-ffmpeg-sidecar = { git = "https://github.com/nathanbabcock/ffmpeg-sidecar", branch = "main" }
+ffmpeg-sidecar = { git = "https://github.com/nathanbabcock/ffmpeg-sidecar", rev = "b0f48a514235d1278d860f4a0af66aa9d6e1618d" }
 log = "0.4.17"
 anyhow = "1.0.86"
 arc-swap = "1"
@@ -88,9 +88,9 @@ libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # accessibility-sys = "0.1.3"
-accessibility-sys = { git = "https://github.com/eiz/accessibility.git", branch = "master" }
+accessibility-sys = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
 # accessibility = "0.1.6"
-accessibility = { git = "https://github.com/eiz/accessibility.git", branch = "master" }
+accessibility = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
 objc = "0.2.7"
 objc-foundation = "0.1.1"
 

--- a/crates/screenpipe-engine/Cargo.toml
+++ b/crates/screenpipe-engine/Cargo.toml
@@ -90,7 +90,7 @@ reqwest = { workspace = true }
 # (see src/privacy_filter.rs). Without this, a MITM or compromised CA could
 # observe unredacted text on its way to the enclave.
 # Upstream tinfoilsh/tinfoil-rs main, post-#21 (the ring-backend fix).
-tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs" }
+tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", rev = "82143d767b540195dea265df0b01c4b4fc93c424" }
 
 # Concurrency
 crossbeam = { workspace = true }
@@ -214,7 +214,7 @@ windows = { version = "0.58", features = [
 socket2 = "0.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { git = "https://github.com/yury/cidre.git", features = ["ax", "ns", "av", "blocks"] }
+cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a", features = ["ax", "ns", "av", "blocks"] }
 tracing-oslog = { workspace = true }
 
 [package.metadata.cargo-machete]

--- a/crates/screenpipe-redact/Cargo.toml
+++ b/crates/screenpipe-redact/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "1"
 # redaction service. See adapters/tinfoil.rs for the threat model
 # (without this a compromised CA can still observe unredacted text in
 # transit even though the enclave itself is honest).
-tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs" }
+tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", rev = "82143d767b540195dea265df0b01c4b4fc93c424" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { workspace = true }
 image = { workspace = true }
 
 # OCR
-rusty-tesseract = { git = "https://github.com/screenpipe/rusty-tesseract.git", branch = "main" }
+rusty-tesseract = { git = "https://github.com/screenpipe/rusty-tesseract.git", rev = "08346c1de08d122c7121425abc79081c30dbf778" }
 
 anyhow = "1.0.86"
 
@@ -77,11 +77,11 @@ harness = false
 
 # macOS: sck-rs for 12.3+ (ScreenCaptureKit), xcap as fallback for older versions
 [target.'cfg(target_os = "macos")'.dependencies]
-sck-rs = { git = "https://github.com/screenpipe/sck-rs" }
+sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "b7f48a1236b2339350baa1375a805c7ce32f88df"}
 xcap = "0.9"
 libc = "0.2.168"
-cidre = { git = "https://github.com/yury/cidre.git", features = ["vn", "cv", "cg", "app"] }
-accessibility-sys = { git = "https://github.com/eiz/accessibility.git", branch = "master" }
+cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a", features = ["vn", "cv", "cg", "app"] }
+accessibility-sys = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
 core-foundation = "0.10"
 core-graphics = "0.24"
 

--- a/ee/sdk/recorder-core/Cargo.toml
+++ b/ee/sdk/recorder-core/Cargo.toml
@@ -21,7 +21,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "process"] }
 tracing = "0.1"
-cpal = { git = "https://github.com/screenpipe/cpal.git", branch = "main" }
+cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "01b68e60c80a59bbc1cac3629e725cf3bb2e4901" }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
This PR explicitly pins all git dependencies across the workspace to their locked revisions in Cargo.lock. This ensures build reproducibility and stability.