### PR TITLE
Fix incorrect Check now update toast in settings

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -36,6 +36,32 @@ export default function GeneralSettings() {
   const handleCheckForUpdates = async () => {
     setIsCheckingForUpdate(true);
     try {
+      const pendingRes = await commands.getPendingUpdate();
+      if (pendingRes.status === "ok" && pendingRes.data) {
+        const pending = pendingRes.data;
+        if (pending.auth_required) {
+          toast({
+            title: "update available",
+            description: `v${pending.version} is available — sign in to download it`,
+          });
+          return;
+        }
+
+        if (pending.downloaded) {
+          toast({
+            title: "update ready",
+            description: `v${pending.version} is ready — restart to update`,
+          });
+          return;
+        }
+
+        toast({
+          title: "update found",
+          description: `v${pending.version} is still downloading in the background`,
+        });
+        return;
+      }
+
       const res = await commands.triggerUpdateCheck();
       if (res.status === "error") throw new Error(res.error);
       const updateFound = res.data;


### PR DESCRIPTION
This PR fixes the update check toast in Settings -> General.

Before this change, the Check now button only looked at the result of a fresh update check. That meant it could sometimes show you're up to date even when the app had already detected a newer version and the top update UI was showing that state.
<img width="1001" height="619" alt="image" src="https://github.com/user-attachments/assets/aa739661-4a02-40f7-bfb2-8855fef3e1b9" />


This change makes the button check the existing pending update state first. If Screenpipe already knows an update is available, downloading, or ready to apply, the toast now reflects that instead of incorrectly saying the app is current.

### What changed:

- check now now checks pending updater state before running the normal update check
- shows the correct toast for:
     - update available but requires sign-in
     - update downloading
     - update ready to restart
- only falls back to the old fresh-check path when there is no pending update state


### Testing:

- logic reviewed against the existing updater flow
- attempted local updater end-to-end testing, but the heavy mock updater build failed due to No space left on device (os error 28)
- full local updater UI verification was not completed because of that environment issue