### PR TITLE
fix(meetings): keep live transcripts on matching audio device

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -9206,7 +9206,10 @@ LIMIT ? OFFSET ?
         // is ~80 chunks), then matched in memory — avoids a per-segment query. We
         // pull file_path because chunk audio is single-device and the device is
         // encoded in the filename ("<name> (input|output)_<ts>.mp4"), which is the
-        // only place a chunk records its device.
+        // only place a chunk records its device. Never fall back to a different
+        // device: mic and system audio are separate tracks, and mirroring a remote
+        // speaker segment onto a mic chunk makes later playback/search look like the
+        // wrong source was recorded.
         let chunk_rows = sqlx::query(
             "SELECT id, timestamp, file_path FROM audio_chunks \
              WHERE timestamp IS NOT NULL \
@@ -9241,9 +9244,9 @@ LIMIT ? OFFSET ?
             // Match the SAME physical device's chunk so an input (mic) segment can't
             // inherit a remote speaker from a System Audio (output) chunk, and vice
             // versa. The device string is sanitized the same way the recorder names
-            // files (only '/' and '\\' replaced). Fall back to nearest-any within the
-            // window if no same-device chunk exists (legacy/odd naming) — never worse
-            // than before.
+            // files (only '/' and '\\' replaced). If no same-device chunk exists,
+            // skip the mirror and leave the chunk pending for backfill rather than
+            // corrupting source attribution.
             let device_key = format!(
                 "{} ({})",
                 s.device_name,
@@ -9254,13 +9257,7 @@ LIMIT ? OFFSET ?
             let pick = chunks
                 .iter()
                 .filter(|c| (c.1 - seg_ms).abs() <= window_ms && c.2.contains(device_key.as_str()))
-                .min_by_key(|c| (c.1 - seg_ms).abs())
-                .or_else(|| {
-                    chunks
-                        .iter()
-                        .filter(|c| (c.1 - seg_ms).abs() <= window_ms)
-                        .min_by_key(|c| (c.1 - seg_ms).abs())
-                });
+                .min_by_key(|c| (c.1 - seg_ms).abs());
             let Some(chunk) = pick else {
                 continue;
             };

--- a/crates/screenpipe-db/tests/timeline_live_meeting_test.rs
+++ b/crates/screenpipe-db/tests/timeline_live_meeting_test.rs
@@ -175,7 +175,7 @@ mod timeline_live_meeting_tests {
 
         // A covering audio chunk at `base` (the background-captured meeting audio).
         let chunk_id = db
-            .insert_audio_chunk("meeting.mp4", Some(base))
+            .insert_audio_chunk("System Audio (output)_meeting.mp4", Some(base))
             .await
             .unwrap();
 
@@ -236,9 +236,12 @@ mod timeline_live_meeting_tests {
         let base = Utc::now();
 
         // Only chunk is 5 minutes away — outside the 15s coverage window.
-        db.insert_audio_chunk("far.mp4", Some(base - Duration::minutes(5)))
-            .await
-            .unwrap();
+        db.insert_audio_chunk(
+            "System Audio (output)_far.mp4",
+            Some(base - Duration::minutes(5)),
+        )
+        .await
+        .unwrap();
         let meeting_id = db
             .insert_meeting("zoom.us", "ui_scan", None, None)
             .await
@@ -267,6 +270,56 @@ mod timeline_live_meeting_tests {
         );
     }
 
+    /// A live output/system segment must not be mirrored onto a nearby mic/input
+    /// chunk when the matching output chunk is missing. Mic and system audio are
+    /// separate tracks; corrupting source attribution is worse than leaving the
+    /// output segment pending for backfill.
+    #[tokio::test]
+    async fn test_mirror_never_falls_back_to_wrong_device_chunk() {
+        let db = setup_test_db().await;
+        let base = Utc::now();
+
+        let mic_chunk_id = db
+            .insert_audio_chunk("Ruark's AirPods (input)_meeting.mp4", Some(base))
+            .await
+            .unwrap();
+        let meeting_id = db
+            .insert_meeting("zoom.us", "ui_scan", None, None)
+            .await
+            .unwrap();
+        db.insert_meeting_transcript_segment(
+            meeting_id,
+            "screenpipe-cloud",
+            Some("nova-3"),
+            "deepgram:0:0",
+            "System Audio",
+            "output",
+            Some("Speaker 1"),
+            "remote audience should not attach to mic",
+            base + Duration::seconds(2),
+        )
+        .await
+        .unwrap();
+
+        let inserted = db
+            .mirror_live_meeting_to_audio_transcriptions(meeting_id, 15.0)
+            .await
+            .unwrap();
+        assert_eq!(
+            inserted, 0,
+            "output live segment without output chunk must not mirror onto mic chunk"
+        );
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM audio_transcriptions WHERE audio_chunk_id = ?1",
+        )
+        .bind(mic_chunk_id)
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 0, "mic chunk must remain free of system transcript");
+    }
+
     /// End-to-end: after the mirror runs (as it does at meeting-end), the live
     /// transcript appears on the timeline via `find_video_chunks` EXACTLY ONCE.
     /// This proves (a) the mirrored `audio_transcriptions` row's timestamp matches
@@ -290,7 +343,7 @@ mod timeline_live_meeting_tests {
         .await
         .unwrap();
         // The background-captured meeting audio (covering chunk).
-        db.insert_audio_chunk("meeting.mp4", Some(base))
+        db.insert_audio_chunk("System Audio (output)_meeting.mp4", Some(base))
             .await
             .unwrap();
 
@@ -348,7 +401,7 @@ mod timeline_live_meeting_tests {
 
         // The meeting's covering audio, already identified with that speaker.
         let chunk_id = db
-            .insert_audio_chunk("meeting.mp4", Some(base))
+            .insert_audio_chunk("System Audio (output)_meeting.mp4", Some(base))
             .await
             .unwrap();
         db.insert_audio_transcription(


### PR DESCRIPTION
## Summary

- Prevent live meeting transcript mirroring from falling back to a different audio source chunk.
- Keep mic and system audio attribution separate when matching live segments to recorded chunks.
- Add regression coverage so output/system transcript cannot attach to a mic/input chunk.

## Tests

```bash
cargo test -p screenpipe-db --test timeline_live_meeting_test mirror -- --nocapture
cargo check -p screenpipe-db
```
