### PR TITLE
chore(workspace): consolidate all shared dependencies

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -52,19 +52,23 @@ jobs:
       - name: Install dependencies
         run: .github/scripts/install_dependencies.sh
 
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
+      - name: Install cargo tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit,cargo-deny,cargo-consolidate
 
       - name: Security audit
         continue-on-error: true
         run: cargo audit
 
-      - name: Install cargo-deny
-        run: cargo install cargo-deny
-
       - name: Check duplicate dependencies
         continue-on-error: true
         run: cargo deny check bans
+
+      - name: Check workspace dependency consolidation
+        run: |
+          cargo consolidate
+          cargo consolidate --path ee/sdk
 
   knip:
     name: Knip (frontend dead code)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,101 @@ http-cache-reqwest = "0.15.0"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "multipart", "json", "form", "query", "rustls"] }
 reqwest-middleware = "0.4.1"
 
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+
+# Error handling
+anyhow = "1.0"
+thiserror = "1"
+
+# Date/time
+chrono = { version = "0.4", features = ["serde"] }
+
+# Async / concurrency
+futures = "0.3"
+async-trait = "0.1"
+tokio-stream = "0.1"
+tokio-tungstenite = "0.24"
+parking_lot = "0.12"
+arc-swap = "1"
+bytes = "1"
+
+# CLI
+clap = { version = "4.3", features = ["derive"] }
+
+# Utilities
+tempfile = "3"
+url = "2"
+toml = "0.8"
+uuid = { version = "1", features = ["v4"] }
+regex = "1"
+lazy_static = "1.4"
+libc = "0.2"
+env_logger = "0.10"
+sysinfo = "0.29"
+axum = { version = "0.7", features = ["ws", "multipart"] }
+hex = "0.4"
+base64 = "0.22"
+sha2 = "0.10"
+
+# Database
+sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
+
+# Math / ML
+ndarray = "0.16"
+rand = "0.9"
+ort = "=2.0.0-rc.10"
+
+# Platform
+dirs = "6"
+which = "7"
+zbus = { version = "5.5", features = ["blocking"] }
+windows = "0.58"
+xcap = "0.9"
+keyring = "3"
+ort-sys = { version = "=2.0.0-rc.10", default-features = false }
+samplerate = "0.2.4"
+libsamplerate-sys = "0.1.10"
+
+# Crypto
+argon2 = "0.5"
+chacha20poly1305 = "0.10"
+zeroize = { version = "1.8", features = ["derive"] }
+
+# Tauri type generation
+specta = { version = "=2.0.0-rc.20", features = ["derive"] }
+
+# Testing
+wiremock = "0.6"
+
+# Audio
+hound = "3.5"
+audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", rev = "2fd5c360651157a5df504394066e509ad4d1bdc9", default-features = false }
+mlx-rs = "0.25"
+
+# Privacy filter enclave attestation (shared by engine + redact)
+tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", rev = "82143d767b540195dea265df0b01c4b4fc93c424" }
+
+# Cache
+moka = { version = "0.12", features = ["future"] }
+
+# SQLite bundled C lib (pinned so all crates link the same copy)
+libsqlite3-sys = { version = "0.26", features = ["bundled"] }
+
+# String similarity
+strsim = "0.10"
+
+# macOS platform deps (used in target-conditional sections)
+objc = "0.2.7"
+accessibility-sys = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
+core-foundation = "0.10"
+core-graphics = { version = "0.24", features = ["highsierra"] }
+
+# Windows platform deps
+uiautomation = "0.16.1"
+
 
 [patch.crates-io]
 # enables chinese mirror (hf is banned in china) and rustls-tls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 
 [workspace.dependencies]
 # AI
-tokenizers = "0.21.0"
+tokenizers = { version = "0.21.0", default-features = false }
 hf-hub = { version = "0.3.2", git = "https://github.com/neo773/hf-hub", rev = "437dcf4049233f4a0e0cfc4e1c1dbf5ed2c57760", default-features = false, features = [
     "native-tls",
     "tokio",
@@ -93,12 +93,12 @@ sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
 # Math / ML
 ndarray = "0.16"
 rand = "0.9"
-ort = "=2.0.0-rc.10"
+ort = { version = "=2.0.0-rc.10", default-features = false }
 
 # Platform
 dirs = "6"
 which = "7"
-zbus = { version = "5.5", features = ["blocking"] }
+zbus = { version = "5.5", default-features = false, features = ["blocking"] }
 windows = "0.58"
 xcap = "0.9"
 keyring = "3"

--- a/crates/screenpipe-a11y/Cargo.toml
+++ b/crates/screenpipe-a11y/Cargo.toml
@@ -14,21 +14,21 @@ screenpipe-db = { path = "../screenpipe-db", optional = true }
 screenpipe-core = { path = "../screenpipe-core" }
 screenpipe-config = { path = "../screenpipe-config" }
 # Core
-anyhow = "1.0"
-tracing = "0.1"
-chrono = { version = "0.4", features = ["serde"] }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+chrono = { workspace = true }
 
 # Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Concurrency
 crossbeam-channel = "0.5"
-parking_lot = "0.12"
-arc-swap = "1"
+parking_lot = { workspace = true }
+arc-swap = { workspace = true }
 
 # Regex for privacy patterns
-regex = "1.10"
+regex = { workspace = true }
 
 # Clipboard access (native NSPasteboard/Win32/X11 — no subprocess)
 arboard = "3"
@@ -37,7 +37,7 @@ arboard = "3"
 # (Obsidian / VS Code fork state files live under `dirs::config_dir()`
 # on every supported OS — `~/Library/Application Support` on macOS,
 # `%APPDATA%` on Windows, `~/.config` on Linux).
-dirs = "5.0"
+dirs = { workspace = true }
 
 # VS Code fork document_path resolution reads `state.vscdb` (SQLite).
 # Pinned to 0.29 because that's the last release on libsqlite3-sys 0.26 —
@@ -45,7 +45,7 @@ dirs = "5.0"
 # copy of the C library into the workspace. `bundled` ensures we ship our
 # own SQLite on every OS rather than depending on the system's.
 rusqlite = { version = "0.29", features = ["bundled"] }
-url = "2.5"
+url = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cidre = { version = "0.13", features = ["ax", "cg", "blocks", "ns", "app", "dispatch"] }
@@ -54,7 +54,7 @@ objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std"
 [target.'cfg(target_os = "windows")'.dependencies]
 # Native Windows APIs - no rdev dependency
 windows-core = "0.58"
-windows = { version = "0.58", features = [
+windows = { workspace = true, features = [
     "implement",
     "Win32_Foundation",
     "Win32_System_Com",
@@ -72,18 +72,18 @@ windows = { version = "0.58", features = [
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # AT-SPI2 accessibility via D-Bus (pure Rust, no system deps for compilation)
-zbus = { version = "5", features = ["blocking"] }
+zbus = { workspace = true }
 # Input device events from /dev/input/event*
 evdev = "0.13"
 # fcntl for non-blocking I/O on evdev fds
-libc = "0.2"
+libc = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tempfile = "3"
+tokio = { workspace = true }
+tempfile = { workspace = true }
 # Linux debug examples are compiled by `cargo clippy --all-targets` on every
 # developer OS, so keep their D-Bus dependency available outside Linux too.
-zbus = { version = "5", features = ["blocking"] }
+zbus = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
-libc = "0.2"
+libc = { workspace = true }

--- a/crates/screenpipe-apple-intelligence/Cargo.toml
+++ b/crates/screenpipe-apple-intelligence/Cargo.toml
@@ -11,15 +11,15 @@ screenpipe-query = ["dep:reqwest", "dep:tokio"]
 server = ["dep:axum", "dep:tokio", "dep:uuid", "dep:tokio-stream"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-anyhow = "1"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"], optional = true }
-chrono = "0.4"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net"], optional = true }
-axum = { version = "0.7", optional = true }
-uuid = { version = "1", features = ["v4"], optional = true }
-tokio-stream = { version = "0.1", optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+reqwest = { workspace = true, optional = true }
+chrono = { workspace = true }
+tokio = { workspace = true, optional = true }
+axum = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
+tokio-stream = { workspace = true, optional = true }
 
 [[bin]]
 name = "fm-server"
@@ -27,6 +27,6 @@ path = "src/server_bin.rs"
 required-features = ["server"]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", features = ["json"] }
-chrono = "0.4"
+tokio = { workspace = true }
+reqwest = { workspace = true }
+chrono = { workspace = true }

--- a/crates/screenpipe-audio-eval/Cargo.toml
+++ b/crates/screenpipe-audio-eval/Cargo.toml
@@ -12,14 +12,14 @@ license-file = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.86"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-toml = "0.8"
-clap = { version = "4.3", features = ["derive"] }
-hound = "3.5"
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+clap = { workspace = true }
+hound = { workspace = true }
 tokio = { workspace = true }
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { workspace = true }
 
 # The whole point of this crate: drive the screenpipe-audio diarization
 # pipeline using only public API. We pull in screenpipe-audio for
@@ -44,10 +44,10 @@ screenpipe-db = { path = "../screenpipe-db" }
 # the engine. Without this, `TranscriptionEngine::new` returns
 # `Disabled` while audiopipe's background download thread runs and the
 # eval silently emits empty hypotheses.
-audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", rev = "2fd5c360651157a5df504394066e509ad4d1bdc9", default-features = false, features = ["parakeet"] }
+audiopipe = { workspace = true, features = ["parakeet"] }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 
 [[bin]]
 name = "screenpipe-eval-diarization"

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -10,11 +10,11 @@ edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-which = "7.0.0"
+which = { workspace = true }
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 oasgen = { workspace = true }
 
 # Cross-platform audio capture. Tracks screenpipe/cpal main, which carries
@@ -22,22 +22,22 @@ oasgen = { workspace = true }
 cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "c7a610aee5c6037c9c69dc5bf7f2a850da8d8b12" }
 
 # Wav encoding
-hound = "3.5"
+hound = { workspace = true }
 
 # MP3 encoding for compressed cloud uploads
 mp3lame-encoder = "0.2.2"
 
 # Cli ! shouldn't be required if using as lib
-clap = { version = "4.3", features = ["derive"] }
+clap = { workspace = true }
 
 # Dates
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { workspace = true }
 
 # Local Embeddings + STT
 # Using fork of vad-rs with Silero VAD v5/v6 support
 # v5/v6: 3x faster, 6000+ languages, better accuracy
 vad-rs = { git = "https://github.com/divanshu-go/vad-rs-1.git", rev = "b14b26ec7093f5398ef6658020259cd7c130ea6c", default-features = false }
-anyhow = "1.0.86"
+anyhow = { workspace = true }
 hf-hub = { workspace = true }
 # https://github.com/pdeljanov/Symphonia/tree/master?tab=readme-ov-file#optimizations
 symphonia = { version = "0.5.4", features = ["aac", "isomp4", "opt-simd"] }
@@ -47,7 +47,7 @@ whisper-rs = { git = "https://github.com/screenpipe/whisper-rs.git", rev = "97e4
 # Log
 log = { workspace = true }
 tracing = { workspace = true }
-env_logger = "0.10"
+env_logger = { workspace = true }
 
 # Bytes
 bytemuck = "1.16.1"
@@ -71,36 +71,36 @@ crossbeam = { workspace = true }
 dashmap = { workspace = true }
 
 # Directories
-dirs = "5.0.1"
+dirs = { workspace = true }
 
-sysinfo = "0.29.0"
-lazy_static = { version = "1.4.0" }
+sysinfo = { workspace = true }
+lazy_static = { workspace = true }
 realfft = "3.4.0"
-ndarray = "0.16"
+ndarray = { workspace = true }
 # Base ort dep — each platform overrides with specific features below
-ort = { version = "=2.0.0-rc.10", default-features = false, features = ["ndarray", "half"] }
-ort-sys = { version = "=2.0.0-rc.10", default-features = false }
+ort = { workspace = true, default-features = false, features = ["ndarray", "half"] }
+ort-sys = { workspace = true }
 knf-rs = "0.3.2"
-futures = "0.3.31"
-audiopipe = { git = "https://github.com/divanshu-go/audiopipe.git", rev = "2fd5c360651157a5df504394066e509ad4d1bdc9", default-features = false, features = ["qwen3-asr-antirez-blas", "parakeet"], optional = true }
-mlx-rs = { version = "0.25", optional = true }
-bytes = { version = "1.9.0", features = ["serde"] }
-rand = "0.9.0"
-tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
-url = "2"
+futures = { workspace = true }
+audiopipe = { workspace = true, features = ["qwen3-asr-antirez-blas", "parakeet"], optional = true }
+mlx-rs = { workspace = true, optional = true }
+bytes = { workspace = true, features = ["serde"] }
+rand = { workspace = true }
+tokio-tungstenite = { workspace = true, features = ["native-tls"] }
+url = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libpulse-binding = { version = "2.28", optional = true }
 libpulse-simple-binding = { version = "2.28", optional = true }
 # Bundle ONNX Runtime on Linux (same as macOS). load-dynamic was tried but
 # broke systems without a system-installed libonnxruntime.so (see #2506).
-ort = { version = "=2.0.0-rc.10", features = ["download-binaries"] }
+ort = { workspace = true, features = ["download-binaries"] }
 
 # Windows COM API for querying the "Default Communications Device" role.
 # MS Teams/Zoom route audio to the eCommunications endpoint, which may
 # differ from the multimedia/console default that cpal returns.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = [
+windows = { workspace = true, features = [
     "Win32_Media_Audio",
     "Win32_System_Com",
     "Win32_Devices_FunctionDiscovery",
@@ -110,30 +110,30 @@ windows = { version = "0.58", features = [
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 # Avoid build-time network downloads (ort-sys download-binaries) for Windows x86_64.
 # When ONNX Runtime is available at runtime, `ort` can load it dynamically.
-ort = { version = "=2.0.0-rc.10", default-features = false, features = ["load-dynamic"] }
-samplerate = { version = "0.2.4" }
-libsamplerate-sys = "0.1.10"
+ort = { workspace = true, default-features = false, features = ["load-dynamic"] }
+samplerate = { workspace = true }
+libsamplerate-sys = { workspace = true }
 
 # Windows ARM64: use our own ONNX Runtime DLL at runtime (load-dynamic); no compile-time link, no ort.pyke.io cache
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
-ort = { version = "=2.0.0-rc.10", default-features = false, features = ["load-dynamic"] }
-ort-sys = { version = "=2.0.0-rc.10", default-features = false }
-samplerate = { version = "0.2.4" }
-libsamplerate-sys = "0.1.10"
+ort = { workspace = true, default-features = false, features = ["load-dynamic"] }
+ort-sys = { workspace = true }
+samplerate = { workspace = true }
+libsamplerate-sys = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a" }
-once_cell = "1.17.1"
-objc = "0.2.7"
-ort = { version = "=2.0.0-rc.10", features = ["download-binaries"] }
+once_cell = { workspace = true }
+objc = { workspace = true }
+ort = { workspace = true, features = ["download-binaries"] }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 infer = "0.15"
 criterion = { workspace = true }
-strsim = "0.10.0"
-futures = "0.3.31"
-tracing-subscriber = "0.3.16"
+strsim = { workspace = true }
+futures = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 
 [features]

--- a/crates/screenpipe-capture/Cargo.toml
+++ b/crates/screenpipe-capture/Cargo.toml
@@ -11,15 +11,15 @@ screenpipe-core = { path = "../screenpipe-core", default-features = false, featu
 screenpipe-db = { path = "../screenpipe-db" }
 screenpipe-screen = { path = "../screenpipe-screen" }
 
-anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
+anyhow = { workspace = true }
+chrono = { workspace = true }
 image = { workspace = true }
 once_cell = { workspace = true }
-regex = "1"
-serde_json = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
-tracing = "0.1"
+regex = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/screenpipe-config/Cargo.toml
+++ b/crates/screenpipe-config/Cargo.toml
@@ -8,17 +8,17 @@ license-file.workspace = true
 edition.workspace = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-toml = "0.8"
-dirs = "6"
-sysinfo = "0.29"
-specta = { version = "=2.0.0-rc.20", features = ["derive"], optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+dirs = { workspace = true }
+sysinfo = { workspace = true }
+specta = { workspace = true, optional = true }
 
 [features]
 default = []
 specta = ["dep:specta"]
 
 [dev-dependencies]
-serde_json = "1"
-tempfile = "3"
+serde_json = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/screenpipe-connect/Cargo.toml
+++ b/crates/screenpipe-connect/Cargo.toml
@@ -13,14 +13,14 @@ edition = { workspace = true }
 ignored = ["libsqlite3-sys"]
 
 [dependencies]
-specta = { version = "=2.0.0-rc.20", features = ["derive"], optional = true }
+specta = { workspace = true, optional = true }
 image = { workspace = true }
 reqwest = { workspace = true }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
-log = "0.4"
-anyhow = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+log = { workspace = true }
+anyhow = { workspace = true }
 screenpipe-core = { path = "../screenpipe-core" }
 screenpipe-secrets = { path = "../screenpipe-secrets" }
 screenpipe-vault = { path = "../screenpipe-vault" }
@@ -33,24 +33,24 @@ tracing = { workspace = true }
 # `pkcs8`. v2.4.170 left this broken on a pristine cargo check.
 russh = { version = "0.60", default-features = false, features = ["ring", "flate2"] }
 russh-sftp = "2.1"
-dirs = "6"
-chrono = "0.4"
+dirs = { workspace = true }
+chrono = { workspace = true }
 chrono-tz = "0.10"
 icalendar = "0.17"
-async-trait = "0.1"
-once_cell = "1"
-uuid = { version = "1.5.0", features = ["v4"] }
-thiserror = "1"
-base64 = "0.22.1"
-sha2 = "0.10.6"
+async-trait = { workspace = true }
+once_cell = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"] }
 mdns-sd = "0.13"
-sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
-libsqlite3-sys = { version = "0.26", features = ["bundled"] }
+sqlx = { workspace = true }
+libsqlite3-sys = { workspace = true }
 
 [dev-dependencies]
-wiremock = "0.6"
-tempfile = "3"
+wiremock = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = []
@@ -61,12 +61,12 @@ eventkit-rs = { git = "https://github.com/divanshu-go/eventkit-rs", rev = "9dd52
 objc2 = "0.6"
 objc2-event-kit = "0.3"
 objc2-foundation = "0.3"
-chrono = "0.4"
+chrono = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.58", features = [
+windows = { workspace = true, features = [
     "ApplicationModel_Appointments",
     "Foundation",
     "Foundation_Collections",
 ] }
-chrono = "0.4"
+chrono = { workspace = true }

--- a/crates/screenpipe-core/Cargo.toml
+++ b/crates/screenpipe-core/Cargo.toml
@@ -9,59 +9,59 @@ edition = { workspace = true }
 
 [dependencies]
 screenpipe-events = { path = "../screenpipe-events" }
-futures = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-which = "6.0.1"
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+which = { workspace = true }
 ffmpeg-sidecar = { git = "https://github.com/nathanbabcock/ffmpeg-sidecar", rev = "b0f48a514235d1278d860f4a0af66aa9d6e1618d" }
-log = "0.4.17"
-anyhow = "1.0.86"
-arc-swap = "1"
+log = { workspace = true }
+anyhow = { workspace = true }
+arc-swap = { workspace = true }
 
 tokio = { workspace = true }
 
 # Security
-regex = { version = "1.10.6", features = ["std"], optional = true }
-lazy_static = { version = "1.4.0", optional = true }
+regex = { workspace = true, optional = true }
+lazy_static = { workspace = true, optional = true }
 
 tracing = { workspace = true }
 
 
-dirs = "5.0.0"
-clap = { version = "4.5.20", features = ["derive"] }
+dirs = { workspace = true }
+clap = { workspace = true }
 
 # random
-rand = "0.8.5"
+rand = { workspace = true }
 
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { workspace = true }
 
 # Cloud sync encryption
-argon2 = { version = "0.5", optional = true }
-chacha20poly1305 = { version = "0.10", optional = true }
+argon2 = { workspace = true, optional = true }
+chacha20poly1305 = { workspace = true, optional = true }
 hmac = { version = "0.12", optional = true }
-sha2 = { version = "0.10", optional = true }
-base64 = { version = "0.22", optional = true }
-zeroize = { version = "1.8", features = ["derive"], optional = true }
-thiserror = { version = "1.0", optional = true }
+sha2 = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+zeroize = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
 reqwest = { workspace = true }
-hex = { version = "0.4", optional = true }
-async-trait = "0.1"
+hex = { workspace = true, optional = true }
+async-trait = { workspace = true }
 screenpipe-secrets = { path = "../screenpipe-secrets", optional = true }
 screenpipe-vault = { path = "../screenpipe-vault", optional = true }
-sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"], optional = true }
+sqlx = { workspace = true, optional = true }
 # Shared sync primitives. `upload_to_s3` delegates to
 # `screenpipe_sync::HttpPutDirect` so the retry / bytes-pool / cancellation
 # code path is the same one ee/ uses. Gated to the cloud-sync feature so
 # consumer builds without sync don't pay the dep cost.
 screenpipe-sync = { path = "../screenpipe-sync", optional = true }
 
-once_cell = "1.19.0"
+once_cell = { workspace = true }
 
 cron = "0.13.0"
 
-serde_yaml = "0.9"
-chrono = { version = "0.4", features = ["serde"] }
-tempfile = "3"
+serde_yaml = { workspace = true }
+chrono = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = ["security"]
@@ -84,24 +84,24 @@ cloud-sync = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # accessibility-sys = "0.1.3"
-accessibility-sys = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
+accessibility-sys = { workspace = true }
 # accessibility = "0.1.6"
 accessibility = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
-objc = "0.2.7"
+objc = { workspace = true }
 objc-foundation = "0.1.1"
 
-core-foundation = "0.10"
-core-graphics = { version = "0.24.0", features = ["highsierra"] }
+core-foundation = { workspace = true }
+core-graphics = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-uiautomation = { version = "0.16.1" }
+uiautomation = { workspace = true }
 windows-sys = { version = "0.59", features = ["Win32_System_Threading", "Win32_Foundation"] }
 
 [dev-dependencies]
 # Used by sync::client wire-compat test (asserts the PUT request shape
 # stays byte-identical after the upload_to_s3 → HttpPutDirect migration).
-wiremock = "0.6"
+wiremock = { workspace = true }

--- a/crates/screenpipe-db/Cargo.toml
+++ b/crates/screenpipe-db/Cargo.toml
@@ -8,33 +8,31 @@ license-file.workspace = true
 edition.workspace = true
 
 [dependencies]
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { workspace = true }
 image = { workspace = true }
-sqlx = { version = "0.7", features = [
-  "sqlite",
-  "runtime-tokio-rustls",
+sqlx = { workspace = true, features = [
   "chrono",
   "migrate",
 ] }
 sqlite-vec = "0.1.3"
-libsqlite3-sys = { version = "0.26", features = ["bundled"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-futures = { version = "0.3.31", features = ["std"] }
+libsqlite3-sys = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+futures = { workspace = true, features = ["std"] }
 
 screenpipe-config = { path = "../screenpipe-config" }
 zerocopy = { version = "0.7.32" }
 
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { workspace = true }
 
 tracing = { workspace = true }
-anyhow = "1.0.86"
-rand = "0.8.5"
+anyhow = { workspace = true }
+rand = { workspace = true }
 criterion = { workspace = true }
 oasgen = { workspace = true }
 tracing-subscriber = { workspace = true }
-regex = "1.11"
-once_cell = "1.19"
+regex = { workspace = true }
+once_cell = { workspace = true }
 
 [dev-dependencies]
 screenpipe-core = { path = "../screenpipe-core" }

--- a/crates/screenpipe-engine/Cargo.toml
+++ b/crates/screenpipe-engine/Cargo.toml
@@ -10,9 +10,9 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-libc = "0.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+libc = { workspace = true }
 oasgen = { workspace = true }
 
 screenpipe-events = { path = "../screenpipe-events" }
@@ -35,28 +35,26 @@ image = { workspace = true }
 imageproc = "0.25"
 
 # Dates
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { workspace = true }
 
 # Database
-sqlx = { version = "0.7", features = [
-    "sqlite",
-    "runtime-tokio-rustls",
+sqlx = { workspace = true, features = [
     "chrono",
     "migrate",
 ] }
 
-anyhow = "1.0.86"
-async-trait = "0.1"
-moka = { version = "0.12", features = ["future"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+moka = { workspace = true }
 
 #opentelemetry
 sentry = { workspace = true }
 
 # Server
-axum = { version = "0.7.5", features = ["ws", "multipart"] }
+axum = { workspace = true }
 http-body-util = "0.1"
-tokio = { version = "1.15", features = ["full", "tracing"] }
-tokio-stream = "0.1"
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
 tower-http = { version = "0.5.2", features = ["cors", "trace"] }
 
 # Log
@@ -65,19 +63,19 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 console-subscriber = { version = "0.4.1", optional = true }
 # Cli ! shouldn't be required if using as lib
-clap = { version = "4.3", features = ["derive", "env"] }
+clap = { workspace = true, features = ["env"] }
 
 # Memory watchdog
-sysinfo = "0.29.0"
+sysinfo = { workspace = true }
 
 # Color
 colored = "2.0"
 
 # Plugins
-futures = { version = "0.3.31", features = ["std"] }
+futures = { workspace = true, features = ["std"] }
 
 # Directory management
-dirs = "5.0"
+dirs = { workspace = true }
 
 # Password input (no-echo for vault CLI)
 rpassword = "5"
@@ -90,46 +88,46 @@ reqwest = { workspace = true }
 # (see src/privacy_filter.rs). Without this, a MITM or compromised CA could
 # observe unredacted text on its way to the enclave.
 # Upstream tinfoilsh/tinfoil-rs main, post-#21 (the ring-backend fix).
-tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", rev = "82143d767b540195dea265df0b01c4b4fc93c424" }
+tinfoil = { workspace = true }
 
 # Concurrency
 crossbeam = { workspace = true }
 
 # base64
-base64 = "0.22.1"
+base64 = { workspace = true }
 
-uuid = { version = "1.5.0", features = ["v4"] }
+uuid = { workspace = true }
 
 # Used by /connections/browsers/:id/navigate to validate URLs up-front so
 # clients get 400 (client error) on malformed input rather than 502 from
 # the upstream eval transport.
-url = "2"
+url = { workspace = true }
 
 # Cloud sync utilities
 hostname = "0.4"
 md5 = "0.7"
 
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 
 
 # Bincode for serializing hot cache
 bincode = "1.3.3"
 
 # SHA256 for hashing
-sha2 = "0.10.6"
+sha2 = { workspace = true }
 
 # Fast random number generator
 fastrand = "2.1.1"
 port_check = "0.2.1"
 
-regex = "1.10.0"
+regex = { workspace = true }
 
 lru = "0.16.3"
 tokio-util = { version = "0.7", features = ["io"] }
 
 once_cell = { workspace = true }
 dashmap = { workspace = true }
-arc-swap = "1"
+arc-swap = { workspace = true }
 
 # Heap profiling (opt-in via --features heap-prof)
 dhat = { version = "0.3", optional = true }
@@ -140,9 +138,9 @@ dhat = { version = "0.3", optional = true }
 tikv-jemallocator = { version = "0.6", optional = true }
 
 [dev-dependencies]
-env_logger = "0.10"
-tempfile = "3.3.0"
-tokio-tungstenite = "0.24"
+env_logger = { workspace = true }
+tempfile = { workspace = true }
+tokio-tungstenite = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
 
 # Benches
@@ -203,7 +201,7 @@ harness = false
 nix = { version = "0.29", features = ["signal"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = [
+windows = { workspace = true, features = [
     "Win32_System_Threading",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_Foundation",

--- a/crates/screenpipe-events/Cargo.toml
+++ b/crates/screenpipe-events/Cargo.toml
@@ -8,20 +8,20 @@ license-file.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow = "1.0.95"
-futures = "0.3.31"
-serde = { version = "1.0.217", features = ["derive"] }
-serde_json = "1.0.137"
-tokio.workspace = true
-tokio-stream = { version = "0.1.17", features = ["sync"] }
-once_cell = { version = "1.18" }
-tracing.workspace = true
-parking_lot = "0.12.3"
-chrono = { version = "0.4.39", features = ["serde"] }
+anyhow = { workspace = true }
+futures = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true, features = ["sync"] }
+once_cell = { workspace = true }
+tracing = { workspace = true }
+parking_lot = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
-criterion = { version = "0.5", features = ["async_tokio"] }
+serde = { workspace = true }
+criterion = { workspace = true }
 serial_test = "3.2.0"
 
 [[bench]]

--- a/crates/screenpipe-meeting-eval/Cargo.toml
+++ b/crates/screenpipe-meeting-eval/Cargo.toml
@@ -12,11 +12,11 @@ license-file = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.86"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-toml = "0.8"
-clap = { version = "4.3", features = ["derive"] }
+anyhow = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+clap = { workspace = true }
 
 # The whole point of this crate: drive `advance_state` from the prod
 # meeting detector against scripted scan traces. We pull

--- a/crates/screenpipe-redact/Cargo.toml
+++ b/crates/screenpipe-redact/Cargo.toml
@@ -14,34 +14,34 @@ edition.workspace = true
 [dependencies]
 # Re-exports & shared deps
 aho-corasick = "1"
-anyhow = "1"
-async-trait = "0.1"
-base64 = "0.22"
-chrono = { version = "0.4", features = ["serde"] }
-dirs = "5"
-image = "0.25"
-moka = { version = "0.12", features = ["future"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
+dirs = { workspace = true }
+image = { workspace = true }
+moka = { workspace = true }
 once_cell = { workspace = true }
-regex = "1"
+regex = { workspace = true }
 reqwest = { workspace = true }
-serde = { version = "1", features = ["derive"] }
-sha2 = "0.10"
+serde = { workspace = true }
+sha2 = { workspace = true }
 sha3 = "0.10"
-sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "sqlite", "chrono"] }
-thiserror = "1"
+sqlx = { workspace = true, features = ["chrono"] }
+thiserror = { workspace = true }
 # Tinfoil enclave attestation: AMD SEV-SNP attestation + Sigstore code-
 # provenance verification + TLS cert pinning for the privacy-filter PII
 # redaction service. See adapters/tinfoil.rs for the threat model
 # (without this a compromised CA can still observe unredacted text in
 # transit even though the enclave itself is honest).
-tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", rev = "82143d767b540195dea265df0b01c4b4fc93c424" }
+tinfoil = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
-tempfile = "3"
-image = "0.25"
+tempfile = { workspace = true }
+image = { workspace = true }
 
 [[example]]
 name = "v45_phase3_smoke"
@@ -80,19 +80,19 @@ opf-text = ["dep:opf"]
 mlx-mac = ["dep:screenpipe-rfdetr-mlx"]
 
 [dependencies.ort]
-version = "=2.0.0-rc.10"
+workspace = true
 features = ["ndarray"]
 optional = true
 
 [dependencies.ndarray]
-version = "0.16"
+workspace = true
 optional = true
 
 # HuggingFace fast tokenizers, used by the ONNX text adapter to load
 # the v45 phase 3 tokenizer.json. ~200 KB compiled, no extra runtime
 # deps beyond what onnxruntime already pulls in. Pinned major version.
 [dependencies.tokenizers]
-version = "0.21"
+workspace = true
 default-features = false
 features = ["onig"]
 optional = true
@@ -101,7 +101,7 @@ optional = true
 # mapping for the 27 BIO tags). Workspace already pulls serde_json
 # transitively; declare explicitly so the dep graph is honest.
 [dependencies.serde_json]
-version = "1"
+workspace = true
 optional = true
 
 # OPF text redactor (pure-Rust candle port; same model as the v3

--- a/crates/screenpipe-rfdetr-mlx/Cargo.toml
+++ b/crates/screenpipe-rfdetr-mlx/Cargo.toml
@@ -16,5 +16,5 @@ mlx-rs = { workspace = true, features = ["safetensors"] }
 mlx-sys = "0.2"
 # Pin to the version mlx-rs uses internally so the TensorView types match.
 safetensors = "0.6"
-image = { workspace = true, default-features = false, features = ["png", "jpeg"] }
+image = { workspace = true, features = ["png", "jpeg"] }
 thiserror = { workspace = true }

--- a/crates/screenpipe-rfdetr-mlx/Cargo.toml
+++ b/crates/screenpipe-rfdetr-mlx/Cargo.toml
@@ -12,9 +12,9 @@ name = "screenpipe_rfdetr_mlx"
 path = "src/lib.rs"
 
 [dependencies]
-mlx-rs = { version = "0.25", features = ["safetensors"] }
+mlx-rs = { workspace = true, features = ["safetensors"] }
 mlx-sys = "0.2"
 # Pin to the version mlx-rs uses internally so the TensorView types match.
 safetensors = "0.6"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-thiserror = "1"
+image = { workspace = true, default-features = false, features = ["png", "jpeg"] }
+thiserror = { workspace = true }

--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -15,8 +15,8 @@ default = []
 
 [dependencies]
 screenpipe-a11y = { path = "../screenpipe-a11y" }
-serde_json = "1.0"
-chrono = { version = "0.4.31", features = ["serde"] }
+serde_json = { workspace = true }
+chrono = { workspace = true }
 
 # async
 tokio = { workspace = true }
@@ -27,7 +27,7 @@ image = { workspace = true }
 # OCR
 rusty-tesseract = { git = "https://github.com/screenpipe/rusty-tesseract.git", rev = "08346c1de08d122c7121425abc79081c30dbf778" }
 
-anyhow = "1.0.86"
+anyhow = { workspace = true }
 
 image-compare = "0.4.1"
 
@@ -39,20 +39,20 @@ screenpipe-core = { path = "../screenpipe-core" }
 screenpipe-db = { path = "../screenpipe-db" }
 
 tracing = { workspace = true }
-serde = "1.0.200"
+serde = { workspace = true }
 
 once_cell = { workspace = true }
-base64 = "0.22.1"
+base64 = { workspace = true }
 reqwest = { workspace = true }
-url = "2.5.0"
+url = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 criterion = { workspace = true }
-strsim = "0.10.0"
+strsim = { workspace = true }
 memory-stats = "1.2.0"
 
-serde = "1.0.200"
+serde = { workspace = true }
 
 [package.metadata.osx]
 framework = ["Vision", "AppKit"]
@@ -78,17 +78,17 @@ harness = false
 # macOS: sck-rs for 12.3+ (ScreenCaptureKit), xcap as fallback for older versions
 [target.'cfg(target_os = "macos")'.dependencies]
 sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "b7f48a1236b2339350baa1375a805c7ce32f88df"}
-xcap = "0.9"
-libc = "0.2.168"
+xcap = { workspace = true }
+libc = { workspace = true }
 cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a", features = ["vn", "cv", "cg", "app"] }
-accessibility-sys = { git = "https://github.com/eiz/accessibility.git", rev = "173e898d4a52ee0afe0224ecb458d324057856e7" }
-core-foundation = "0.10"
-core-graphics = "0.24"
+accessibility-sys = { workspace = true }
+core-foundation = { workspace = true }
+core-graphics = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-xcap = { version = "0.9", features = ["wgc"] }
-uiautomation = { version = "0.16.1" }
-windows = { version = "0.58", features = [
+xcap = { workspace = true, features = ["wgc"] }
+uiautomation = { workspace = true }
+windows = { workspace = true, features = [
   "Graphics_Imaging",
   "Globalization",
   "Media_Ocr",
@@ -98,9 +98,9 @@ windows = { version = "0.58", features = [
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-xcap = "0.9"
-libc = "0.2.168"
+xcap = { workspace = true }
+libc = { workspace = true }
 atspi = { version = "0.25.0", features = ["tokio","proxies-tokio","zbus"] }
-zbus       = { version = "5.5", default-features = false }
+zbus = { workspace = true, default-features = false }
 atspi-common     = { version = "0.9.0", default-features = false }
 atspi-proxies    = { version = "0.9.0", default-features = false }

--- a/crates/screenpipe-secrets/Cargo.toml
+++ b/crates/screenpipe-secrets/Cargo.toml
@@ -4,23 +4,23 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio-rustls"] }
-base64 = "0.22"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-anyhow = "1"
-tokio = { version = "1", features = ["full"] }
-chacha20poly1305 = "0.10"
-rand = "0.8"
-chrono = { version = "0.4", features = ["serde"] }
+sqlx = { workspace = true }
+base64 = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true }
+chacha20poly1305 = { workspace = true }
+rand = { workspace = true }
+chrono = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-keyring = { version = "3", features = ["windows-native"] }
+keyring = { workspace = true, features = ["windows-native"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-keyring = { version = "3", features = ["linux-native-sync-persistent"] }
+keyring = { workspace = true, features = ["linux-native-sync-persistent"] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full", "test-util"] }
-tempfile = "3"
+tokio = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }

--- a/crates/screenpipe-sync/Cargo.toml
+++ b/crates/screenpipe-sync/Cargo.toml
@@ -8,33 +8,33 @@ license-file = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "1.0"
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
 # Hashing — always on; tiny and used for object-name + manifest sha256.
-sha2 = "0.10"
-hex = "0.4"
+sha2 = { workspace = true }
+hex = { workspace = true }
 
 # Feature-gated: HTTP transport. Required for `HttpPutDirect` + `TicketedPipeline`.
 reqwest = { workspace = true, optional = true }
 # Used by `HttpPutDirect` to hold the upload body once and clone refcount-
 # only across retries (a 50MB batch retried 3× should not allocate 150MB).
-bytes = { version = "1", optional = true }
+bytes = { workspace = true, optional = true }
 
 # Feature-gated: body encryption (ChaCha20-Poly1305 + per-recipient key wrap).
-chacha20poly1305 = { version = "0.10", optional = true }
-base64 = { version = "0.22", optional = true }
-rand = { version = "0.8", optional = true }
-zeroize = { version = "1.8", features = ["derive"], optional = true }
+chacha20poly1305 = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+rand = { workspace = true, optional = true }
+zeroize = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-wiremock = "0.6"
-tempfile = "3"
+wiremock = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = ["http", "encrypt"]

--- a/crates/screenpipe-team-memory/Cargo.toml
+++ b/crates/screenpipe-team-memory/Cargo.toml
@@ -15,6 +15,6 @@ edition = { workspace = true }
 # Frontmatter parsing/rendering. serde_yaml 0.9 is what
 # screenpipe-core already pins — keep the workspace on one version to
 # avoid pulling in two copies of the yaml stack.
-serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
-thiserror = "1.0"
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/screenpipe-vault/Cargo.toml
+++ b/crates/screenpipe-vault/Cargo.toml
@@ -9,20 +9,20 @@ edition.workspace = true
 
 [dependencies]
 # Crypto
-chacha20poly1305 = "0.10"
-argon2 = "0.5"
-zeroize = { version = "1.8", features = ["derive"] }
-rand = "0.8"
+chacha20poly1305 = { workspace = true }
+argon2 = { workspace = true }
+zeroize = { workspace = true }
+rand = { workspace = true }
 
 # Async
 tokio = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Error handling
-thiserror = "1"
+thiserror = { workspace = true }
 
 # Logging
 tracing = { workspace = true }
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 walkdir = "2"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }
 
 [features]
 default = []

--- a/ee/sdk/Cargo.toml
+++ b/ee/sdk/Cargo.toml
@@ -18,6 +18,20 @@ members = ["recorder-core", "tauri/rust"]
 # tauri-build / signing configs; they keep their own workspace roots.
 exclude = ["examples"]
 
+[workspace.dependencies]
+# Shared across recorder-core + tauri/rust
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt-multi-thread", "rt", "sync", "macros", "time", "process"] }
+# Used in recorder-core deps + dev-deps
+chrono = { version = "0.4", features = ["serde"] }
+anyhow = "1"
+tracing = "0.1"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+# Used in tauri/rust
+base64 = "0.22"
+thiserror = "2"
+tempfile = "3"
+
 [lib]
 crate-type = ["cdylib"]
 
@@ -29,7 +43,7 @@ screenpipe-recorder = { path = "recorder-core" }
 
 napi = { version = "2", default-features = false, features = ["napi4", "async"] }
 napi-derive = "2"
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "macros"] }
+tokio = { workspace = true }
 
 [build-dependencies]
 napi-build = "2"

--- a/ee/sdk/recorder-core/Cargo.toml
+++ b/ee/sdk/recorder-core/Cargo.toml
@@ -14,14 +14,14 @@ screenpipe-capture = { path = "../../../crates/screenpipe-capture" }
 screenpipe-db      = { path = "../../../crates/screenpipe-db" }
 screenpipe-config  = { path = "../../../crates/screenpipe-config" }
 
-anyhow = "1"
-chrono = { version = "0.4", features = ["serde"] }
+anyhow = { workspace = true }
+chrono = { workspace = true }
 crossbeam-channel = "0.5"
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros", "process"] }
-tracing = "0.1"
+image = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "01b68e60c80a59bbc1cac3629e725cf3bb2e4901" }
 
 [dev-dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }

--- a/ee/sdk/tauri/rust/Cargo.toml
+++ b/ee/sdk/tauri/rust/Cargo.toml
@@ -19,12 +19,12 @@ links = "screenpipe"
 # lets this plugin avoid spawning a Node helper at runtime.
 screenpipe-recorder = { path = "../../recorder-core" }
 
-base64 = "0.22"
-serde = { version = "1", features = ["derive"] }
+base64 = { workspace = true }
+serde = { workspace = true }
 serde_json = "1"
 tauri = { version = "2", default-features = false }
-thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 # Native telemetry sender (PostHog + Sentry). The `rustls` feature avoids a
 # system OpenSSL dependency, keeping the plugin portable across macOS/Windows/Linux.
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
@@ -36,4 +36,4 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 tauri-plugin = { version = "2", features = ["build"] }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }


### PR DESCRIPTION
## Summary

- Moves every repeated dependency across 19 workspace crates to `[workspace.dependencies]` in root `Cargo.toml` — versions are now declared once, crates use `{ workspace = true }`


- Adds `cargo consolidate` step to the `optimize` CI job in `style.yml`


