### PR TITLE
fix(audio): prevent CoreAudio Process Tap crash (SIGSEGV UAF)

### DIFF
--- a/crates/screenpipe-audio/src/core/process_tap.rs
+++ b/crates/screenpipe-audio/src/core/process_tap.rs
@@ -425,7 +425,7 @@ extern "C" fn tap_io_proc(
 /// Owns all CoreAudio resources for a Process Tap capture session.
 /// Drop order: _started (stops IO) → _tap (destroys tap) → _ctx_ptr (frees memory).
 struct ProcessTapCapture {
-    _started: cidre::core_audio::hardware::StartedDevice<ca::AggregateDevice>,
+    _started: Option<cidre::core_audio::hardware::StartedDevice<ca::AggregateDevice>>,
     _tap: ca::hardware_tapping::TapGuard,
     _ctx_ptr: *mut TapCallbackCtx,
 }
@@ -435,6 +435,10 @@ unsafe impl Send for ProcessTapCapture {}
 impl Drop for ProcessTapCapture {
     fn drop(&mut self) {
         info!("Process Tap capture stopping");
+        // Drop started device first to stop CoreAudio thread synchronously before freeing context
+        if let Some(started) = self._started.take() {
+            std::mem::drop(started);
+        }
         if !self._ctx_ptr.is_null() {
             unsafe {
                 let _ = Box::from_raw(self._ctx_ptr);
@@ -555,7 +559,7 @@ fn build_capture(
 
     let ctx_ptr = Box::into_raw(ctx);
     let capture = ProcessTapCapture {
-        _started: started,
+        _started: Some(started),
         _tap: tap,
         _ctx_ptr: ctx_ptr,
     };


### PR DESCRIPTION
## Problem / Crash Cause
1. **Use-after-free (UAF)** in `crates/screenpipe-audio/src/core/process_tap.rs`.
2. `ProcessTapCapture` implemented custom `Drop`. In Rust, custom `Drop::drop` runs before fields are dropped.
3. In `ProcessTapCapture::drop`, heap-allocated context pointer `_ctx_ptr` was freed first.
4. Then `_started` field was dropped, which calls `AudioDeviceStop` to stop the CoreAudio thread.
5. CoreAudio thread (Thread 101) kept executing callback `tap_io_proc` during/after free, dereferencing freed `_ctx_ptr` (specifically accessing `ctx.tx` broadcast sender).
6. Result: SIGSEGV crash.

## Fix Applied
1. Changed `_started` inside `ProcessTapCapture` to `Option<StartedDevice<ca::AggregateDevice>>`.
2. Modified custom `Drop::drop` to `.take()` and drop `_started` first. This synchronously stops CoreAudio callback execution.
3. Freed `_ctx_ptr` only after callback thread was completely stopped.
4. Compiled and verified change. Use-after-free eliminated.


https://gist.github.com/divanshu-go/d87cccf620463bb5f5acb601359bbafc