### PR TITLE
docs(readme): fix outdated claims in the 📖 LLM reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Minimum requirements: 8 GB RAM recommended. ~5–10 GB disk space per month. CPU
 Instead of recording every second, screenpipe listens for meaningful events — app switches, clicks, typing pauses, scrolling — and captures a screenshot only when something actually changes. Each capture pairs a screenshot with the accessibility tree (the structured text the OS already knows about: buttons, labels, text fields). If accessibility data isn't available (e.g. remote desktops, games), it falls back to OCR. This gives you maximum data quality with minimal CPU and storage — no more processing thousands of identical frames.
 
 ### Audio transcription
-Captures system audio (what you hear) and microphone input (what you say). Real-time speech-to-text using OpenAI Whisper running locally on your device. Speaker identification and diarization. Works with any audio source — Zoom, Google Meet, Teams, or any other application.
+Captures system audio (what you hear) and microphone input (what you say). Real-time speech-to-text using Whisper (Large-V3-Turbo) running locally on your device, or Deepgram for cloud transcription. Speaker identification and diarization. Works with any audio source — Zoom, Google Meet, Teams, or any other application.
 
 On macOS 14.4+, you can exclude specific apps from system-audio capture by listing their bundle IDs in `~/.screenpipe/audio-exclusions.json`. Enable Experimental CoreAudio System Audio in Settings → Recording first; the picker UI only appears once that flag is on.
 
@@ -202,16 +202,19 @@ On macOS 14.4+, you can exclude specific apps from system-audio capture by listi
 The exclusion list hot-reloads — edits to the file and excluded apps launching/quitting are picked up on the engine's existing 500 ms tap-rebuild loop without restarting screenpipe. Override the file path with `SCREENPIPE_AUDIO_EXCLUSIONS_PATH` for testing. Note: this requires the "System Audio Recording Only" TCC permission in System Settings → Privacy & Security → Screen & System Audio Recording.
 
 ### AI-powered search
-Natural language search across accessibility-first screen text, OCR fallback text, and audio transcriptions. Filter by application name, window title, browser URL, date range. Semantic search using embeddings. Returns screenshots and audio clips alongside text results.
+Natural language search across accessibility-first screen text, OCR fallback text, and audio transcriptions. Filter by application name, window title, browser URL, date range. Full-text keyword search (SQLite FTS5) under the hood. Returns screenshots and audio clips alongside text results.
 
 ### Timeline view
 Visual timeline of your entire screen history. Scroll through your day like a DVR. Click any moment to see the full screenshot and extracted text. Play back audio from any time period.
 
 ### Plugin system (Pipes)
 Pipes are scheduled AI agents defined as markdown files. Each pipe is a `pipe.md` with a prompt and schedule — screenpipe runs an AI coding agent (like pi or claude-code) that queries your screen data, calls APIs, writes files, and takes actions. Built-in pipes include:
-- **Obsidian sync**: Automatically sync screen activity to Obsidian vault as daily logs
-- **Reminders**: Scan activity for todos and create Apple Reminders (macOS)
-- **Idea tracker**: Surface startup ideas from your browsing + market trends
+- **meeting-summary**: Summarizes the meeting that just ended and patches the note back onto the meeting record
+- **day-recap**: Today's accomplishments, key moments, and unfinished work
+- **standup-update**: What you did, what's next, and any blockers
+- **time-breakdown**: Where your time went, by app, project, and category
+- **ai-prompt-journal**: Captures every prompt you send to AI tools, saved to Obsidian or local markdown
+- **video-export**: Create a video of your recent screen activity
 
 Developers can create pipes by writing a markdown file in `~/.screenpipe/pipes/`.
 
@@ -228,7 +231,7 @@ Enforced at three layers — skill gating (AI never learns denied endpoints), ag
 screenpipe runs as an MCP server, allowing AI assistants to query your screen history:
 - Works with Claude Desktop, Cursor, VS Code (Cline, Continue), and any MCP-compatible client
 - AI assistants can search your screen history, get recent context, and access meeting transcriptions
-- Zero configuration: `claude mcp add screenpipe -- npx -y screenpipe-mcp`
+- Zero configuration: `claude mcp add screenpipe -- npx -y screenpipe-mcp@latest`
 
 ### Developer API
 Full REST API running on localhost (default port 3030). Endpoints for searching screen content, audio, frames. Raw SQL access to the underlying SQLite database. JavaScript/TypeScript SDK available.
@@ -259,14 +262,17 @@ On supported Macs, screenpipe uses Apple Intelligence for on-device AI processin
 | Plugin system | ✅ Pipes (AI agents) | ❌ | ❌ | ❌ |
 | AI model choice | Any (local or cloud) | Proprietary | Microsoft AI | Proprietary |
 | Team deployment | ✅ Central config, AI permissions | ❌ | ❌ | ❌ |
-| Pricing | One-time purchase | Subscription | Bundled with Windows | Subscription |
+| Pricing | Free OSS core · app from $25/mo | Subscription | Bundled with Windows | Subscription |
 
 ## Pricing
 
-- **Lifetime**: $400 one-time purchase. All features, all future updates, forever.
-- **Lifetime + Pro 1 year**: $600 one-time. Includes lifetime app + 1 year of Pro (cloud sync, priority support).
-- **Pro subscription**: $39/month for cloud sync between devices, priority support, and pro AI models.
-- **Teams**: Custom pricing. Shared configs, shared pipes, per-pipe AI data permissions, admin dashboard, MDM ready (Intune / SCCM). See [screenpi.pe/team](https://screenpi.pe/team).
+The core engine and CLI are free and open source (MIT). The signed desktop app uses a subscription:
+
+- **Standard**: $25/month. Local-first capture, search, and timeline, all on your device.
+- **Pro**: $50/seat/month. Everything in Standard plus cloud sync, cloud AI, and integrations. Teams buy 5+ seats self-serve.
+- **Enterprise**: $150/seat/month. Managed deployment, central config, shared pipes, per-pipe AI data permissions, admin dashboard, SSO/SAML, MDM ready (Intune / SCCM). Sales-led. See [screenpi.pe/team](https://screenpi.pe/team).
+
+Existing lifetime licenses remain valid; new lifetime purchases are no longer sold.
 
 ## Integrations
 
@@ -330,7 +336,7 @@ Make sure to understand the main branch is moving fast and breaking things, if y
 ## Frequently asked questions
 
 **Is screenpipe free?**
-The core engine is open source (MIT license). The desktop app is a one-time lifetime purchase ($400). No recurring subscription required for the core app.
+The core engine and CLI are free and open source (MIT license), so you can run screenpipe yourself for free. The signed desktop app uses a subscription starting at $25/month; existing lifetime licenses remain valid.
 
 **Does screenpipe send my data to the cloud?**
 No. All data is stored locally by default. You can use fully local AI models via Ollama for complete privacy.


### PR DESCRIPTION
Scoped to the **📖 LLM reference** collapsible only (the machine-readable block), not the main README body. Fixes hallucinated / stale copy, each verified against the **codebase**, **Louis's brain**, and the **in-flight pricing launch** (website [#238](https://github.com/screenpipe/website/pull/238) `launch subscription pricing` + app [#3846](https://github.com/screenpipe/screenpipe/pull/3846) `gate app access behind subscription`).

## Pricing — before → after

**Before (removed/stale):**
```
- Lifetime: $400 one-time...
- Lifetime + Pro 1 year: $600 one-time...
- Pro subscription: $39/month...
- Teams: Custom pricing...
```
**After (matches website #238):**
```
Core engine + CLI are free and open source (MIT). Signed desktop app is a subscription:
- Standard:   $25/month        (local-first app)
- Pro:        $50/seat/month    (cloud sync, cloud AI, integrations; teams = 5+ seats self-serve)
- Enterprise: $150/seat/month   (managed deployment, SSO/SAML, MDM; sales-led)
Existing lifetime licenses remain valid; new lifetime purchases are no longer sold.
```

## Every change and its source of truth

| Fix | Was | Now | Verified against |
|-----|-----|-----|------------------|
| Pricing block + FAQ + comparison table | $400 lifetime / $600 / $39 Pro / "one-time" / "no subscription" | Standard $25 / Pro $50-seat / Enterprise $150-seat; lifetime grandfathered | website PR #238 + brain (060126 $150/seat motion; Gustaf/Joe "ship new pricing") |
| AI-powered search | "Semantic search using embeddings" | "Full-text keyword search (SQLite FTS5)" | engine uses FTS5; embeddings exist **only** for speaker-id (`calendar_speaker_id.rs`); content embeddings are a `future` TODO (`pipes/mod.rs:58`) |
| Built-in pipes | obsidian-sync / reminders / idea-tracker (none exist) | meeting-summary, day-recap, standup-update, time-breakdown, ai-prompt-journal, video-export | `crates/screenpipe-core/assets/pipes/` |
| Audio transcription | "OpenAI Whisper" | "Whisper (Large-V3-Turbo) locally, or Deepgram cloud" | `recording_config.rs:250` default `WhisperLargeV3Turbo` + Deepgram config |
| MCP snippet | `screenpipe-mcp` | `screenpipe-mcp@latest` | consistency with the install snippet |

## Notes
- All changes are inside the `<details>📖 LLM reference</details>` block (lines 156-373). Main README body untouched.
- Kept lifetime as grandfathered (still honored) per #238 — did **not** delete it.
- No data-sharing/training-rights copy: #238 explicitly excludes that for now.
- Scope is English `README.md`. The 6 `translated_readmes/*` still carry old pricing and want the same sweep as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)