### PR TITLE
Fix owned browser cookie access preference

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -596,7 +596,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
 
   const setCookieAccessGranted = useCallback(
     async (granted: boolean) => {
-      await commands.setBrowserCookieAccessGranted(granted);
+      await commands.setBrowserCookieAccessState(granted, !granted);
       await updateSettings({ browserCookieAccessGranted: granted });
     },
     [updateSettings],
@@ -611,6 +611,12 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
     });
   }, [currentUrl]);
 
+  const enableAndRetryWithCookies = useCallback(async () => {
+    await setCookieAccessGranted(true);
+    await commands.confirmBrowserCookieAccessForSession();
+    if (currentUrl) await retryWithCookies();
+  }, [currentUrl, retryWithCookies, setCookieAccessGranted]);
+
   const openCookieMenu = useCallback(
     async (event: React.MouseEvent<HTMLButtonElement>) => {
       try {
@@ -619,47 +625,26 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
         const win = getCurrentWindow();
         const menu = await Menu.new({
           items: [
-          {
-            id: "browser-cookie-status",
-            text: granted
-              ? "Browser sessions: enabled"
-              : "Browser sessions: ask before use",
-            enabled: false,
-          },
-          {
-            id: "browser-cookie-explain",
-            text: "Uses cookies only, never passwords",
-            enabled: false,
-          },
-          {
-            id: granted
-              ? "browser-cookie-revoke"
-              : "browser-cookie-enable",
-            text: granted
-              ? "Ask again before using cookies"
-              : currentUrl
-                ? "Enable and retry current page"
-                : "Enable browser sessions",
-            action: () => {
-              if (granted) {
-                void setCookieAccessGranted(false);
-                return;
-              }
-              void (async () => {
-                await setCookieAccessGranted(true);
-                await commands.confirmBrowserCookieAccessForSession();
-                if (currentUrl) await retryWithCookies();
-              })();
+            {
+              id: "browser-cookie-toggle",
+              text: "Use browser login",
+              checked: granted,
+              action: () => {
+                if (granted) {
+                  void setCookieAccessGranted(false);
+                } else {
+                  void enableAndRetryWithCookies();
+                }
+              },
             },
-          },
-          {
-            id: "browser-cookie-retry",
-            text: "Retry current page with cookies",
-            enabled: Boolean(currentUrl),
-            action: () => {
-              void retryWithCookies();
+            {
+              id: "browser-cookie-retry",
+              text: "Retry page",
+              enabled: Boolean(currentUrl),
+              action: () => {
+                void retryWithCookies();
+              },
             },
-          },
           ],
         });
         await menu.popup(
@@ -672,6 +657,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
     },
     [
       currentUrl,
+      enableAndRetryWithCookies,
       retryWithCookies,
       setCookieAccessGranted,
       settings.browserCookieAccessGranted,
@@ -696,18 +682,14 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
       if (!request || sessionAccessAnswer) return;
       setSessionAccessAnswer(allow ? "allow" : "deny");
       try {
-        if (allow) {
-          await commands.setBrowserCookieAccessGranted(true);
-        }
+        await commands.setBrowserCookieAccessState(allow, !allow);
         await commands.ownedBrowserResolveSessionAccess(
           request.requestId,
           allow,
         );
-        if (allow) {
-          await updateSettings({ browserCookieAccessGranted: true }).catch((e) => {
-            console.error("persist browserCookieAccessGranted failed", e);
-          });
-        }
+        await updateSettings({ browserCookieAccessGranted: allow }).catch((e) => {
+          console.error("persist browserCookieAccessGranted failed", e);
+        });
         setSessionAccessRequest((current) =>
           current?.requestId === request.requestId ? null : current,
         );

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -351,8 +351,8 @@ export type Settings = SettingsStore & {
 	encryptStore?: boolean;
 	/** Global blanket permission: allow screenpipe to copy browser cookies
 	 *  into the owned browser so the agent can browse sites the user is
-	 *  logged into. When true, the session-access prompt card never appears.
-	 *  Revocable from Settings → Browser URL Capture. */
+	 *  logged into. Revocable from the owned-browser cookie menu.
+	 *  Undefined = not decided yet, false = disabled, true = enabled. */
 	browserCookieAccessGranted?: boolean;
 }
 
@@ -587,7 +587,6 @@ let DEFAULT_SETTINGS: Settings = {
 			localRetentionDays: 14,
 			localRetentionMode: "media",
 			encryptStore: true,
-			browserCookieAccessGranted: false,
 			hdRecordingDefault: "ask",
 			hdRecordingIntervalMs: 100,
 		};
@@ -959,8 +958,9 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 				// Hydrate Rust's owned-browser runtime cache from persisted settings.
 				// This prevents the cookie-access prompt from reappearing after restart.
 				await commands
-					.setBrowserCookieAccessGranted(
+					.setBrowserCookieAccessState(
 						loadedSettings.browserCookieAccessGranted === true,
+						loadedSettings.browserCookieAccessGranted === false,
 					)
 					.catch(() => {});
 			} catch (error) {

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1623,6 +1623,18 @@ async setBrowserCookieAccessGranted(granted: boolean) : Promise<Result<null, str
 }
 },
 /**
+ * Hydrate/update the complete browser cookie access state. `granted=false`
+ * with `disabled=false` means first-run unknown: prompt once if cookies exist.
+ */
+async setBrowserCookieAccessState(granted: boolean, disabled: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_browser_cookie_access_state", { granted, disabled }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Toggle the "Cloud audio + video + image analysis" capability
  * in the screenpipe-api skill that Pi installs on every run.
  *

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -154,6 +154,9 @@ static SESSION_ACCESS_PENDING: OnceLock<
 /// this AtomicBool is the runtime cache so every navigate avoids
 /// an async store read. Set via `set_browser_cookie_access_granted`.
 static GLOBAL_SESSION_ACCESS_GRANTED: AtomicBool = AtomicBool::new(false);
+/// User explicitly disabled browser cookie access. When true, do not prompt
+/// and do not read cookies. User can re-enable from the cookie menu.
+static GLOBAL_SESSION_ACCESS_DISABLED: AtomicBool = AtomicBool::new(false);
 /// Guards against showing duplicate prompt cards when multiple
 /// navigations fire before the user answers the first one.
 static SESSION_ACCESS_PROMPT_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
@@ -204,12 +207,32 @@ pub async fn owned_browser_resolve_session_access(
 #[tauri::command]
 pub async fn set_browser_cookie_access_granted(granted: bool) -> Result<(), String> {
     GLOBAL_SESSION_ACCESS_GRANTED.store(granted, Ordering::SeqCst);
-    if !granted {
+    if granted {
+        GLOBAL_SESSION_ACCESS_DISABLED.store(false, Ordering::SeqCst);
+    } else {
         SESSION_ACCESS_PRIMED_THIS_RUN.store(false, Ordering::SeqCst);
     }
     info!(
         granted,
         "owned-browser: global cookie access permission updated"
+    );
+    Ok(())
+}
+
+/// Hydrate/update the complete browser cookie access state. `granted=false`
+/// with `disabled=false` means first-run unknown: prompt once if cookies exist.
+#[specta::specta]
+#[tauri::command]
+pub async fn set_browser_cookie_access_state(granted: bool, disabled: bool) -> Result<(), String> {
+    GLOBAL_SESSION_ACCESS_GRANTED.store(granted, Ordering::SeqCst);
+    GLOBAL_SESSION_ACCESS_DISABLED.store(disabled && !granted, Ordering::SeqCst);
+    if !granted {
+        SESSION_ACCESS_PRIMED_THIS_RUN.store(false, Ordering::SeqCst);
+    }
+    info!(
+        granted,
+        disabled,
+        "owned-browser: global cookie access state updated"
     );
     Ok(())
 }
@@ -1238,6 +1261,14 @@ async fn browser_session_decision_for_url(
         return BrowserSessionDecision::ContinueLoggedOut;
     }
 
+    if GLOBAL_SESSION_ACCESS_DISABLED.load(Ordering::SeqCst) {
+        info!(
+            host = host_key.as_str(),
+            "owned-browser cookies: disabled by user — navigating without real-browser session"
+        );
+        return BrowserSessionDecision::ContinueLoggedOut;
+    }
+
     let already_granted = GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst);
 
     // On Windows there is no OS-level permission dialog (unlike macOS Keychain),
@@ -1252,8 +1283,14 @@ async fn browser_session_decision_for_url(
     // Keychain prompt, so require an in-app confirmation once per process
     // before reading Keychain.
     #[cfg(target_os = "macos")]
-    if already_granted && SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst) {
-        return BrowserSessionDecision::UseBrowserSession;
+    if already_granted {
+        if SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst) {
+            return BrowserSessionDecision::UseBrowserSession;
+        }
+        if !crate::owned_browser_cookies::safe_storage_likely_prompts_for_host(&host_key).await {
+            SESSION_ACCESS_PRIMED_THIS_RUN.store(true, Ordering::SeqCst);
+            return BrowserSessionDecision::UseBrowserSession;
+        }
     }
 
     // If a prompt is already on screen (concurrent navigations), wait for it
@@ -1261,10 +1298,15 @@ async fn browser_session_decision_for_url(
     // atomic so two parallel navigations can't both show cards.
     loop {
         #[cfg(target_os = "macos")]
-        if GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst)
-            && SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst)
-        {
-            return BrowserSessionDecision::UseBrowserSession;
+        if GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst) {
+            if SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst) {
+                return BrowserSessionDecision::UseBrowserSession;
+            }
+            if !crate::owned_browser_cookies::safe_storage_likely_prompts_for_host(&host_key).await
+            {
+                SESSION_ACCESS_PRIMED_THIS_RUN.store(true, Ordering::SeqCst);
+                return BrowserSessionDecision::UseBrowserSession;
+            }
         }
         if SESSION_ACCESS_PROMPT_IN_FLIGHT
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
@@ -1275,10 +1317,16 @@ async fn browser_session_decision_for_url(
         let wait_deadline = Instant::now() + SESSION_ACCESS_TIMEOUT;
         while SESSION_ACCESS_PROMPT_IN_FLIGHT.load(Ordering::SeqCst) {
             #[cfg(target_os = "macos")]
-            if GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst)
-                && SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst)
-            {
-                return BrowserSessionDecision::UseBrowserSession;
+            if GLOBAL_SESSION_ACCESS_GRANTED.load(Ordering::SeqCst) {
+                if SESSION_ACCESS_PRIMED_THIS_RUN.load(Ordering::SeqCst) {
+                    return BrowserSessionDecision::UseBrowserSession;
+                }
+                if !crate::owned_browser_cookies::safe_storage_likely_prompts_for_host(&host_key)
+                    .await
+                {
+                    SESSION_ACCESS_PRIMED_THIS_RUN.store(true, Ordering::SeqCst);
+                    return BrowserSessionDecision::UseBrowserSession;
+                }
             }
             if Instant::now() >= wait_deadline {
                 warn!(
@@ -1336,7 +1384,13 @@ async fn browser_session_decision_for_url(
         // Set the global runtime flag — frontend is responsible for
         // persisting to the store and calling set_browser_cookie_access_granted.
         GLOBAL_SESSION_ACCESS_GRANTED.store(true, Ordering::SeqCst);
+        GLOBAL_SESSION_ACCESS_DISABLED.store(false, Ordering::SeqCst);
         SESSION_ACCESS_PRIMED_THIS_RUN.store(true, Ordering::SeqCst);
+    } else {
+        // First-time "Continue logged out" is a real preference: don't keep
+        // prompting. User can enable cookies later from the cookie menu.
+        GLOBAL_SESSION_ACCESS_GRANTED.store(false, Ordering::SeqCst);
+        GLOBAL_SESSION_ACCESS_DISABLED.store(true, Ordering::SeqCst);
     }
     decision
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser_cookies.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser_cookies.rs
@@ -68,6 +68,8 @@ use std::time::{Duration, Instant};
 
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::{ffi::c_void, ptr};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::sync::OnceLock;
 
@@ -149,6 +151,26 @@ pub async fn has_cookies_for_host(host: &str) -> bool {
         return false;
     }
     has_cookies_for_host_impl(host).await
+}
+
+/// macOS UX preflight: returns true when reading the browser Safe Storage
+/// key is likely to trigger a Keychain prompt, or when we cannot prove it
+/// will not. It inspects Keychain ACL metadata without requesting password
+/// bytes; unknown = prompt to keep OS prompts from surprising users.
+#[cfg(target_os = "macos")]
+pub async fn safe_storage_likely_prompts_for_host(host: &str) -> bool {
+    if host.is_empty() {
+        return false;
+    }
+    let host_owned = host.to_string();
+    tokio::task::spawn_blocking(move || safe_storage_likely_prompts_for_host_impl(&host_owned))
+        .await
+        .unwrap_or(true)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub async fn safe_storage_likely_prompts_for_host(_host: &str) -> bool {
+    false
 }
 
 #[cfg(target_os = "windows")]
@@ -939,6 +961,234 @@ fn has_cookie_rows(source: &KeychainEntry, host: &str) -> Result<bool, String> {
     rows.next()
         .map(|row| row.is_some())
         .map_err(|e| format!("row: {e}"))
+}
+
+#[cfg(target_os = "macos")]
+type OSStatus = i32;
+#[cfg(target_os = "macos")]
+type CFTypeRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFArrayRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFStringRef = *const c_void;
+#[cfg(target_os = "macos")]
+type CFDataRef = *const c_void;
+#[cfg(target_os = "macos")]
+type SecKeychainItemRef = *mut c_void;
+#[cfg(target_os = "macos")]
+type SecAccessRef = *mut c_void;
+#[cfg(target_os = "macos")]
+type SecACLRef = *const c_void;
+#[cfg(target_os = "macos")]
+type SecTrustedApplicationRef = *mut c_void;
+
+#[cfg(target_os = "macos")]
+#[link(name = "Security", kind = "framework")]
+unsafe extern "C" {
+    fn SecKeychainFindGenericPassword(
+        keychain_or_array: CFTypeRef,
+        service_name_length: u32,
+        service_name: *const i8,
+        account_name_length: u32,
+        account_name: *const i8,
+        password_length: *mut u32,
+        password_data: *mut *mut c_void,
+        item_ref: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+    fn SecKeychainItemCopyAccess(item_ref: SecKeychainItemRef, access: *mut SecAccessRef)
+        -> OSStatus;
+    fn SecAccessCopyACLList(access: SecAccessRef, acl_list: *mut CFArrayRef) -> OSStatus;
+    fn SecACLCopyContents(
+        acl: SecACLRef,
+        application_list: *mut CFArrayRef,
+        description: *mut CFStringRef,
+        prompt_selector: *mut u32,
+    ) -> OSStatus;
+    fn SecTrustedApplicationCreateFromPath(
+        path: *const i8,
+        app: *mut SecTrustedApplicationRef,
+    ) -> OSStatus;
+    fn SecTrustedApplicationCopyData(app_ref: SecTrustedApplicationRef, data: *mut CFDataRef)
+        -> OSStatus;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+    fn CFArrayGetCount(array: CFArrayRef) -> isize;
+    fn CFArrayGetValueAtIndex(array: CFArrayRef, idx: isize) -> *const c_void;
+    fn CFDataGetLength(data: CFDataRef) -> isize;
+    fn CFDataGetBytePtr(data: CFDataRef) -> *const u8;
+    fn CFRelease(value: *const c_void);
+}
+
+#[cfg(target_os = "macos")]
+struct CfOwned<T>(*const T);
+
+#[cfg(target_os = "macos")]
+impl<T> Drop for CfOwned<T> {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe { CFRelease(self.0.cast()) };
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn safe_storage_likely_prompts_for_host_impl(host: &str) -> bool {
+    let mut checked_any = false;
+    for source in SOURCES {
+        match has_cookie_rows(source, host) {
+            Ok(true) => {
+                checked_any = true;
+                match safe_storage_entry_trusts_current_app(source) {
+                    Ok(true) => {
+                        debug!(
+                            source = source.name,
+                            host,
+                            "owned-browser cookies: Safe Storage ACL preflight trusted"
+                        );
+                    }
+                    Ok(false) => {
+                        info!(
+                            source = source.name,
+                            host,
+                            "owned-browser cookies: Safe Storage ACL preflight would prompt"
+                        );
+                        return true;
+                    }
+                    Err(e) => {
+                        info!(
+                            source = source.name,
+                            host,
+                            "owned-browser cookies: Safe Storage ACL preflight unknown — {e}"
+                        );
+                        return true;
+                    }
+                }
+            }
+            Ok(false) => {}
+            Err(e) => debug!(
+                source = source.name,
+                host,
+                "owned-browser cookies: Safe Storage ACL preflight row skip — {e}"
+            ),
+        }
+    }
+    !checked_any
+}
+
+#[cfg(target_os = "macos")]
+fn safe_storage_entry_trusts_current_app(source: &KeychainEntry) -> Result<bool, String> {
+    let current_app_data = current_trusted_application_data()?;
+    let mut item: SecKeychainItemRef = ptr::null_mut();
+    let status = unsafe {
+        SecKeychainFindGenericPassword(
+            ptr::null(),
+            source.keychain_service.len() as u32,
+            source.keychain_service.as_ptr().cast(),
+            source.keychain_account.len() as u32,
+            source.keychain_account.as_ptr().cast(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut item,
+        )
+    };
+    if status != 0 || item.is_null() {
+        return Err(format!("find keychain item: status {status}"));
+    }
+    let _item = CfOwned(item.cast_const());
+
+    let mut access: SecAccessRef = ptr::null_mut();
+    let status = unsafe { SecKeychainItemCopyAccess(item, &mut access) };
+    if status != 0 || access.is_null() {
+        return Err(format!("copy access: status {status}"));
+    }
+    let _access = CfOwned(access.cast_const());
+
+    let mut acl_list: CFArrayRef = ptr::null();
+    let status = unsafe { SecAccessCopyACLList(access, &mut acl_list) };
+    if status != 0 || acl_list.is_null() {
+        return Err(format!("copy acl list: status {status}"));
+    }
+    let _acl_list = CfOwned(acl_list);
+
+    let count = unsafe { CFArrayGetCount(acl_list) };
+    for idx in 0..count {
+        let acl = unsafe { CFArrayGetValueAtIndex(acl_list, idx) } as SecACLRef;
+        if acl.is_null() {
+            continue;
+        }
+        if acl_trusts_current_app(acl, &current_app_data)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(target_os = "macos")]
+fn current_trusted_application_data() -> Result<Vec<u8>, String> {
+    let mut app: SecTrustedApplicationRef = ptr::null_mut();
+    let status = unsafe { SecTrustedApplicationCreateFromPath(ptr::null(), &mut app) };
+    if status != 0 || app.is_null() {
+        return Err(format!("current trusted app: status {status}"));
+    }
+    let _app = CfOwned(app.cast_const());
+    trusted_application_data(app)
+}
+
+#[cfg(target_os = "macos")]
+fn acl_trusts_current_app(acl: SecACLRef, current_app_data: &[u8]) -> Result<bool, String> {
+    let mut app_list: CFArrayRef = ptr::null();
+    let mut description: CFStringRef = ptr::null();
+    let mut prompt_selector = 0u32;
+    let status = unsafe {
+        SecACLCopyContents(
+            acl,
+            &mut app_list,
+            &mut description,
+            &mut prompt_selector,
+        )
+    };
+    if status != 0 {
+        return Err(format!("copy acl contents: status {status}"));
+    }
+    let _description = CfOwned(description);
+    if app_list.is_null() {
+        return Ok(false);
+    }
+    let _app_list = CfOwned(app_list);
+
+    let count = unsafe { CFArrayGetCount(app_list) };
+    for idx in 0..count {
+        let app = unsafe { CFArrayGetValueAtIndex(app_list, idx) } as SecTrustedApplicationRef;
+        if app.is_null() {
+            continue;
+        }
+        if trusted_application_data(app)? == current_app_data {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(target_os = "macos")]
+fn trusted_application_data(app: SecTrustedApplicationRef) -> Result<Vec<u8>, String> {
+    let mut data: CFDataRef = ptr::null();
+    let status = unsafe { SecTrustedApplicationCopyData(app, &mut data) };
+    if status != 0 || data.is_null() {
+        return Err(format!("trusted app data: status {status}"));
+    }
+    let _data = CfOwned(data);
+    let len = unsafe { CFDataGetLength(data) };
+    if len < 0 {
+        return Err("trusted app data has negative length".to_string());
+    }
+    let ptr = unsafe { CFDataGetBytePtr(data) };
+    if ptr.is_null() {
+        return Err("trusted app data pointer is null".to_string());
+    }
+    Ok(unsafe { std::slice::from_raw_parts(ptr, len as usize) }.to_vec())
 }
 
 /// Synchronous worker — runs inside spawn_blocking. Returns Vec on


### PR DESCRIPTION
# Description

Owned browser cookie access is now a clear macOS preference: enabled or disabled.

First undecided navigation asks once. If user continues logged out, cookies are disabled and Screenpipe never prompts again. If user enables browser login, consent persists and no per-domain prompts appear.

Before touching macOS Safe Storage, Screenpipe checks Keychain ACL metadata. If macOS already trusts Screenpipe, no extra warning appears. If macOS would likely prompt or state is unknown, Screenpipe explains first.

<img width="1207" height="827" alt="image" src="https://github.com/user-attachments/assets/10a5a265-4e5d-493d-aa80-d43fddeaf9c8" />


A cookie button beside refresh opens a native menu with a checked "Use browser login" toggle and a short "Retry page" action.

<img width="618" height="123" alt="Screenshot 2026-06-02 at 8 35 32 PM" src="https://github.com/user-attachments/assets/cf07e256-bd3b-4ba4-bb73-8fac4267e19d" />


# How to test

- [ ] On macOS, open owned browser to a logged-in site with matching real-browser cookies.
- [ ] Confirm one Screenpipe prompt appears for an undecided user.
- [ ] Click "Continue logged out".
- [ ] Navigate again and confirm Screenpipe does not prompt again.
- [ ] Confirm no macOS Safe Storage prompt appears while disabled.
- [ ] Click cookie button beside refresh.
- [ ] Confirm native menu shows unchecked "Use browser login".
- [ ] Choose "Use browser login".
- [ ] Confirm macOS Safe Storage prompt appears only after explicit enable.
- [ ] Navigate to another logged-in domain and confirm no per-domain prompt appears.
- [ ] Restart app and navigate again.
- [ ] If macOS already trusts Screenpipe, confirm no Screenpipe restart warning appears.
- [ ] If macOS does not trust Screenpipe yet, confirm Screenpipe warning appears before macOS prompt.
- [ ] Uncheck "Use browser login" from menu and confirm future navigations do not prompt or read cookies.
