### PR TITLE
 Fix owned browser cookie permission prompt to ask once

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -26,17 +26,20 @@
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { commands } from "@/lib/utils/tauri";
+import { LogicalPosition } from "@tauri-apps/api/dpi";
 import { listen } from "@tauri-apps/api/event";
+import { Menu } from "@tauri-apps/api/menu";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { platform as getPlatform } from "@tauri-apps/plugin-os";
-import { ExternalLink, KeyRound, Loader2, RotateCw, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { Cookie, ExternalLink, KeyRound, Loader2, RotateCw, PanelRightClose, PanelRightOpen } from "lucide-react";
 import {
   loadConversationFile,
   updateConversationFlags,
 } from "@/lib/chat-storage";
 import { Button } from "@/components/ui/button";
 import { localFetch } from "@/lib/api";
+import { useSettings } from "@/lib/hooks/use-settings";
 
 const NAVIGATE_EVENT = "owned-browser:navigate";
 const SESSION_ACCESS_REQUEST_EVENT = "owned-browser:session-access-request";
@@ -57,12 +60,15 @@ interface SessionAccessEvent {
   requestId?: string;
   url: string;
   host: string;
+  already_granted?: boolean;
+  alreadyGranted?: boolean;
 }
 
 interface ActiveSessionAccessRequest {
   requestId: string;
   url: string;
   host: string;
+  alreadyGranted: boolean;
 }
 
 interface V20CookieBlockEvent {
@@ -102,6 +108,7 @@ function clampWidth(want: number, available: number): number {
 }
 
 export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
+  const { settings, updateSettings } = useSettings();
   const [visible, setVisible] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
@@ -300,6 +307,8 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
           requestId,
           url: payload.url,
           host: payload.host,
+          alreadyGranted:
+            payload.alreadyGranted ?? payload.already_granted ?? false,
         };
         setSessionAccessRequest(request);
         setSessionAccessAnswer(null);
@@ -585,6 +594,90 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
     }
   }, [currentUrl]);
 
+  const setCookieAccessGranted = useCallback(
+    async (granted: boolean) => {
+      await commands.setBrowserCookieAccessGranted(granted);
+      await updateSettings({ browserCookieAccessGranted: granted });
+    },
+    [updateSettings],
+  );
+
+  const retryWithCookies = useCallback(async () => {
+    if (!currentUrl) return;
+    await commands.confirmBrowserCookieAccessForSession();
+    setLoading(true);
+    await commands.ownedBrowserNavigate(currentUrl).catch((e) => {
+      console.error("retry cookie navigation failed", e);
+    });
+  }, [currentUrl]);
+
+  const openCookieMenu = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      try {
+        const granted = settings.browserCookieAccessGranted === true;
+        const buttonRect = event.currentTarget.getBoundingClientRect();
+        const win = getCurrentWindow();
+        const menu = await Menu.new({
+          items: [
+          {
+            id: "browser-cookie-status",
+            text: granted
+              ? "Browser sessions: enabled"
+              : "Browser sessions: ask before use",
+            enabled: false,
+          },
+          {
+            id: "browser-cookie-explain",
+            text: "Uses cookies only, never passwords",
+            enabled: false,
+          },
+          {
+            id: granted
+              ? "browser-cookie-revoke"
+              : "browser-cookie-enable",
+            text: granted
+              ? "Ask again before using cookies"
+              : currentUrl
+                ? "Enable and retry current page"
+                : "Enable browser sessions",
+            action: () => {
+              if (granted) {
+                void setCookieAccessGranted(false);
+                return;
+              }
+              void (async () => {
+                await setCookieAccessGranted(true);
+                await commands.confirmBrowserCookieAccessForSession();
+                if (currentUrl) await retryWithCookies();
+              })();
+            },
+          },
+          {
+            id: "browser-cookie-retry",
+            text: "Retry current page with cookies",
+            enabled: Boolean(currentUrl),
+            action: () => {
+              void retryWithCookies();
+            },
+          },
+          ],
+        });
+        await menu.popup(
+          new LogicalPosition(buttonRect.left, buttonRect.bottom + 4),
+          win,
+        );
+      } catch (e) {
+        console.error("owned-browser cookie menu failed", e);
+      }
+    },
+    [
+      currentUrl,
+      retryWithCookies,
+      setCookieAccessGranted,
+      settings.browserCookieAccessGranted,
+    ],
+  );
+
   const collapse = useCallback(() => {
     setCollapsed(true);
     setLoading(false);
@@ -603,10 +696,18 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
       if (!request || sessionAccessAnswer) return;
       setSessionAccessAnswer(allow ? "allow" : "deny");
       try {
+        if (allow) {
+          await commands.setBrowserCookieAccessGranted(true);
+        }
         await commands.ownedBrowserResolveSessionAccess(
           request.requestId,
           allow,
         );
+        if (allow) {
+          await updateSettings({ browserCookieAccessGranted: true }).catch((e) => {
+            console.error("persist browserCookieAccessGranted failed", e);
+          });
+        }
         setSessionAccessRequest((current) =>
           current?.requestId === request.requestId ? null : current,
         );
@@ -621,7 +722,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
         setSessionAccessAnswer(null);
       }
     },
-    [sessionAccessRequest, sessionAccessAnswer],
+    [sessionAccessRequest, sessionAccessAnswer, updateSettings],
   );
 
   // ---------------------------------------------------------------------------
@@ -668,6 +769,15 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                 </div>
               )}
             </div>
+            {isMac && (
+              <button
+                onClick={openCookieMenu}
+                title="Browser session cookies"
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground"
+              >
+                <Cookie className="h-3.5 w-3.5" />
+              </button>
+            )}
             <button
               onClick={reload}
               title="Reload"
@@ -709,7 +819,9 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                     </div>
                     <div className="min-w-0">
                       <div className="text-sm font-medium text-foreground">
-                        Use your browser login?
+                        {sessionAccessRequest.alreadyGranted
+                          ? "macOS may ask for access"
+                          : "Use your browser login?"}
                       </div>
                       <div className="mt-1 break-all text-xs text-muted-foreground">
                         {sessionAccessRequest.host}
@@ -717,11 +829,11 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                     </div>
                   </div>
                   <p className="text-xs leading-5 text-muted-foreground">
-                    ScreenPipe Browser can copy matching session cookies from
-                    your browser so the agent opens this site already signed
-                    in. It does not read saved passwords.
+                    {sessionAccessRequest.alreadyGranted
+                      ? "Screenpipe is about to copy browser session cookies. macOS may ask for browser Safe Storage access next."
+                      : "ScreenPipe can use your browser sessions so the agent opens sites already signed in. This applies to all sites. It does not read saved passwords."}
                   </p>
-                  {isMac && (
+                  {isMac && !sessionAccessRequest.alreadyGranted && (
                     <p className="mt-2 text-xs leading-5 text-muted-foreground">
                       If you allow it, macOS may ask for access to browser safe
                       storage next.
@@ -736,7 +848,9 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                     >
                       {sessionAccessAnswer === "allow"
                         ? isMac ? "Waiting for macOS…" : "Applying…"
-                        : "Use browser session"}
+                        : sessionAccessRequest.alreadyGranted
+                          ? "Continue"
+                          : "Use browser session"}
                     </Button>
                     <Button
                       size="sm"

--- a/apps/screenpipe-app-tauri/components/settings/browser-url-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/browser-url-card.tsx
@@ -247,6 +247,7 @@ export function BrowserUrlCard({ onStatusChange }: BrowserUrlCardProps) {
           </div>
         </div>
 
+
         <div className="px-4 py-2 bg-muted/50 border-t border-border">
           <p className="text-xs text-muted-foreground">
             if a browser was denied, toggle it on manually in System Settings →

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -349,6 +349,11 @@ export type Settings = SettingsStore & {
 	 */
 	listenOnLan?: boolean;
 	encryptStore?: boolean;
+	/** Global blanket permission: allow screenpipe to copy browser cookies
+	 *  into the owned browser so the agent can browse sites the user is
+	 *  logged into. When true, the session-access prompt card never appears.
+	 *  Revocable from Settings → Browser URL Capture. */
+	browserCookieAccessGranted?: boolean;
 }
 
 export function getEffectiveFilters(settings: Settings) {
@@ -582,6 +587,7 @@ let DEFAULT_SETTINGS: Settings = {
 			localRetentionDays: 14,
 			localRetentionMode: "media",
 			encryptStore: true,
+			browserCookieAccessGranted: false,
 			hdRecordingDefault: "ask",
 			hdRecordingIntervalMs: 100,
 		};
@@ -949,6 +955,14 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 					port: loadedSettings.port ?? 3030,
 					authEnabled: loadedSettings.apiAuth ?? true,
 				});
+
+				// Hydrate Rust's owned-browser runtime cache from persisted settings.
+				// This prevents the cookie-access prompt from reappearing after restart.
+				await commands
+					.setBrowserCookieAccessGranted(
+						loadedSettings.browserCookieAccessGranted === true,
+					)
+					.catch(() => {});
 			} catch (error) {
 				console.error("Failed to load settings:", error);
 				setLoadingError(error instanceof Error ? error.message : "Unknown error");

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -229,6 +229,20 @@ async completeOnboarding() : Promise<Result<null, string>> {
 }
 },
 /**
+ * Mark the current app run as explicitly cleared to read browser Safe Storage.
+ * Used by the owned-browser cookie menu's enable-and-retry action so the next
+ * navigate can proceed to the macOS Keychain prompt without showing a second
+ * in-app confirmation card.
+ */
+async confirmBrowserCookieAccessForSession() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("confirm_browser_cookie_access_for_session") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Copy a frame deeplink (screenpipe://frame/N) to clipboard. Native API only.
  */
 async copyDeeplinkToClipboard(frameId: number) : Promise<Result<null, string>> {
@@ -469,6 +483,14 @@ async getAudioDevices() : Promise<Result<AudioDeviceInfo[], string>> {
  */
 async getBootPhase() : Promise<BootPhaseSnapshot> {
     return await TAURI_INVOKE("get_boot_phase");
+},
+/**
+ * Read the current runtime value of the global cookie-access flag.
+ * Frontend calls this on startup to hydrate the AtomicBool from the
+ * persisted store value.
+ */
+async getBrowserCookieAccessGranted() : Promise<boolean> {
+    return await TAURI_INVOKE("get_browser_cookie_access_granted");
 },
 /**
  * Returns per-browser automation permission status for all installed Chromium browsers.
@@ -1582,6 +1604,19 @@ async setApiAuthKey(key: string) : Promise<Result<null, string>> {
 async setAutostart(enabled: boolean) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_autostart", { enabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Persist the global browser cookie-access permission. Called from the
+ * frontend when the user clicks "Use browser session" in the prompt card
+ * or toggles the setting in the settings page.
+ */
+async setBrowserCookieAccessGranted(granted: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_browser_cookie_access_granted", { granted }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -33,8 +33,9 @@
 use async_trait::async_trait;
 use screenpipe_connect::connections::browser::{EvalResult, OwnedWebviewHandle};
 use serde::Serialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::{Duration, Instant};
 use tauri::webview::PageLoadEvent;
@@ -128,6 +129,7 @@ struct BrowserSessionAccessRequestPayload {
     request_id: String,
     url: String,
     host: String,
+    already_granted: bool,
 }
 
 #[cfg(target_os = "windows")]
@@ -147,22 +149,23 @@ struct V20CookieBlockPayload {
 static SESSION_ACCESS_PENDING: OnceLock<
     Mutex<HashMap<String, oneshot::Sender<BrowserSessionDecision>>>,
 > = OnceLock::new();
-/// Hosts the user allowed this app session (`Use browser session`). Cleared on
-/// restart. We never remember "continue logged out" — deny is per navigation.
-static SESSION_ACCESS_ALLOWED: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
-static SESSION_ACCESS_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+/// Global flag: user has granted blanket cookie-access permission.
+/// Persisted to the frontend store (`browserCookieAccessGranted`);
+/// this AtomicBool is the runtime cache so every navigate avoids
+/// an async store read. Set via `set_browser_cookie_access_granted`.
+static GLOBAL_SESSION_ACCESS_GRANTED: AtomicBool = AtomicBool::new(false);
+/// Guards against showing duplicate prompt cards when multiple
+/// navigations fire before the user answers the first one.
+static SESSION_ACCESS_PROMPT_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+/// macOS-only UX guard: after app launch, even if global cookie access is
+/// already persisted, show Screenpipe's own warning before the first Keychain
+/// Safe Storage read can trigger an OS prompt. Explicit menu enable/retry or
+/// prompt allow primes this for the current process.
+static SESSION_ACCESS_PRIMED_THIS_RUN: AtomicBool = AtomicBool::new(false);
 
 fn pending_session_access(
 ) -> &'static Mutex<HashMap<String, oneshot::Sender<BrowserSessionDecision>>> {
     SESSION_ACCESS_PENDING.get_or_init(|| Mutex::new(HashMap::new()))
-}
-
-fn session_access_allowed() -> &'static Mutex<HashSet<String>> {
-    SESSION_ACCESS_ALLOWED.get_or_init(|| Mutex::new(HashSet::new()))
-}
-
-fn session_access_in_flight() -> &'static Mutex<HashSet<String>> {
-    SESSION_ACCESS_IN_FLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
 /// Normalize host keys so `www.example.com` and `example.com` share one decision.
@@ -172,13 +175,6 @@ fn session_host_key(host: &str) -> String {
         .strip_prefix("www.")
         .map(|rest| rest.to_string())
         .unwrap_or(lower)
-}
-
-async fn remember_session_access_allow(host: &str) {
-    session_access_allowed()
-        .lock()
-        .await
-        .insert(session_host_key(host));
 }
 
 #[specta::specta]
@@ -199,6 +195,43 @@ pub async fn owned_browser_resolve_session_access(
         .ok_or_else(|| "session access request expired".to_string())?;
     tx.send(decision)
         .map_err(|_| "session access request was already closed".to_string())
+}
+
+/// Persist the global browser cookie-access permission. Called from the
+/// frontend when the user clicks "Use browser session" in the prompt card
+/// or toggles the setting in the settings page.
+#[specta::specta]
+#[tauri::command]
+pub async fn set_browser_cookie_access_granted(granted: bool) -> Result<(), String> {
+    GLOBAL_SESSION_ACCESS_GRANTED.store(granted, Ordering::SeqCst);
+    if !granted {
+        SESSION_ACCESS_PRIMED_THIS_RUN.store(false, Ordering::SeqCst);
+    }
+    info!(
+        granted,
+        "owned-browser: global cookie access permission updated"
+    );
+    Ok(())
+}
+
+/// Mark the current app run as explicitly cleared to read browser Safe Storage.
+/// Used by the owned-browser cookie menu's enable-and-retry action so the next
+/// navigate can proceed to the macOS Keychain prompt without showing a second
+/// in-app confirmation card.
+#[specta::specta]
+#[tauri::command]
+pub async fn confirm_browser_cookie_access_for_session() -> Result<(), String> {
+    SESSION_ACCESS_PRIMED_THIS_RUN.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Read the current runtime value of the global cookie-access flag.
+/// Frontend calls this on startup to hydrate the AtomicBool from the
+/// persisted store value.
+#[specta::specta]
+#[tauri::command]
+pub async fn get_browser_cookie_access_granted() -> bool {
+    GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst)
 }
 
 // ---------------------------------------------------------------------------
@@ -1205,46 +1238,58 @@ async fn browser_session_decision_for_url(
         return BrowserSessionDecision::ContinueLoggedOut;
     }
 
-    if session_access_allowed().lock().await.contains(&host_key) {
-        return BrowserSessionDecision::UseBrowserSession;
-    }
+    let already_granted = GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst);
 
     // On Windows there is no OS-level permission dialog (unlike macOS Keychain),
     // so we don't need an explicit consent step. DPAPI cookies inject silently;
     // if they are v20-encrypted inject_cookies_for_url will show the single
     // "Browser login is protected" card which already acts as consent + setup.
-    // SESSION_ACCESS_ALLOWED is a macOS-only concept (remembers "user clicked
-    // allow" to skip the Keychain consent dialog next time) — we don't store
-    // anything on Windows because there is no dialog to skip.
     #[cfg(target_os = "windows")]
     return BrowserSessionDecision::UseBrowserSession;
 
-    // Agent may navigate the same host repeatedly while the first prompt is open.
-    let wait_deadline = Instant::now() + SESSION_ACCESS_TIMEOUT;
-    loop {
-        if session_access_allowed().lock().await.contains(&host_key) {
-            return BrowserSessionDecision::UseBrowserSession;
-        }
-        let in_flight = session_access_in_flight().lock().await;
-        if !in_flight.contains(&host_key) {
-            drop(in_flight);
-            break;
-        }
-        drop(in_flight);
-        if Instant::now() >= wait_deadline {
-            warn!(
-                host = host_key.as_str(),
-                "owned-browser session access: timed out waiting for in-flight prompt"
-            );
-            return BrowserSessionDecision::ContinueLoggedOut;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
+    // macOS: a persisted app-level grant is not enough to avoid surprise.
+    // The first Safe Storage read after app launch can still trigger a macOS
+    // Keychain prompt, so require an in-app confirmation once per process
+    // before reading Keychain.
+    #[cfg(target_os = "macos")]
+    if already_granted && SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst) {
+        return BrowserSessionDecision::UseBrowserSession;
     }
 
-    session_access_in_flight()
-        .lock()
-        .await
-        .insert(host_key.clone());
+    // If a prompt is already on screen (concurrent navigations), wait for it
+    // instead of spawning a second card. compare_exchange makes prompt ownership
+    // atomic so two parallel navigations can't both show cards.
+    loop {
+        #[cfg(target_os = "macos")]
+        if GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst)
+            && SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst)
+        {
+            return BrowserSessionDecision::UseBrowserSession;
+        }
+        if SESSION_ACCESS_PROMPT_IN_FLIGHT
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            break;
+        }
+        let wait_deadline = Instant::now() + SESSION_ACCESS_TIMEOUT;
+        while SESSION_ACCESS_PROMPT_IN_FLIGHT.load(Ordering::SeqCst) {
+            #[cfg(target_os = "macos")]
+            if GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst)
+                && SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst)
+            {
+                return BrowserSessionDecision::UseBrowserSession;
+            }
+            if Instant::now() >= wait_deadline {
+                warn!(
+                    host = host_key.as_str(),
+                    "owned-browser session access: timed out waiting for in-flight prompt"
+                );
+                return BrowserSessionDecision::ContinueLoggedOut;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
 
     let state = browser_state();
     if let Some(active) = state.active().await {
@@ -1263,11 +1308,12 @@ async fn browser_session_decision_for_url(
         request_id: request_id.clone(),
         url: url.as_str().to_string(),
         host: host_key.clone(),
+        already_granted,
     };
 
     if let Err(e) = app.emit(SESSION_ACCESS_REQUEST_EVENT, payload) {
         pending_session_access().lock().await.remove(&request_id);
-        session_access_in_flight().lock().await.remove(&host_key);
+        SESSION_ACCESS_PROMPT_IN_FLIGHT.store(false, Ordering::SeqCst);
         warn!("owned-browser session access: failed to emit request: {e}");
         return BrowserSessionDecision::ContinueLoggedOut;
     }
@@ -1285,9 +1331,12 @@ async fn browser_session_decision_for_url(
         }
     };
 
-    session_access_in_flight().lock().await.remove(&host_key);
+    SESSION_ACCESS_PROMPT_IN_FLIGHT.store(false, Ordering::SeqCst);
     if decision == BrowserSessionDecision::UseBrowserSession {
-        remember_session_access_allow(&host_key).await;
+        // Set the global runtime flag — frontend is responsible for
+        // persisting to the store and calling set_browser_cookie_access_granted.
+        GLOBAL_SESSION_ACCESS_GRANTED.store(true, Ordering::SeqCst);
+        SESSION_ACCESS_PRIMED_THIS_RUN.store(true, Ordering::SeqCst);
     }
     decision
 }


### PR DESCRIPTION
# Description

Owned browser now treats browser-session cookie access as one global macOS permission. First cookie-bearing navigation asks once, persists consent, and skips repeated per-domain prompts.

macOS Safe Storage is still guarded: Screenpipe explains first, then macOS may ask after the user continues. Deny never reads cookies for that navigation.

A cookie button now sits beside refresh in the owned browser header on macOS. It opens a native Tauri menu for status, enable/revoke, and retrying the current page with cookies.

# How to test

- [ ] On macOS, open owned browser to logged-in site with matching real-browser cookies.
- [ ] Confirm "Use your browser login?" appears before any macOS Safe Storage prompt.
- [ ] Click "Continue logged out" and confirm no macOS Safe Storage prompt appears.
- [ ] Navigate again and click "Use browser session".
- [ ] Confirm macOS Safe Storage prompt appears only after Screenpipe prompt is accepted.
- [ ] Confirm prompts are sequential, not simultaneous.
- [ ] Navigate to another logged-in domain and confirm Screenpipe prompt does not reappear in same app run.
- [ ] Restart app and navigate again.
- [ ] Confirm Screenpipe Safe Storage warning appears before any macOS prompt.
- [ ] Click cookie button beside refresh.
- [ ] Confirm native menu opens above browser content.
- [ ] Choose "Ask again before using cookies".
- [ ] Navigate to cookie-bearing site and confirm prompt appears again.
- [ ] Choose "Retry current page with cookies" and confirm current page reloads through cookie path.
