### PR TITLE
fix(connections): github proxy returns 403 — inject required User-Agent

### DIFF
--- a/crates/screenpipe-connect/src/connections/github_issues.rs
+++ b/crates/screenpipe-connect/src/connections/github_issues.rs
@@ -41,12 +41,26 @@ impl Integration for GithubIssues {
     }
 
     fn proxy_config(&self) -> Option<&'static ProxyConfig> {
+        // GitHub's REST API edge rejects requests with a missing or empty
+        // User-Agent before they ever hit auth, returning 403 with body:
+        //   "Request forbidden by administrative rules. Please make sure
+        //    your request has a User-Agent header."
+        // reqwest 0.13's default Client sends no User-Agent at all, so the
+        // proxy MUST inject one for every outbound call. Accept + version
+        // headers follow GitHub's documented REST conventions and pin the
+        // API version so server-side changes don't surprise pipes.
+        // Refs: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required
+        //       https://docs.github.com/en/rest/overview/api-versions
         static CFG: ProxyConfig = ProxyConfig {
             base_url: "https://api.github.com",
             auth: ProxyAuth::Bearer {
                 credential_key: "api_key",
             },
-            extra_headers: &[],
+            extra_headers: &[
+                ("User-Agent", "screenpipe"),
+                ("Accept", "application/vnd.github+json"),
+                ("X-GitHub-Api-Version", "2022-11-28"),
+            ],
         };
         Some(&CFG)
     }

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -1695,6 +1695,27 @@ async fn connection_proxy(
         }
     }
 
+    // Forward User-Agent and Accept from the caller when present. Two reasons:
+    //  1. Some upstreams (e.g. GitHub) reject requests with an empty/missing
+    //     UA at the edge with 403 — and reqwest's default Client sends no UA.
+    //     This makes the proxy behave like the caller's HTTP client would.
+    //  2. Pipes that hit content-negotiated APIs need to set Accept to pick a
+    //     media type; silently dropping it forces 406s or wrong serializations.
+    // Per-integration `extra_headers` are injected AFTER these and therefore
+    // override on key collision — integration policy still wins over caller hint.
+    if let Some(ua) = headers.get("user-agent") {
+        if let Ok(s) = ua.to_str() {
+            if !s.is_empty() {
+                req = req.header("user-agent", s);
+            }
+        }
+    }
+    if let Some(accept) = headers.get("accept") {
+        if let Ok(s) = accept.to_str() {
+            req = req.header("accept", s);
+        }
+    }
+
     // Inject auth
     match auth {
         ResolvedAuth::Header(name, value) => {


### PR DESCRIPTION
### Description:


https://github.com/user-attachments/assets/ad55bb0b-0905-4ac6-8ac9-0400c21c052e

Fixes #3734 

The GitHub connection was completely broken. Any call to `/connections/github/proxy/*` returned 403:

> Request forbidden by administrative rules. Please make sure your request has a User-Agent header.

So creating issues, reading repos — none of it worked. People had to fall back to opening GitHub in the browser.

### Bug: 

GitHub's API rejects any request that doesn't have a User-Agent header. Our proxy wasn't sending one, for two reasons:

1. The GitHub integration's `extra_headers` was empty — it never declared a User-Agent.
2. The reqwest client we use doesn't send a default User-Agent either.

So every request went out with no UA and GitHub blocked it at the edge, before even checking the token. (The Settings → Test button worked because that code path set a UA inline — which is why nobody caught this earlier.)

### Fix: 

Set the User-Agent (plus the Accept and API version headers GitHub recommends) on the GitHub integration so every proxied call has them.

Also made the generic proxy forward the caller's User-Agent and Accept headers when they send them — so if any future integration forgets, the caller can still make it work, and it matches what people naturally expect from a proxy.