### PR TITLE
fix(rewind): open browser url links that lack a scheme

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -1230,28 +1230,36 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 				{(() => {
 					const browserUrl = currentFrame?.devices?.[0]?.metadata?.browser_url;
 					if (!browserUrl) return null;
+					// browser_url from screenpipe often lacks a protocol (e.g. "github.com/foo");
+					// both tauri shell.open and window.open reject/misroute schemeless inputs.
+					const openableUrl = browserUrl.includes("://") ? browserUrl : `https://${browserUrl}`;
+					const isHttps = openableUrl.startsWith("https://");
 					return (
 						<div className={`absolute ${embedded ? "top-[56px]" : "top-[calc(env(safe-area-inset-top)+4px)]"} left-0 right-0 z-[45] flex justify-center pointer-events-none`}>
 							<button
 								type="button"
 								className="flex items-center gap-1.5 max-w-lg min-w-0 px-3 py-1 rounded-full bg-black/70 backdrop-blur-sm border border-white/10 hover:bg-black/80 hover:border-white/20 transition-colors cursor-pointer pointer-events-auto"
-								title={`Open ${browserUrl}`}
-								onClick={async () => {
+								title={`Open ${openableUrl}`}
+								onClick={async (e) => {
+									e.stopPropagation();
 									try {
-										const { open } = await import("@tauri-apps/plugin-shell");
-										await open(browserUrl);
-									} catch {
-										window.open(browserUrl, "_blank");
+										const { openUrl } = await import("@tauri-apps/plugin-opener");
+										await openUrl(openableUrl);
+									} catch (err) {
+										console.error("failed to open url", openableUrl, err);
+										try {
+											window.open(openableUrl, "_blank", "noopener,noreferrer");
+										} catch {}
 									}
 								}}
 							>
-								{browserUrl.startsWith("https") ? (
+								{isHttps ? (
 									<Lock className="w-3 h-3 text-green-400/80 shrink-0" />
 								) : (
 									<Globe className="w-3 h-3 text-white/40 shrink-0" />
 								)}
 								<span className="text-[12px] font-mono text-white/80 truncate">
-									{browserUrl.replace(/^https?:\/\/(www\.)?/, "")}
+									{openableUrl.replace(/^https?:\/\/(www\.)?/, "")}
 								</span>
 								<ExternalLink className="w-3 h-3 text-white/40 shrink-0" />
 							</button>

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
@@ -304,14 +304,19 @@ export function AppContextPopover({
 						<div className="pl-4 space-y-0.5">
 							{data.topUrls.map((u, i) => {
 								const domain = extractDomain(u.url);
+								// browser_url from screenpipe often lacks a protocol (e.g. "github.com/foo");
+								// openUrl rejects such inputs silently, so normalize before opening.
+								const openableUrl = u.url.includes("://") ? u.url : `https://${u.url}`;
 								return (
 									<button
 										key={i}
-										className="flex items-center gap-1 text-blue-400 hover:text-blue-300 truncate w-full text-left transition-colors"
-										title={u.url}
-										onClick={() => {
-											openUrl(u.url).catch(() => {});
-											commands.closeWindow("Main").catch(() => {});
+										className="flex items-center gap-1 text-blue-400 hover:text-blue-300 truncate w-full text-left transition-colors cursor-pointer"
+										title={openableUrl}
+										onClick={(e) => {
+											e.stopPropagation();
+											openUrl(openableUrl).catch((err) => {
+												console.error("failed to open url", openableUrl, err);
+											});
 										}}
 									>
 										{domain ? (


### PR DESCRIPTION
### Description:

Normalize schemeless `browser_url` values (e.g. `github.com/foo`) to `https://` before passing to the opener, so clicking the URL pill and "top sites" links actually opens the browser instead of silently failing.

- before:


https://github.com/user-attachments/assets/8ee3a268-1e8d-4522-95d6-396fc60aba5c



- after:


https://github.com/user-attachments/assets/414b75d9-c943-4847-be59-673af13a4b36

