### PR TITLE
Show platform-specific calendar name on all OSes

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/source-citation-footer.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/source-citation-footer.tsx
@@ -51,6 +51,8 @@ const KIND_LABEL: Record<SourceCitationKind, string> = {
 const CONNECTION_SOURCE_ICON_PATHS: Array<[string, string]> = [
   ["apple-calendar", "/images/apple.svg"],
   ["apple calendar", "/images/apple.svg"],
+  ["windows-calendar", "/images/windows.svg"],
+  ["windows calendar", "/images/windows.svg"],
   ["asana", "/images/asana.svg"],
   ["airtable", "/images/airtable.png"],
   ["bitrix24", "/images/bitrix24.png"],

--- a/apps/screenpipe-app-tauri/components/chat/source-citation-footer.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/source-citation-footer.tsx
@@ -51,8 +51,6 @@ const KIND_LABEL: Record<SourceCitationKind, string> = {
 const CONNECTION_SOURCE_ICON_PATHS: Array<[string, string]> = [
   ["apple-calendar", "/images/apple.svg"],
   ["apple calendar", "/images/apple.svg"],
-  ["windows-calendar", "/images/windows.svg"],
-  ["windows calendar", "/images/windows.svg"],
   ["asana", "/images/asana.svg"],
   ["airtable", "/images/airtable.png"],
   ["bitrix24", "/images/bitrix24.png"],

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -311,6 +311,7 @@ export function IntegrationIcon({
     "ics-calendar": <CalendarIcon className="h-5 w-5 text-muted-foreground" />,
     "apple-calendar": <img src="/images/apple.svg" alt="Apple Calendar" className="w-5 h-5" />,
     "windows-calendar": <CalendarIcon className="h-5 w-5 text-muted-foreground" />,
+    "os-calendar": <CalendarIcon className="h-5 w-5 text-muted-foreground" />,
     openclaw: <img src="/openclaw-icon.svg" alt="OpenClaw" className="w-5 h-5" />,
     hermes: <img src="/images/hermes.png" alt="Hermes" className="w-5 h-5 rounded" />,
     bee: <img src="/images/bee.png" alt="Bee" className="w-5 h-5 rounded" />,

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -309,6 +309,8 @@ export function IntegrationIcon({
     "google-calendar": <img src="/images/google-calendar.svg" alt="Google Calendar" className="w-5 h-5" />,
     "google-docs": <img src="/images/google-docs.svg" alt="Google Docs" className="w-5 h-5" />,
     "ics-calendar": <CalendarIcon className="h-5 w-5 text-muted-foreground" />,
+    "apple-calendar": <img src="/images/apple.svg" alt="Apple Calendar" className="w-5 h-5" />,
+    "windows-calendar": <CalendarIcon className="h-5 w-5 text-muted-foreground" />,
     openclaw: <img src="/openclaw-icon.svg" alt="OpenClaw" className="w-5 h-5" />,
     hermes: <img src="/images/hermes.png" alt="Hermes" className="w-5 h-5 rounded" />,
     bee: <img src="/images/bee.png" alt="Bee" className="w-5 h-5 rounded" />,

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -186,19 +186,11 @@ type ConnectedIntegration = {
 type ConnectionListItem = ConnectedIntegration & { connected: boolean };
 type ActivityAppItem = { name: string; count: number; app_name?: string };
 
-function normalizeConnectionForPlatform<T extends ConnectedIntegration>(connection: T, isWindows: boolean): T {
-  if (isWindows && connection.id === "apple-calendar") {
-    return {
-      ...connection,
-      name: "Windows Calendar",
-      icon: "windows-calendar",
-    };
-  }
+function normalizeConnectionForPlatform<T extends ConnectedIntegration>(connection: T, _isWindows: boolean): T {
   return connection;
 }
 
-function connectionMentionTag(connection: ConnectedIntegration, isWindows: boolean) {
-  if (isWindows && connection.id === "apple-calendar") return "@windows-calendar";
+function connectionMentionTag(connection: ConnectedIntegration, _isWindows: boolean) {
   return `@${connection.id}`;
 }
 
@@ -1267,6 +1259,7 @@ const STATIC_APP_ICONS: Record<string, string> = {
   airtable: "/images/airtable.png",
   apple: "/images/apple.svg",
   "apple-calendar": "/images/apple.svg",
+  "windows-calendar": "/images/windows.svg",
   "apple intelligence": "/images/apple-intelligence.png",
   screenpipe: "/images/screenpipe.png",
 };

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1259,7 +1259,6 @@ const STATIC_APP_ICONS: Record<string, string> = {
   airtable: "/images/airtable.png",
   apple: "/images/apple.svg",
   "apple-calendar": "/images/apple.svg",
-  "windows-calendar": "/images/windows.svg",
   "apple intelligence": "/images/apple-intelligence.png",
   screenpipe: "/images/screenpipe.png",
 };

--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -58,7 +58,7 @@ Never POST, PUT, or PATCH to a connection proxy unless the user explicitly asks 
 
 # Tool selection
 
-- "upcoming meetings / calendar events / what's on my calendar / schedule" → if a calendar integration is connected (google-calendar, apple-calendar), call its events endpoint first; only fall back to audio search if no calendar is connected
+- "upcoming meetings / calendar events / what's on my calendar / schedule" → if a calendar integration is connected (google-calendar, apple-calendar, windows-calendar), call its events endpoint first; only fall back to audio search if no calendar is connected
 - "meeting / call / conversation / what did I/they say" → search with content_type: "audio", no q param (for past meetings/calls captured by screenpipe)
 - "how long / time spent / which apps / most used" → activity-summary (not raw frame counts or SQL)
 - "what was on screen / what was I reading" → search with content_type: "all" or "accessibility"

--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -58,7 +58,7 @@ Never POST, PUT, or PATCH to a connection proxy unless the user explicitly asks 
 
 # Tool selection
 
-- "upcoming meetings / calendar events / what's on my calendar / schedule" → if a calendar integration is connected (google-calendar, apple-calendar, windows-calendar), call its events endpoint first; only fall back to audio search if no calendar is connected
+- "upcoming meetings / calendar events / what's on my calendar / schedule" → if a calendar integration is connected (google-calendar, apple-calendar, windows-calendar, os-calendar), call its events endpoint first; only fall back to audio search if no calendar is connected
 - "meeting / call / conversation / what did I/they say" → search with content_type: "audio", no q param (for past meetings/calls captured by screenpipe)
 - "how long / time spent / which apps / most used" → activity-summary (not raw frame counts or SQL)
 - "what was on screen / what was I reading" → search with content_type: "all" or "accessibility"

--- a/apps/screenpipe-app-tauri/lib/constants/connections.ts
+++ b/apps/screenpipe-app-tauri/lib/constants/connections.ts
@@ -18,6 +18,7 @@ export const CONNECTION_CATEGORY_BY_ID: Record<string, string> = {
   "google-sheets": "Documents",
   gmail: "Communication",
   "ics-calendar": "Calendar",
+  "windows-calendar": "Calendar",
   openclaw: "Productivity",
   hermes: "Communication",
   whatsapp: "Communication",

--- a/apps/screenpipe-app-tauri/lib/constants/connections.ts
+++ b/apps/screenpipe-app-tauri/lib/constants/connections.ts
@@ -19,6 +19,7 @@ export const CONNECTION_CATEGORY_BY_ID: Record<string, string> = {
   gmail: "Communication",
   "ics-calendar": "Calendar",
   "windows-calendar": "Calendar",
+  "os-calendar": "Calendar",
   openclaw: "Productivity",
   hermes: "Communication",
   whatsapp: "Communication",

--- a/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
@@ -114,9 +114,9 @@ export function useHardcodedTiles(): HardcodedTile[] {
     ] as HardcodedTile[] : []),
     ...(os === "macos" ? [{ id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false } as HardcodedTile] : []),
     {
-      id: os === "windows" ? "windows-calendar" : "apple-calendar",
-      name: os === "windows" ? "Windows Calendar" : "Apple Calendar",
-      icon: os === "windows" ? "windows-calendar" : "apple-calendar",
+      id: os === "macos" ? "apple-calendar" : os === "windows" ? "windows-calendar" : "os-calendar",
+      name: os === "macos" ? "Apple Calendar" : os === "windows" ? "Windows Calendar" : "OS Calendar",
+      icon: os === "macos" ? "apple-calendar" : os === "windows" ? "windows-calendar" : "os-calendar",
       connected: calendarConnected,
     },
   ];

--- a/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
@@ -114,7 +114,7 @@ export function useHardcodedTiles(): HardcodedTile[] {
     ] as HardcodedTile[] : []),
     ...(os === "macos" ? [{ id: "apple-intelligence", name: "Apple Intelligence", icon: "apple-intelligence", connected: false } as HardcodedTile] : []),
     {
-      id: "apple-calendar",
+      id: os === "windows" ? "windows-calendar" : "apple-calendar",
       name: os === "windows" ? "Windows Calendar" : "Apple Calendar",
       icon: os === "windows" ? "windows-calendar" : "apple-calendar",
       connected: calendarConnected,

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -292,10 +292,15 @@ async fn list_connections(State(state): State<ConnectionsState>) -> Json<Value> 
         let cal_available = tokio::task::spawn_blocking(is_native_calendar_available)
             .await
             .unwrap_or(false);
+        let (cal_id, cal_name, cal_icon) = if cfg!(target_os = "windows") {
+            ("windows-calendar", "Windows Calendar", "windows-calendar")
+        } else {
+            ("apple-calendar", "Apple Calendar", "apple-calendar")
+        };
         arr.push(json!({
-            "id": "apple-calendar",
-            "name": "Apple Calendar",
-            "icon": "apple-calendar",
+            "id": cal_id,
+            "name": cal_name,
+            "icon": cal_icon,
             "category": "calendar",
             "description": format!(
                 "Read-only access to your native {} calendar. \

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -292,10 +292,12 @@ async fn list_connections(State(state): State<ConnectionsState>) -> Json<Value> 
         let cal_available = tokio::task::spawn_blocking(is_native_calendar_available)
             .await
             .unwrap_or(false);
-        let (cal_id, cal_name, cal_icon) = if cfg!(target_os = "windows") {
+        let (cal_id, cal_name, cal_icon) = if cfg!(target_os = "macos") {
+            ("apple-calendar", "Apple Calendar", "apple-calendar")
+        } else if cfg!(target_os = "windows") {
             ("windows-calendar", "Windows Calendar", "windows-calendar")
         } else {
-            ("apple-calendar", "Apple Calendar", "apple-calendar")
+            ("os-calendar", "OS Calendar", "os-calendar")
         };
         arr.push(json!({
             "id": cal_id,


### PR DESCRIPTION
The backend always sent "Apple Calendar" as the name regardless of OS. Windows users saw "Apple Calendar connected" in their connections page. Fixed by making the backend return "OS specific Calendar" on different OS builds. Updated frontend icons, constants, chat prompt, and citations to handle the new windows-calendar ID. Removed the old client-side name-swap workaround since the backend now sends correct data. 

Connect/disconnect is unaffected it uses store keys and Tauri commands, not the tile.