### PR TITLE
fix(connections): hide apple calendar tile on non-macos platforms

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
@@ -113,11 +113,6 @@ export function useHardcodedTiles(): HardcodedTile[] {
       { id: "voice-memos", name: "Voice Memos", icon: "voice-memos", connected: false },
     ] as HardcodedTile[] : []),
     ...(os === "macos" ? [{ id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false } as HardcodedTile] : []),
-    {
-      id: "apple-calendar",
-      name: os === "windows" ? "Windows Calendar" : "Apple Calendar",
-      icon: os === "windows" ? "windows-calendar" : "apple-calendar",
-      connected: calendarConnected,
-    },
+    ...(os === "macos" ? [{ id: "apple-calendar", name: "Apple Calendar", icon: "apple-calendar", connected: calendarConnected } as HardcodedTile] : []),
   ];
 }


### PR DESCRIPTION
Apple Calendar tile was unconditionally shown on all platforms including Windows.

Fixes #3797 

- before:

<img width="1131" height="434" alt="Screenshot 2026-06-03 202816" src="https://github.com/user-attachments/assets/8d8c541b-90c6-4670-a410-446e124d38c8" />
 
- after:

<img width="1919" height="1077" alt="image" src="https://github.com/user-attachments/assets/a6256849-866e-40c2-98af-8bdde48850a3" />

