### PR TITLE
feat(browser): clear owned browser data

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -611,6 +611,18 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
     });
   }, [currentUrl]);
 
+  const clearBrowserData = useCallback(async () => {
+    try {
+      await commands.ownedBrowserClearBrowsingData();
+      if (currentUrl) {
+        setLoading(true);
+        await commands.ownedBrowserNavigate(currentUrl);
+      }
+    } catch (e) {
+      console.error("clear owned-browser browsing data failed", e);
+    }
+  }, [currentUrl]);
+
   const enableAndRetryWithCookies = useCallback(async () => {
     await setCookieAccessGranted(true);
     await commands.confirmBrowserCookieAccessForSession();
@@ -645,6 +657,13 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
                 void retryWithCookies();
               },
             },
+            {
+              id: "browser-clear-data",
+              text: "Clear browser data",
+              action: () => {
+                void clearBrowserData();
+              },
+            },
           ],
         });
         await menu.popup(
@@ -656,6 +675,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
       }
     },
     [
+      clearBrowserData,
       currentUrl,
       enableAndRetryWithCookies,
       retryWithCookies,

--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -613,6 +613,9 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
 
   const clearBrowserData = useCallback(async () => {
     try {
+      // If browser login stays enabled, reload immediately re-injects cookies
+      // from the user's real browser, making clear look like a no-op.
+      await setCookieAccessGranted(false);
       await commands.ownedBrowserClearBrowsingData();
       if (currentUrl) {
         setLoading(true);
@@ -621,7 +624,7 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
     } catch (e) {
       console.error("clear owned-browser browsing data failed", e);
     }
-  }, [currentUrl]);
+  }, [currentUrl, setCookieAccessGranted]);
 
   const enableAndRetryWithCookies = useCallback(async () => {
     await setCookieAccessGranted(true);

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1007,6 +1007,19 @@ async openWindowsShellTarget(target: string) : Promise<Result<null, string>> {
 }
 },
 /**
+ * Clear all browsing data for the owned-browser webview: cookies, injected
+ * cookies, site storage, and cache. This resets the current shared owned
+ * browser slate; per-chat isolation belongs to the follow-up PR.
+ */
+async ownedBrowserClearBrowsingData() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("owned_browser_clear_browsing_data") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Hide the embedded webview without destroying it. Equivalent to calling
  * `set_bounds` with zero dimensions, but more explicit at the call site.
  */

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -954,6 +954,24 @@ pub async fn owned_browser_hide(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Clear all browsing data for the owned-browser webview: cookies, injected
+/// cookies, site storage, and cache. This resets the current shared owned
+/// browser slate; per-chat isolation belongs to the follow-up PR.
+#[specta::specta]
+#[tauri::command]
+pub async fn owned_browser_clear_browsing_data(app: AppHandle) -> Result<(), String> {
+    let _ = app;
+    let state = browser_state();
+    let Some(active) = state.active().await else {
+        return Err("owned-browser child webview not attached".to_string());
+    };
+    active
+        .clear_all_browsing_data()
+        .map_err(|e| format!("owned-browser clear browsing data failed: {e}"))?;
+    info!("owned-browser: cleared browsing data");
+    Ok(())
+}
+
 /// E2E-only probe: whether the owned-browser native webview is currently shown.
 /// Mirrors `e2e_main_overlay_visible` — internal visibility state stays hidden
 /// in production binaries and is only exposed under the `e2e` feature. Used by


### PR DESCRIPTION
# Description

Adds a native menu action to reset the owned browser slate.

The cookie menu now includes “Clear browser data”, which clears the owned-browser webview’s browsing data: injected cookies, current cookies, site storage, and cache. If a page is open, the owned browser reloads the current URL after clearing so the user sees the logged-out/clean state.



# How to test

- [ ] Open owned browser to a site with cookies/session state.
- [ ] Click the cookie button beside refresh.
- [ ] Choose “Clear browser data”.
- [ ] Confirm the current page reloads.
- [ ] Confirm the page no longer has the previous logged-in/session state.
- [ ] Confirm “Use browser login” can still be enabled again and retry page works.
