### PR TITLE
Add minimize to tray toggle for Windows app.

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -9,7 +9,7 @@ import { commands } from "@/lib/utils/tauri";
 import { useTheme } from "@/components/theme-provider";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardContent } from "@/components/ui/card";
-import { Moon, Sun, Monitor, Layers, MessageSquare, PanelLeft, Maximize2, EyeOff } from "lucide-react";
+import { Moon, Sun, Monitor, Layers, MessageSquare, PanelLeft, Maximize2, EyeOff, MinusSquare } from "lucide-react";
 import { usePlatform } from "@/lib/hooks/use-platform";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { useToast } from "@/components/ui/use-toast";
@@ -21,7 +21,7 @@ export function DisplaySection() {
   const { settings, updateSettings } = useSettings();
   const { theme, setTheme } = useTheme();
   const { toast } = useToast();
-  const { isMac } = usePlatform();
+  const { isMac, isWindows } = usePlatform();
   // Guards the Disable-Timeline toggle against double-invoke (rapid toggle /
   // re-render) so we never fire two overlapping screenpipe restarts.
   const timelineRestartingRef = React.useRef(false);
@@ -301,6 +301,50 @@ export function DisplaySection() {
                     handleSettingsChange({ translucentSidebar: checked });
                     toast({
                       title: checked ? "translucent sidebar enabled" : "translucent sidebar disabled",
+                    });
+                  }}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/*
+         * Windows-only: hide-to-tray toggle. The Rust close handler in
+         * src-tauri/src/main.rs reads `minimizeToTrayOnClose` directly from the
+         * settings store, so this switch only needs to round-trip the value —
+         * no IPC command required. When ON, closing the Home window hides it
+         * and removes it from the taskbar; the system tray icon (single
+         * left-click) restores it. Default OFF preserves the historical
+         * minimize-to-taskbar behavior.
+         */}
+        {isWindows && (
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <MinusSquare className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                      Minimize to System Tray on Close
+                      <HelpTooltip text="When enabled, clicking the X on the Home window hides it and removes it from the Windows taskbar. screenpipe keeps running in the system tray — click the tray icon to bring the window back." />
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      Keep running in the tray when the window is closed
+                    </p>
+                  </div>
+                </div>
+                <Switch
+                  checked={settings?.minimizeToTrayOnClose ?? false}
+                  onCheckedChange={(checked) => {
+                    handleSettingsChange({ minimizeToTrayOnClose: checked });
+                    toast({
+                      title: checked
+                        ? "Close button will hide to system tray"
+                        : "Close button will minimize to taskbar",
+                      description: checked
+                        ? "Click the tray icon to bring screenpipe back."
+                        : undefined,
                     });
                   }}
                 />

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -353,6 +353,10 @@ export type Settings = SettingsStore & {
 	 *  logged into. Revocable from the owned-browser cookie menu.
 	 *  Undefined = not decided yet, false = disabled, true = enabled. */
 	browserCookieAccessGranted?: boolean;
+	/** Windows-only: when true, closing the Home window hides it to the system
+	 * tray (and removes it from the taskbar) instead of minimizing. The Rust
+	 * close handler in src-tauri/src/main.rs reads this directly. Default off. */
+	minimizeToTrayOnClose?: boolean;
 }
 
 export function getEffectiveFilters(settings: Settings) {

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -2716,7 +2716,14 @@ hideThinkingBlocks?: boolean;
 /**
  * UI theme: "light", "dark", or "system".
  */
-uiTheme?: string }
+uiTheme?: string;
+/**
+ * Windows-only: when true, clicking the X on the Home window hides it to
+ * the system tray (and removes it from the taskbar) instead of minimizing.
+ * Read by the CloseRequested handler in main.rs. Default off (historical
+ * minimize-to-taskbar behavior).
+ */
+minimizeToTrayOnClose?: boolean }
 export type ShowRewindWindow = "Main" | { Home: { page: string | null } } | { Search: { query: string | null } } | "Onboarding" | "Chat" | "PermissionRecovery"
 export type Suggestion = { text: string;
 /**

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -802,9 +802,45 @@ async fn main() {
                 #[cfg(target_os = "windows")]
                 {
                     if window.label() == "home" {
-                        // Minimize instead of closing so the Home window stays in the
-                        // taskbar as the persistent app icon.
-                        let _ = window.minimize();
+                        // Behavior depends on the user setting `minimizeToTrayOnClose`:
+                        //  - false (default, historical behavior): minimize the Home
+                        //    window so its icon stays in the Windows taskbar as the
+                        //    persistent app entry point.
+                        //  - true (opt-in): hide the window AND remove it from the
+                        //    taskbar so the system tray icon becomes the only entry
+                        //    point. The app process keeps running (see ExitRequested
+                        //    handler below). The tray left-click handler in
+                        //    tray.rs::setup_tray_click_handlers restores the window,
+                        //    and window/show.rs::show_existing_main resets
+                        //    skip_taskbar back to false on restore.
+                        //
+                        // Settings reads are best-effort: if the store can't be read
+                        // we fall back to the historical minimize() behavior so the
+                        // user never loses access to the window. set_skip_taskbar /
+                        // hide failures also fall back to minimize() for the same
+                        // reason — see plan.md "lost-window risk".
+                        let minimize_to_tray = crate::store::SettingsStore::get(
+                            window.app_handle(),
+                        )
+                        .ok()
+                        .flatten()
+                        .map(|s| s.minimize_to_tray_on_close)
+                        .unwrap_or(false);
+
+                        if minimize_to_tray {
+                            let skip_ok = window.set_skip_taskbar(true).is_ok();
+                            let hide_ok = window.hide().is_ok();
+                            if !(skip_ok && hide_ok) {
+                                // Hard fallback so the user is never left with an
+                                // off-taskbar but visible window.
+                                let _ = window.set_skip_taskbar(false);
+                                let _ = window.minimize();
+                            }
+                        } else {
+                            // Minimize instead of closing so the Home window stays in
+                            // the taskbar as the persistent app icon.
+                            let _ = window.minimize();
+                        }
                     } else {
                         // Overlay and other windows: hide (they're skip_taskbar anyway)
                         let _ = window.hide();

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -697,6 +697,13 @@ pub struct SettingsStore {
     /// serialize only known fields and silently wipe frontend-only data.
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
+
+    /// Windows-only: when true, clicking the X on the Home window hides it to
+    /// the system tray (and removes it from the taskbar) instead of minimizing.
+    /// Read by the CloseRequested handler in main.rs. Default off (historical
+    /// minimize-to-taskbar behavior).
+    #[serde(rename = "minimizeToTrayOnClose", default)]
+    pub minimize_to_tray_on_close: bool,
 }
 
 fn generate_device_id() -> String {
@@ -1050,6 +1057,7 @@ Rules:
             translucent_sidebar: false,
             hide_thinking_blocks: true,
             ui_theme: "system".to_string(),
+            minimize_to_tray_on_close: false,
             extra: std::collections::HashMap::new(),
         }
     }

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -537,6 +537,13 @@ impl ShowRewindWindow {
                         ));
                     }
                 }
+                // Windows: if the user opted into `minimizeToTrayOnClose`, the
+                // Home window may have been hidden with skip_taskbar(true) on
+                // close. Clear that flag here so the window reappears in the
+                // taskbar regardless of whether we were previously hidden or
+                // minimized. No-op on macOS/Linux. See main.rs CloseRequested.
+                #[cfg(target_os = "windows")]
+                let _ = window.set_skip_taskbar(false);
                 window.show().ok();
 
                 #[cfg(target_os = "macos")]


### PR DESCRIPTION
---
  ## description

  Adds a Windows-only **"Minimize to System Tray on Close"** toggle (Settings → Display). When enabled, clicking the X
  on the Home window hides it and removes it from the taskbar while screenpipe keeps running in the system tray;
  clicking the tray icon brings the window back. When disabled (the default), the historical minimize-to-taskbar
  behavior is preserved, so existing users see no change.

  Implementation notes:
  - New `minimizeToTrayOnClose` setting persisted in the existing `settings` store (`SettingsStore` in `store.rs`),
  defaulting to `false`.
  - The Windows `CloseRequested` handler in `main.rs` reads the setting directly from the store (no IPC command needed).
  On `true` it calls `set_skip_taskbar(true)` + `hide()`, with a hard fallback to `minimize()` if either call fails —
  so the user can never be left with an invisible, off-taskbar window.
  - The restore path in `window/show.rs` clears `skip_taskbar(false)`, shows, unminimizes if needed, and focuses —
  covering both the hidden (tray) and minimized (default) states. The Windows tray left-click handler already routes to
  `ShowRewindWindow::Home`, which is the window the close handler acts on.
  - macOS/Linux are unaffected: the UI toggle is gated behind `isWindows`, and all native calls sit inside
  `#[cfg(target_os = "windows")]`.

** Note: I verified this worked, but my pc crashed for unrelated reasons and I was forced to roll back and lost all the dependencies and am having issues getting it back to the state I had it where this was running. If the video/screenshots of it working are a hard requirement, please let me know and I will work to get it up and running again! **

  ## how to test

  Windows only.

  1. Open **Settings → Display** and enable **"Minimize to System Tray on Close"** (a toast confirms the new behavior).
  2. Click the **X** on the Home window → the window hides and disappears from the taskbar; the screenpipe tray icon
  stays and the app keeps running (recording continues).
  3. **Left-click the tray icon** → the Home window reappears in the taskbar, restored and focused.
  4. Toggle the setting **off**, click **X** again → confirm the window minimizes to the taskbar as before (historical
  behavior unchanged).

  ## desktop app checklist (if applicable)

  This PR changes a Rust type exported to the frontend (`SettingsStore` gained the `minimizeToTrayOnClose` field). No
  new or changed `#[tauri::command]` handlers.

  - [x] `bun run bindings:generate` — `lib/utils/tauri.ts` regenerated; `SettingsStore` now includes
  `minimizeToTrayOnClose?: boolean`.
  - [x] `bun run bindings:check` — passes (generated bindings match committed `tauri.ts`).
  - [x] `bun run typecheck` — passes.

  ---