### PR TITLE
Hide owned browser when leaving chat 

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -256,6 +256,14 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
     };
   }, []);
 
+  useEffect(() => {
+    return () => {
+      // Route changes like /home -> /settings unmount the React owner, but the
+      // native child webview can remain visible unless we hide it explicitly.
+      commands.ownedBrowserHide().catch(() => {});
+    };
+  }, []);
+
   // ---------------------------------------------------------------------------
   // Viewport resize tracking — drives both the JS clamp and re-pushing bounds
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR hides the native owned browser webview when `BrowserSidebar` unmounts. It Fixes the case where navigating from chat to `/settings` could leave the owned browser floating over the settings page.

Before -

https://github.com/user-attachments/assets/c4c4efd3-5938-49dc-bf51-85536be2c6cb

After -

https://github.com/user-attachments/assets/3622280c-187d-44c3-9bdb-98bd100a682e


