### PR TITLE
fix: silence xcap log spam & retry start_capture after mic grant

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -981,15 +981,20 @@ async fn main() {
                 .build(log_dir)?;
 
             // Create a custom layer for file logging
+            // xcap probes stale monitor / window IDs every refresh and logs
+            // ERROR for IDs that don't exist (e.g. after a display unplug).
+            // Benign noise that swamps real errors in user feedback logs.
+            const LOG_FILTER: &str = "info,hyper=error,tower_http=error,whisper_rs=warn,audiopipe=warn,ort=warn,xcap::platform::impl_window=off,xcap::platform::impl_monitor=off,xcap::platform::utils=off";
+
             let file_layer = tracing_subscriber::fmt::layer()
                 .with_writer(file_appender)
                 .with_ansi(false)
-                .with_filter(EnvFilter::new("info,hyper=error,tower_http=error,whisper_rs=warn,audiopipe=warn,ort=warn"));
+                .with_filter(EnvFilter::new(LOG_FILTER));
 
             // Create a custom layer for console logging
             let console_layer = tracing_subscriber::fmt::layer()
                 .with_writer(std::io::stdout)
-                .with_filter(EnvFilter::new("info,hyper=error,tower_http=error,whisper_rs=warn,audiopipe=warn,ort=warn"));
+                .with_filter(EnvFilter::new(LOG_FILTER));
 
             // Initialize the tracing subscriber with both layers + optional Sentry layer
             // The Sentry layer captures error!() and warn!() events (not just panics)

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -146,6 +146,13 @@ fn request_av_permission(app: tauri::AppHandle, media_type: nokhwa_bindings_maco
 
 /// Stop and restart capture so `capture_session::start` re-queries TCC and
 /// repopulates audio devices. Matches the settings-toggle path.
+///
+/// When the user grants the mic permission immediately on first launch, the
+/// AVCaptureDevice completion callback can fire before the backend
+/// `ServerCore` has been constructed — `start_capture` then errors with
+/// "Server not running" and capture stays dead until the user manually toggles
+/// it. Wait up to ~10s with short backoff so we ride out backend boot before
+/// giving up.
 #[cfg(target_os = "macos")]
 pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
     use tauri::Manager;
@@ -161,10 +168,43 @@ pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
             warn!("stop_capture before mic-grant audio reinit: {}", e);
         }
     }
-    let state = app.state::<crate::recording::RecordingState>();
-    if let Err(e) = crate::recording::start_capture(state, app.clone()).await {
-        warn!("start_capture after mic grant: {}", e);
+
+    // Retry start_capture with backoff while the backend is still booting.
+    // "Server not running" / "Server not responding" are the two transient
+    // errors emitted before `ServerCore` is wired into RecordingState.
+    const MAX_ATTEMPTS: u32 = 20;
+    const BACKOFF_MS: u64 = 500;
+    let mut last_err: Option<String> = None;
+    for attempt in 1..=MAX_ATTEMPTS {
+        let state = app.state::<crate::recording::RecordingState>();
+        match crate::recording::start_capture(state, app.clone()).await {
+            Ok(()) => {
+                if attempt > 1 {
+                    info!(
+                        "start_capture after mic grant: succeeded on attempt {}/{}",
+                        attempt, MAX_ATTEMPTS
+                    );
+                }
+                return;
+            }
+            Err(e) => {
+                let transient = e.contains("Server not running")
+                    || e.contains("Server not responding");
+                if !transient {
+                    warn!("start_capture after mic grant: {}", e);
+                    return;
+                }
+                last_err = Some(e);
+                tokio::time::sleep(std::time::Duration::from_millis(BACKOFF_MS)).await;
+            }
+        }
     }
+    warn!(
+        "start_capture after mic grant: gave up after {} attempts ({}s): {}",
+        MAX_ATTEMPTS,
+        (MAX_ATTEMPTS as u64 * BACKOFF_MS) / 1000,
+        last_err.unwrap_or_else(|| "unknown error".to_string())
+    );
 }
 
 // Accessibility permission APIs using ApplicationServices framework

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -213,7 +213,13 @@ fn setup_logging(
             // SCREENPIPE_LOG=ort=info.
             .add_directive("ort=warn".parse().unwrap());
 
-        #[cfg(target_os = "windows")]
+        // xcap probes stale monitor / window IDs on every refresh and emits
+        // ERROR-level lines for IDs that don't exist (e.g. ImplMonitor::new(8)
+        // failed after a display was unplugged). Hundreds per session, all
+        // benign, and they crowd out real errors in user feedback logs.
+        // Silence on every platform — was previously windows-only, but the
+        // same spam happens on macOS (Core Graphics display IDs persist after
+        // disconnect) and on Linux X11.
         let filter = filter
             .add_directive("xcap::platform::impl_window=off".parse().unwrap())
             .add_directive("xcap::platform::impl_monitor=off".parse().unwrap())


### PR DESCRIPTION
### Description:

- Before:

<img width="1679" height="445" alt="image" src="https://github.com/user-attachments/assets/e816ffe4-8ef4-4e09-9627-8b6cff2f4a34" />

- After: 


https://github.com/user-attachments/assets/ceef8f8e-e42c-4132-9c0d-42612829f682



three small reliability fixes from a user feedback log: drop the windows-only gate on xcap log silencing (was producing 735 ERROR lines/session on macOS), apply the same filter in the tauri app, and retry start_capture after a mic grant while the backend is still booting so capture doesn't stay dead until manual toggle.