### PR TITLE
fix(vocab): show correct custom vocabulary limit

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -1153,9 +1153,11 @@ const getAudioDeviceIcon = (name: string) => {
 
 // ─── Transcription Dictionary ────────────────────────────────────────────────
 
-const VOCAB_LIMIT = 1000;
 const DEEPGRAM_LIMIT = 100;
 const WHISPER_CHAR_LIMIT = 800;
+// Cap stored terms at the strictest real engine limit (Deepgram cloud).
+// Whisper's offline limit is on total chars, not term count, and is surfaced separately below.
+const VOCAB_LIMIT = DEEPGRAM_LIMIT;
 
 function parseTerms(raw: string): string[] {
   // Auto-detect delimiter: if there are newlines, split by newlines; otherwise commas; otherwise semicolons; otherwise tabs


### PR DESCRIPTION
### Description: 
header badge said 74/1000 while the detail line said 74/100 — tied VOCAB_LIMIT to the real Deepgram cap so both match.

<img width="1192" height="721" alt="image" src="https://github.com/user-attachments/assets/63b330d5-44f5-4518-9740-57a1a3d70d41" />
