### PR TITLE
feat(app): dev-only login helper to get past the gate without deep links

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -13,6 +13,7 @@ import {
   AppUser,
   hasAppEntitlement,
   isDevBillingBypassEnabled,
+  isDevLoginEnabled,
   needsAppEntitlementRefresh,
   normalizePlanLabel,
   PRICING_URL,
@@ -49,6 +50,9 @@ export function AppEntitlementGate({ children }: { children: React.ReactNode }) 
   const { settings, updateSettings, loadUser, isSettingsLoaded } = useSettings();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [refreshError, setRefreshError] = useState<string | null>(null);
+  const [devToken, setDevToken] = useState("");
+  const [devSubmitting, setDevSubmitting] = useState(false);
+  const [devError, setDevError] = useState<string | null>(null);
   const stoppedForGateRef = useRef(false);
   const autoVerifiedRef = useRef(false);
   const prevEntitledRef = useRef<boolean | null>(null);
@@ -121,6 +125,26 @@ export function AppEntitlementGate({ children }: { children: React.ReactNode }) 
     commands.openLoginWindow();
   }, [updateSettings]);
 
+  // Dev/preview only: deep links do not reach the `bun tauri dev` binary on
+  // macOS, so paste the login token (or the whole screenpipe://...api_key=...
+  // URL the browser tried to open) here to sign in without the OAuth callback.
+  const devLogin = useCallback(async () => {
+    const raw = devToken.trim();
+    if (!raw) return;
+    const match = raw.match(/[?&]api_key=([^&\s]+)/);
+    const token = match ? decodeURIComponent(match[1]) : raw;
+    setDevSubmitting(true);
+    setDevError(null);
+    try {
+      await loadUser(token, true);
+      setDevToken("");
+    } catch (err) {
+      setDevError(err instanceof Error ? err.message : "login failed");
+    } finally {
+      setDevSubmitting(false);
+    }
+  }, [devToken, loadUser]);
+
   // A signed-in user who is not yet entitled may have just paid, with the Stripe
   // webhook still in flight. Verify once against the server (Stripe fallback) so
   // they unlock without waiting for the next periodic poll.
@@ -145,6 +169,35 @@ export function AppEntitlementGate({ children }: { children: React.ReactNode }) 
       });
     }
   }, [devBypass, isEntitled, isSettingsLoaded]);
+
+  const devLoginBlock = isDevLoginEnabled() ? (
+    <div className="mt-5 border-t border-border pt-4">
+      <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-muted-foreground mb-2">
+        dev login
+      </p>
+      <input
+        value={devToken}
+        onChange={(e) => setDevToken(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void devLogin();
+        }}
+        placeholder="paste token or screenpipe://…api_key=…"
+        spellCheck={false}
+        className="w-full border border-border bg-background px-3 py-2 font-mono text-[11px] outline-none focus:border-foreground"
+      />
+      <Button
+        onClick={() => void devLogin()}
+        variant="secondary"
+        className="mt-2 w-full"
+        disabled={devSubmitting || !devToken.trim()}
+      >
+        {devSubmitting ? "signing in…" : "dev sign in"}
+      </Button>
+      {devError && (
+        <p className="mt-1 font-mono text-[11px] leading-5 text-destructive">{devError}</p>
+      )}
+    </div>
+  ) : null;
 
   if (!isSettingsLoaded) {
     return (
@@ -177,6 +230,7 @@ export function AppEntitlementGate({ children }: { children: React.ReactNode }) 
             choose plan
           </Button>
         </div>
+        {devLoginBlock}
       </EntitlementShell>
     );
   }
@@ -225,6 +279,7 @@ export function AppEntitlementGate({ children }: { children: React.ReactNode }) 
           </p>
         )}
       </div>
+      {devLoginBlock}
     </EntitlementShell>
   );
 }

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -85,6 +85,18 @@ export function isDevBillingBypassEnabled() {
   );
 }
 
+// Show the dev-only login helper (paste a token / screenpipe:// URL) when we are
+// not in a plain production build, i.e. dev, a forced gate, or pointed at a
+// non-prod website. Never shows in a normal prod release.
+export function isDevLoginEnabled() {
+  return (
+    process.env.NODE_ENV === "development" ||
+    process.env.TAURI_ENV_DEBUG === "true" ||
+    process.env.NEXT_PUBLIC_SCREENPIPE_FORCE_BILLING_GATE === "true" ||
+    !!process.env.NEXT_PUBLIC_SCREENPIPE_WEB_URL
+  );
+}
+
 function asEntitlement(entitlement: AppUser["entitlement"] | undefined): AppEntitlement | null {
   if (!entitlement || typeof entitlement !== "object" || Array.isArray(entitlement)) {
     return null;


### PR DESCRIPTION
Lets you sign in during `bun tauri dev` on macOS, where the `screenpipe://` OAuth callback can't reach the dev binary.

The gate now renders a **dev login** box (input + button) that accepts a bare token or the full `screenpipe://…?api_key=…` URL the browser tried to open, extracts the key, and calls `loadUser` directly.

Gated by `isDevLoginEnabled()` — only shows in dev / preview (`NEXT_PUBLIC_SCREENPIPE_WEB_URL`) / forced-gate builds, **never** a normal prod release.

Validation: tsc clean, next lint clean, vitest 7/7 (gate component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)