### PR TITLE
refactor(chat): drop query-time privacy filter toggle (redaction now at rest)

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { useSettings, ChatMessage, ChatConversation } from "@/lib/hooks/use-settings";
 import { cn } from "@/lib/utils";
-import { Loader2, Send, Square, Settings, ExternalLink, X, ImageIcon, History, Search, Trash2, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Plus, Copy, Check, Clock, Calendar, Paperclip, Filter, RefreshCw, GitBranch, MoreHorizontal, Pencil, Pin, Shield, ShieldCheck, Sparkles, Plug, CornerDownRight } from "lucide-react";
+import { Loader2, Send, Square, Settings, ExternalLink, X, ImageIcon, History, Search, Trash2, ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Plus, Copy, Check, Clock, Calendar, Paperclip, Filter, RefreshCw, GitBranch, MoreHorizontal, Pencil, Pin, Sparkles, Plug, CornerDownRight } from "lucide-react";
 import { SchedulePromptDialog } from "@/components/chat/schedule-prompt-dialog";
 import { PipeContextBanner } from "@/components/chat/pipe-context-banner";
 import { SourceCitationFooter } from "@/components/chat/source-citation-footer";
@@ -7426,8 +7426,6 @@ export function StandaloneChat({
   };
 
   const renderComposerUtilityMenu = () => {
-    const isPro = settings.user?.cloud_subscribed === true;
-    const privacyOn = isPro && settings.piPrivacyFilter === true;
     const timeLabels: Record<string, string> = {
       "today's activity": "today",
       "yesterday": "yesterday",
@@ -7451,66 +7449,6 @@ export function StandaloneChat({
             <Paperclip className="h-4 w-4 text-muted-foreground shrink-0" />
             <span>add photos & files</span>
           </button>
-          <TooltipProvider delayDuration={150}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  disabled={isLoading}
-                  onClick={() => {
-                    if (!isPro) {
-                      setAppFilterOpen(false);
-                      openUrl("https://screenpipe.com/onboarding");
-                      return;
-                    }
-                    updateSettings({ piPrivacyFilter: !privacyOn });
-                  }}
-                  className="w-full flex items-center gap-2 px-2 py-2 text-left text-sm rounded-md hover:bg-muted disabled:opacity-40 disabled:pointer-events-none transition-colors"
-                >
-                  {privacyOn ? (
-                    <ShieldCheck className="h-4 w-4 text-foreground shrink-0" />
-                  ) : (
-                    <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
-                  )}
-                  <span className="flex-1 min-w-0">privacy filter</span>
-                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                    {!isPro ? "pro" : privacyOn ? "on" : "off"}
-                  </span>
-                </button>
-              </TooltipTrigger>
-              <TooltipContent
-                side="right"
-                align="start"
-                className="max-w-[320px] p-3 space-y-2 text-xs leading-relaxed"
-              >
-                <div className="font-medium text-sm">
-                  {!isPro
-                    ? "Privacy filter — Pro"
-                    : privacyOn
-                      ? "Privacy filter: ON"
-                      : "Privacy filter: OFF"}
-                </div>
-                <div className="text-muted-foreground">
-                  {!isPro
-                    ? "Remove names, emails, phone numbers and other personal info from your screen data before the AI sees it. Adds ~1-2s per search. Click to upgrade."
-                    : privacyOn
-                      ? "Names, emails, phone numbers and other personal info are removed from your screen data before it reaches the AI. Adds ~1-2s per search. Click to turn off."
-                      : "Turn this on to strip personal info (names, emails, phones, addresses, account numbers) from your screen data before the AI sees it. Adds ~1-2s per search."}
-                </div>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    openUrl("https://docs.screenpi.pe/privacy-filter");
-                  }}
-                  className="text-[11px] underline text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  How it works →
-                </button>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
         </div>
 
         <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-muted/30 border-b border-border/50 flex items-center gap-1.5">

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -252,9 +252,6 @@ export type Settings = SettingsStore & {
 	filterMusic?: boolean;
 	/** Maximum batch transcription duration in seconds (0 = engine default: Deepgram 5000s, OpenAI 3000s, Whisper 600s) */
 	batchMaxDurationSecs?: number;
-	/** Redact PII from screenpipe API responses before they reach the LLM.
-	 *  Pro-only; enforced client-side (UI hides the toggle for non-pro). */
-	piPrivacyFilter?: boolean;
 	/** Show periodic notifications suggesting pipe ideas based on user's data (default: true) */
 	pipeSuggestionsEnabled?: boolean;
 	/** Hours between pipe suggestion notifications (default: 24) */

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -1488,26 +1488,6 @@ pub async fn pi_start_inner(
         cmd.env("BASH_ENV", p);
     }
 
-    // Privacy filter: if the user enabled the toggle in chat, set the env
-    // var the shim reads so every `curl .../search*` gets rewritten with
-    // `filter_pii=1`. Pro-gated client-side — non-pro can't flip the UI
-    // toggle so this branch won't fire for them.
-    if let Some(home) = dirs::home_dir() {
-        let store_path = home.join(".screenpipe").join("store.bin");
-        if let Ok(data) = std::fs::read_to_string(&store_path) {
-            if let Ok(store) = serde_json::from_str::<serde_json::Value>(&data) {
-                let settings = store.get("settings").unwrap_or(&store);
-                if settings
-                    .get("piPrivacyFilter")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false)
-                {
-                    cmd.env("SCREENPIPE_FILTER_PII", "1");
-                }
-            }
-        }
-    }
-
     // Pass the user's API key as env var for non-screenpipe providers
     if let Some(ref config) = provider_config {
         // ChatGPT OAuth: inject token from secret store (no api_key in config)

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -159,8 +159,9 @@ pub struct PipeConfig {
     /// parties (Slack, Notion, Google Docs, etc.).
     ///
     /// NOTE: the front-matter field parses but the pipe runner does NOT
-    /// yet read it into the spawned Pi env. Wire-up is pending — tracked
-    /// separately from the chat-side feature which is already live.
+    /// yet read it into the spawned Pi env. Wire-up is pending. The
+    /// chat-side toggle that used to set this env was removed once PII
+    /// redaction moved to the at-rest redact worker.
     #[serde(default, skip_serializing_if = "is_false")]
     pub privacy_filter: bool,
 


### PR DESCRIPTION
## Why

PII redaction now happens at rest in the redact worker, so the per-chat query-time privacy filter is redundant. This removes the chat-side feature: the composer-menu toggle, the `piPrivacyFilter` setting, and the Rust wiring that set `SCREENPIPE_FILTER_PII=1` for the chat agent.

## What changed

**Removed (chat only):**
- `standalone-chat.tsx`: the "privacy filter" toggle in the composer utility menu (plus its now-unused `Shield`/`ShieldCheck` imports and `isPro`/`privacyOn` locals).
- `use-settings.tsx`: the `piPrivacyFilter?: boolean` setting.
- `pi.rs`: the block that read `piPrivacyFilter` from `store.bin` and set `SCREENPIPE_FILTER_PII=1` on the chat agent.

**Left intact (out of scope):**
- The generic `BASH_ENV` shim that appends `filter_pii=1` when `SCREENPIPE_FILTER_PII=1` (shared infra, still targeted by the pending pipes `privacy_filter` field).
- The `/search?filter_pii=` route param (used by onboarding previews and the e2e suite).

### Composer menu, before vs after

```
  BEFORE                              AFTER
  +-------------------------+         +-------------------------+
  | (paperclip) add photos  |         | (paperclip) add photos  |
  |             & files     |         |             & files     |
  | (shield)  privacy   off |         +-------------------------+
  |           filter        |
  +-------------------------+
  ... time / app filters ...          ... time / app filters ...
```

### Redaction flow, before vs after

```mermaid
flowchart LR
  subgraph BEFORE [before: query-time filter]
    Q1[chat agent search] --> S1[BASH_ENV shim adds filter_pii=1 when toggle ON]
    S1 --> F1[/search redacts full PII via Tinfoil enclave/]
    F1 --> L1[results to LLM]
  end
```

```mermaid
flowchart LR
  subgraph AFTER [after: at-rest only]
    R2[redact worker redacts at rest] --> DB2[(indexed data)]
    DB2 --> Q2[chat agent search]
    Q2 --> L2[results to LLM]
  end
```

## Caveat worth confirming

The removed chat filter routed text through the Tinfoil `privacy-filter` enclave, which redacts **full PII** (names, emails, phones, addresses). The at-rest redact worker's **default policy is secrets-only** (`TextRedactionPolicy::default()`, see `crates/screenpipe-redact/src/span.rs` and the `default_policy_redacts_secrets_only` test). A bare email is not redacted under the default policy.

So with the default policy, names/emails/phones in screen data now reach the chat LLM where a Pro user who toggled the filter previously had them stripped. If full-PII stripping before the LLM is still wanted, broaden the redact policy rather than rely on the per-chat toggle.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run build` (next build) — compiled + exported successfully (exit 0)
- `cargo check --bin screenpipe-app` — finished, no new warnings (exit 0)
- No e2e specs reference the chat privacy toggle (only the generic `/search?filter_pii=` param, untouched)
