### PR TITLE
fix: honor Windows OCR language selection

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -3052,7 +3052,7 @@ pub async fn perform_ocr_on_image(
         OcrEngine::AppleNative => screenpipe_screen::perform_ocr_apple(&img, &languages),
         OcrEngine::Tesseract => screenpipe_screen::perform_ocr_tesseract(&img, languages),
         #[cfg(target_os = "windows")]
-        OcrEngine::WindowsNative => screenpipe_screen::perform_ocr_windows(&img)
+        OcrEngine::WindowsNative => screenpipe_screen::perform_ocr_windows(&img, &languages)
             .await
             .map_err(|e| format!("windows ocr failed: {}", e))?,
         _ => return Err("unsupported ocr engine".to_string()),

--- a/crates/screenpipe-capture/src/paired_capture.rs
+++ b/crates/screenpipe-capture/src/paired_capture.rs
@@ -179,7 +179,7 @@ pub async fn paired_capture(
         // Windows native OCR is async, so call it directly (not inside spawn_blocking)
         #[cfg(target_os = "windows")]
         let raw = {
-            match screenpipe_screen::perform_ocr_windows(&ctx.image).await {
+            match screenpipe_screen::perform_ocr_windows(&ctx.image, &ctx.languages).await {
                 Ok((text, json, _confidence)) => (text, json),
                 Err(e) => {
                     warn!("windows OCR failed: {}", e);

--- a/crates/screenpipe-engine/src/routes/frames.rs
+++ b/crates/screenpipe-engine/src/routes/frames.rs
@@ -964,7 +964,7 @@ pub async fn run_frame_ocr(
     .unwrap_or_else(|_| (String::new(), "[]".to_string()));
 
     #[cfg(target_os = "windows")]
-    let ocr_result = match screenpipe_screen::perform_ocr_windows(&image).await {
+    let ocr_result = match screenpipe_screen::perform_ocr_windows(&image, &[]).await {
         Ok((text, json, _confidence)) => (text, json),
         Err(e) => {
             error!("Windows on-demand OCR failed: {}", e);

--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -90,6 +90,7 @@ xcap = { version = "0.9", features = ["wgc"] }
 uiautomation = { version = "0.16.1" }
 windows = { version = "0.58", features = [
   "Graphics_Imaging",
+  "Globalization",
   "Media_Ocr",
   "Storage",
   "Storage_Streams",

--- a/crates/screenpipe-screen/benches/ocr_benchmark.rs
+++ b/crates/screenpipe-screen/benches/ocr_benchmark.rs
@@ -169,7 +169,8 @@ fn bench_windows_ocr(c: &mut Criterion) {
 
                     for _ in 0..iters {
                         let start = std::time::Instant::now();
-                        let (result, _, _) = perform_ocr_windows(black_box(&image)).await.unwrap();
+                        let (result, _, _) =
+                            perform_ocr_windows(black_box(&image), &[]).await.unwrap();
                         total_duration += start.elapsed();
 
                         let accuracy = calculate_accuracy(&result, EXPECTED_KEYWORDS);

--- a/crates/screenpipe-screen/src/core.rs
+++ b/crates/screenpipe-screen/src/core.rs
@@ -555,7 +555,7 @@ async fn perform_ocr_with_engine(
             .map_err(|e| ContinuousCaptureError::ErrorProcessingOcr(e.to_string())),
         OcrEngine::Tesseract => Ok(perform_ocr_tesseract(image, languages)),
         #[cfg(target_os = "windows")]
-        OcrEngine::WindowsNative => perform_ocr_windows(image)
+        OcrEngine::WindowsNative => perform_ocr_windows(image, &languages)
             .await
             .map_err(|e| ContinuousCaptureError::ErrorProcessingOcr(e.to_string())),
         #[cfg(target_os = "macos")]

--- a/crates/screenpipe-screen/src/lib.rs
+++ b/crates/screenpipe-screen/src/lib.rs
@@ -7,7 +7,7 @@ pub mod apple;
 pub mod core;
 pub mod custom_ocr;
 pub mod frame_comparison;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", test))]
 pub mod microsoft;
 pub mod monitor;
 #[cfg(target_os = "windows")]

--- a/crates/screenpipe-screen/src/microsoft.rs
+++ b/crates/screenpipe-screen/src/microsoft.rs
@@ -5,6 +5,7 @@ use screenpipe_core::Language;
 
 #[cfg(target_os = "windows")]
 use windows::{
+    core::HSTRING,
     Globalization::Language as WindowsLanguage,
     Graphics::Imaging::BitmapDecoder,
     Media::Ocr::OcrEngine as WindowsOcrEngine,
@@ -172,7 +173,8 @@ fn create_windows_ocr_engine_for_requested_languages(
 
 #[cfg(target_os = "windows")]
 fn try_create_windows_ocr_engine_for_tag(tag: &str) -> Result<Option<WindowsOcrEngine>> {
-    let language = WindowsLanguage::CreateLanguage(tag)?;
+    let language_tag = HSTRING::from(tag);
+    let language = WindowsLanguage::CreateLanguage(&language_tag)?;
     if !WindowsOcrEngine::IsLanguageSupported(&language)? {
         return Ok(None);
     }

--- a/crates/screenpipe-screen/src/microsoft.rs
+++ b/crates/screenpipe-screen/src/microsoft.rs
@@ -1,14 +1,22 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use image::{DynamicImage, GenericImageView};
+#[cfg(any(target_os = "windows", test))]
+use screenpipe_core::Language;
 
 #[cfg(target_os = "windows")]
-pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String, Option<f64>)> {
+use windows::{
+    Globalization::Language as WindowsLanguage,
+    Graphics::Imaging::BitmapDecoder,
+    Media::Ocr::OcrEngine as WindowsOcrEngine,
+    Storage::Streams::{DataWriter, InMemoryRandomAccessStream},
+};
+
+#[cfg(target_os = "windows")]
+pub async fn perform_ocr_windows(
+    image: &DynamicImage,
+    languages: &[Language],
+) -> Result<(String, String, Option<f64>)> {
     use std::io::Cursor;
-    use windows::{
-        Graphics::Imaging::BitmapDecoder,
-        Media::Ocr::OcrEngine as WindowsOcrEngine,
-        Storage::Streams::{DataWriter, InMemoryRandomAccessStream},
-    };
 
     // Check image dimensions
     let (width, height) = image.dimensions();
@@ -34,7 +42,11 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String
 
     let bitmap = decoder.GetSoftwareBitmapAsync()?.get()?;
 
-    let engine = WindowsOcrEngine::TryCreateFromUserProfileLanguages()?;
+    let (engine, recognizer_language) = create_windows_ocr_engine(languages)?;
+    tracing::debug!(
+        "windows OCR using recognizer language: {}",
+        recognizer_language
+    );
     let result = engine.RecognizeAsync(&bitmap)?.get()?;
 
     let mut full_text = String::new();
@@ -78,4 +90,202 @@ pub async fn perform_ocr_windows(image: &DynamicImage) -> Result<(String, String
     let json_output = serde_json::to_string(&ocr_results).unwrap_or_else(|_| "[]".to_string());
 
     Ok((full_text, json_output, Some(1.0)))
+}
+
+#[cfg(target_os = "windows")]
+fn create_windows_ocr_engine(languages: &[Language]) -> Result<(WindowsOcrEngine, String)> {
+    if !languages.is_empty() {
+        return create_windows_ocr_engine_for_requested_languages(languages);
+    }
+
+    match WindowsOcrEngine::TryCreateFromUserProfileLanguages() {
+        Ok(engine) => {
+            let tag = recognizer_language_tag(&engine);
+            Ok((engine, tag))
+        }
+        Err(profile_err) => {
+            let available_tags = available_windows_ocr_language_tags().unwrap_or_default();
+            if available_tags.is_empty() {
+                return Err(anyhow!(
+                    "Windows OCR unavailable: no OCR recognizer languages are installed. \
+                     Install a Windows OCR language pack in Settings > Time & language > Language & region. \
+                     User profile engine creation failed: {}",
+                    profile_err
+                ));
+            }
+
+            for tag in &available_tags {
+                if let Some(engine) = try_create_windows_ocr_engine_for_tag(tag)? {
+                    tracing::debug!(
+                        "windows OCR user profile languages did not create an engine; falling back to installed recognizer language: {}",
+                        tag
+                    );
+                    return Ok((engine, tag.clone()));
+                }
+            }
+
+            Err(anyhow!(
+                "Windows OCR unavailable: user profile languages do not match any installed OCR recognizer. \
+                 Available Windows OCR recognizer languages: {}. \
+                 User profile engine creation failed: {}",
+                format_available_tags(&available_tags),
+                profile_err
+            ))
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn create_windows_ocr_engine_for_requested_languages(
+    languages: &[Language],
+) -> Result<(WindowsOcrEngine, String)> {
+    let available_tags = available_windows_ocr_language_tags().unwrap_or_default();
+    let mut attempted_tags: Vec<&'static str> = Vec::new();
+
+    for language in languages {
+        for tag in windows_language_tags_for(language) {
+            if attempted_tags.contains(&tag) {
+                continue;
+            }
+            attempted_tags.push(tag);
+
+            if let Some(engine) = try_create_windows_ocr_engine_for_tag(tag)? {
+                return Ok((engine, tag.to_string()));
+            }
+        }
+    }
+
+    Err(anyhow!(
+        "Windows OCR unavailable for requested language(s): {}. \
+         Tried Windows language tag(s): {}. \
+         Available Windows OCR recognizer languages: {}. \
+         Install the matching Windows OCR language pack or pass a language that is available.",
+        languages
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", "),
+        attempted_tags.join(", "),
+        format_available_tags(&available_tags)
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn try_create_windows_ocr_engine_for_tag(tag: &str) -> Result<Option<WindowsOcrEngine>> {
+    let language = WindowsLanguage::CreateLanguage(tag)?;
+    if !WindowsOcrEngine::IsLanguageSupported(&language)? {
+        return Ok(None);
+    }
+
+    match WindowsOcrEngine::TryCreateFromLanguage(&language) {
+        Ok(engine) => Ok(Some(engine)),
+        Err(err) if is_null_ocr_engine_error(&err) => Ok(None),
+        Err(err) => Err(anyhow!(
+            "failed to create Windows OCR engine for language tag '{}': {}",
+            tag,
+            err
+        )),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn is_null_ocr_engine_error(err: &windows::core::Error) -> bool {
+    // windows-rs reports null WinRT interface results as an Error whose HRESULT
+    // is success. Turn that confusing "operation completed successfully" state
+    // into a normal "no engine for this language" branch.
+    err.code().0 == 0
+}
+
+#[cfg(target_os = "windows")]
+fn recognizer_language_tag(engine: &WindowsOcrEngine) -> String {
+    engine
+        .RecognizerLanguage()
+        .and_then(|language| language.LanguageTag())
+        .map(|tag| tag.to_string())
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn available_windows_ocr_language_tags() -> Result<Vec<String>> {
+    let languages = WindowsOcrEngine::AvailableRecognizerLanguages()?;
+    let mut tags = Vec::new();
+    for language in languages {
+        tags.push(language.LanguageTag()?.to_string());
+    }
+    Ok(tags)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn windows_language_tags_for(language: &Language) -> Vec<&'static str> {
+    match language {
+        Language::English => vec!["en-US", "en"],
+        Language::Chinese => vec!["zh-Hans", "zh-CN", "zh-Hans-CN", "zh"],
+        Language::German => vec!["de-DE", "de"],
+        Language::Spanish => vec!["es-ES", "es-MX", "es"],
+        Language::Russian => vec!["ru-RU", "ru"],
+        Language::Korean => vec!["ko-KR", "ko"],
+        Language::French => vec!["fr-FR", "fr-CA", "fr"],
+        Language::Japanese => vec!["ja-JP", "ja"],
+        Language::Portuguese => vec!["pt-BR", "pt-PT", "pt"],
+        Language::Turkish => vec!["tr-TR", "tr"],
+        Language::Polish => vec!["pl-PL", "pl"],
+        Language::Dutch => vec!["nl-NL", "nl"],
+        Language::Arabic => vec!["ar-SA", "ar"],
+        Language::Swedish => vec!["sv-SE", "sv"],
+        Language::Italian => vec!["it-IT", "it"],
+        Language::Hindi => vec!["hi-IN", "hi"],
+        Language::Vietnamese => vec!["vi-VN", "vi"],
+        Language::Finnish => vec!["fi-FI", "fi"],
+        Language::Hebrew => vec!["he-IL", "he"],
+        Language::Ukrainian => vec!["uk-UA", "uk"],
+        Language::Greek => vec!["el-GR", "el"],
+        Language::Czech => vec!["cs-CZ", "cs"],
+        Language::Romanian => vec!["ro-RO", "ro"],
+        Language::Danish => vec!["da-DK", "da"],
+        Language::Hungarian => vec!["hu-HU", "hu"],
+        Language::Norwegian => vec!["nb-NO", "nn-NO", "no"],
+        Language::Thai => vec!["th-TH", "th"],
+        Language::Bulgarian => vec!["bg-BG", "bg"],
+        Language::Lithuanian => vec!["lt-LT", "lt"],
+        Language::Latvian => vec!["lv-LV", "lv"],
+        Language::Serbian => vec!["sr-Cyrl-RS", "sr-Latn-RS", "sr"],
+        Language::Slovenian => vec!["sl-SI", "sl"],
+        Language::Estonian => vec!["et-EE", "et"],
+        Language::Croatian => vec!["hr-HR", "hr"],
+        _ => vec![language.as_lang_code()],
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn format_available_tags(tags: &[String]) -> String {
+    if tags.is_empty() {
+        "none".to_string()
+    } else {
+        tags.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_language_tags_include_chinese_simplified_candidates() {
+        let tags = windows_language_tags_for(&Language::Chinese);
+        assert_eq!(tags[0], "zh-Hans");
+        assert!(tags.contains(&"zh-CN"));
+        assert!(tags.contains(&"zh"));
+    }
+
+    #[test]
+    fn windows_language_tags_include_english_fallback() {
+        let tags = windows_language_tags_for(&Language::English);
+        assert_eq!(tags, vec!["en-US", "en"]);
+    }
+
+    #[test]
+    fn windows_language_tags_default_to_core_lang_code() {
+        let tags = windows_language_tags_for(&Language::Catalan);
+        assert_eq!(tags, vec!["ca"]);
+    }
 }


### PR DESCRIPTION
### Description:

Fixes #3902 


<img width="1692" height="498" alt="image" src="https://github.com/user-attachments/assets/0250811b-eb51-426f-810b-5ab5a1b81e53" />

<img width="1475" height="423" alt="image" src="https://github.com/user-attachments/assets/fd79fc39-b732-4c20-974d-c1636287a1f5" />




- Windows native OCR ignored the selected language and could fail with a misleading success-code error on Windows 11.

### Fix:

- Pass requested OCR languages into Windows OCR and fall back to installed recognizer languages with clearer errors.