### PR TITLE
fix(e2e): target deep-link login at home window only (zz-logout-resurrect flake)

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/zz-logout-resurrect.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-logout-resurrect.spec.ts
@@ -45,20 +45,37 @@ import { openHomeWindow, waitForAppReady, waitForTestId, t } from "../helpers/te
 const FAKE_TOKEN = "e2e-fake-token-logout-resurrect";
 const FAKE_EMAIL = "e2e-logout@screenpipe.test";
 
-/** Emit a deep-link over the global Tauri bus (same path the chat / updater
- *  specs use). Returns once the emit promise settles. */
+/** Emit a deep-link to the HOME window only, via emitTo (not the global emit).
+ *
+ *  Why targeted, not broadcast: every window mounts the deep-link handler, and
+ *  the login handler calls loadUser(api_key) (components/deeplink-handler.tsx).
+ *  A global emit therefore fires loadUser in EVERY window. Only the home window
+ *  has our /api/user mock; the others hit the real network with the fake token,
+ *  get a 401, and the auth interceptor broadcasts "screenpipe-auth-signout",
+ *  which writes user:null into the shared settings store and clears the
+ *  freshly-logged-in home window too. On slow CI that 401 lands between our
+ *  "logged in" wait and the email assertion, so Phase A flapped to
+ *  "not logged in" (~50% failure, Windows worst, also seen on Linux).
+ *
+ *  Targeting "home" keeps every loadUser in the one mocked window — the
+ *  in-flight-loadUser resurrection race this spec guards is per-window anyway
+ *  (home fires the slow loadUser, home clicks logout, home's generation guard
+ *  must abort the late write), so coverage is unchanged. Returns once the emit
+ *  promise settles. */
 async function emitDeepLink(url: string): Promise<void> {
   const emitErr = (await browser.executeAsync(
     (payload: string, done: (v?: unknown) => void) => {
       const g = globalThis as unknown as {
-        __TAURI__?: { event?: { emit: (n: string, p: unknown) => Promise<unknown> } };
+        __TAURI__?: {
+          event?: { emitTo?: (target: string, n: string, p: unknown) => Promise<unknown> };
+        };
       };
-      const emit = g.__TAURI__?.event?.emit;
-      if (!emit) {
-        done("global __TAURI__.event.emit unavailable");
+      const emitTo = g.__TAURI__?.event?.emitTo;
+      if (!emitTo) {
+        done("global __TAURI__.event.emitTo unavailable");
         return;
       }
-      void emit("deep-link-received", payload)
+      void emitTo("home", "deep-link-received", payload)
         .then(() => done(null))
         .catch((e: unknown) => done(String(e)));
     },
@@ -130,30 +147,6 @@ async function userFetchCalls(): Promise<number> {
   )) as number;
 }
 
-/** Run `fn` in every open window, then restore focus to the starting window.
- *
- *  Why this matters: the deep-link login broadcasts loadUser() to EVERY window
- *  (the handler is mounted per-window). A window that lacks our /api/user mock
- *  hits the real network with the fake token, gets a 401, and the auth
- *  interceptor (lib/auth-guard.tsx) reacts by broadcasting a cross-window
- *  "screenpipe-auth-signout" — which clears the freshly-logged-in HOME window
- *  too. On slow Windows CI that 401 can land between our "logged in as" wait and
- *  the email assertion, so Phase A flaps to "not logged in" (~50% Windows-only
- *  failure). Installing the mock in every window removes the only source of a
- *  real 401, making Phase A deterministic. */
-async function forEachWindow(fn: () => Promise<void>): Promise<void> {
-  const start = await browser.getWindowHandle();
-  for (const handle of await browser.getWindowHandles()) {
-    try {
-      await browser.switchToWindow(handle);
-      await fn();
-    } catch {
-      // window may be transient/native or lack a webview context — best-effort
-    }
-  }
-  await browser.switchToWindow(start).catch(() => {});
-}
-
 async function loginStatusText(): Promise<string> {
   const el = await waitForTestId("account-login-status", 8000);
   return (await el.getText()).toLowerCase();
@@ -176,10 +169,7 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
   before(async () => {
     await waitForAppReady();
     await openHomeWindow();
-    // Mock /api/user in EVERY window, not just home — otherwise a foreign
-    // window's loadUser 401s the fake token and signs the whole app back out
-    // mid-login (see forEachWindow doc + Windows-CI flake).
-    await forEachWindow(() => tuneUserFetchMock(0, FAKE_EMAIL));
+    await tuneUserFetchMock(0, FAKE_EMAIL);
     await openAccountSettings();
   });
 
@@ -194,9 +184,7 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
     } catch {
       // best-effort
     }
-    // Restore fetch in every window we patched so the fake /api/user mock
-    // can't leak into the next spec in the shared session.
-    await forEachWindow(restoreFetch).catch(() => {});
+    await restoreFetch().catch(() => {});
     await browser.execute(() => window.location.reload());
     await browser
       .waitUntil(
@@ -213,10 +201,10 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
     // ── Phase A: log in (fast mock) so the logout button is present ──────────
     await tuneUserFetchMock(0, FAKE_EMAIL);
     await emitDeepLink(`screenpipe://login?api_key=${FAKE_TOKEN}`);
-    // Wait for the login to land AND carry the fake email. Polling the full
-    // condition (not just "logged in as") means a one-frame settle can't slip a
-    // stale status into the assertion below — this is Phase A setup, the real
-    // regression assertion lives in Phase B.
+    // Poll the FULL condition (status carries the fake email), not just
+    // "logged in as", so a one-frame settle can't slip a stale status into the
+    // assertion below. Phase A is setup; the real regression assertion is in
+    // Phase B.
     await browser.waitUntil(
       async () => (await loginStatusText()).includes(FAKE_EMAIL.toLowerCase()),
       {

--- a/apps/screenpipe-app-tauri/e2e/specs/zz-logout-resurrect.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-logout-resurrect.spec.ts
@@ -130,6 +130,30 @@ async function userFetchCalls(): Promise<number> {
   )) as number;
 }
 
+/** Run `fn` in every open window, then restore focus to the starting window.
+ *
+ *  Why this matters: the deep-link login broadcasts loadUser() to EVERY window
+ *  (the handler is mounted per-window). A window that lacks our /api/user mock
+ *  hits the real network with the fake token, gets a 401, and the auth
+ *  interceptor (lib/auth-guard.tsx) reacts by broadcasting a cross-window
+ *  "screenpipe-auth-signout" — which clears the freshly-logged-in HOME window
+ *  too. On slow Windows CI that 401 can land between our "logged in as" wait and
+ *  the email assertion, so Phase A flaps to "not logged in" (~50% Windows-only
+ *  failure). Installing the mock in every window removes the only source of a
+ *  real 401, making Phase A deterministic. */
+async function forEachWindow(fn: () => Promise<void>): Promise<void> {
+  const start = await browser.getWindowHandle();
+  for (const handle of await browser.getWindowHandles()) {
+    try {
+      await browser.switchToWindow(handle);
+      await fn();
+    } catch {
+      // window may be transient/native or lack a webview context — best-effort
+    }
+  }
+  await browser.switchToWindow(start).catch(() => {});
+}
+
 async function loginStatusText(): Promise<string> {
   const el = await waitForTestId("account-login-status", 8000);
   return (await el.getText()).toLowerCase();
@@ -152,7 +176,10 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
   before(async () => {
     await waitForAppReady();
     await openHomeWindow();
-    await tuneUserFetchMock(0, FAKE_EMAIL);
+    // Mock /api/user in EVERY window, not just home — otherwise a foreign
+    // window's loadUser 401s the fake token and signs the whole app back out
+    // mid-login (see forEachWindow doc + Windows-CI flake).
+    await forEachWindow(() => tuneUserFetchMock(0, FAKE_EMAIL));
     await openAccountSettings();
   });
 
@@ -167,7 +194,9 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
     } catch {
       // best-effort
     }
-    await restoreFetch().catch(() => {});
+    // Restore fetch in every window we patched so the fake /api/user mock
+    // can't leak into the next spec in the shared session.
+    await forEachWindow(restoreFetch).catch(() => {});
     await browser.execute(() => window.location.reload());
     await browser
       .waitUntil(
@@ -184,11 +213,18 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
     // ── Phase A: log in (fast mock) so the logout button is present ──────────
     await tuneUserFetchMock(0, FAKE_EMAIL);
     await emitDeepLink(`screenpipe://login?api_key=${FAKE_TOKEN}`);
-    await browser.waitUntil(async () => (await loginStatusText()).includes("logged in as"), {
-      timeout: t(15_000),
-      interval: 250,
-      timeoutMsg: "did not log in via synthetic deep link",
-    });
+    // Wait for the login to land AND carry the fake email. Polling the full
+    // condition (not just "logged in as") means a one-frame settle can't slip a
+    // stale status into the assertion below — this is Phase A setup, the real
+    // regression assertion lives in Phase B.
+    await browser.waitUntil(
+      async () => (await loginStatusText()).includes(FAKE_EMAIL.toLowerCase()),
+      {
+        timeout: t(15_000),
+        interval: 250,
+        timeoutMsg: "did not log in via synthetic deep link",
+      },
+    );
     expect(await loginStatusText()).toContain(FAKE_EMAIL.toLowerCase());
 
     // Let the post-login auto-refresh loadUser (also fast) settle before we


### PR DESCRIPTION
## Problem

`zz-logout-resurrect.spec.ts` failed intermittently on **E2E** — ~50% on Windows, occasionally on Linux, never on macOS — always at the **Phase A login setup** (`:192`):

```
Expected substring: "e2e-logout@screenpipe.test"
Received string:    "not logged in"
```

It has been flaky since it landed (passed on 3 of the last 7 main commits, failed on 4), so it reds `main`'s E2E roughly every other merge.

## Root cause (a real cross-window race)

The deep-link login used a **global `emit`**, so every window's deep-link handler ran `loadUser(api_key)`:

```
 deep-link login (global emit, fake token)
        |
        +--> HOME window:    loadUser -> /api/user  [MOCKED 200]  -> "logged in as e2e-logout@..."   <- waitUntil passes
        |
        +--> FOREIGN windows: loadUser -> /api/user  [REAL net]   -> 401
                                                          |
                                   auth interceptor: clearSession() + emit "screenpipe-auth-signout"
                                                          |
                                   writes user:null into the SHARED settings store (settingsStore.listen)
                                                          |
                                   HOME window clears -> "not logged in"   <- line 192 reads this, FAILS
```

On slower CI the foreign-window 401 lands between the `waitUntil("logged in")` and the email assertion, so Phase A flaps to logged-out.

## Fix

Emit the deep-link with **`emitTo("home", ...)`** instead of the global `emit`, so every `loadUser` stays in the one window that has the `/api/user` mock. No foreign 401, no cross-window sign-out, **no window switching**.

The resurrection race this spec guards is per-window (home fires the slow `loadUser`, home clicks logout, home's generation guard must abort the late write), so coverage is unchanged. Also polls Phase A for the email itself (not just "logged in as") as defense in depth.

Test-only change. No product code touched.

> Note: an earlier push tried mocking `/api/user` in every window by switching WebDriver windows — that poisoned the shared session (hung the after-hook, cascaded `Failed to create a session`). Reverted in favor of this targeted-emit approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)