### PR TITLE
fix(engine): prevent panics in FrameCache initialization and frame extraction

### DIFF
--- a/crates/screenpipe-engine/src/video_cache.rs
+++ b/crates/screenpipe-engine/src/video_cache.rs
@@ -450,8 +450,12 @@ pub struct FrameCache {
 
 impl FrameCache {
     pub async fn new(screenpipe_dir: PathBuf, db: Arc<DatabaseManager>) -> Result<Self> {
+        let cache_dir_path = cache_dir()
+            .map(|d| d.join("screenpipe").join("frames"))
+            .unwrap_or_else(|| screenpipe_dir.join("cache").join("frames"));
+
         let cache_config = CacheConfig {
-            cache_dir: cache_dir().unwrap().join("screenpipe").join("frames"),
+            cache_dir: cache_dir_path,
             ..Default::default()
         };
 
@@ -750,7 +754,7 @@ async fn extract_frame(
         "1",         // Limit to single thread
         "-cpu-used", // Faster encoding
         "4",
-        output_pattern.to_str().unwrap(),
+        output_pattern.to_str().ok_or_else(|| anyhow::anyhow!("output pattern is not valid UTF-8"))?,
     ]);
 
     #[cfg(windows)]


### PR DESCRIPTION
## Problem / Panic Causes
1. **Startup Panic in Headless/Sandboxed Environments:**
   - `FrameCache::new` in `crates/screenpipe-engine/src/video_cache.rs` called `cache_dir().unwrap()`.
   - If the OS/environment does not define a standard cache directory (common in headless Linux or sandboxed systems), it would panic and crash the engine on boot.
2. **Panic on non-UTF-8 Paths:**
   - `extract_frame` called `output_pattern.to_str().unwrap()`.
   - If the path contains non-UTF-8 sequences, it would panic and crash the frame extraction process.

## Fixes Applied
1. Added a fallback to `screenpipe_dir.join("cache").join("frames")` when `cache_dir()` is `None`.
2. Replaced the `.unwrap()` on `output_pattern.to_str()` with safe error handling using `?` returning a clean `Result`.