### PR TITLE
fix(a11y/macos): avoid main-queue deadlock in headless clipboard reads

### DIFF
--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -1578,6 +1578,36 @@ fn check_clipboard_crash_marker() {
     });
 }
 
+/// `true` when something drains the libdispatch main queue — i.e. the main
+/// thread runs an AppKit/tao runloop (the desktop app). In headless CLI mode
+/// (`screenpipe record`), main() is tokio's `block_on`: the main queue is
+/// never serviced, so a `dispatch_sync` hop onto it blocks forever (observed:
+/// clipboard worker parked in `_dispatch_thread_main_event_wait_slow` on the
+/// first Cmd+C, inflight marker left behind, dead-man switch tripping on the
+/// next launch — clipboard permanently disabled). Probed once per process:
+/// dispatch an async no-op and see whether it runs within 500ms. If the
+/// queue is dead the leaked block is harmless (it would only ever run at
+/// exit, sending on a closed channel).
+fn main_queue_alive() -> bool {
+    static ALIVE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ALIVE.get_or_init(|| {
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        cidre::dispatch::Queue::main().async_once(move || {
+            let _ = tx.send(());
+        });
+        let alive = rx
+            .recv_timeout(std::time::Duration::from_millis(500))
+            .is_ok();
+        if !alive {
+            tracing::info!(
+                "main dispatch queue not serviced (headless CLI) — clipboard reads \
+                 will run on the capture worker thread, guarded by the crash marker"
+            );
+        }
+        alive
+    })
+}
+
 fn get_clipboard() -> Option<String> {
     check_clipboard_crash_marker();
     if CLIPBOARD_DISABLED.load(std::sync::atomic::Ordering::Relaxed) {
@@ -1590,10 +1620,7 @@ fn get_clipboard() -> Option<String> {
     // case is we don't detect a crash next startup.
     let _ = std::fs::write(&inflight, std::process::id().to_string());
 
-    // dispatch_sync onto the main queue — the only thread where NSPasteboard
-    // is documented to behave. AppKit serializes pasteboard observers on
-    // main, so this side-steps the cache-invalidation race entirely.
-    let result = cidre::dispatch::Queue::main().sync_once(|| {
+    let read = || {
         let mut clipboard = arboard::Clipboard::new().ok()?;
         let text = clipboard.get_text().ok()?;
         if text.is_empty() {
@@ -1601,7 +1628,21 @@ fn get_clipboard() -> Option<String> {
         } else {
             Some(text)
         }
-    });
+    };
+
+    let result = if main_queue_alive() {
+        // dispatch_sync onto the main queue — the only thread where NSPasteboard
+        // is documented to behave. AppKit serializes pasteboard observers on
+        // main, so this side-steps the cache-invalidation race entirely.
+        cidre::dispatch::Queue::main().sync_once(read)
+    } else {
+        // Headless: no runloop drains the main queue, so the sync hop above
+        // would deadlock. Read on this worker thread instead — this re-exposes
+        // the off-main cache-invalidation race (arboard#218), but it's the only
+        // option without a main runloop, the window is microseconds, and the
+        // dead-man switch above catches a crash loop.
+        read()
+    };
 
     let _ = std::fs::remove_file(&inflight);
     result


### PR DESCRIPTION
## description

In headless CLI mode (`screenpipe record`), the first Cmd+C permanently breaks clipboard capture.

`get_clipboard()` hops onto the libdispatch **main queue** via `dispatch_sync` (introduced in c3598dc23 to fix the off-main NSPasteboard SIGSEGV). That's correct in the desktop app, where the main thread runs the runloop — but the CLI's main thread is `#[tokio::main]`'s `block_on`, so the main queue is never drained and the sync hop blocks forever. The clipboard worker hangs, no clipboard row is written, and `clipboard-read-inflight` is left behind — so on the next startup the dead-man switch promotes the stale marker to `clipboard-disabled-after-crash` and clipboard capture is silently disabled until the user manually deletes the file.

**Fix:** probe the main queue once per process (async no-op, 500ms timeout). Alive (desktop app) → keep the main-thread `sync_once` read, unchanged. Dead (headless CLI) → read the pasteboard on the worker thread. This re-exposes the off-main race from 1Password/arboard#218, but it's the only option without a main runloop, the window is microseconds per read, and the existing crash-marker dead-man switch backstops a crash loop. If the queue is dead, the leaked probe block is harmless (it could only run at process exit).

related issue: none filed — happy to open one if preferred.

## before

```
$ screenpipe record --disable-audio --disable-vision --data-dir /tmp/sp-test
# press Cmd+C with any text selected …

$ ls /tmp/sp-test/clipboard*
/tmp/sp-test/clipboard-read-inflight          # never cleaned up — worker hung
$ sqlite3 /tmp/sp-test/db.sqlite "SELECT count(*) FROM ui_events WHERE event_type='clipboard'"
0                                              # no clipboard row ever written
```

Sampled stack of the hung worker (100% of 1589 samples over 2s):

```
Thread: clipboard-capture
  _dispatch_sync_f_slow
    __DISPATCH_WAIT_FOR_QUEUE__
      _dispatch_thread_main_event_wait_slow   ← waiting for main thread to drain main queue
        __ulock_wait
```

Main thread at the same time: `pthread_cond_wait` inside tokio's `block_on` — never touches the dispatch main queue. On the next launch, the stale inflight marker is promoted to `clipboard-disabled-after-crash` → clipboard permanently off.

## after

```
$ screenpipe record --disable-audio --disable-vision --data-dir /tmp/sp-test
# log on first Cmd+C:
INFO screenpipe_a11y::platform::macos: main dispatch queue not serviced (headless CLI) — clipboard reads will run on the capture worker thread, guarded by the crash marker

$ sqlite3 /tmp/sp-test/db.sqlite "SELECT text_content FROM ui_events WHERE event_type='clipboard'"
CLIP-PATCH-VERIFY-67890                        # payload captured
$ ls /tmp/sp-test/clipboard*
zsh: no matches found                          # inflight marker cleaned up
```

Desktop app path unaffected: the probe succeeds there, so reads stay on the main thread exactly as today.

## how to test

1. `cargo build --release --bin screenpipe`, then `./target/release/screenpipe record --disable-audio --disable-vision --data-dir /tmp/sp-test --port 3042`
2. Copy any text (Cmd+C), wait ~2s
3. `sqlite3 /tmp/sp-test/db.sqlite "SELECT text_content FROM ui_events WHERE event_type='clipboard'"` → shows the copied text (before this patch: zero rows, and `/tmp/sp-test/clipboard-read-inflight` is left behind)
4. Desktop app regression check: copy/paste with the app running — behavior unchanged (probe succeeds → main-thread read)

### test status

`cargo test -p screenpipe-a11y --lib`: 166 passed, 3 failed — the 3 failures (`test_get_clipboard_{set_and_read,unicode,large_content}`) are **pre-existing and fail identically on unpatched `main`** (verified: 3 passed / 3 failed, same `None` assertion, baseline at f62ba66f4). They round-trip the real pasteboard from the test process, which doesn't work in a headless test environment on recent macOS — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)