### PR TITLE
Preserve absolute media file paths

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
@@ -26,6 +26,30 @@ describe("normalizeMediaFilePath", () => {
       "C:/Users/Hugo Azevedo/.screenpipe/data/audio.wav",
     );
   });
+
+  it("preserves the leading slash when decoding Unix file URLs", () => {
+    const path = "file:///Users/ansh/.screenpipe/data/audio%20clip.wav";
+
+    expect(normalizeMediaFilePath(path)).toBe(
+      "/Users/ansh/.screenpipe/data/audio clip.wav",
+    );
+  });
+
+  it("preserves the full absolute Unix path", () => {
+    const path = "/Users/ansh/.screenpipe/data/audio clip.wav";
+
+    expect(normalizeMediaFilePath(path)).toBe(
+      "/Users/ansh/.screenpipe/data/audio clip.wav",
+    );
+  });
+
+  it("trims outer whitespace before stripping surrounding quotes", () => {
+    const path = '  "file:///Users/ansh/.screenpipe/data/audio%20clip.wav"  ';
+
+    expect(normalizeMediaFilePath(path)).toBe(
+      "/Users/ansh/.screenpipe/data/audio clip.wav",
+    );
+  });
 });
 
 describe("isAudioMediaPath", () => {

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
@@ -35,6 +35,15 @@ describe("normalizeMediaFilePath", () => {
     );
   });
 
+  it("normalizes Unix file URLs with non-standard slash counts", () => {
+    expect(
+      normalizeMediaFilePath("file:/Users/ansh/.screenpipe/data/audio%20clip.wav"),
+    ).toBe("/Users/ansh/.screenpipe/data/audio clip.wav");
+    expect(
+      normalizeMediaFilePath("file:////Users/ansh/.screenpipe/data/audio%20clip.wav"),
+    ).toBe("/Users/ansh/.screenpipe/data/audio clip.wav");
+  });
+
   it("preserves the full absolute Unix path", () => {
     const path = "/Users/ansh/.screenpipe/data/audio clip.wav";
 

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
@@ -17,7 +17,7 @@ export function normalizeMediaFilePath(path: string): string {
   if (/^file:\/\/\/[A-Z]:[\\/]/i.test(cleaned)) {
     cleaned = cleaned.replace(/^file:\/\/\//i, "");
   } else {
-    cleaned = cleaned.replace(/^file:\/\//i, "");
+    cleaned = cleaned.replace(/^file:\/+/i, "/");
   }
 
   // Windows file URLs often become /C:/Users/... after stripping file://.

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
@@ -6,7 +6,7 @@ const MEDIA_EXTENSIONS = ["mp4", "mp3", "wav", "webm", "ogg", "m4a"] as const;
 const MEDIA_EXTENSION_PATTERN = MEDIA_EXTENSIONS.join("|");
 
 export function normalizeMediaFilePath(path: string): string {
-  let cleaned = path.replace(/^["'`]|["'`]$/g, "").trim();
+  let cleaned = path.trim().replace(/^["'`]|["'`]$/g, "").trim();
 
   try {
     cleaned = decodeURIComponent(cleaned);
@@ -14,7 +14,11 @@ export function normalizeMediaFilePath(path: string): string {
     // Keep the original string if it contains malformed percent escapes.
   }
 
-  cleaned = cleaned.replace(/^file:\/+/i, "");
+  if (/^file:\/\/\/[A-Z]:[\\/]/i.test(cleaned)) {
+    cleaned = cleaned.replace(/^file:\/\/\//i, "");
+  } else {
+    cleaned = cleaned.replace(/^file:\/\//i, "");
+  }
 
   // Windows file URLs often become /C:/Users/... after stripping file://.
   cleaned = cleaned.replace(/^\/([A-Z]:[\\/])/i, "$1");
@@ -25,7 +29,7 @@ export function normalizeMediaFilePath(path: string): string {
   if (windowsMatch) return windowsMatch[0].trim();
 
   const unixMatch = cleaned.match(
-    new RegExp(`/(?:[^\\n\\r\`"<>]+?/)??[^\\n\\r\`"<>]+?\\.(${MEDIA_EXTENSION_PATTERN})`, "i"),
+    new RegExp(`/[^\\n\\r\`"<>]+?\\.(${MEDIA_EXTENSION_PATTERN})`, "i"),
   );
   if (unixMatch) return unixMatch[0].trim();
 


### PR DESCRIPTION
## Summary

- preserve absolute Unix media paths in `normalizeMediaFilePath`
- keep the leading slash when decoding `file:///Users/...` URLs
- trim outer whitespace before stripping surrounding quotes from media paths

## Changed area

- `apps/screenpipe-app-tauri/lib/utils/media-file-path.ts`
- `apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts`

## Validation

- `vet "Fix normalizeMediaFilePath so quoted file URLs and absolute Unix media paths normalize correctly" --agentic --agent-harness claude --history-loader "python3 ~/.codex/skills/vet/scripts/export_codex_session.py --session-file /Users/isaac.sanchez/.codex/sessions/2026/06/05/rollout-2026-06-05T09-01-02-019e97df-6c2f-73a0-826d-f4565aa6426d.jsonl"` (initial run returned `No issues found`; later rerun hung with no findings emitted)
- `node --experimental-strip-types --input-type=module` assertion check covering absolute Unix paths, Unix `file:///...` URLs, quoted Unix file URLs, and encoded Windows file URLs
- `git diff --check`

## Risk notes

- low risk: the change is isolated to path normalization for local media references
- Windows handling is preserved by keeping the existing drive-letter normalization path

## Skipped-test rationale

- `bun x vitest run --config vitest.config.ts lib/utils/media-file-path.test.ts` was blocked by `error: bun is unable to write files to tempdir: PermissionDenied`
- `bun run typecheck` was blocked by the same Bun tempdir permission error
