### PR TITLE
fix(a11y): stop Chromium/Electron phantom keystrokes by disabling the capture-path AX tree walk

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1818,10 +1818,31 @@ async fn do_capture(
         config.walk_timeout_override = Some(decision.timeout);
     }
 
-    let tree_walk_result = tokio::task::spawn_blocking(move || {
-        screenpipe_capture::paired_capture::walk_accessibility_tree(&config)
-    })
-    .await?;
+    // DISABLED: walking a Chromium/Electron app's AX tree makes the renderer
+    // enter accessibility mode, and when screenpipe disconnects (process exit or
+    // Ctrl+C) Chromium REPLAYS recently typed text into the focused field — the
+    // phantom-keystroke / on-close duplication bug (type "abcd", quit screenpipe,
+    // the focused field gains "bcdbcdbcd"). The poke is not the cause: even with
+    // AXEnhancedUserInterface never set, descending into the AXWebArea is enough
+    // to trip it. This walk was wired into the `record` capture path in c50423318
+    // (2026-05-22) — exactly when the duplication started; before that, `record`
+    // captured via OCR only and there was no phantom.
+    //
+    // Returning NotFound makes every frame fall through to the OCR safety net
+    // below — the pre-c50423318 behavior. Skipping only Chromium/Electron would
+    // keep native-app a11y, but missing a single Electron app re-triggers the bug
+    // (most desktop apps are Electron: Discord, Slack, Obsidian, VS Code, Hyper…),
+    // so we disable the deep walk outright. Re-enable only once Chromium stops
+    // replaying input on assistive-tech disconnect.
+    const AX_TREE_WALK_ENABLED: bool = false;
+    let tree_walk_result = if AX_TREE_WALK_ENABLED {
+        tokio::task::spawn_blocking(move || {
+            screenpipe_capture::paired_capture::walk_accessibility_tree(&config)
+        })
+        .await?
+    } else {
+        TreeWalkResult::NotFound
+    };
 
     // If the window was skipped (incognito/private browsing or user filter),
     // bail out entirely — don't OCR the screenshot.


### PR DESCRIPTION
## What

Typing into a Chromium/Electron app (Discord, Obsidian, Slack, VS Code, Arc, Hyper, Claude desktop, ...) and then stopping screenpipe (quit or Ctrl+C) duplicates the recently typed text into the focused field. Example: type `abcd`, quit screenpipe, the field becomes `abcdbcdbcd`.

## Root cause

Chromium only builds its DOM accessibility tree when it detects an assistive technology. Reading that tree (descending into the `AXWebArea`) makes the renderer enter "accessibility mode". When the assistive-tech client (the screenpipe process) then disconnects, Chromium handles the abrupt departure by REPLAYING recently buffered key events into the focused field. This is a long-standing Chromium/AppKit interaction, not a screenpipe input bug.

screenpipe walks the focused window's AX tree once per captured frame. For Chromium/Electron windows that walk descends into the web content, which is exactly the trigger. On shutdown the process disconnects and Chromium replays.

Dead ends ruled out during debugging (so reviewers don't repeat them):

- It is NOT the `AXEnhancedUserInterface` / `AXManualAccessibility` poke. With the poke fully disabled, merely reading the tree still triggers it.
- The flags cannot be cleared on shutdown to force a clean transition: `AXEnhancedUserInterface=false` returns `-25208` (kAXErrorNotImplemented) and `AXManualAccessibility=false` returns `-25205` (kAXErrorAttributeUnsupported) on most apps. Even when the set succeeds, the replay still happens.
- The per-keystroke focused-element read (`get_focused_element_context`) is NOT the trigger; it predates the bug by months. Only the full tree-walk descent into web content trips it.

## Regression bisect

- The `AXEnhancedUserInterface` poke landed 2026-04-17 (#3004) and ran for weeks with no phantom.
- `c50423318` (2026-05-22) wired the per-frame AX tree walk into the `record` / event-driven capture path. The duplication started right around then. Before that commit, `record` captured Chromium/Electron via OCR and there was no phantom.

## Fix

Disable the AX tree walk in the capture path. The result becomes `TreeWalkResult::NotFound`, which falls through to the existing OCR safety net, so every app is still captured (via OCR), exactly as `record` behaved before `c50423318`.

```
 [capture frame]
       |
       v
   AX tree walk  --(now DISABLED: returns NotFound)-->  OCR fallback  -->  text captured
       |
       |  (when enabled it descends into the Chromium AXWebArea,
       |   the renderer enters a11y mode, and on the next screenpipe
       v   disconnect Chromium replays the typed text = phantom)
   [phantom keystrokes]
```

Bonus: this also removes the per-frame tree-walk CPU/lag (#3789).

## Trade-off

a11y-tree text capture is off for all apps; content is captured via OCR instead (the pre-`c50423318` state). A more surgical version could skip the walk for Chromium/Electron only and keep native-app a11y, but reliable Electron detection without first touching the app's AX (which is itself the trigger) is the open problem, and missing one app re-introduces the bug. Disabling outright is the safe stop. It is gated behind `AX_TREE_WALK_ENABLED` for a one-line re-enable once Chromium stops replaying input on AT disconnect.

## Verification

- `cargo check -p screenpipe-engine` passes (the identical gate pattern also builds clean as a full binary).
- Behavioral note (important): local re-tests can still show duplication because a Chromium app stays in accessibility mode until its process restarts. Any poke/walk-enabled build run after the app launched re-flags that app, so the residue persists across later runs on the same process. To verify cleanly: fully quit the target app (or reboot), then run ONLY this build, type, and quit screenpipe. This change is mechanically incapable of the trigger (it never reads the tree) and restores the known-good pre-`c50423318` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
