### PR TITLE
fix(macos): resolve frontmost app via window server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8034,6 +8034,8 @@ dependencies = [
  "arc-swap",
  "chrono",
  "cidre 0.13.1",
+ "core-foundation 0.10.1",
+ "core-graphics",
  "crossbeam-channel",
  "dirs 5.0.1",
  "evdev",

--- a/crates/screenpipe-a11y/Cargo.toml
+++ b/crates/screenpipe-a11y/Cargo.toml
@@ -48,6 +48,11 @@ rusqlite = { version = "0.29", features = ["bundled"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 cidre = { version = "0.13", features = ["ax", "cg", "blocks", "ns", "app", "dispatch"] }
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSPasteboard"] }
+# Window-server queries (CGWindowListCopyWindowInfo) for frontmost-app
+# resolution — same versions as screenpipe-screen. cidre's cg module does not
+# bind the window-list API.
+core-foundation = "0.10"
+core-graphics = "0.24"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # Native Windows APIs - no rdev dependency

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -1407,22 +1407,145 @@ fn get_bool_attr(elem: &ax::UiElement, attr: &ax::Attr) -> Option<bool> {
     })
 }
 
+/// Frontmost application pid straight from the window server.
+///
+/// `CGWindowListCopyWindowInfo` performs a fresh window-server query on every
+/// call. That matters because the two obvious alternatives are both broken
+/// here:
+///
+/// - `NSWorkspace`/`NSRunningApplication.is_active` state is refreshed only
+///   when the **main thread** pumps an AppKit run loop. This daemon's main
+///   thread is a tokio runtime that never does, so those values freeze at
+///   whatever was frontmost at process start.
+/// - The system-wide `AXFocusedApplication` query goes stale on
+///   Chromium/Electron apps that haven't enabled accessibility yet (they
+///   never register with the AX server), so it keeps returning the
+///   previously focused app.
+///
+/// The frontmost app is the owner of the first layer-0 window in the
+/// front-to-back z-order. Layer 0 is the normal application-window layer;
+/// everything else (menu bar, Dock, overlays, notifications) sits on other
+/// layers. Works without Screen Recording permission — window *names* are
+/// redacted without it, but owner pid and layer are always present.
+fn frontmost_pid_via_window_server() -> Option<i32> {
+    use core_foundation::base::TCFType;
+    use core_foundation::number::CFNumber;
+    use core_foundation::string::CFString;
+    use core_graphics::window::{
+        copy_window_info, kCGNullWindowID, kCGWindowListExcludeDesktopElements,
+        kCGWindowListOptionOnScreenOnly,
+    };
+
+    let options = kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements;
+    let window_list = copy_window_info(options, kCGNullWindowID)?;
+    let count =
+        unsafe { core_foundation::array::CFArrayGetCount(window_list.as_concrete_TypeRef()) };
+    for i in 0..count {
+        unsafe {
+            let dict_ref = core_foundation::array::CFArrayGetValueAtIndex(
+                window_list.as_concrete_TypeRef(),
+                i,
+            );
+            if dict_ref.is_null() {
+                continue;
+            }
+            let dict = dict_ref as core_foundation::dictionary::CFDictionaryRef;
+
+            // Only layer-0 (normal app) windows count toward frontmost.
+            let layer_key = CFString::new("kCGWindowLayer");
+            let mut layer_val = std::ptr::null();
+            if core_foundation::dictionary::CFDictionaryGetValueIfPresent(
+                dict,
+                layer_key.as_concrete_TypeRef() as *const _,
+                &mut layer_val,
+            ) == 0
+                || layer_val.is_null()
+            {
+                continue;
+            }
+            let layer =
+                CFNumber::wrap_under_get_rule(layer_val as core_foundation::number::CFNumberRef)
+                    .to_i64()
+                    .unwrap_or(-1);
+            if layer != 0 {
+                continue;
+            }
+
+            let pid_key = CFString::new("kCGWindowOwnerPID");
+            let mut pid_val = std::ptr::null();
+            if core_foundation::dictionary::CFDictionaryGetValueIfPresent(
+                dict,
+                pid_key.as_concrete_TypeRef() as *const _,
+                &mut pid_val,
+            ) == 0
+                || pid_val.is_null()
+            {
+                continue;
+            }
+            if let Some(pid) =
+                CFNumber::wrap_under_get_rule(pid_val as core_foundation::number::CFNumberRef)
+                    .to_i64()
+            {
+                return Some(pid as i32);
+            }
+        }
+    }
+    None
+}
+
+/// Localized app name for a pid. `NSRunningApplication` objects created
+/// per-pid carry current launch-services info; the name is static for the
+/// process lifetime, so no staleness concern here (unlike `is_active`).
+fn app_name_for_pid(pid: i32) -> String {
+    ns::RunningApp::with_pid(pid)
+        .and_then(|app| app.localized_name())
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
 fn resolve_focused_ax_app() -> Option<(Retained<ax::UiElement>, i32, String)> {
+    // Resolve the real frontmost app from the window server first and use it
+    // to validate the AX answer. If the AX query is trusted unconditionally,
+    // a Chromium/Electron app that hasn't enabled accessibility yet is
+    // mis-resolved to the previously focused app: the walk produces frames
+    // attributed to the wrong app (or dedup-drops them entirely), and — worse
+    // — the AXManualAccessibility enable poke goes to the wrong pid, so the
+    // app never builds its tree and stays invisible forever.
+    let ws_pid = frontmost_pid_via_window_server();
+
     let sys = ax::UiElement::sys_wide();
     if let Ok(focused_app) = sys.focused_app() {
         if let Ok(pid) = focused_app.pid() {
-            let app_name = ns::RunningApp::with_pid(pid)
-                .and_then(|app| app.localized_name())
-                .map(|s| s.to_string())
-                .unwrap_or_default();
-            return Some((focused_app, pid, app_name));
+            if let Some(ws) = ws_pid {
+                if ws != pid {
+                    let app_name = app_name_for_pid(ws);
+                    debug!(
+                        "focused AX app stale: AX pid={} vs window-server pid={} app={}; using window server",
+                        pid, ws, app_name
+                    );
+                    return Some((ax::UiElement::with_app_pid(ws), ws, app_name));
+                }
+            }
+            return Some((focused_app, pid, app_name_for_pid(pid)));
         }
     }
 
-    // Electron apps can return no AXFocusedApplication even while NSWorkspace
-    // correctly reports them active. Build the app AX element from the active
-    // process pid so Obsidian/Discord can still be walked instead of falling
-    // straight to OCR.
+    // AX returned nothing (Electron apps can return no AXFocusedApplication
+    // even while genuinely frontmost) — the window-server pid alone is enough
+    // to build the app element and walk it instead of falling straight to OCR.
+    if let Some(ws) = ws_pid {
+        let app_name = app_name_for_pid(ws);
+        debug!(
+            "focused AX app fallback via window server: pid={} app={}",
+            ws, app_name
+        );
+        return Some((ax::UiElement::with_app_pid(ws), ws, app_name));
+    }
+
+    // Last resort: NSWorkspace active-app scan. Known limitation: this state
+    // freezes at process start on threads that never pump the main run loop,
+    // so it is kept only for the case where the window-server query itself
+    // failed (should be near-impossible in a GUI session).
     let workspace = ns::Workspace::shared();
     for app in workspace.running_apps().iter() {
         if !app.is_active() {

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2081,6 +2081,22 @@ fn get_focused_app_name_lightweight() -> Option<String> {
 fn query_frontmost_app_name_uncached() -> Option<String> {
     use cidre::{ax, ns, objc};
 
+    // Window server first: `get_frontmost_pid` does a fresh
+    // CGWindowListCopyWindowInfo query on every call. The NSWorkspace scan
+    // below freezes at process start on threads that never pump the main
+    // AppKit run loop (all of this daemon's threads), and the AX query goes
+    // stale on Chromium/Electron apps that haven't enabled accessibility.
+    if let Some(pid) = screenpipe_screen::capture_screenshot_by_window::get_frontmost_pid() {
+        let from_ws = objc::ar_pool(|| {
+            ns::RunningApp::with_pid(pid)
+                .and_then(|app| app.localized_name())
+                .map(|s| s.to_string())
+        });
+        if from_ws.as_deref().is_some_and(|n| !n.is_empty()) {
+            return from_ws;
+        }
+    }
+
     // Wrapped in an autorelease pool because `running_apps()` returns
     // autoreleased NSRunningApplication objects; without draining they
     // leak across polls (same precedent as get_frontmost_pid in

--- a/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
+++ b/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
@@ -388,11 +388,25 @@ struct WindowData {
 /// agree on which app is focused. Without this, each window.is_focused() call
 /// independently queries NSWorkspace, and the active app can change mid-iteration
 /// causing multiple apps to appear as "focused" simultaneously.
+///
+/// Sourced from the window server (first layer-0 window in front-to-back
+/// z-order) rather than NSWorkspace: `NSRunningApplication.is_active` is
+/// refreshed only when the main thread pumps an AppKit run loop, which never
+/// happens in this daemon — the NSWorkspace answer freezes at whatever app
+/// was frontmost at process start. The window-server query is fresh on every
+/// call. NSWorkspace is kept as a fallback for the (near-impossible) case
+/// where the window-list query fails.
 #[cfg(target_os = "macos")]
-fn get_frontmost_pid() -> Option<i32> {
-    // Wrap in autorelease pool — running_apps() returns autoreleased
-    // NSRunningApplication objects that accumulate on Rust threads
-    // (no automatic drain), causing ~800MB+ leak over hours.
+pub fn get_frontmost_pid() -> Option<i32> {
+    let (cg_windows, _) = get_cg_window_list();
+    if let Some(w) = cg_windows.iter().find(|w| w.layer == 0) {
+        return Some(w.pid);
+    }
+
+    // Fallback: NSWorkspace active-app scan (stale in long-running daemon
+    // threads — see doc comment). Wrap in autorelease pool — running_apps()
+    // returns autoreleased NSRunningApplication objects that accumulate on
+    // Rust threads (no automatic drain), causing ~800MB+ leak over hours.
     cidre::objc::ar_pool(|| {
         let workspace = cidre::ns::Workspace::shared();
         let apps = workspace.running_apps();


### PR DESCRIPTION
## description

**electron/chromium apps are silently invisible to screenpipe on macos — their frames are either attributed to the wrong app or dropped entirely, and the failure is permanent and self-sustaining.** this hits cursor, claude desktop, codex, antigravity, slack, discord, notion, obsidian — any chromium-based app, which for many users is most of their working day. on my machine, **cursor had 0 frames ever recorded** and 5 days of claude desktop / codex usage was either labelled `Google Chrome`/`Code` or missing outright. the user-visible symptom is "screenpipe doesn't see app X", with no error anywhere — you only find it by diffing the db against what you actually did.

### root cause (two independent bugs that lock each other in)

**bug 1 — the system-wide `AXFocusedApplication` query goes stale on chromium apps.** chromium ships with its accessibility tree disabled and only builds it when an assistive technology announces itself. an app with no AX tree never registers with macos's accessibility focus tracker, so `resolve_focused_ax_app()` (`screenpipe-a11y/src/tree/macos.rs`) keeps *succeeding* with the previously focused app. the walker then walks the **wrong app's** tree:

- if the stale app's tree is unchanged → identical content hash → content dedup silently drops every capture (i measured a 30s hole in `frames` while actively clicking in claude desktop)
- if the stale tree is thin → OCR of the real pixels gets stored under the **wrong `app_name`** (i have frames labelled `Google Chrome` whose text is plainly the antigravity editor)

worse: the `AXManualAccessibility` enable poke (the fix for #3002) is aimed using this same stale answer, so **it pokes the wrong pid and never reaches the chromium app — which therefore never builds its tree, never registers with AX focus, and stays invisible forever.** a perfect chicken-and-egg.

**bug 2 — the NSWorkspace fallback is frozen at process start.** `NSRunningApplication.is_active` (and `frontmostApplication`) only refresh when the **main thread pumps an AppKit run loop**. screenpipe's main thread is a tokio runtime that never does, so every `running_apps()` + `is_active()` scan in the daemon returns whatever was frontmost **when the process started** — forever. i verified this empirically: after restarting screenpipe while in system settings, every subsequent NSWorkspace answer was "System Settings" for the life of the process, across hours and dozens of real app switches. this affects `resolve_focused_ax_app`'s fallback, `get_focused_app_name_lightweight()` (`event_driven_capture.rs`), and `get_frontmost_pid()` (`capture_screenshot_by_window.rs`).

### the fix

resolve the frontmost app from the **window server**: `CGWindowListCopyWindowInfo` → owner pid of the first layer-0 window in front-to-back z-order. it is fresh on every call, needs no run loop, no AX registration, and no extra permission (pid + layer are returned even without screen recording). the codebase already trusts this exact query in `drm_detector.rs` and `get_cg_window_list()`.

applied to all three sites:
1. `resolve_focused_ax_app()` — window-server answer cross-checks the AX answer and wins on disagreement; AX result is kept when they agree (no behavior change for well-behaved apps). **this also fixes the poke targeting, which dissolves the chicken-and-egg**: the first time the user focuses a chromium app, the poke lands on the right pid, the tree materialises in ~1–3s, and capture works from then on.
2. `get_focused_app_name_uncached()` — window-server pid first, existing NSWorkspace/AX paths kept as fallbacks.
3. `get_frontmost_pid()` — reuses the existing `get_cg_window_list()`, NSWorkspace kept as fallback.

net: +173/−13 across 3 crates, no new public API, no behavior change when AX agrees with the window server.

related issue: #3002 (obsidian/discord falling back to OCR — same family; the NSWorkspace fallback added there is subject to bug 2, which this pr fixes)

## before

(screen recordings can't show this bug — the failure *is* missing/mislabeled data, so the database is the observable. all from a live machine, macos 26, single monitor:)

frames written while actively using antigravity — labelled chrome, content is the IDE:

```
id 83777 | app_name=Google Chrome | text: "Ask Gemini … EXPLORER ∨ MERIDIAN › .agents cargo .claude…"
id 83771 | app_name=Google Chrome | text: "…Antigravity - Settings  Try Antigravity 2.0→"
```

typing in cursor for 30s — every frame is a re-walk of the stale VS Code tree:

```
84104 | Code | install-from-bundle.sh — meridian | key_press   ← user was in cursor
84105 | Code | install-from-bundle.sh — meridian | key_press
```

actively clicking in claude desktop: **zero frames for 30 seconds** (dedup ate them all).

cursor, all time, before the fix: **0 frames**.

## after

cold-launched codex (plain, no flags, accessibility off) — first focus, same machine:

```
84905 | Codex | Codex | window_focus | accessibility_text = 47,360 chars
84906 | Codex | Codex | click        | accessibility_text = 36,412 chars
```

plain claude desktop relaunch: captured from the first click, 14k-char tree. six different apps correctly attributed within 60s of a daemon restart (the frozen-NSWorkspace scenario that previously stamped everything with one app).

a/b/a/b causality check on codex (launch plain → broken; launch with `--force-renderer-accessibility` → works; plain again → broken; flag again → works) pinned the mechanism before writing the fix; with this pr the plain launches behave like the flagged ones with no flags needed.

## how to test

1. on macos, with screenpipe recording, open any chromium app that doesn't force accessibility on (claude desktop and codex are reliable reproducers; or any electron app launched plainly) and click/type in it for ~30s
2. before this pr: `sqlite3 ~/.screenpipe/db.sqlite "select app_name, count(*) from frames where timestamp > datetime('now','-2 minutes') group by 1"` shows the app missing entirely or its activity counted under the previously focused app
3. with this pr: the app appears under its own name within seconds, and `length(accessibility_text)` grows to a full tree (tens of kB) after ~1–3s as the renderer materialises it
4. regression check (bug 2): restart screenpipe while one app is frontmost, then switch through several apps — attribution must follow you instead of freezing on the startup app
5. `cargo test -p screenpipe-a11y -p screenpipe-screen -p screenpipe-engine` and `cargo clippy` pass

## desktop app checklist (if applicable)

n/a — no `#[tauri::command]` or exported types touched; CLI/engine-only change.
