### PR TITLE
fix(audio): contain reconciliation sweep panics so the worker survives

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -4,8 +4,10 @@
 
 use anyhow::{anyhow, Result};
 use dashmap::DashMap;
+use futures::FutureExt;
 use std::{
     collections::HashSet,
+    panic::AssertUnwindSafe,
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
@@ -329,41 +331,61 @@ impl AudioManager {
                 // Wait for model to load + initial recordings
                 tokio::time::sleep(Duration::from_secs(120)).await;
                 loop {
-                    if let Some(detector) = &meeting_detector_bg {
-                        detector.check_grace_period().await;
-                        if detector.is_in_audio_session() {
-                            debug!(
-                                "reconciliation: skipping background sweep during active audio session"
-                            );
-                            tokio::time::sleep(Duration::from_secs(120)).await;
-                            continue;
+                    // Contain a panic inside a sweep so it cannot kill this
+                    // long-lived worker (issue #3498: a single panic used to
+                    // stop the loop permanently, silently piling up pending
+                    // chunks until the app was restarted). The sweep stays on
+                    // this task, so shutdown still cancels an in-flight sweep at
+                    // its next await. The locks it holds are tokio::sync locks,
+                    // which do not poison, so a caught panic releases them
+                    // cleanly.
+                    let swept = AssertUnwindSafe(async {
+                        if let Some(detector) = &meeting_detector_bg {
+                            detector.check_grace_period().await;
+                            if detector.is_in_audio_session() {
+                                debug!(
+                                    "reconciliation: skipping background sweep during active audio session"
+                                );
+                                return;
+                            }
                         }
-                    }
 
-                    let engine_guard = engine_ref.read().await;
-                    if let Some(ref transcription_engine) = *engine_guard {
-                        let opts = options_ref.read().await;
-                        let audio_engine = opts.transcription_engine.clone();
-                        let batch_max_dur = opts.batch_max_duration_secs;
-                        drop(opts);
+                        let engine_guard = engine_ref.read().await;
+                        if let Some(ref transcription_engine) = *engine_guard {
+                            let opts = options_ref.read().await;
+                            let audio_engine = opts.transcription_engine.clone();
+                            let batch_max_dur = opts.batch_max_duration_secs;
+                            drop(opts);
 
-                        let data_dir = output_path_bg.as_deref();
-                        let count = super::reconciliation::reconcile_untranscribed(
-                            &db,
-                            transcription_engine,
-                            on_insert_bg.as_ref(),
-                            audio_engine,
-                            Some(seg_mgr.clone()),
-                            data_dir,
-                            batch_max_dur,
-                            Some(metrics_bg.clone()),
-                        )
-                        .await;
-                        if count > 0 {
-                            info!("reconciliation: transcribed {} orphaned chunks", count);
+                            let count = super::reconciliation::reconcile_untranscribed(
+                                &db,
+                                transcription_engine,
+                                on_insert_bg.as_ref(),
+                                audio_engine,
+                                Some(seg_mgr.clone()),
+                                output_path_bg.as_deref(),
+                                batch_max_dur,
+                                Some(metrics_bg.clone()),
+                            )
+                            .await;
+                            if count > 0 {
+                                info!("reconciliation: transcribed {} orphaned chunks", count);
+                            }
                         }
+                    })
+                    .catch_unwind()
+                    .await;
+                    if let Err(panic) = swept {
+                        let reason = panic
+                            .downcast_ref::<&str>()
+                            .copied()
+                            .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                            .unwrap_or("unknown cause");
+                        error!(
+                            "reconciliation: sweep panicked, worker continues: {}",
+                            reason
+                        );
                     }
-                    drop(engine_guard);
                     tokio::time::sleep(Duration::from_secs(120)).await;
                 }
             });


### PR DESCRIPTION
## Problem

The batch-mode reconciliation worker in `AudioManager::start_internal` is a single fire-and-forget `tokio::spawn` loop on a 120s cadence. Its `JoinHandle` (`reconciliation_handle`) is stored only to `.abort()` on shutdown; nothing reads `is_finished()` or restarts it. `check_and_restart_central_handlers` supervises `recording_receiver_handle` and `transcription_receiver_handle`, but not this one.

If a sweep panics, the loop task dies permanently. Live capture and live transcription keep running, so the app looks healthy, but pending chunks stop draining and pile up until the app is restarted and the loop is re-spawned. That matches the symptom in #3498 (a backlog accumulating over days, cleared by an app restart).

#3724 removed one ffmpeg `unwrap` panic in this same loop, so a panic reaching this worker is a demonstrated failure mode, not a hypothetical one.

## Fix

Wrap the existing sweep body in `futures::FutureExt::catch_unwind` (with `AssertUnwindSafe`). A panic inside a sweep is caught, logged with its message, and treated as non-fatal; the loop continues to the next tick. No new task is spawned, so the sweep stays on the worker task and `shutdown` / `Drop` still cancel an in-flight sweep at its next await before the engine is dropped (the read-lock invariant the shutdown path depends on). The 120s cadence, the in-audio-session skip, and the `reconcile_untranscribed` call are unchanged.

`catch_unwind` is the panic-isolation idiom already used in this crate (`speaker/mod.rs`, `transcription/engine.rs`). The locks held across awaits in the sweep are `tokio::sync` locks, which do not poison, so a caught panic drops the guard and releases the lock cleanly.

## Scope

This contains a sweep panic. It does not fix a hung await or a silently aborted cloud request, which would leave the task alive (`is_finished()` stays false) and are among the reporter's own hypotheses in #3498. The exact panic trigger is not reproduced here; this is a defensive boundary against task death, not a root-cause fix, and it now logs the panic message so the trigger surfaces if it recurs.

## Alternative considered

Registering `reconciliation_handle` in `check_and_restart_central_handlers` (the supervision pattern the central handlers use) was considered and not taken. The reconciliation worker pre-captures its inputs and snapshots `output_path` and the meeting detector at spawn time, so supervision needs a dedicated respawn helper plus a new restart-result field. It also spawns in batch mode only, so an empty handle slot must not be treated as dead, or it would thrash the device-monitor restart-storm cap in realtime mode, and a respawn re-incurs the 120s warmup before the next sweep. That is a larger behavioral change than containing a panic in place. Supervision can follow up if clean exits or hangs turn out to matter.

## Testing

`cargo test -p screenpipe-audio --lib` (176 passed, 0 failed). `cargo fmt --check` and `cargo clippy -p screenpipe-audio --lib` are clean with no new warnings. The panic path is a defensive boundary around an existing 50-line worker loop; it is exercised by the suite above rather than by a dedicated test, since a meaningful test would only assert the standard library's documented `catch_unwind` behavior.
