### PR TITLE
[codex] Fix CLI image redactor MLX crash

### DIFF
--- a/crates/screenpipe-engine/Cargo.toml
+++ b/crates/screenpipe-engine/Cargo.toml
@@ -165,9 +165,10 @@ apple-intelligence = ["dep:screenpipe-apple-intelligence"]
 qwen3-asr = ["screenpipe-audio/qwen3-asr"]
 parakeet = ["screenpipe-audio/parakeet"]
 parakeet-mlx = ["screenpipe-audio/parakeet-mlx"]
-# Image-PII detector via MLX (Apple Silicon-only). Off by default;
-# Mac release builds opt in to pick up the ~6× speedup over the ONNX
-# CoreML EP path.
+# Image-PII detector via MLX (Apple Silicon-only). Compiled into macOS
+# release builds for experiments, but the CLI runtime keeps ONNX as the
+# default stable path unless SCREENPIPE_ENABLE_EXPERIMENTAL_RFDETR_MLX=1
+# is set.
 rfdetr-mlx = ["screenpipe-redact/mlx-mac"]
 
 # v45 phase 3 text-PII redactor via ONNX Runtime. CPU baseline for

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1880,43 +1880,48 @@ async fn main() -> anyhow::Result<()> {
         use screenpipe_redact::{ImageRedactionPolicy, ImageRedactor};
         use std::sync::Arc;
 
-        // Prefer the MLX runtime on Mac when the safetensors weights
-        // are present (~6× faster than the CoreML EP path). Falls
-        // through to the ONNX adapter otherwise — load_or_download
-        // fetches rfdetr_v9.onnx from
-        // huggingface.co/screenpipe/pii-image-redactor on first run
-        // (~108 MB), verifies SHA-256, caches at
-        // ~/.screenpipe/models/. Subsequent starts are instant.
+        // The desktop app intentionally uses the ONNX image redactor for
+        // local mode. Keep the standalone CLI on that same stable path by
+        // default: the MLX RF-DETR port is still experimental and can crash
+        // the process while reconciling large frame backlogs. Developers can
+        // still opt in while iterating on that runtime.
         #[allow(unused_mut)]
         let mut detector_arc: Option<Arc<dyn ImageRedactor>> = None;
         #[cfg(all(feature = "rfdetr-mlx", target_os = "macos", target_arch = "aarch64"))]
         {
-            use screenpipe_redact::adapters::rfdetr_mlx::{RfdetrMlxConfig, RfdetrMlxRedactor};
-            let mlx_cfg = RfdetrMlxConfig::default();
-            // Mirrors the ONNX adapter: download once, verify SHA-256,
-            // cache at ~/.screenpipe/models/rfdetr_v9.safetensors.
-            if let Err(e) = mlx_cfg.ensure_model_present().await {
-                tracing::info!(
-                    "rfdetr-mlx safetensors download failed ({e}); falling back to ONNX adapter"
-                );
-            } else {
-                match RfdetrMlxRedactor::load(mlx_cfg) {
-                    Ok(d) => {
-                        info!("image-PII detector: rfdetr-mlx (Apple Silicon GPU)");
-                        // Lazy-load + 60 s idle-unload — frees the
-                        // ~150–200 MB MLX resident footprint when the
-                        // worker is paused or the reconciliation queue
-                        // has drained. Same pattern as OpfAdapter.
-                        let d = Arc::new(d);
-                        let _ = Arc::clone(&d).spawn_idle_unloader();
-                        detector_arc = Some(d as Arc<dyn ImageRedactor>);
-                    }
-                    Err(e) => {
-                        tracing::info!(
-                            "rfdetr-mlx load failed ({e}); falling back to ONNX adapter"
-                        );
+            if std::env::var_os("SCREENPIPE_ENABLE_EXPERIMENTAL_RFDETR_MLX").is_some() {
+                use screenpipe_redact::adapters::rfdetr_mlx::{RfdetrMlxConfig, RfdetrMlxRedactor};
+                let mlx_cfg = RfdetrMlxConfig::default();
+                // Mirrors the ONNX adapter: download once, verify SHA-256,
+                // cache at ~/.screenpipe/models/rfdetr_v9.safetensors.
+                if let Err(e) = mlx_cfg.ensure_model_present().await {
+                    tracing::info!(
+                        "rfdetr-mlx safetensors download failed ({e}); falling back to ONNX adapter"
+                    );
+                } else {
+                    match RfdetrMlxRedactor::load(mlx_cfg) {
+                        Ok(d) => {
+                            info!("image-PII detector: rfdetr-mlx (Apple Silicon GPU)");
+                            // Lazy-load + 60 s idle-unload — frees the
+                            // ~150–200 MB MLX resident footprint when the
+                            // worker is paused or the reconciliation queue
+                            // has drained. Same pattern as OpfAdapter.
+                            let d = Arc::new(d);
+                            let _ = Arc::clone(&d).spawn_idle_unloader();
+                            detector_arc = Some(d as Arc<dyn ImageRedactor>);
+                        }
+                        Err(e) => {
+                            tracing::info!(
+                                "rfdetr-mlx load failed ({e}); falling back to ONNX adapter"
+                            );
+                        }
                     }
                 }
+            } else {
+                tracing::info!(
+                    "rfdetr-mlx disabled by default for CLI stability; \
+                     set SCREENPIPE_ENABLE_EXPERIMENTAL_RFDETR_MLX=1 to opt in"
+                );
             }
         }
         if detector_arc.is_none() {


### PR DESCRIPTION
## Summary

- Keep the standalone CLI on the same stable local image-PII path as the desktop app: RF-DETR ONNX by default.
- Move the experimental `rfdetr-mlx` image redactor behind `SCREENPIPE_ENABLE_EXPERIMENTAL_RFDETR_MLX=1`.
- Update the feature comment so macOS release builds can still compile the experimental code without auto-selecting it at runtime.

## Root Cause

Louis's `npx screenpipe@latest record` run crashed twice with `SIGSEGV` in the native `screenpipe` binary on macOS. The crash reports pointed at a Tokio worker thread inside the stripped release binary, with public symbols near the MLX/Metal scheduler. The CLI startup path preferred `rfdetr-mlx` for async image-PII reconciliation when built with the macOS release features, while the desktop app already used the ONNX redactor for local image PII.

The risky case is a real existing DB/backlog where the CLI starts the image redaction worker and MLX is active while other work is running. This change removes that default footgun but keeps the MLX path available for explicit experiments.

## Validation

- `cargo fmt --check`
- `cargo check -p screenpipe-engine --bin screenpipe --features redact-onnx-coreml`
- Compared branch against `main`: 1 commit, 2 files changed.

Blocked locally: `cargo check -p screenpipe-engine --bin screenpipe --features metal,parakeet-mlx,rfdetr-mlx,redact-onnx-coreml` could not complete because this machine is missing Apple's Metal Toolchain (`xcodebuild -downloadComponent MetalToolchain`).
