### PR TITLE
fix(core,audio): prevent panic if ffmpeg is not found or path is invalid UTF-8

### DIFF
--- a/crates/screenpipe-audio/src/utils/ffmpeg.rs
+++ b/crates/screenpipe-audio/src/utils/ffmpeg.rs
@@ -132,11 +132,16 @@ pub fn get_new_file_path_with_timestamp(
 pub fn read_audio_from_file(path: &Path) -> Result<(Vec<f32>, u32)> {
     let sample_rate: u32 = 16000;
 
-    let mut command = screenpipe_core::ffmpeg_cmd(find_ffmpeg_path().unwrap());
+    let ffmpeg_path = find_ffmpeg_path()
+        .ok_or_else(|| anyhow::anyhow!("ffmpeg not found in PATH or bundled binaries"))?;
+    let path_str = path.to_str()
+        .ok_or_else(|| anyhow::anyhow!("path is not valid UTF-8: {}", path.display()))?;
+
+    let mut command = screenpipe_core::ffmpeg_cmd(ffmpeg_path);
     command
         .args([
             "-i",
-            path.to_str().unwrap(),
+            path_str,
             "-f",
             "f32le",
             "-ar",

--- a/crates/screenpipe-core/src/video.rs
+++ b/crates/screenpipe-core/src/video.rs
@@ -100,7 +100,8 @@ pub async fn start_ffmpeg_process(
 
     info!("Starting FFmpeg process for file: {}", output_file);
     let fps_str = fps.to_string();
-    let mut command = crate::ffmpeg_cmd_async(find_ffmpeg_path().unwrap());
+    let ffmpeg_path = find_ffmpeg_path().ok_or_else(|| anyhow::anyhow!("ffmpeg not found"))?;
+    let mut command = crate::ffmpeg_cmd_async(ffmpeg_path);
     let mut args = vec![
         "-f",
         "image2pipe",


### PR DESCRIPTION
## Problem / Panic Cause
1. `read_audio_from_file` in `crates/screenpipe-audio/src/utils/ffmpeg.rs` called `find_ffmpeg_path().unwrap()` and `path.to_str().unwrap()`.
2. `start_ffmpeg_process` in `crates/screenpipe-core/src/video.rs` called `find_ffmpeg_path().unwrap()`.
3. If the system lacks ffmpeg, or if the file path is not valid UTF-8, these functions would panic and crash the background audio reconciliation loop / video recording thread.

## Fix Applied
1. Replaced `.unwrap()` with safe error handling returning `Result` or using the `?` operator.
2. Hardened both functions against missing ffmpeg or malformed paths.