### PR TITLE
Trim pipe preset IDs during parsing

### DIFF
--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -176,6 +176,11 @@ where
 {
     use serde::de;
 
+    fn normalized_preset(s: &str) -> Option<String> {
+        let trimmed = s.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    }
+
     struct PresetVisitor;
 
     impl<'de> de::Visitor<'de> for PresetVisitor {
@@ -186,11 +191,7 @@ where
         }
 
         fn visit_str<E: de::Error>(self, v: &str) -> Result<Vec<String>, E> {
-            if v.is_empty() {
-                Ok(vec![])
-            } else {
-                Ok(vec![v.to_string()])
-            }
+            Ok(normalized_preset(v).into_iter().collect())
         }
 
         fn visit_none<E: de::Error>(self) -> Result<Vec<String>, E> {
@@ -204,7 +205,7 @@ where
         fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<String>, A::Error> {
             let mut result = Vec::new();
             while let Some(s) = seq.next_element::<String>()? {
-                if !s.is_empty() {
+                if let Some(s) = normalized_preset(&s) {
                     result.push(s);
                 }
             }
@@ -4957,6 +4958,14 @@ mod tests {
         assert_eq!(config.model, "auto");
         assert!(config.enabled);
         assert!(config.provider.is_none());
+    }
+
+    #[test]
+    fn test_parse_frontmatter_trims_preset_ids() {
+        let content = "---\nschedule: every 1h\nenabled: true\npreset:\n  - \" primary \"\n  - \"   \"\n  - \"fallback  \"\n---\n\nBody";
+        let (config, body) = parse_frontmatter(content).unwrap();
+        assert_eq!(config.preset, vec!["primary", "fallback"]);
+        assert_eq!(body, "Body");
     }
 
     #[test]

--- a/crates/screenpipe-core/src/pipes/preset_fallback.rs
+++ b/crates/screenpipe-core/src/pipes/preset_fallback.rs
@@ -384,10 +384,15 @@ fn now_epoch() -> u64 {
 /// ```
 pub fn parse_preset_list(value: &serde_json::Value) -> Vec<String> {
     match value {
-        serde_json::Value::String(s) if !s.is_empty() => vec![s.clone()],
+        serde_json::Value::String(s) => s
+            .trim()
+            .is_empty()
+            .then(Vec::new)
+            .unwrap_or_else(|| vec![s.trim().to_string()]),
         serde_json::Value::Array(arr) => arr
             .iter()
             .filter_map(|v| v.as_str())
+            .map(str::trim)
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
             .collect(),
@@ -421,6 +426,12 @@ mod tests {
     fn test_parse_preset_list_empty_string() {
         let v = serde_json::json!("");
         assert!(parse_preset_list(&v).is_empty());
+    }
+
+    #[test]
+    fn test_parse_preset_list_trims_whitespace() {
+        let v = serde_json::json!([" primary ", "   ", "fallback  "]);
+        assert_eq!(parse_preset_list(&v), vec!["primary", "fallback"]);
     }
 
     #[test]


### PR DESCRIPTION
## summary
- trim pipe preset IDs when parsing frontmatter and preset fallback config values
- drop whitespace-only preset entries instead of preserving invalid empty IDs
- add regression tests for whitespace-padded preset values

## validation
- `vet "Trim pipe preset IDs during parsing so surrounding whitespace does not break preset resolution" --agentic --agent-harness claude`
- `cargo test -p screenpipe-core preset`
- `git diff --check`

## risk notes
- low risk: affects only preset ID normalization at parse time
- preserves existing behavior for already-valid preset IDs

## changed area
- `crates/screenpipe-core/src/pipes/mod.rs`
- `crates/screenpipe-core/src/pipes/preset_fallback.rs`

## skipped tests
- no broader workspace test run; targeted `screenpipe-core` preset parsing coverage exercised the touched paths
