### PR TITLE
Fix shortcut UI sync and disabled states

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -947,12 +947,12 @@ function HomeContent() {
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="text-xs">
                   search
-                  <kbd className="ml-1 px-1 py-0.5 bg-muted rounded text-[10px]">
-                    {formatShortcutDisplay(
-                      settings.searchShortcut || (isMac ? "Control+Super+K" : "Alt+K"),
-                      isMac,
-                    )}
-                  </kbd>
+                  {!settings.disabledShortcuts.includes("searchShortcut") &&
+                  settings.searchShortcut ? (
+                    <kbd className="ml-1 px-1 py-0.5 bg-muted rounded text-[10px]">
+                      {formatShortcutDisplay(settings.searchShortcut, isMac)}
+                    </kbd>
+                  ) : null}
                 </TooltipContent>
               </Tooltip>
             </>
@@ -1162,12 +1162,12 @@ function HomeContent() {
                       </TooltipTrigger>
                       <TooltipContent side="right" className="text-xs">
                         search
-                        <kbd className="ml-1 px-1 py-0.5 bg-muted rounded text-[10px]">
-                          {formatShortcutDisplay(
-                            settings.searchShortcut || (isMac ? "Control+Super+K" : "Alt+K"),
-                            isMac,
-                          )}
-                        </kbd>
+                        {!settings.disabledShortcuts.includes("searchShortcut") &&
+                        settings.searchShortcut ? (
+                          <kbd className="ml-1 px-1 py-0.5 bg-muted rounded text-[10px]">
+                            {formatShortcutDisplay(settings.searchShortcut, isMac)}
+                          </kbd>
+                        ) : null}
                       </TooltipContent>
                     </Tooltip>
                     {/* Divider between the search affordance and the

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -21,6 +21,14 @@ import { ScreenMatrix } from "./screen-matrix";
 import { computeMeetingActive, type MeetingStatusResponse } from "@/lib/utils/meeting-state";
 import { appendAuthToken, ensureApiReady, getApiBaseUrl } from "@/lib/api";
 
+type ReminderSettings = {
+  disabledShortcuts?: string[];
+  shortcutOverlaySize?: string;
+  showChatShortcut?: string;
+  showScreenpipeShortcut?: string;
+  searchShortcut?: string;
+};
+
 function useMeetingState() {
   const [meetingState, setMeetingState] = useState(() => computeMeetingActive(null, 0));
   const [loading, setLoading] = useState(false);
@@ -117,6 +125,28 @@ export default function ShortcutReminderPage() {
   const isMacRef = useRef(isMac);
   isMacRef.current = isMac;
 
+  const applyReminderSettings = useCallback((settings?: ReminderSettings | null) => {
+    if (!settings) return;
+
+    const disabledShortcuts = new Set(settings.disabledShortcuts ?? []);
+    const formatForReminder = (shortcut: string | undefined, disabledKey: string) => {
+      if (disabledShortcuts.has(disabledKey)) return "";
+      if (!shortcut || shortcut.trim() === "") return "";
+      return formatShortcut(shortcut, isMacRef.current);
+    };
+
+    setOverlayShortcut(
+      formatForReminder(settings.showScreenpipeShortcut, "showScreenpipeShortcut")
+    );
+    setChatShortcut(formatForReminder(settings.showChatShortcut, "showChatShortcut"));
+    setSearchShortcut(formatForReminder(settings.searchShortcut, "searchShortcut"));
+
+    if (settings.shortcutOverlaySize) {
+      const s = settings.shortcutOverlaySize;
+      setOverlayScale(s === "large" ? 2 : s === "medium" ? 1.5 : 1);
+    }
+  }, []);
+
   // Read shortcuts directly from the store.bin file on disk (bypasses TS store plugin)
   const loadShortcutsFromFile = useCallback(async () => {
     try {
@@ -129,27 +159,14 @@ export default function ShortcutReminderPage() {
       const raw = await readTextFile(path);
       if (!raw) return;
       const data = JSON.parse(raw);
-      const settings = data?.settings;
-      if (settings?.showScreenpipeShortcut) {
-        setOverlayShortcut(formatShortcut(settings.showScreenpipeShortcut, isMacRef.current));
-      }
-      if (settings?.showChatShortcut) {
-        setChatShortcut(formatShortcut(settings.showChatShortcut, isMacRef.current));
-      }
-      if (settings?.searchShortcut) {
-        setSearchShortcut(formatShortcut(settings.searchShortcut, isMacRef.current));
-      }
-      if (settings?.shortcutOverlaySize) {
-        const s = settings.shortcutOverlaySize;
-        setOverlayScale(s === "large" ? 2 : s === "medium" ? 1.5 : 1);
-      }
+      applyReminderSettings(data?.settings as ReminderSettings | undefined);
     } catch (e) {
       // Error objects don't survive JSON.stringify — extract the human-readable parts
       // so the report isn't just "{}".
       const msg = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
       console.error("Failed to read shortcuts from store file:", msg);
     }
-  }, []);
+  }, [applyReminderSettings]);
 
   // Load shortcuts on mount + listen for updates
   useEffect(() => {
@@ -282,9 +299,11 @@ export default function ShortcutReminderPage() {
               <rect x="3" y="3" width="18" height="18" />
               <line x1="3" y1="9" x2="21" y2="9" />
             </svg>
-            <span className="font-mono font-medium text-white whitespace-nowrap truncate" style={{ fontSize: `${fontPx}px` }}>
-              {overlayShortcut ?? "..."}
-            </span>
+            {overlayShortcut ? (
+              <span className="font-mono font-medium text-white whitespace-nowrap truncate" style={{ fontSize: `${fontPx}px` }}>
+                {overlayShortcut}
+              </span>
+            ) : null}
           </button>
           <div className="bg-white/25" />
           <button
@@ -301,9 +320,11 @@ export default function ShortcutReminderPage() {
             <svg width={iconPx} height={iconPx} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-white/70 shrink-0">
               <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
             </svg>
-            <span className="font-mono font-medium text-white whitespace-nowrap truncate" style={{ fontSize: `${fontPx}px` }}>
-              {chatShortcut ?? "..."}
-            </span>
+            {chatShortcut ? (
+              <span className="font-mono font-medium text-white whitespace-nowrap truncate" style={{ fontSize: `${fontPx}px` }}>
+                {chatShortcut}
+              </span>
+            ) : null}
           </button>
           <div className="bg-white/25" />
           <button
@@ -321,9 +342,11 @@ export default function ShortcutReminderPage() {
               <circle cx="11" cy="11" r="8" />
               <line x1="21" y1="21" x2="16.65" y2="16.65" />
             </svg>
-            <span className="font-mono font-medium text-white whitespace-nowrap truncate" style={{ fontSize: `${fontPx}px` }}>
-              {searchShortcut ?? "..."}
-            </span>
+            {searchShortcut ? (
+              <span className="font-mono font-medium text-white whitespace-nowrap truncate" style={{ fontSize: `${fontPx}px` }}>
+                {searchShortcut}
+              </span>
+            ) : null}
           </button>
 
           {/* Divider row */}

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline-controls.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline-controls.tsx
@@ -90,13 +90,21 @@ export function TimelineControls({
 		};
 	}, [calendarOpen]);
 	const searchShortcutDisplay = useMemo(
-		() => formatShortcutDisplay(settings.searchShortcut || (isMac ? "Control+Super+K" : "Alt+K"), isMac),
-		[settings.searchShortcut, isMac]
+		() => {
+			if (settings.disabledShortcuts.includes("searchShortcut")) return "";
+			if (!settings.searchShortcut) return "";
+			return formatShortcutDisplay(settings.searchShortcut, isMac);
+		},
+		[settings.searchShortcut, settings.disabledShortcuts, isMac]
 	);
 
 	const chatShortcutDisplay = useMemo(
-		() => formatShortcutDisplay(settings.showChatShortcut || (isMac ? "Control+Super+L" : "Alt+L"), isMac),
-		[settings.showChatShortcut, isMac]
+		() => {
+			if (settings.disabledShortcuts.includes("showChatShortcut")) return "";
+			if (!settings.showChatShortcut) return "";
+			return formatShortcutDisplay(settings.showChatShortcut, isMac);
+		},
+		[settings.showChatShortcut, settings.disabledShortcuts, isMac]
 	);
 
 	const jumpDay = async (days: number) => {
@@ -298,7 +306,9 @@ export function TimelineControls({
 							onClick={onSearchClick}
 							className="flex items-center h-10 gap-1.5 bg-background border border-border px-4 font-mono hover:bg-foreground hover:text-background transition-colors duration-150 cursor-pointer group"
 						>
-							<span className="text-xs text-muted-foreground group-hover:text-background">{searchShortcutDisplay}</span>
+							{searchShortcutDisplay ? (
+								<span className="text-xs text-muted-foreground group-hover:text-background">{searchShortcutDisplay}</span>
+							) : null}
 							<span className="text-xs text-foreground group-hover:text-background">search</span>
 						</button>
 					)
@@ -310,7 +320,9 @@ export function TimelineControls({
 						onClick={onChatClick}
 						className="flex items-center h-10 gap-1.5 bg-background border border-border px-4 font-mono hover:bg-foreground hover:text-background transition-colors duration-150 cursor-pointer group"
 					>
-						<span className="text-xs text-muted-foreground group-hover:text-background">{chatShortcutDisplay}</span>
+						{chatShortcutDisplay ? (
+							<span className="text-xs text-muted-foreground group-hover:text-background">{chatShortcutDisplay}</span>
+						) : null}
 						<span className="text-xs text-foreground group-hover:text-background">chat</span>
 					</button>
 				)}

--- a/apps/screenpipe-app-tauri/components/settings/shortcut-row.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/shortcut-row.tsx
@@ -201,6 +201,14 @@ const ShortcutRow = ({
           };
           await syncShortcuts(updatedShortcuts);
 
+          if (reminderShortcutKeys.has(shortcut)) {
+            try {
+              await commands.refreshTrayMenu();
+            } catch (e) {
+              // Tray may not exist in some environments, that's ok.
+            }
+          }
+
           // Keep the visible reminder in sync when one of its displayed shortcuts changes.
           if (settings.showShortcutOverlay && reminderShortcutKeys.has(shortcut)) {
             try {
@@ -245,6 +253,14 @@ const ShortcutRow = ({
       searchShortcut: settings.searchShortcut,
       lockVaultShortcut: settings.lockVaultShortcut || "",
     });
+
+    if (reminderShortcutKeys.has(shortcut)) {
+      try {
+        await commands.refreshTrayMenu();
+      } catch (e) {
+        // Tray may not exist in some environments, that's ok.
+      }
+    }
 
     if (settings.showShortcutOverlay && reminderShortcutKeys.has(shortcut)) {
       try {

--- a/apps/screenpipe-app-tauri/components/settings/shortcut-row.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/shortcut-row.tsx
@@ -29,6 +29,11 @@ const ShortcutRow = ({
   type,
   value,
 }: ShortcutRowProps) => {
+  const reminderShortcutKeys = new Set([
+    "showScreenpipeShortcut",
+    "showChatShortcut",
+    "searchShortcut",
+  ]);
   const [isRecording, setIsRecording] = useState(false);
   const { settings, updateSettings } = useSettings();
 
@@ -111,6 +116,7 @@ const ShortcutRow = ({
     startAudioShortcut: string;
     stopAudioShortcut: string;
     showChatShortcut: string;
+    searchShortcut: string;
     lockVaultShortcut?: string;
   }) => {
     console.log("syncing shortcuts:", {
@@ -120,6 +126,7 @@ const ShortcutRow = ({
       startAudioShortcut: updatedShortcuts.startAudioShortcut,
       stopAudioShortcut: updatedShortcuts.stopAudioShortcut,
       showChatShortcut: updatedShortcuts.showChatShortcut,
+      searchShortcut: updatedShortcuts.searchShortcut,
     });
     // wait 1 second for settings to persist
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -189,12 +196,13 @@ const ShortcutRow = ({
             startAudioShortcut: shortcut === "startAudioShortcut" ? keys : settings.startAudioShortcut,
             stopAudioShortcut: shortcut === "stopAudioShortcut" ? keys : settings.stopAudioShortcut,
             showChatShortcut: shortcut === "showChatShortcut" ? keys : settings.showChatShortcut,
+            searchShortcut: shortcut === "searchShortcut" ? keys : settings.searchShortcut,
             lockVaultShortcut: shortcut === "lockVaultShortcut" ? keys : (settings.lockVaultShortcut || ""),
           };
           await syncShortcuts(updatedShortcuts);
 
-          // Update the shortcut reminder overlay if either show shortcut changed
-          if (shortcut === "showScreenpipeShortcut" || shortcut === "showChatShortcut") {
+          // Keep the visible reminder in sync when one of its displayed shortcuts changes.
+          if (settings.showShortcutOverlay && reminderShortcutKeys.has(shortcut)) {
             try {
               await commands.showShortcutReminder(updatedShortcuts.showScreenpipeShortcut);
             } catch (e) {
@@ -221,7 +229,7 @@ const ShortcutRow = ({
       title: "shortcut disabled",
       description: `${shortcut.replace(/_/g, " ")} disabled`,
     });
-    updateSettings({
+    await updateSettings({
       disabledShortcuts: Array.from(
         new Set([...settings.disabledShortcuts, shortcut as Shortcut])
       ),
@@ -234,8 +242,17 @@ const ShortcutRow = ({
       startAudioShortcut: settings.startAudioShortcut,
       stopAudioShortcut: settings.stopAudioShortcut,
       showChatShortcut: settings.showChatShortcut,
+      searchShortcut: settings.searchShortcut,
       lockVaultShortcut: settings.lockVaultShortcut || "",
     });
+
+    if (settings.showShortcutOverlay && reminderShortcutKeys.has(shortcut)) {
+      try {
+        await commands.showShortcutReminder(settings.showScreenpipeShortcut);
+      } catch (e) {
+        // Window may not exist, that's ok
+      }
+    }
   };
 
   const isValueEmpty = (v: string | undefined): boolean =>

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -7725,9 +7725,12 @@ export function StandaloneChat({
               <Plus size={14} />
               <span>New</span>
             </Button>
-            <kbd suppressHydrationWarning className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-mono text-muted-foreground bg-muted/50 border border-border/50 rounded">
-              {formatShortcutDisplay(settings.showChatShortcut || (isMac ? "Control+Super+L" : "Alt+L"), isMac)}
-            </kbd>
+            {!settings.disabledShortcuts.includes("showChatShortcut") &&
+            settings.showChatShortcut ? (
+              <kbd suppressHydrationWarning className="hidden sm:inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-mono text-muted-foreground bg-muted/50 border border-border/50 rounded">
+                {formatShortcutDisplay(settings.showChatShortcut, isMac)}
+              </kbd>
+            ) : null}
           </>
         )}
       </div>

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1353,6 +1353,14 @@ async reencryptStore() : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async refreshTrayMenu() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("refresh_tray_menu") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Wipe the persisted API auth key and write a fresh `sp-<uuid8>` to the
  * secret store. Returns the new key. The running server keeps its old key

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -2122,11 +2122,60 @@ pub async fn open_search_window(
     Ok(())
 }
 
+fn shortcut_reminder_label(
+    value: &str,
+    setting_key: &str,
+    disabled_shortcuts: &[String],
+) -> String {
+    if disabled_shortcuts.iter().any(|disabled| disabled == setting_key) {
+        String::new()
+    } else if value.trim().is_empty() {
+        String::new()
+    } else {
+        value.to_string()
+    }
+}
+
+fn shortcut_reminder_payload(
+    settings: &crate::store::SettingsStore,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "overlay".to_string(),
+        serde_json::Value::String(shortcut_reminder_label(
+            &settings.show_screenpipe_shortcut,
+            "showScreenpipeShortcut",
+            &settings.disabled_shortcuts,
+        )),
+    );
+    map.insert(
+        "chat".to_string(),
+        serde_json::Value::String(shortcut_reminder_label(
+            &settings.show_chat_shortcut,
+            "showChatShortcut",
+            &settings.disabled_shortcuts,
+        )),
+    );
+    map.insert(
+        "search".to_string(),
+        serde_json::Value::String(shortcut_reminder_label(
+            &settings.search_shortcut,
+            "searchShortcut",
+            &settings.disabled_shortcuts,
+        )),
+    );
+    map.insert(
+        "shortcutOverlaySize".to_string(),
+        serde_json::Value::String(settings.shortcut_overlay_size.clone()),
+    );
+    map
+}
+
 #[tauri::command]
 #[specta::specta]
 pub async fn show_shortcut_reminder(
     app_handle: tauri::AppHandle,
-    shortcut: String,
+    _shortcut: String,
 ) -> Result<(), String> {
     use tauri::{Emitter, WebviewWindowBuilder};
 
@@ -2137,20 +2186,16 @@ pub async fn show_shortcut_reminder(
     // The screenpipe shortcut only opens the timeline/rewind overlay, so the
     // reminder is pointless when the timeline is disabled. Suppress it here so
     // every caller (startup, settings toggles, shortcut edits) is covered.
-    let timeline_disabled = crate::store::SettingsStore::get(&app_handle)
+    let store = crate::store::SettingsStore::get(&app_handle)
         .unwrap_or_default()
-        .unwrap_or_default()
-        .recording
-        .disable_timeline;
-    if timeline_disabled {
+        .unwrap_or_default();
+    if store.recording.disable_timeline {
         info!("timeline disabled: skipping shortcut reminder overlay");
         return Ok(());
     }
 
-    let shortcut_overlay_size = crate::store::SettingsStore::get(&app_handle)
-        .unwrap_or_default()
-        .unwrap_or_default()
-        .shortcut_overlay_size;
+    let shortcut_overlay_size = store.shortcut_overlay_size.clone();
+    let shortcut_payload = serde_json::Value::Object(shortcut_reminder_payload(&store)).to_string();
 
     // On macOS, try the native SwiftUI shortcut reminder first
     #[cfg(target_os = "macos")]
@@ -2193,24 +2238,7 @@ pub async fn show_shortcut_reminder(
                 }
             }
 
-            let mut map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
-            match serde_json::from_str::<serde_json::Value>(&shortcut) {
-                Ok(serde_json::Value::Object(o)) => {
-                    for (k, v) in o {
-                        map.insert(k, v);
-                    }
-                }
-                _ => {
-                    map.insert(
-                        "overlay".to_string(),
-                        serde_json::Value::String(shortcut.clone()),
-                    );
-                }
-            }
-            map.insert(
-                "shortcutOverlaySize".to_string(),
-                serde_json::Value::String(shortcut_overlay_size.clone()),
-            );
+            let mut map = shortcut_reminder_payload(&store);
             if let Some(state) = app_handle.try_state::<RecordingState>() {
                 let guard = state.server.lock().await;
                 if let Some(ref core) = *guard {
@@ -2300,7 +2328,7 @@ pub async fn show_shortcut_reminder(
             window_height,
         )));
         let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(x, y)));
-        let _ = app_handle.emit_to(label, "shortcut-reminder-update", &shortcut);
+        let _ = app_handle.emit_to(label, "shortcut-reminder-update", &shortcut_payload);
         let _ = window.show();
 
         #[cfg(target_os = "macos")]
@@ -2445,7 +2473,7 @@ pub async fn show_shortcut_reminder(
     });
 
     // Send the shortcut info to the window
-    let _ = app_handle.emit_to(label, "shortcut-reminder-update", &shortcut);
+    let _ = app_handle.emit_to(label, "shortcut-reminder-update", &shortcut_payload);
 
     Ok(())
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -2122,6 +2122,20 @@ pub async fn open_search_window(
     Ok(())
 }
 
+#[tauri::command]
+#[specta::specta]
+pub async fn refresh_tray_menu(app_handle: tauri::AppHandle) -> Result<(), String> {
+    let app_handle_clone = app_handle.clone();
+    app_handle
+        .run_on_main_thread(move || {
+            if let Err(err) = crate::tray::force_tray_rebuild(&app_handle_clone) {
+                error!("tray rebuild failed: {}", err);
+            }
+        })
+        .map_err(|err| err.to_string())?;
+    Ok(())
+}
+
 fn shortcut_reminder_label(
     value: &str,
     setting_key: &str,

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -9,7 +9,7 @@ use crate::health::{
     set_high_fps_status, DeviceKind, HighFpsCacheEntry, RecordingStatus,
 };
 use crate::recording::{local_api_context_from_app, RecordingState};
-use crate::store::{get_store, OnboardingStore, SettingsStore};
+use crate::store::{OnboardingStore, SettingsStore};
 use crate::updates::{is_enterprise_build, is_source_build};
 use crate::window::ShowRewindWindow;
 use anyhow::Result;
@@ -65,35 +65,49 @@ fn prefetch_tray_menu_data(app: &AppHandle) -> TrayMenuData {
         ("Control+Super+S", "Control+Super+K", "Control+Super+L")
     };
 
-    let (show_shortcut, search_shortcut, chat_shortcut) = if let Ok(store) = get_store(app, None) {
-        (
-            store
-                .get("showScreenpipeShortcut")
-                .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| default_show.to_string()),
-            store
-                .get("searchShortcut")
-                .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| default_search.to_string()),
-            store
-                .get("showChatShortcut")
-                .and_then(|v| v.as_str().map(String::from))
-                .unwrap_or_else(|| default_chat.to_string()),
-        )
+    let settings = SettingsStore::get(app)
+        .unwrap_or_default()
+        .unwrap_or_default();
+
+    let mut show_shortcut = if settings.show_screenpipe_shortcut.trim().is_empty() {
+        default_show.to_string()
     } else {
-        (
-            default_show.to_string(),
-            default_search.to_string(),
-            default_chat.to_string(),
-        )
+        settings.show_screenpipe_shortcut.clone()
+    };
+    let mut search_shortcut = if settings.search_shortcut.trim().is_empty() {
+        default_search.to_string()
+    } else {
+        settings.search_shortcut.clone()
+    };
+    let mut chat_shortcut = if settings.show_chat_shortcut.trim().is_empty() {
+        default_chat.to_string()
+    } else {
+        settings.show_chat_shortcut.clone()
     };
 
-    let cloud_subscribed = SettingsStore::get(app)
-        .unwrap_or_default()
-        .unwrap_or_default()
-        .user
-        .cloud_subscribed
-        == Some(true);
+    if settings
+        .disabled_shortcuts
+        .iter()
+        .any(|shortcut| shortcut == "showScreenpipeShortcut")
+    {
+        show_shortcut.clear();
+    }
+    if settings
+        .disabled_shortcuts
+        .iter()
+        .any(|shortcut| shortcut == "searchShortcut")
+    {
+        search_shortcut.clear();
+    }
+    if settings
+        .disabled_shortcuts
+        .iter()
+        .any(|shortcut| shortcut == "showChatShortcut")
+    {
+        chat_shortcut.clear();
+    }
+
+    let cloud_subscribed = settings.user.cloud_subscribed == Some(true);
 
     let app_ui_hidden = is_app_ui_hidden();
 
@@ -561,25 +575,25 @@ fn create_dynamic_menu(
     // --- Primary actions (most-used first) ---
     // Use native accelerators for right-aligned shortcut display (like Notion Calendar)
     if !data.app_ui_hidden && !is_tray_item_hidden("tray_chat") {
-        menu_builder = menu_builder.item(
-            &MenuItemBuilder::with_id("show_chat", "Chat")
-                .accelerator(&to_accelerator(&chat_shortcut))
-                .build(app)?,
-        );
+        let mut item = MenuItemBuilder::with_id("show_chat", "Chat");
+        if !chat_shortcut.is_empty() {
+            item = item.accelerator(&to_accelerator(chat_shortcut));
+        }
+        menu_builder = menu_builder.item(&item.build(app)?);
     }
     if !data.app_ui_hidden && !is_tray_item_hidden("tray_search") {
-        menu_builder = menu_builder.item(
-            &MenuItemBuilder::with_id("show_search", "Search")
-                .accelerator(&to_accelerator(&search_shortcut))
-                .build(app)?,
-        );
+        let mut item = MenuItemBuilder::with_id("show_search", "Search");
+        if !search_shortcut.is_empty() {
+            item = item.accelerator(&to_accelerator(search_shortcut));
+        }
+        menu_builder = menu_builder.item(&item.build(app)?);
     }
     if !data.app_ui_hidden && !is_tray_item_hidden("tray_timeline") {
-        menu_builder = menu_builder.item(
-            &MenuItemBuilder::with_id("show", "Timeline")
-                .accelerator(&to_accelerator(&show_shortcut))
-                .build(app)?,
-        );
+        let mut item = MenuItemBuilder::with_id("show", "Timeline");
+        if !show_shortcut.is_empty() {
+            item = item.accelerator(&to_accelerator(show_shortcut));
+        }
+        menu_builder = menu_builder.item(&item.build(app)?);
     }
 
     // --- Recording status + devices ---

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -216,7 +216,7 @@ fn send_notify(title: impl Into<String>, body: impl Into<String>) {
 }
 
 /// Immediately rebuild the tray menu (called from main thread after optimistic status set).
-fn force_tray_rebuild(app: &AppHandle) -> Result<()> {
+pub(crate) fn force_tray_rebuild(app: &AppHandle) -> Result<()> {
     let update_item = UPDATE_MENU_ITEM
         .lock()
         .unwrap_or_else(|e| e.into_inner())


### PR DESCRIPTION
This PR fixes shortcut UI inconsistencies across the reminder, tray menu, overlay, sidebar, and chat UI.

### Changes

- fixed the shortcut reminder so it stays in sync with current shortcut settings
- made disabled or unset reminder slots render as icon-only instead of clipped status text
- fixed tray menu shortcut labels to use current settings instead of stale/default values
- hid tray shortcut labels when those shortcuts are disabled
- refreshed the tray menu immediately after shortcut changes instead of waiting for the periodic refresh
- hid shortcut labels in overlay, sidebar search, and chat UI when those shortcuts are disabled or unset

### Before

https://github.com/user-attachments/assets/da1fb977-af45-4a04-8dec-f4322dc10494


https://github.com/user-attachments/assets/63dd6dc4-8f3b-422b-9fed-c7a83a28a134

### After

https://github.com/user-attachments/assets/1545752b-81e5-422c-bb1a-789b3fdd1a67


https://github.com/user-attachments/assets/2f4944f7-8219-4f52-bb83-8990c045bc73

