### PR TITLE
ship(redact): v45 secret-loop champion (iter7 INT8) → v45_phase4

### DIFF
--- a/crates/screenpipe-redact/src/adapters/onnx.rs
+++ b/crates/screenpipe-redact/src/adapters/onnx.rs
@@ -50,8 +50,8 @@ use async_trait::async_trait;
 
 use crate::{RedactError, RedactedSpan, RedactionOutput, Redactor, SpanLabel};
 
-const ONNX_REDACTOR_NAME: &str = "v45_phase3_onnx";
-const ONNX_REDACTOR_VERSION: u32 = 3;
+const ONNX_REDACTOR_NAME: &str = "v45_phase4_onnx";
+const ONNX_REDACTOR_VERSION: u32 = 4;
 
 /// Configuration for an ONNX text redactor.
 #[derive(Debug, Clone)]
@@ -78,11 +78,11 @@ impl Default for OnnxConfig {
 }
 
 impl OnnxConfig {
-    /// `~/.screenpipe/models/v45_phase3_onnx/` by convention.
+    /// `~/.screenpipe/models/v45_phase4_onnx/` by convention.
     pub fn default_model_dir() -> PathBuf {
         dirs::home_dir()
-            .map(|h| h.join(".screenpipe").join("models").join("v45_phase3_onnx"))
-            .unwrap_or_else(|| PathBuf::from(".screenpipe/models/v45_phase3_onnx"))
+            .map(|h| h.join(".screenpipe").join("models").join("v45_phase4_onnx"))
+            .unwrap_or_else(|| PathBuf::from(".screenpipe/models/v45_phase4_onnx"))
     }
 
     fn resolve_model_file(&self) -> PathBuf {
@@ -109,7 +109,7 @@ impl OnnxConfig {
     /// code change (URL + expected SHA-256 + [`ONNX_REDACTOR_VERSION`]
     /// all bumped together — same discipline as `RfdetrConfig`).
     pub const HF_REPO_BASE: &'static str =
-        "https://huggingface.co/screenpipe/pii-redactor/resolve/main/v45_phase3_onnx";
+        "https://huggingface.co/screenpipe/pii-redactor/resolve/main/v45_phase4_onnx";
 
     /// Files to download from the HF repo on first run. Each is
     /// (filename, expected sha256). Recompute via
@@ -119,17 +119,17 @@ impl OnnxConfig {
         // INT8-quantized model. ~278 MB.
         (
             "model_quantized.onnx",
-            "77bb202c542bcd3f835992cde3cafb3df868a8a6fc14ca9d1b028452be6b5787",
+            "286c628349c0145fdfbfc773cd44a6e22680abb42b00730d6ec78d366aac610b",
         ),
         // SentencePiece tokenizer (HF fast format). ~17 MB.
         (
             "tokenizer.json",
-            "14c7e8bf7d9b58ca061fcda93bc8d0eedd1a51ffc3af01a1ba1ef54e2154887e",
+            "d0091a328b3441d754e481db5a390d7f3b8dabc6016869fd13ba350d23ddc4cd",
         ),
         // id2label + model config. ~2 KB.
         (
             "config.json",
-            "e9a8a3dda702b9efa2b9b5960567a560bf410e92e619184081dd3c9e9990b35d",
+            "61dc24e4e4816d723143974268ef0b7a303d4b1f208bdd96db4d38a3359036f2",
         ),
     ];
 


### PR DESCRIPTION
## What
Ships the 24/7 secret-loop's champion (iter 7, INT8-quantized) as the prod text PII redactor. Model is already uploaded to a **new** HF path `screenpipe/pii-redactor/v45_phase4_onnx/`, so current `v45_phase3` installs are untouched until this releases.

## Numbers vs current shipping v45 (same bench, corrected decoder)
| metric | before | after |
|---|---:|---:|
| secret recall (in-bench) | 0.825 | **0.961** |
| secret probe (34 dev shapes) | 32/34 | **34/34** |
| held-out (54 novel-provider secrets) | — | **54/54** |
| oversmash | 34.5% | **6.8%** |
| size | 1110 MB | **278 MB** (INT8) |
| latency p50 | 5 ms | **~3 ms** |
| names (private_person) | 0.94 | 0.93 |

## Changes (`crates/screenpipe-redact/src/adapters/onnx.rs`)
- `HF_REPO_BASE` → `…/v45_phase4_onnx`
- `FILES` → 3 refreshed SHA-256 pins (model_quantized.onnx / tokenizer.json / config.json)
- `ONNX_REDACTOR_VERSION` 3 → 4; redactor name + local cache dir → `v45_phase4_onnx`

## Verification
- ONNX export **parity-verified** against the safetensors champion (identical spans).
- INT8 holds accuracy: probe 34/34 + held-out 54/54 unchanged; in-bench secret 0.971→0.961 (~1% quant nick); oversmash unchanged.
- Model produced **autonomously** by the training loop (Opus strategist), not human-tuned.

## Before merge / release
- [ ] Rust-runtime smoke test on real input (I verified via Python/ORT; Rust uses the same ONNX + its own BIO decoder).
- [ ] cargo CI (const-only change — local `cargo check` didn't finish in the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)