### PR TITLE
Fix empty state for starred pipe filter

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -824,6 +824,14 @@ export function PipesSection() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pipes]);
 
+  const starredEmptyTitle = React.useMemo(() => {
+    if (!pipeFavorites.showOnly) return null;
+
+    if (pipeTypeFilter === "triggered") return "no starred triggered pipes";
+    if (pipeTypeFilter === "manual") return "no starred manual pipes";
+    return "no starred scheduled pipes";
+  }, [pipeFavorites.showOnly, pipeTypeFilter]);
+
   const sharePipePublic = async (pipe: PipeStatus) => {
     setSharingPublic(pipe.config.name);
     try {
@@ -1480,6 +1488,28 @@ export function PipesSection() {
           <CardContent className="py-8 text-center text-muted-foreground">
             {searchQuery ? (
               <p>no pipes match your search</p>
+            ) : pipeFavorites.showOnly && tabCounts[pipeTypeFilter] > 0 ? (
+              <div className="space-y-4">
+                <div>
+                  <p className="text-foreground font-medium text-base">
+                    {starredEmptyTitle}
+                  </p>
+                  <p className="text-sm mt-1">
+                    {pipeFavorites.favorites.size === 0
+                      ? "star any pipe to keep your favorites here"
+                      : "none of your starred pipes match this filter right now"}
+                  </p>
+                </div>
+                <div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => pipeFavorites.setShowOnly(false)}
+                  >
+                    show all pipes
+                  </Button>
+                </div>
+              </div>
             ) : pipeTypeFilter === "triggered" ? (
               <>
                 <p>no triggered pipes installed</p>

--- a/crates/screenpipe-vault/src/manager.rs
+++ b/crates/screenpipe-vault/src/manager.rs
@@ -397,7 +397,10 @@ mod tests {
         }
 
         // Double lock should error
-        assert!(matches!(vault.lock("pw").await, Err(VaultError::AlreadyLocked)));
+        assert!(matches!(
+            vault.lock("pw").await,
+            Err(VaultError::AlreadyLocked)
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
This PR fixes the pipes empty-state logic when the starred filter is active.
We now show the starred-specific empty state only when pipes exist in the selected category but none of them are starred; otherwise, the normal category empty state is shown.

### Before 

Even there were pipes installed when starred it shows no pipe installed

<img width="1183" height="600" alt="image" src="https://github.com/user-attachments/assets/08b9c66a-2494-4218-ba45-2af8a44ec7a0" />


### After

when the starred filter is active, the empty state is only shown as a starred-specific state if pipes exist in that category but none are starred
if there are actually no pipes in that category, the normal empty state is shown.

<img width="1183" height="460" alt="image" src="https://github.com/user-attachments/assets/ee420dac-a480-494e-96ba-8e4d531cef23" />
