### PR TITLE
Handle CRLF in notification toggles

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/notification-toggle.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/notification-toggle.test.ts
@@ -66,6 +66,14 @@ describe("isNotificationsDenied", () => {
       )
     ).toBe(false);
   });
+
+  it("supports CRLF frontmatter line endings", () => {
+    expect(
+      isNotificationsDenied(
+        "---\r\npermissions:\r\n  deny:\r\n    - Api(POST /notify)\r\n---\r\n\r\n# Hello"
+      )
+    ).toBe(true);
+  });
 });
 
 // ─── toggleNotificationInContent: DISABLE (enabled=false) ──────────────
@@ -124,6 +132,16 @@ describe("toggleNotificationInContent — disable notifications", () => {
     expect(result).toContain("permissions:");
     expect(result).toContain("deny:");
     expect(result).toContain("- Api(POST /notify)");
+    expect(isNotificationsDenied(result)).toBe(true);
+  });
+
+  it("updates CRLF frontmatter without duplicating it", () => {
+    const input = "---\r\nschedule: every 30m\r\n---\r\n\r\n# My Pipe";
+    const result = toggleNotificationInContent(input, false);
+    expect(result).toContain("schedule: every 30m");
+    expect(result).toContain("permissions:");
+    expect(result).toContain("- Api(POST /notify)");
+    expect(result.match(/^---/gm)?.length).toBe(2);
     expect(isNotificationsDenied(result)).toBe(true);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/notification-toggle.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/notification-toggle.ts
@@ -9,14 +9,19 @@
 
 const DENY_RULE = "Api(POST /notify)";
 const DENY_RULE_PATTERN = /^-\s*Api\(\s*(\*)?\s*POST\s+\/notify\s*\)/i;
+const FRONTMATTER_PATTERN = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+function detectEol(rawContent: string): "\n" | "\r\n" {
+  return rawContent.includes("\r\n") ? "\r\n" : "\n";
+}
 
 /**
  * Check if notifications are denied in the pipe's raw content.
  */
 export function isNotificationsDenied(rawContent: string): boolean {
-  const match = rawContent.match(/^---\n([\s\S]*?)\n---/);
+  const match = rawContent.match(FRONTMATTER_PATTERN);
   if (!match) return false;
-  const lines = match[1].split("\n");
+  const lines = match[1].split(/\r?\n/);
   let inDeny = false;
   for (const line of lines) {
     const trimmed = line.trim();
@@ -45,19 +50,20 @@ export function toggleNotificationInContent(
   rawContent: string,
   enabled: boolean
 ): string {
-  const frontmatterMatch = rawContent.match(/^---\n([\s\S]*?)\n---/);
+  const frontmatterMatch = rawContent.match(FRONTMATTER_PATTERN);
+  const eol = detectEol(rawContent);
 
   if (!frontmatterMatch) {
     // No frontmatter
     if (!enabled) {
-      return `---\npermissions:\n  deny:\n    - ${DENY_RULE}\n---\n\n${rawContent}`;
+      return `---${eol}permissions:${eol}  deny:${eol}    - ${DENY_RULE}${eol}---${eol}${eol}${rawContent}`;
     }
     return rawContent; // nothing to remove
   }
 
   const yaml = frontmatterMatch[1];
   const body = rawContent.slice(frontmatterMatch[0].length);
-  let lines = yaml.split("\n");
+  let lines = yaml.split(/\r?\n/);
 
   if (!enabled) {
     // === DISABLE notifications: add deny rule ===
@@ -119,11 +125,11 @@ export function toggleNotificationInContent(
   const trimmedYaml = lines.join("\n").trim();
   if (!trimmedYaml) {
     // Frontmatter is completely empty after cleanup — remove it entirely
-    const trimmedBody = body.replace(/^\n+/, "");
+    const trimmedBody = body.replace(/^\r?\n+/, "");
     return trimmedBody || rawContent;
   }
 
-  return `---\n${trimmedYaml}\n---${body}`;
+  return `---${eol}${lines.join(eol).trim()}${eol}---${body}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- handle CRLF frontmatter in pipe notification toggles
- preserve the existing line-ending style when rewriting pipe markdown
- add regression coverage for CRLF detection and disable flows

## Validation
- `node --experimental-strip-types --input-type=module -e 'import assert from "node:assert/strict"; import { isNotificationsDenied, toggleNotificationInContent } from "./apps/screenpipe-app-tauri/lib/utils/notification-toggle.ts"; assert.equal(isNotificationsDenied("---\\r\\npermissions:\\r\\n  deny:\\r\\n    - Api(POST /notify)\\r\\n---\\r\\n\\r\\n# Hello"), true); const result = toggleNotificationInContent("---\\r\\nschedule: every 30m\\r\\n---\\r\\n\\r\\n# My Pipe", false); assert.match(result, /permissions:/); assert.match(result, /Api\\(POST \\/notify\\)/); assert.match(result, /\\r\\n/);'`
- `node --experimental-strip-types --input-type=module -e 'import assert from "node:assert/strict"; import { isNotificationsDenied, toggleNotificationInContent } from "./apps/screenpipe-app-tauri/lib/utils/notification-toggle.ts"; const input = "---\\r\\nschedule: every 30m\\r\\n---\\r\\n\\r\\n# My Pipe"; const disabled = toggleNotificationInContent(input, false); assert.equal(isNotificationsDenied(disabled), true); const enabled = toggleNotificationInContent(disabled, true); assert.equal(isNotificationsDenied(enabled), false); assert.ok(enabled.includes("# My Pipe")); assert.ok(enabled.includes("\\r\\n"));'`
- `git diff --check`

## Risk Notes
- low risk: changes are isolated to frontmatter parsing in `notification-toggle.ts`
- no runtime behavior changes outside pipe notification permission helpers

## Changed Area
- `apps/screenpipe-app-tauri/lib/utils/notification-toggle.ts`
- `apps/screenpipe-app-tauri/lib/utils/notification-toggle.test.ts`

## Skipped Tests
- `bunx vitest run apps/screenpipe-app-tauri/lib/utils/notification-toggle.test.ts` is currently blocked in this sandbox because Bun cannot write to its temp directory (`PermissionDenied`)
- `vet "Fix CRLF frontmatter handling in pipe notification toggles" --agentic --agent-harness claude` hit repeated Claude API `529 Overloaded` errors
