### PR TITLE
fix(team): open team page in system browser

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/team-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/team-section.tsx
@@ -29,6 +29,7 @@ import React from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Users, ExternalLink } from "lucide-react";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 
 const TEAM_MARKETING_URL = "https://screenpi.pe/team";
 
@@ -56,7 +57,7 @@ export function TeamSection() {
           </p>
 
           <Button
-            onClick={() => window.open(TEAM_MARKETING_URL, "_blank")}
+            onClick={() => openUrl(TEAM_MARKETING_URL)}
             className="gap-2"
           >
             Open team on the web


### PR DESCRIPTION
### Description: 


https://github.com/user-attachments/assets/da24b4e0-6744-4720-b59a-ecb498d5e354



window.open is a no-op in the Tauri webview; switched to plugin-shell openUrl so the "open team on the web" button actually opens screenpi.pe/team.