### PR TITLE
fix: honor "pipe notifications" toggle on /notify route

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/notifications/routes.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/notifications/routes.rs
@@ -7,10 +7,41 @@
 use super::rewrite::rewrite_file_links;
 use super::store::{self, NotificationHistoryEntry};
 use crate::server::{ApiResponse, ServerState};
+use crate::store::SettingsStore;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
-use tracing::{error, info};
+use tauri::AppHandle;
+use tracing::{debug, error, info};
+
+/// Read `notificationPrefs.pipeNotifications` from the settings store.
+/// Default `true` (matches the frontend default). Missing store / parse
+/// failure also defaults to `true` — we'd rather show one extra toast
+/// than silently swallow pipe alerts when the store hiccups. Mirrors
+/// `display_changes_enabled` in `monitor_events.rs`.
+fn pipe_notifications_enabled(app: &AppHandle) -> bool {
+    let settings = match SettingsStore::get(app) {
+        Ok(Some(s)) => s,
+        _ => return true,
+    };
+    pipe_notifications_enabled_from_extra(&settings.extra)
+}
+
+/// Pure helper split out for unit testing — same fail-open semantics
+/// as `pipe_notifications_enabled` but operates directly on the
+/// settings `extra` map so tests don't need a Tauri `AppHandle`.
+fn pipe_notifications_enabled_from_extra(
+    extra: &std::collections::HashMap<String, serde_json::Value>,
+) -> bool {
+    let prefs = match extra.get("notificationPrefs") {
+        Some(p) => p,
+        None => return true,
+    };
+    prefs
+        .get("pipeNotifications")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
 
 /// `POST /notify` — show a notification panel and persist to disk.
 pub async fn send_notification(
@@ -23,6 +54,24 @@ pub async fn send_notification(
         .id
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let dismiss_ms = payload.auto_dismiss_ms.or(payload.timeout).unwrap_or(20000);
+    let resolved_type = payload
+        .notification_type
+        .clone()
+        .unwrap_or_else(|| "pipe".to_string());
+
+    // Gate pipe-typed alerts behind the `Pipe notifications` toggle.
+    // Other types (`system`, `captureStalls`, …) self-gate upstream
+    // before they reach `/notify`, so we let them through here to
+    // avoid double-blocking. Mirrors the display-change path which
+    // logs `notify: skipped (display-change toasts disabled)` and
+    // drops the event entirely (no history write, no panel).
+    if resolved_type == "pipe" && !pipe_notifications_enabled(&state.app_handle) {
+        debug!("notify: skipped (pipe notifications disabled)");
+        return Ok(Json(ApiResponse {
+            success: true,
+            message: "pipe notifications disabled".to_string(),
+        }));
+    }
 
     // Rewrite file-path markdown links to screenpipe://view?path=… so they
     // open in the in-app viewer instead of the OS default app (Xcode for
@@ -31,7 +80,7 @@ pub async fn send_notification(
 
     let panel_payload = serde_json::json!({
         "id": panel_id,
-        "type": payload.notification_type.unwrap_or_else(|| "pipe".to_string()),
+        "type": resolved_type,
         "title": payload.title,
         "body": body,
         "actions": payload.actions,
@@ -127,4 +176,59 @@ pub struct NotifyPayload {
     pub timeout: Option<u64>,
     #[serde(default)]
     pub actions: Vec<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn extra_with(prefs: serde_json::Value) -> HashMap<String, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("notificationPrefs".to_string(), prefs);
+        m
+    }
+
+    #[test]
+    fn gate_defaults_true_when_prefs_missing() {
+        let extra: HashMap<String, serde_json::Value> = HashMap::new();
+        assert!(pipe_notifications_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_defaults_true_when_key_missing() {
+        let extra = extra_with(json!({ "displayChanges": false }));
+        assert!(pipe_notifications_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_defaults_true_when_value_not_bool() {
+        // Parse failure / wrong type → fail open. Better one extra toast
+        // than silently swallowing a pipe alert.
+        let extra = extra_with(json!({ "pipeNotifications": "yes" }));
+        assert!(pipe_notifications_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_respects_explicit_false() {
+        let extra = extra_with(json!({ "pipeNotifications": false }));
+        assert!(!pipe_notifications_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_respects_explicit_true() {
+        let extra = extra_with(json!({ "pipeNotifications": true }));
+        assert!(pipe_notifications_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn other_toggles_do_not_affect_pipe_gate() {
+        // displayChanges=false should NOT silence pipe notifications.
+        let extra = extra_with(json!({
+            "displayChanges": false,
+            "pipeNotifications": true,
+        }));
+        assert!(pipe_notifications_enabled_from_extra(&extra));
+    }
 }


### PR DESCRIPTION
### Description:

Fixes #3879 

- before: when notification pipes toggle is off: system and pipes both notification working and i.e. wrong/bug.


https://github.com/user-attachments/assets/e0b87f72-d77c-4971-b2ea-af2d797bc524



- after: Shown demo of pipes and system both notification working when toogle on & when notification toggle off only system notification will work.


https://github.com/user-attachments/assets/3319ef50-7659-4f84-a4d6-74b50c44a4dc

- tests passing:


<img width="965" height="381" alt="image" src="https://github.com/user-attachments/assets/802186d2-6e3b-43c2-95ed-04df7939076e" />



The `Pipe notifications` toggle in Settings → Notifications was ignored — pipes POSTing to `localhost:11435/notify` always showed the native panel; this PR gates the `/notify` route on `notificationPrefs.pipeNotifications` (matching the display-change path), so turning the toggle off now actually suppresses pipe alerts.