### PR TITLE
Open calendar-filtered Connections from Meeting Notes

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -77,7 +77,11 @@ import {
 } from "@/components/ui/tooltip";
 
 type MainSection = "home" | "timeline" | "memories" | "pipes" | "connections" | "meetings" | "help";
-type ConnectionFocusRequest = { id: string | null; requestId: number };
+type ConnectionFocusRequest = {
+  id: string | null;
+  category: string | null;
+  requestId: number;
+};
 
 // All valid URL sections for the home page
 const ALL_SECTIONS = [
@@ -719,6 +723,9 @@ function HomeContent() {
   const openSettings = useCallback((section: string = "general") => {
     router.push(`/settings?section=${section}`);
   }, [router]);
+  const clearConnectionFocusRequest = useCallback(() => {
+    setConnectionFocusRequest(null);
+  }, []);
 
   // Listen for open-settings events from child components (e.g. connections strip)
   useEffect(() => {
@@ -729,6 +736,7 @@ function HomeContent() {
       if (section === "connections") {
         setConnectionFocusRequest({
           id: typeof detail?.connectionId === "string" ? detail.connectionId : null,
+          category: typeof detail?.category === "string" ? detail.category : null,
           requestId: Date.now(),
         });
         setActiveSection("connections");
@@ -765,7 +773,9 @@ function HomeContent() {
         return (
           <ConnectionsSection
             focusConnectionId={connectionFocusRequest?.id ?? null}
+            focusCategory={connectionFocusRequest?.category ?? null}
             focusRequestId={connectionFocusRequest?.requestId ?? 0}
+            onFocusRequestConsumed={clearConnectionFocusRequest}
           />
         );
       case "meetings":

--- a/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
@@ -517,7 +517,7 @@ export function MeetingNotesSection({
   const openCalendarConnections = useCallback(() => {
     window.dispatchEvent(
       new CustomEvent("open-settings", {
-        detail: { section: "connections" },
+        detail: { section: "connections", category: "Calendar" },
       }),
     );
   }, []);

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -2249,10 +2249,17 @@ function ApiIntegrationPanel({ integration, onRefresh }: {
 
 interface ConnectionsSectionProps {
   focusConnectionId?: string | null;
+  focusCategory?: string | null;
   focusRequestId?: number;
+  onFocusRequestConsumed?: () => void;
 }
 
-export function ConnectionsSection({ focusConnectionId, focusRequestId = 0 }: ConnectionsSectionProps = {}) {
+export function ConnectionsSection({
+  focusConnectionId,
+  focusCategory,
+  focusRequestId = 0,
+  onFocusRequestConsumed,
+}: ConnectionsSectionProps = {}) {
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState(ALL_CONNECTION_CATEGORIES);
   const [sortBy, setSortBy] = useState<ConnectionSort>("default");
@@ -2272,7 +2279,15 @@ export function ConnectionsSection({ focusConnectionId, focusRequestId = 0 }: Co
   useEffect(() => {
     if (!focusRequestId) return;
     setSelected(focusConnectionId || null);
-  }, [focusConnectionId, focusRequestId]);
+    setCategoryFilter(
+      focusCategory
+        ? normalizeConnectionCategory(focusCategory)
+        : ALL_CONNECTION_CATEGORIES,
+    );
+    setSearch("");
+    setSortBy("default");
+    onFocusRequestConsumed?.();
+  }, [focusCategory, focusConnectionId, focusRequestId, onFocusRequestConsumed]);
 
   // Hardcoded connection status
   const [claudeInstalled, setClaudeInstalled] = useState(false);

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -296,7 +296,7 @@ async fn list_connections(State(state): State<ConnectionsState>) -> Json<Value> 
             "id": "apple-calendar",
             "name": "Apple Calendar",
             "icon": "apple-calendar",
-            "category": "productivity",
+            "category": "calendar",
             "description": format!(
                 "Read-only access to your native {} calendar. \
                 Query events via GET /connections/calendar/events?hours_back=1&hours_ahead=8",


### PR DESCRIPTION
This PR updates the Meeting Notes calendar flow so the `calendars` action opens a calendar-scoped Connections view instead of the broad Connections page.

Before:
- Clicking `calendars` from Meeting Notes opened the full Connections page, which felt too broad
- Apple Calendar did not appear under the `Calendar` filter because it was categorized as `productivity`


https://github.com/user-attachments/assets/7247177b-86ba-45fb-8c53-cdfb8410089f



After:
- The user lands directly in the relevant calendar connection view
- Apple Calendar appears in the expected filter group
- The scoped filter is only applied for that entry flow


https://github.com/user-attachments/assets/44f074ff-815c-4fd5-861e-b8a882b32610



