### PR TITLE
Preserve pinned and archived conversation state during chat saves

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -704,6 +704,8 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       // plain chat (kind/pipeContext dropped on disk).
       ...(existing?.kind ? { kind: existing.kind } : {}),
       ...(existing?.pipeContext ? { pipeContext: existing.pipeContext } : {}),
+      ...(existing?.pinned ? { pinned: existing.pinned } : {}),
+      ...(existing?.hidden ? { hidden: existing.hidden } : {}),
       // Preserve sort key across reloads. Source of truth: the in-memory
       // chat-store, which is bumped exactly once per user-send.
       ...(await (async () => {


### PR DESCRIPTION
Saving a chat was rebuilding the conversation object without keeping pinned and archived, so those states could get lost after later saves. This PR keeps that metadata when conversations are saved so sidebar and chat history state stays intact.

Before -

https://github.com/user-attachments/assets/3d943f33-c87c-4fc6-9f7b-d28080fa1b2c


https://github.com/user-attachments/assets/e53675fa-15cc-4038-9524-874e4f949fe2




After - 



https://github.com/user-attachments/assets/c190c237-f325-45e8-b249-fa7ccef1763a



https://github.com/user-attachments/assets/247dcb0e-2a0a-4119-a561-ec5ca6a5eb31

