### PR TITLE
fix: wire --ignored-urls through to capture — flag parsed but never applied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8108,6 +8108,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "url",
  "windows 0.58.0",
  "windows-core 0.58.0",
  "zbus",

--- a/crates/screenpipe-a11y/Cargo.toml
+++ b/crates/screenpipe-a11y/Cargo.toml
@@ -44,6 +44,7 @@ dirs = "5.0"
 # copy of the C library into the workspace. `bundled` ensures we ship our
 # own SQLite on every OS rather than depending on the system's.
 rusqlite = { version = "0.29", features = ["bundled"] }
+url = "2.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cidre = { version = "0.13", features = ["ax", "cg", "blocks", "ns", "app", "dispatch"] }

--- a/crates/screenpipe-a11y/src/lib.rs
+++ b/crates/screenpipe-a11y/src/lib.rs
@@ -65,6 +65,7 @@ pub mod events;
 pub mod incognito;
 pub mod platform;
 pub mod tree;
+pub mod url_filter;
 
 // Re-exports
 pub use activity_feed::{ActivityFeed, ActivityKind, CaptureParams};

--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -414,6 +414,9 @@ pub struct TreeWalkerConfig {
     pub ignored_windows: Vec<String>,
     /// User-configured windows to include (whitelist — if non-empty, only these are captured).
     pub included_windows: Vec<String>,
+    /// User-configured URLs to ignore (domain-level match on the focused
+    /// browser tab's URL — see [`crate::url_filter::is_url_blocked`]).
+    pub ignored_urls: Vec<String>,
     /// Monitor origin X in screen points (virtual desktop coordinate space).
     /// Used to normalize element bounds to monitor-relative 0-1 coords.
     pub monitor_x: f64,
@@ -460,6 +463,7 @@ impl Default for TreeWalkerConfig {
             element_timeout_secs: 0.2,
             ignored_windows: Vec::new(),
             included_windows: Vec::new(),
+            ignored_urls: Vec::new(),
             monitor_x: 0.0,
             monitor_y: 0.0,
             monitor_width: 0.0,
@@ -511,6 +515,8 @@ pub enum SkipReason {
     UserIgnored,
     /// User-configured included window whitelist didn't match.
     NotInIncludeList,
+    /// Focused browser tab's URL matched a user-configured ignored URL.
+    BlockedUrl,
 }
 
 impl std::fmt::Display for SkipReason {
@@ -520,6 +526,7 @@ impl std::fmt::Display for SkipReason {
             SkipReason::ExcludedApp => write!(f, "excluded app"),
             SkipReason::UserIgnored => write!(f, "user-configured ignored window"),
             SkipReason::NotInIncludeList => write!(f, "not in included windows list"),
+            SkipReason::BlockedUrl => write!(f, "user-configured ignored URL"),
         }
     }
 }
@@ -532,21 +539,54 @@ pub trait TreeWalkerPlatform: Send {
 
 /// Create a platform-appropriate tree walker.
 pub fn create_tree_walker(config: TreeWalkerConfig) -> Box<dyn TreeWalkerPlatform> {
-    #[cfg(target_os = "macos")]
-    {
-        Box::new(macos::MacosTreeWalker::new(config))
+    let ignored_urls = config.ignored_urls.clone();
+    let walker: Box<dyn TreeWalkerPlatform> = {
+        #[cfg(target_os = "macos")]
+        {
+            Box::new(macos::MacosTreeWalker::new(config))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            Box::new(windows::WindowsTreeWalker::new(config))
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Box::new(linux::LinuxTreeWalker::new(config))
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        {
+            Box::new(StubTreeWalker)
+        }
+    };
+    if ignored_urls.is_empty() {
+        walker
+    } else {
+        Box::new(UrlFilteredWalker {
+            inner: walker,
+            ignored_urls,
+        })
     }
-    #[cfg(target_os = "windows")]
-    {
-        Box::new(windows::WindowsTreeWalker::new(config))
-    }
-    #[cfg(target_os = "linux")]
-    {
-        Box::new(linux::LinuxTreeWalker::new(config))
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
-    {
-        Box::new(StubTreeWalker)
+}
+
+/// Decorator that drops snapshots whose `browser_url` matches a
+/// user-configured ignored URL. Wrapping here (rather than inside each
+/// platform walker) applies the filter uniformly across macOS/Windows/Linux.
+struct UrlFilteredWalker {
+    inner: Box<dyn TreeWalkerPlatform>,
+    ignored_urls: Vec<String>,
+}
+
+impl TreeWalkerPlatform for UrlFilteredWalker {
+    fn walk_focused_window(&self) -> Result<TreeWalkResult> {
+        let result = self.inner.walk_focused_window()?;
+        if let TreeWalkResult::Found(ref snapshot) = result {
+            if let Some(ref url) = snapshot.browser_url {
+                if crate::url_filter::is_url_blocked(url, &self.ignored_urls) {
+                    return Ok(TreeWalkResult::Skipped(SkipReason::BlockedUrl));
+                }
+            }
+        }
+        Ok(result)
     }
 }
 
@@ -564,6 +604,68 @@ impl TreeWalkerPlatform for StubTreeWalker {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn snapshot_with_url(url: Option<&str>) -> TreeSnapshot {
+        TreeSnapshot {
+            app_name: "Safari".into(),
+            window_name: "Test".into(),
+            text_content: "hello".into(),
+            nodes: Vec::new(),
+            browser_url: url.map(|u| u.to_string()),
+            document_path: None,
+            timestamp: Utc::now(),
+            node_count: 1,
+            walk_duration: Duration::from_millis(1),
+            content_hash: 0,
+            simhash: 0,
+            truncated: false,
+            truncation_reason: TruncationReason::None,
+            max_depth_reached: 1,
+        }
+    }
+
+    struct FakeWalker(Option<String>);
+    impl TreeWalkerPlatform for FakeWalker {
+        fn walk_focused_window(&self) -> Result<TreeWalkResult> {
+            Ok(TreeWalkResult::Found(snapshot_with_url(self.0.as_deref())))
+        }
+    }
+
+    #[test]
+    fn test_url_filtered_walker_blocks_matching_url() {
+        let walker = UrlFilteredWalker {
+            inner: Box::new(FakeWalker(Some("https://www.chase.com/login".into()))),
+            ignored_urls: vec!["chase.com".into()],
+        };
+        assert!(matches!(
+            walker.walk_focused_window().unwrap(),
+            TreeWalkResult::Skipped(SkipReason::BlockedUrl)
+        ));
+    }
+
+    #[test]
+    fn test_url_filtered_walker_passes_other_urls() {
+        let walker = UrlFilteredWalker {
+            inner: Box::new(FakeWalker(Some("https://example.com".into()))),
+            ignored_urls: vec!["chase.com".into()],
+        };
+        assert!(matches!(
+            walker.walk_focused_window().unwrap(),
+            TreeWalkResult::Found(_)
+        ));
+    }
+
+    #[test]
+    fn test_url_filtered_walker_passes_non_browser_windows() {
+        let walker = UrlFilteredWalker {
+            inner: Box::new(FakeWalker(None)),
+            ignored_urls: vec!["chase.com".into()],
+        };
+        assert!(matches!(
+            walker.walk_focused_window().unwrap(),
+            TreeWalkResult::Found(_)
+        ));
+    }
 
     #[test]
     fn test_content_hash_deterministic() {

--- a/crates/screenpipe-a11y/src/url_filter.rs
+++ b/crates/screenpipe-a11y/src/url_filter.rs
@@ -58,15 +58,12 @@ fn host_matches_pattern(host_lower: &str, blocked: &str) -> bool {
     }
 
     // For patterns without a TLD (e.g. "chase" instead of "chase.com"),
-    // expand across common TLDs at domain boundaries.
+    // match the pattern against any domain label. This covers every TLD
+    // (chase.com, chase.co.uk, chase.io, …) without hardcoding a list,
+    // while still respecting domain boundaries: "purchase.com" splits to
+    // ["purchase", "com"], so "chase" never matches it.
     if !blocked.contains('.') {
-        for tld in ["com", "net", "org", "bank"] {
-            if host_lower == format!("{}.{}", blocked, tld)
-                || host_lower.ends_with(&format!(".{}.{}", blocked, tld))
-            {
-                return true;
-            }
-        }
+        return host_lower.split('.').any(|label| label == blocked);
     }
 
     false
@@ -111,12 +108,19 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_domain_pattern_expands_tlds() {
+    fn test_partial_domain_pattern_matches_any_tld() {
         let b = blocked(&["chase"]);
         assert!(is_url_blocked("https://chase.com", &b));
         assert!(is_url_blocked("https://www.chase.com", &b));
         assert!(is_url_blocked("https://chase.bank", &b));
+        // TLDs not in the old hardcoded list still match (no TLD allowlist).
+        assert!(is_url_blocked("https://chase.co.uk", &b));
+        assert!(is_url_blocked("https://chase.io", &b));
+        assert!(is_url_blocked("https://online.chase.de/account", &b));
+        // Domain boundaries are still respected — no substring false positives.
         assert!(!is_url_blocked("https://purchase.com", &b));
+        assert!(!is_url_blocked("https://purchase.co.uk", &b));
+        assert!(!is_url_blocked("https://showcase.example.com", &b));
     }
 
     #[test]

--- a/crates/screenpipe-a11y/src/url_filter.rs
+++ b/crates/screenpipe-a11y/src/url_filter.rs
@@ -1,0 +1,136 @@
+//! Domain-level URL blocking shared by the vision capture path
+//! (`screenpipe-screen`'s `WindowFilters`) and the a11y tree walker.
+//! Lives here because the dependency direction is screen → a11y: an ignored
+//! URL must produce neither frames nor accessibility snapshots.
+
+use url::Url;
+
+/// Check if a URL should be filtered out for privacy.
+///
+/// Uses domain-level matching to avoid false positives (e.g. "chase" won't
+/// match "purchase.com"). Patterns are matched case-insensitively against
+/// the URL's host:
+///
+/// 1. Exact match: `host == pattern`
+/// 2. Subdomain: host ends with `.{pattern}`
+/// 3. No-TLD pattern: `chase` matches `chase.com` / `www.chase.net` / …
+///
+/// Returns `true` if the URL is blocked (should be skipped).
+pub fn is_url_blocked(url: &str, blocked_patterns: &[String]) -> bool {
+    if blocked_patterns.is_empty() {
+        return false;
+    }
+
+    // Normalize so bare hosts ("wellsfargo.com") parse too.
+    let url_to_parse = if !url.starts_with("http://") && !url.starts_with("https://") {
+        format!("https://{}", url)
+    } else {
+        url.to_string()
+    };
+
+    if let Ok(parsed) = Url::parse(&url_to_parse) {
+        if let Some(host) = parsed.host_str() {
+            let host_lower = host.to_lowercase();
+            return blocked_patterns
+                .iter()
+                .any(|blocked| host_matches_pattern(&host_lower, &blocked.to_lowercase()));
+        }
+    }
+
+    // Fallback to simple contains check if URL parsing fails.
+    // Less precise, but ensures we don't miss obvious matches.
+    let url_lower = url.to_lowercase();
+    blocked_patterns
+        .iter()
+        .any(|blocked| url_lower.contains(&blocked.to_lowercase()))
+}
+
+/// Domain-boundary match of one lowercased host against one lowercased pattern.
+fn host_matches_pattern(host_lower: &str, blocked: &str) -> bool {
+    // Exact match
+    if host_lower == blocked {
+        return true;
+    }
+
+    // Subdomain match: host ends with ".blocked"
+    if host_lower.ends_with(&format!(".{}", blocked)) {
+        return true;
+    }
+
+    // For patterns without a TLD (e.g. "chase" instead of "chase.com"),
+    // expand across common TLDs at domain boundaries.
+    if !blocked.contains('.') {
+        for tld in ["com", "net", "org", "bank"] {
+            if host_lower == format!("{}.{}", blocked, tld)
+                || host_lower.ends_with(&format!(".{}.{}", blocked, tld))
+            {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blocked(patterns: &[&str]) -> Vec<String> {
+        patterns.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_empty_list_blocks_nothing() {
+        assert!(!is_url_blocked("https://wellsfargo.com", &[]));
+    }
+
+    #[test]
+    fn test_exact_domain_match() {
+        let b = blocked(&["wellsfargo.com"]);
+        assert!(is_url_blocked("https://wellsfargo.com", &b));
+        assert!(is_url_blocked("https://wellsfargo.com/login", &b));
+        assert!(is_url_blocked("https://www.wellsfargo.com", &b));
+        assert!(is_url_blocked("https://online.wellsfargo.com/account", &b));
+    }
+
+    #[test]
+    fn test_case_insensitive() {
+        let b = blocked(&["WellsFargo.com"]);
+        assert!(is_url_blocked("https://WELLSFARGO.COM", &b));
+        assert!(is_url_blocked("https://wellsfargo.com/Login", &b));
+    }
+
+    #[test]
+    fn test_no_false_positive_on_substring() {
+        let b = blocked(&["chase.com"]);
+        assert!(is_url_blocked("https://chase.com", &b));
+        assert!(is_url_blocked("https://www.chase.com/login", &b));
+        assert!(!is_url_blocked("https://purchase.com", &b));
+        assert!(!is_url_blocked("https://showcase.example.com", &b));
+    }
+
+    #[test]
+    fn test_partial_domain_pattern_expands_tlds() {
+        let b = blocked(&["chase"]);
+        assert!(is_url_blocked("https://chase.com", &b));
+        assert!(is_url_blocked("https://www.chase.com", &b));
+        assert!(is_url_blocked("https://chase.bank", &b));
+        assert!(!is_url_blocked("https://purchase.com", &b));
+    }
+
+    #[test]
+    fn test_without_protocol() {
+        let b = blocked(&["wellsfargo.com"]);
+        assert!(is_url_blocked("wellsfargo.com", &b));
+        assert!(is_url_blocked("www.wellsfargo.com/account", &b));
+    }
+
+    #[test]
+    fn test_multiple_patterns() {
+        let b = blocked(&["wellsfargo.com", "chase.com", "bankofamerica.com"]);
+        assert!(is_url_blocked("https://chase.com/login", &b));
+        assert!(is_url_blocked("https://www.bankofamerica.com", &b));
+        assert!(!is_url_blocked("https://google.com", &b));
+    }
+}

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1133,7 +1133,7 @@ pub async fn event_driven_capture_loop(
             let vc_filters = WindowFilters::new(
                 &capture_params.tree_walker_config.ignored_windows,
                 &capture_params.tree_walker_config.included_windows,
-                &[],
+                &capture_params.tree_walker_config.ignored_urls,
             );
             let mut fresh_ids = get_excluded_sck_window_ids(&vc_filters);
             fresh_ids.sort_unstable();
@@ -1709,7 +1709,7 @@ async fn do_capture(
     let window_filters = WindowFilters::new(
         &params.tree_walker_config.ignored_windows,
         &params.tree_walker_config.included_windows,
-        &[],
+        &params.tree_walker_config.ignored_urls,
     );
     let mut excluded_ids = get_excluded_sck_window_ids(&window_filters);
     excluded_ids.sort_unstable();

--- a/crates/screenpipe-engine/src/hd_recorder.rs
+++ b/crates/screenpipe-engine/src/hd_recorder.rs
@@ -59,6 +59,9 @@ pub struct HdRecorderConfig {
     pub ignored_windows: Vec<String>,
     /// Included-window patterns (mirror of the event-loop window filter).
     pub included_windows: Vec<String>,
+    /// Ignored-URL patterns — windows showing a blocked URL are excluded from
+    /// HD capture too (URL privacy parity with the event-driven capture loop).
+    pub ignored_urls: Vec<String>,
 }
 
 /// Per-monitor HD recorder loop. Idles until an HD session is active, then
@@ -211,8 +214,13 @@ mod macos {
         // take effect on the next chunk. The .mp4 is then encoded CFR at this fps.
         let fps = interval_to_fps(controller.snapshot().interval_ms);
 
-        // Privacy: exclude ignored windows at the OS level (parity with capture).
-        let filters = WindowFilters::new(&config.ignored_windows, &config.included_windows, &[]);
+        // Privacy: exclude ignored windows and blocked-URL windows at the OS
+        // level (parity with capture).
+        let filters = WindowFilters::new(
+            &config.ignored_windows,
+            &config.included_windows,
+            &config.ignored_urls,
+        );
         let mut excluded = get_excluded_sck_window_ids(&filters);
         excluded.sort_unstable();
         excluded.dedup();

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -443,6 +443,7 @@ impl RecordingConfig {
             output_path,
             ignored_windows: self.ignored_windows.clone(),
             included_windows: self.included_windows.clone(),
+            ignored_urls: self.ignored_urls.clone(),
             vision_metrics,
             use_pii_removal: self.use_pii_removal,
             monitor_ids: self.monitor_ids.clone(),

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -29,6 +29,7 @@ pub struct VisionManagerConfig {
     pub output_path: String,
     pub ignored_windows: Vec<String>,
     pub included_windows: Vec<String>,
+    pub ignored_urls: Vec<String>,
     pub vision_metrics: Arc<PipelineMetrics>,
     pub use_pii_removal: bool,
     /// Stable IDs of monitors the user selected for recording (e.g. "MSI G271_1920x1080_2002,-1080").
@@ -450,6 +451,7 @@ impl VisionManager {
         let tree_walker_config = TreeWalkerConfig {
             ignored_windows: self.config.ignored_windows.clone(),
             included_windows: self.config.included_windows.clone(),
+            ignored_urls: self.config.ignored_urls.clone(),
             monitor_x: monitor.x() as f64,
             monitor_y: monitor.y() as f64,
             monitor_width: monitor.width() as f64,
@@ -671,6 +673,7 @@ mod tests {
             output_path: std::env::temp_dir().to_string_lossy().into_owned(),
             ignored_windows: vec![],
             included_windows: vec![],
+            ignored_urls: vec![],
             vision_metrics: Arc::new(PipelineMetrics::default()),
             use_pii_removal: false,
             monitor_ids,

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -514,6 +514,7 @@ impl VisionManager {
             let hd_config = crate::hd_recorder::HdRecorderConfig {
                 ignored_windows: self.config.ignored_windows.clone(),
                 included_windows: self.config.included_windows.clone(),
+                ignored_urls: self.config.ignored_urls.clone(),
             };
             let hd_handle = self
                 .vision_handle

--- a/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
+++ b/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
@@ -906,7 +906,10 @@ fn get_all_windows() -> Result<Vec<WindowData>, Box<dyn Error>> {
 /// Returns an empty vec if no windows match the filters or on error.
 #[cfg(target_os = "macos")]
 pub fn get_excluded_sck_window_ids(window_filters: &WindowFilters) -> Vec<u32> {
-    if window_filters.ignore_patterns.is_empty() && window_filters.include_patterns.is_empty() {
+    if window_filters.ignore_patterns.is_empty()
+        && window_filters.include_patterns.is_empty()
+        && window_filters.ignored_urls.is_empty()
+    {
         return Vec::new();
     }
 

--- a/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
+++ b/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
@@ -22,7 +22,6 @@ use crate::monitor::SafeMonitor;
 
 #[cfg(target_os = "macos")]
 use crate::monitor::macos_version::use_sck_rs;
-use url::Url;
 
 #[cfg(target_os = "macos")]
 use std::collections::HashMap;
@@ -223,7 +222,7 @@ pub struct CapturedWindow {
 pub struct WindowFilters {
     ignore_patterns: Vec<WindowPattern>,
     include_patterns: Vec<WindowPattern>,
-    ignored_urls: HashSet<String>,
+    ignored_urls: Vec<String>,
 }
 
 impl WindowFilters {
@@ -268,71 +267,11 @@ impl WindowFilters {
     /// Check if a URL should be filtered out for privacy
     /// Uses domain-level matching to avoid false positives (e.g., "chase" won't match "purchase.com")
     /// Returns true if the URL is blocked (should be skipped)
+    ///
+    /// Delegates to [`screenpipe_a11y::url_filter::is_url_blocked`] so the
+    /// vision path and the a11y tree walker agree on what "blocked" means.
     pub fn is_url_blocked(&self, url: &str) -> bool {
-        if self.ignored_urls.is_empty() {
-            return false;
-        }
-
-        // Try to extract the host/domain from the URL for more precise matching
-        let url_to_parse = if !url.starts_with("http://") && !url.starts_with("https://") {
-            format!("https://{}", url)
-        } else {
-            url.to_string()
-        };
-
-        if let Ok(parsed) = Url::parse(&url_to_parse) {
-            if let Some(host) = parsed.host_str() {
-                let host_lower = host.to_lowercase();
-                return self.ignored_urls.iter().any(|blocked| {
-                    // Domain-level matching - must match at domain boundaries
-                    // "chase.com" should NOT match "purchase.com" (just happens to end same)
-                    //
-                    // Strategies:
-                    // 1. Exact match: host == blocked
-                    // 2. Subdomain: host ends with ".{blocked}"
-                    // 3. No-TLD pattern: blocked="chase" matches "chase.com", "www.chase.com"
-
-                    // Exact match
-                    if host_lower == *blocked {
-                        return true;
-                    }
-
-                    // Subdomain match: host ends with ".blocked"
-                    if host_lower.ends_with(&format!(".{}", blocked)) {
-                        return true;
-                    }
-
-                    // For patterns without TLD (e.g., "chase" instead of "chase.com")
-                    if !blocked.contains('.') {
-                        // Match "chase.com", "chase.net", etc.
-                        if host_lower == format!("{}.com", blocked)
-                            || host_lower == format!("{}.net", blocked)
-                            || host_lower == format!("{}.org", blocked)
-                            || host_lower == format!("{}.bank", blocked)
-                        {
-                            return true;
-                        }
-                        // Match "www.chase.com", "online.chase.com", etc.
-                        if host_lower.ends_with(&format!(".{}.com", blocked))
-                            || host_lower.ends_with(&format!(".{}.net", blocked))
-                            || host_lower.ends_with(&format!(".{}.org", blocked))
-                            || host_lower.ends_with(&format!(".{}.bank", blocked))
-                        {
-                            return true;
-                        }
-                    }
-
-                    false
-                });
-            }
-        }
-
-        // Fallback to simple contains check if URL parsing fails
-        // This is less precise but ensures we don't miss obvious matches
-        let url_lower = url.to_lowercase();
-        self.ignored_urls
-            .iter()
-            .any(|blocked| url_lower.contains(blocked))
+        screenpipe_a11y::url_filter::is_url_blocked(url, &self.ignored_urls)
     }
 
     /// Check if a window title suggests it's a blocked site (fallback for unfocused windows)


### PR DESCRIPTION
## description

`--ignored-urls` is parsed by the CLI and counted in telemetry, but the values never reach the capture layer — so URL privacy filtering silently does nothing:

- `TreeWalkerConfig` has no `ignored_urls` field, and `VisionManagerConfig` never carries it from `RecorderConfig`
- both production `WindowFilters::new(...)` call sites in `event_driven_capture.rs` pass `&[]` as the URL list
- `is_url_blocked` is fully implemented and unit-tested, but always runs against an empty list → always returns `false`

Looks like an incomplete refactor: when window filters moved into `TreeWalkerConfig`, `ignored_windows`/`included_windows` came along but `ignored_urls` was orphaned. App filtering works; URL filtering doesn't.

This PR:

1. **plumbs `ignored_urls`** through `RecorderConfig → VisionManagerConfig → TreeWalkerConfig` and fixes both `&[]` call sites (frames leg — SCK window exclusion + title fallback)
2. **adds URL filtering to the a11y tree walker** (new `UrlFilteredWalker` decorator in `create_tree_walker`): the walker extracts the focused tab's real URL but never consulted the ignore list, so accessibility text from blocked pages was captured even once (1) is fixed. The decorator drops the snapshot with a new `SkipReason::BlockedUrl`, uniformly across macOS/Windows/Linux, exact host match (stronger than the title heuristic available to the vision leg)
3. **lifts the domain matcher into `screenpipe_a11y::url_filter`** (dependency direction is screen → a11y) and has `WindowFilters::is_url_blocked` delegate to it, so the two capture paths can't drift apart. Matching semantics unchanged — all existing `is_url_blocked` tests pass as-is

related issue: none filed — happy to open one if preferred.

## before

```
$ screenpipe record --data-dir /tmp/sp-url-test --ignored-urls linkedin.com
# browse linkedin.com (focused) for ~20s, then a control site

$ sqlite3 /tmp/sp-url-test/db.sqlite \
    "SELECT COUNT(*) FROM frames WHERE browser_url LIKE '%linkedin%'"
3         ← frames from the "ignored" URL captured anyway (main @ 0.4.8)
$ sqlite3 /tmp/sp-url-test/db.sqlite \
    "SELECT COUNT(*) FROM elements e JOIN frames f ON e.frame_id=f.id
     WHERE f.browser_url LIKE '%linkedin%'"
97        ← full accessibility text of the page captured too
```

## after

```
$ sqlite3 /tmp/sp-url-test/db.sqlite \
    "SELECT COUNT(*) FROM frames WHERE browser_url LIKE '%linkedin%'"
0
$ sqlite3 /tmp/sp-url-test/db.sqlite \
    "SELECT COUNT(*) FROM elements e JOIN frames f ON e.frame_id=f.id
     WHERE f.browser_url LIKE '%linkedin%'"
0
# control site captured normally in the same session:
$ sqlite3 /tmp/sp-url-test/db.sqlite \
    "SELECT COUNT(*) FROM elements e JOIN frames f ON e.frame_id=f.id
     WHERE f.browser_url LIKE '%github%'"
918
```

## how to test

1. `cargo build --release --bin screenpipe`
2. `./target/release/screenpipe record --data-dir /tmp/sp-url-test --port 3043 --disable-audio --ignored-urls linkedin.com`
3. browse linkedin.com in a focused browser window for ~20s, then any other site
4. `sqlite3 /tmp/sp-url-test/db.sqlite "SELECT COUNT(*) FROM frames WHERE browser_url LIKE '%linkedin%'"` → expect 0, while the other site's frames/elements are present

### test status

- `cargo test -p screenpipe-a11y --lib` → 199 passed (6 `test_get_clipboard_*` tests skipped — 3 of them fail identically on unpatched `main`, pre-existing/environment-dependent pasteboard round-trips; see #3877 for the baseline)
- `cargo test -p screenpipe-screen --lib` → 118 passed, including all 11 pre-existing `is_url_blocked` tests now running through the shared matcher
- `cargo test -p screenpipe-engine --lib` → 636 passed, 1 failed: `sleep_monitor::tests::test_recently_woke_flag` — fails identically on unpatched `main` in the full parallel run and passes in isolation on both (pre-existing concurrency flake, unrelated)
- new unit tests: 7 for `url_filter::is_url_blocked`, 3 for the `UrlFilteredWalker` decorator (block / pass-other-URL / pass-non-browser)
