### PR TITLE
fix(meetings): keep live calls alive on deferred output audio

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -1190,17 +1190,24 @@ impl DatabaseManager {
         })
     }
 
-    /// Returns true if there are audio transcriptions from output devices
-    /// within the given number of seconds. Used by meeting detection to keep
-    /// browser-based meetings alive when the user switches tabs but audio is
-    /// still flowing (i.e. the meeting is still going).
+    /// Returns true if output audio was recently captured. Used by meeting
+    /// detection to keep meetings alive when controls disappear but call audio
+    /// still flows.
+    ///
+    /// Important: batch mode defers `audio_transcriptions` while the meeting is
+    /// active, so this must also inspect durable `audio_chunks` file paths.
     pub async fn has_recent_output_audio(&self, within_secs: i64) -> Result<bool, sqlx::Error> {
-        // EXISTS short-circuits on the first matching row instead of scanning
-        // every transcription in the window like COUNT(*) would.
+        // EXISTS short-circuits on the first matching row. Match both old
+        // transcribed output rows and fresh persisted chunks that have not been
+        // transcribed yet (batch/live meeting path).
         let exists = sqlx::query_scalar::<_, i64>(
             "SELECT EXISTS(
                  SELECT 1 FROM audio_transcriptions
                  WHERE is_input_device = 0
+                   AND timestamp >= strftime('%Y-%m-%dT%H:%M:%S+00:00', 'now', ?1)
+                 UNION ALL
+                 SELECT 1 FROM audio_chunks
+                 WHERE lower(file_path) LIKE '%(output)%'
                    AND timestamp >= strftime('%Y-%m-%dT%H:%M:%S+00:00', 'now', ?1)
              )",
         )

--- a/crates/screenpipe-db/tests/db.rs
+++ b/crates/screenpipe-db/tests/db.rs
@@ -96,6 +96,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_recent_output_audio_detects_deferred_output_chunk() {
+        let db = setup_test_db().await;
+
+        db.insert_audio_chunk("System Audio (output)_recent.mp4", Some(Utc::now()))
+            .await
+            .unwrap();
+
+        assert!(db.has_recent_output_audio(30).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_recent_output_audio_ignores_input_chunk() {
+        let db = setup_test_db().await;
+
+        db.insert_audio_chunk("Ruark’s AirPods (input)_recent.mp4", Some(Utc::now()))
+            .await
+            .unwrap();
+
+        assert!(!db.has_recent_output_audio(30).await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_insert_and_search_audio() {
         let db = setup_test_db().await;
         let audio_chunk_id = db.insert_audio_chunk("test_audio.mp4", None).await.unwrap();


### PR DESCRIPTION
## Problem

Live meetings get ended and **fragmented mid-call**: "recorded my voice for the first section… then stopped recording both, randomly recorded my voice for a min and then didn't record anything for the rest of the call."

## Root cause

The meeting detector keeps a meeting alive when the meeting app's UI controls momentarily disappear (browser tab switch, app relaunch / PID change) **as long as output audio is still flowing** — gated on `has_recent_output_audio(30)`.

But that check only looked at the background `audio_transcriptions` table. During a **live** meeting the output audio is handled by the live transcription path, so background transcription of output is deferred/suppressed and **no recent output `audio_transcriptions` rows exist**. So `has_recent_output_audio` returned `false` for exactly the meetings it was meant to protect — and a transient control blip was enough to end the call, splitting one meeting into fragments with gaps.

## Fix

`has_recent_output_audio` now also inspects durable **`audio_chunks`** — the output `.mp4` files are written every segment regardless of transcription state (`file_path LIKE '%(output)%'`). So a live meeting whose output audio is still being captured stays alive even though its transcriptions are deferred.

```sql
SELECT EXISTS(
   SELECT 1 FROM audio_transcriptions WHERE is_input_device = 0 AND timestamp >= ...
   UNION ALL
   SELECT 1 FROM audio_chunks WHERE lower(file_path) LIKE '%(output)%' AND timestamp >= ...
)
```

