### PR TITLE
Improve pipe store install flow with a safety warning dialog

### DIFF
--- a/apps/screenpipe-app-tauri/components/pipe-install-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-install-dialog.tsx
@@ -16,13 +16,11 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { listen } from "@tauri-apps/api/event";
 import posthog from "posthog-js";
-import { PermissionsReview, getPipeInstallRisk } from "@/components/pipe-store";
+import { InstallRiskSummary, getPipeInstallRisk } from "@/components/pipe-store";
 import { localFetch } from "@/lib/api";
 import { useFeedbackStore } from "@/lib/stores/feedback-store";
 
@@ -201,8 +199,8 @@ export function PipeInstallDialog() {
             <AlertDialogDescription className="text-xs">
               {isRegistry
                 ? registryRisk === "high"
-                  ? "this store pipe is from an unverified publisher and has full access to your data. review it carefully before installing."
-                  : "a pipe from the store wants to install. review the permissions below before installing."
+                  ? "Unverified publisher. Can access all your screen data."
+                  : "Review the requested access before installing."
                 : "a pipe from an external link wants to install. pipes are AI agents that run on your screen data — review the prompt below before installing."}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -217,35 +215,15 @@ export function PipeInstallDialog() {
               {isRegistry ? "loading pipe details..." : "loading pipe content..."}
             </div>
           ) : isRegistry && registryDetail ? (
-            <div className="space-y-3">
-              <div className="text-sm font-medium">
-                {registryDetail.title}
-                <span className="text-xs text-muted-foreground ml-2">
-                  by {registryDetail.author}
-                </span>
-              </div>
-              <PermissionsReview
-                permissions={registryDetail.permissions as any}
-                authorVerified={registryDetail.author_verified}
-              />
-              {registryRisk === "high" && (
-                <div className="border border-foreground bg-muted/50 rounded-none p-4 space-y-3">
-                  <p className="text-xs text-muted-foreground leading-relaxed">
-                    this pipe can access all your screen text, audio, keyboard input, and raw queries.
-                  </p>
-                  <div className="flex items-start gap-2">
-                    <Checkbox
-                      id="registry-pipe-risk-ack"
-                      checked={installRiskAcknowledged}
-                      onCheckedChange={(value) => setInstallRiskAcknowledged(value === true)}
-                    />
-                    <Label htmlFor="registry-pipe-risk-ack" className="text-xs leading-relaxed">
-                      I understand this pipe can access all my data.
-                    </Label>
-                  </div>
-                </div>
-              )}
-            </div>
+            <InstallRiskSummary
+              title={registryDetail.title}
+              author={registryDetail.author}
+              authorVerified={registryDetail.author_verified}
+              permissions={registryDetail.permissions as any}
+              acknowledgeId="registry-pipe-risk-ack"
+              acknowledged={installRiskAcknowledged}
+              onAcknowledgedChange={setInstallRiskAcknowledged}
+            />
           ) : preview ? (
             <div className="border rounded overflow-hidden">
               <div className="px-3 py-1.5 bg-muted text-[10px] uppercase tracking-wider text-muted-foreground border-b">
@@ -268,7 +246,7 @@ export function PipeInstallDialog() {
 
           <AlertDialogFooter>
             <AlertDialogCancel className="text-xs" onClick={handleCancel}>
-              cancel
+              not now
             </AlertDialogCancel>
             <AlertDialogAction
               className="text-xs"
@@ -281,7 +259,7 @@ export function PipeInstallDialog() {
                   installing...
                 </>
               ) : (
-                "install"
+                "install pipe"
               )}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/screenpipe-app-tauri/components/pipe-install-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-install-dialog.tsx
@@ -16,11 +16,13 @@ import {
   AlertDialogCancel,
   AlertDialogAction,
 } from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { listen } from "@tauri-apps/api/event";
 import posthog from "posthog-js";
-import { PermissionsReview } from "@/components/pipe-store";
+import { PermissionsReview, getPipeInstallRisk } from "@/components/pipe-store";
 import { localFetch } from "@/lib/api";
 import { useFeedbackStore } from "@/lib/stores/feedback-store";
 
@@ -50,6 +52,7 @@ export function PipeInstallDialog() {
   const [preview, setPreview] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [installing, setInstalling] = useState(false);
+  const [installRiskAcknowledged, setInstallRiskAcknowledged] = useState(false);
   const [registryDetail, setRegistryDetail] = useState<RegistryPipeDetail | null>(null);
   const [, setSection] = useQueryState("section");
   const { toast } = useToast();
@@ -61,6 +64,7 @@ export function PipeInstallDialog() {
       setRequest(event.payload);
       setPreview(null);
       setRegistryDetail(null);
+      setInstallRiskAcknowledged(false);
       setLoading(true);
 
       const url = event.payload.url;
@@ -173,6 +177,7 @@ export function PipeInstallDialog() {
   const handleCancel = () => {
     posthog.capture("pipe_install_cancelled", { url: request?.url });
     setRequest(null);
+    setInstallRiskAcknowledged(false);
   };
 
   // Strip frontmatter for display
@@ -180,6 +185,12 @@ export function PipeInstallDialog() {
   const previewLines = body.split("\n").slice(0, 15).join("\n");
 
   const isRegistry = request ? isRegistrySource(request.url) : false;
+  const registryRisk = registryDetail
+    ? getPipeInstallRisk({
+      permissions: registryDetail.permissions as any,
+      author_verified: registryDetail.author_verified,
+    })
+    : "safe";
 
   return (
     <>
@@ -189,7 +200,9 @@ export function PipeInstallDialog() {
             <AlertDialogTitle className="text-sm">install pipe?</AlertDialogTitle>
             <AlertDialogDescription className="text-xs">
               {isRegistry
-                ? "a pipe from the store wants to install. review the permissions below before installing."
+                ? registryRisk === "high"
+                  ? "this store pipe is from an unverified publisher and has full access to your data. review it carefully before installing."
+                  : "a pipe from the store wants to install. review the permissions below before installing."
                 : "a pipe from an external link wants to install. pipes are AI agents that run on your screen data — review the prompt below before installing."}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -215,6 +228,23 @@ export function PipeInstallDialog() {
                 permissions={registryDetail.permissions as any}
                 authorVerified={registryDetail.author_verified}
               />
+              {registryRisk === "high" && (
+                <div className="border border-foreground bg-muted/50 rounded-none p-4 space-y-3">
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    this pipe can access all your screen text, audio, keyboard input, and raw queries.
+                  </p>
+                  <div className="flex items-start gap-2">
+                    <Checkbox
+                      id="registry-pipe-risk-ack"
+                      checked={installRiskAcknowledged}
+                      onCheckedChange={(value) => setInstallRiskAcknowledged(value === true)}
+                    />
+                    <Label htmlFor="registry-pipe-risk-ack" className="text-xs leading-relaxed">
+                      I understand this pipe can access all my data.
+                    </Label>
+                  </div>
+                </div>
+              )}
             </div>
           ) : preview ? (
             <div className="border rounded overflow-hidden">
@@ -243,7 +273,7 @@ export function PipeInstallDialog() {
             <AlertDialogAction
               className="text-xs"
               onClick={handleInstall}
-              disabled={installing}
+              disabled={installing || (isRegistry && registryRisk === "high" && !installRiskAcknowledged)}
             >
               {installing ? (
                 <>

--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -169,6 +169,14 @@ function isUnrestricted(perms?: PipePermissions): boolean {
   );
 }
 
+export function getPipeInstallRisk(pipe: { permissions?: PipePermissions; author_verified?: boolean | null }): "safe" | "warning" | "high" {
+  const unrestricted = isUnrestricted(pipe.permissions);
+  const verified = !!pipe.author_verified;
+  if (unrestricted && !verified) return "high";
+  if (unrestricted || !verified) return "warning";
+  return "safe";
+}
+
 function getReadmeFromPipeMd(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed.startsWith("---")) return trimmed;
@@ -366,7 +374,8 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
 
   // Install state
   const [installing, setInstalling] = useState<string | null>(null);
-  const [sourceReviewed, setSourceReviewed] = useState(false);
+  const [pendingInstall, setPendingInstall] = useState<StorePipe | PipeDetail | null>(null);
+  const [installRiskAcknowledged, setInstallRiskAcknowledged] = useState(false);
 
   // Review state
   const [reviewExpanded, setReviewExpanded] = useState(false);
@@ -493,7 +502,6 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
   const openDetail = async (slug: string) => {
     setShowDetail(true);
     setDetailLoading(true);
-    setSourceReviewed(false);
     setReviewExpanded(false);
     setSourceExpanded(false);
     setReviewRating(0);
@@ -516,6 +524,42 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
     } finally {
       setDetailLoading(false);
     }
+  };
+
+  const requestInstall = (pipe: StorePipe | PipeDetail) => {
+    const risk = getPipeInstallRisk(pipe);
+    if (risk === "safe" || !!availableUpdates[pipe.slug]) {
+      void handleInstall(pipe.slug);
+      return;
+    }
+    setPendingInstall(pipe);
+    setInstallRiskAcknowledged(false);
+  };
+
+  const closeInstallGate = () => {
+    setPendingInstall(null);
+    setInstallRiskAcknowledged(false);
+  };
+
+  const confirmPendingInstall = () => {
+    if (!pendingInstall) return;
+    const risk = getPipeInstallRisk(pendingInstall);
+    if (risk === "high" && !installRiskAcknowledged) return;
+    const slug = pendingInstall.slug;
+    closeInstallGate();
+    void handleInstall(slug);
+  };
+
+  const reviewPendingInstallSource = () => {
+    if (!pendingInstall) return;
+    const slug = pendingInstall.slug;
+    closeInstallGate();
+    if (showDetail && selectedPipe?.slug === slug) {
+      setSourceExpanded(true);
+      return;
+    }
+    void openDetail(slug);
+    setSourceExpanded(true);
   };
 
   // Install pipe
@@ -657,6 +701,91 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
     });
   }, [pipes, category]);
 
+  const installGateDialog = (
+    <Dialog open={!!pendingInstall} onOpenChange={(open) => !open && closeInstallGate()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="text-base">
+            {pendingInstall && getPipeInstallRisk(pendingInstall) === "high"
+              ? "review full-access pipe"
+              : "review pipe access"}
+          </DialogTitle>
+          <DialogDescription className="text-sm">
+            {pendingInstall && getPipeInstallRisk(pendingInstall) === "high"
+              ? "this pipe is from an unverified publisher and has full access to your screen data. make sure you trust it before installing."
+              : "this pipe needs a quick review before installation so you understand what data it can access."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {pendingInstall ? (
+          <div className="space-y-4">
+            <div className="border border-border rounded-none p-4 space-y-1.5">
+              <div className="text-sm font-medium">{pendingInstall.title}</div>
+              <div className="text-xs text-muted-foreground">
+                by {pendingInstall.author || "community publisher"}
+              </div>
+            </div>
+
+            <PermissionsReview
+              permissions={pendingInstall.permissions}
+              authorVerified={pendingInstall.author_verified}
+            />
+
+            {getPipeInstallRisk(pendingInstall) === "high" && (
+              <div className="border border-foreground bg-muted/50 rounded-none p-4 space-y-3">
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  this pipe can access all your screen text, audio, keyboard input, and raw queries.
+                </p>
+                <div className="flex items-start gap-2">
+                  <Checkbox
+                    id="pipe-risk-ack"
+                    data-testid="pipe-risk-ack"
+                    checked={installRiskAcknowledged}
+                    onCheckedChange={(value) => setInstallRiskAcknowledged(value === true)}
+                  />
+                  <Label htmlFor="pipe-risk-ack" className="text-xs leading-relaxed">
+                    I understand this pipe can access all my data.
+                  </Label>
+                </div>
+              </div>
+            )}
+          </div>
+        ) : null}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="ghost" onClick={closeInstallGate}>
+            cancel
+          </Button>
+          <Button
+            variant="outline"
+            data-testid="pipe-risk-review-source"
+            onClick={reviewPendingInstallSource}
+          >
+            review source
+          </Button>
+          <Button
+            data-testid="pipe-risk-install-confirm"
+            disabled={
+              !pendingInstall ||
+              installing === pendingInstall.slug ||
+              (getPipeInstallRisk(pendingInstall) === "high" && !installRiskAcknowledged)
+            }
+            onClick={confirmPendingInstall}
+          >
+            {pendingInstall && installing === pendingInstall.slug ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
+                installing...
+              </>
+            ) : (
+              "install anyway"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+
   // If showing detail view, render full-width detail panel
   if (showDetail) {
     return (
@@ -680,9 +809,7 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
           <PipeDetailPanel
             pipe={selectedPipe}
             installing={installing}
-            sourceReviewed={sourceReviewed}
-            onSourceReviewedChange={setSourceReviewed}
-            onInstall={handleInstall}
+            onInstall={() => requestInstall(selectedPipe)}
             isInstalled={installedNames.has(selectedPipe.slug)}
             hasUpdate={!!availableUpdates[selectedPipe.slug]}
             sourceExpanded={sourceExpanded}
@@ -693,6 +820,8 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
             onRefresh={() => openDetail(selectedPipe.slug)}
           />
         ) : null}
+
+        {installGateDialog}
       </div>
     );
   }
@@ -812,7 +941,7 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
               pipe={pipe}
               isInstalled={installedNames.has(pipe.slug)}
               hasUpdate={!!availableUpdates[pipe.slug]}
-              onInstall={() => handleInstall(pipe.slug)}
+              onInstall={() => requestInstall(pipe)}
               installing={installing === pipe.slug}
               onClick={() => openDetail(pipe.slug)}
             />
@@ -831,6 +960,8 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
           toast({ title: "pipe published to store" });
         }}
       />
+
+      {installGateDialog}
 
     </div>
   );
@@ -934,8 +1065,6 @@ function PipeCard({
 function PipeDetailPanel({
   pipe,
   installing,
-  sourceReviewed,
-  onSourceReviewedChange,
   onInstall,
   isInstalled,
   hasUpdate,
@@ -947,9 +1076,7 @@ function PipeDetailPanel({
 }: {
   pipe: PipeDetail;
   installing: string | null;
-  sourceReviewed: boolean;
-  onSourceReviewedChange: (v: boolean) => void;
-  onInstall: (slug: string) => void;
+  onInstall: () => void;
   isInstalled: boolean;
   hasUpdate?: boolean;
   sourceExpanded: boolean;
@@ -961,7 +1088,6 @@ function PipeDetailPanel({
 }) {
   const { toast } = useToast();
   const unrestricted = isUnrestricted(pipe.permissions);
-  const needsReview = unrestricted && !pipe.author_verified;
   const isOwner = !!(currentUserId && pipe.author_id && currentUserId === pipe.author_id);
 
   const [editing, setEditing] = useState(false);
@@ -1195,9 +1321,9 @@ IMPORTANT: first read the screenpipe skill file to understand how pipes work, th
                   hasUpdate && "bg-amber-500 hover:bg-amber-600 text-white"
                 )}
                 disabled={
-                  installing === pipe.slug || (isInstalled && !hasUpdate) || (needsReview && !sourceReviewed)
+                  installing === pipe.slug || (isInstalled && !hasUpdate)
                 }
-                onClick={() => onInstall(pipe.slug)}
+                onClick={onInstall}
               >
                 {installing === pipe.slug ? (
                   <>
@@ -1351,17 +1477,10 @@ IMPORTANT: first read the screenpipe skill file to understand how pipes work, th
               this pipe has no data access restrictions. it can access all your
               screen text, audio, keyboard input, and raw database queries.
             </p>
-            {needsReview && (
-              <div className="flex items-center gap-2 pt-1">
-                <Checkbox
-                  id="source-reviewed"
-                  checked={sourceReviewed}
-                  onCheckedChange={(v) => onSourceReviewedChange(v === true)}
-                />
-                <Label htmlFor="source-reviewed" className="text-xs">
-                  I have reviewed the source code below
-                </Label>
-              </div>
+            {!pipe.author_verified && (
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                this publisher is not verified. use the source section below if you want to inspect the pipe before installing.
+              </p>
             )}
           </div>
         )}

--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -177,6 +177,65 @@ export function getPipeInstallRisk(pipe: { permissions?: PipePermissions; author
   return "safe";
 }
 
+function getPipeInstallDescription(pipe: { permissions?: PipePermissions; author_verified?: boolean | null }): string {
+  const risk = getPipeInstallRisk(pipe);
+  const unrestricted = isUnrestricted(pipe.permissions);
+  if (risk === "high") {
+    return "Unverified publisher. Can access all your screen data.";
+  }
+  if (unrestricted) {
+    return "Verified publisher. Can access all your screen data.";
+  }
+  if (!pipe.author_verified) {
+    return "Unverified publisher. Review the requested access before installing.";
+  }
+  return "Review the requested access before installing.";
+}
+
+function getAllowedAccessLabels(perms?: PipePermissions): string[] {
+  if (isUnrestricted(perms)) {
+    return [
+      "screen text",
+      "audio",
+      "keyboard input",
+      "screenshots",
+      "accessibility",
+      "raw queries",
+      "connections",
+    ];
+  }
+
+  const labelsByKey: Record<string, string> = {
+    ocr: "screen text",
+    audio: "audio",
+    input: "keyboard input",
+    raw_sql: "raw queries",
+    frames: "screenshots",
+    connections: "connections",
+    accessibility: "accessibility",
+  };
+
+  return PERMISSION_LABELS.flatMap((perm) => {
+    const status = getPermissionStatus(perms, perm.key);
+    return status === "allowed" ? [labelsByKey[perm.key] || perm.label.toLowerCase()] : [];
+  });
+}
+
+function getPipeAccessSummary(perms?: PipePermissions): string {
+  const labels = getAllowedAccessLabels(perms);
+  if (labels.length === 0) {
+    return "No explicit access was declared.";
+  }
+
+  if (labels.length === 1) {
+    return `This pipe requests access to ${labels[0]}.`;
+  }
+
+  const last = labels[labels.length - 1];
+  const rest = labels.slice(0, -1);
+  return `This pipe requests access to ${rest.join(", ")}, and ${last}.`;
+}
+
 function getReadmeFromPipeMd(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed.startsWith("---")) return trimmed;
@@ -528,7 +587,7 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
 
   const requestInstall = (pipe: StorePipe | PipeDetail) => {
     const risk = getPipeInstallRisk(pipe);
-    if (risk === "safe" || !!availableUpdates[pipe.slug]) {
+    if (risk === "safe" || availableUpdates[pipe.slug]) {
       void handleInstall(pipe.slug);
       return;
     }
@@ -703,65 +762,25 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
 
   const installGateDialog = (
     <Dialog open={!!pendingInstall} onOpenChange={(open) => !open && closeInstallGate()}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle className="text-base">
-            {pendingInstall && getPipeInstallRisk(pendingInstall) === "high"
-              ? "review full-access pipe"
-              : "review pipe access"}
-          </DialogTitle>
-          <DialogDescription className="text-sm">
-            {pendingInstall && getPipeInstallRisk(pendingInstall) === "high"
-              ? "this pipe is from an unverified publisher and has full access to your screen data. make sure you trust it before installing."
-              : "this pipe needs a quick review before installation so you understand what data it can access."}
-          </DialogDescription>
-        </DialogHeader>
+      <DialogContent className="max-w-lg pt-8">
+        <DialogTitle className="sr-only">review pipe access</DialogTitle>
 
         {pendingInstall ? (
-          <div className="space-y-4">
-            <div className="border border-border rounded-none p-4 space-y-1.5">
-              <div className="text-sm font-medium">{pendingInstall.title}</div>
-              <div className="text-xs text-muted-foreground">
-                by {pendingInstall.author || "community publisher"}
-              </div>
-            </div>
-
-            <PermissionsReview
-              permissions={pendingInstall.permissions}
-              authorVerified={pendingInstall.author_verified}
-            />
-
-            {getPipeInstallRisk(pendingInstall) === "high" && (
-              <div className="border border-foreground bg-muted/50 rounded-none p-4 space-y-3">
-                <p className="text-xs text-muted-foreground leading-relaxed">
-                  this pipe can access all your screen text, audio, keyboard input, and raw queries.
-                </p>
-                <div className="flex items-start gap-2">
-                  <Checkbox
-                    id="pipe-risk-ack"
-                    data-testid="pipe-risk-ack"
-                    checked={installRiskAcknowledged}
-                    onCheckedChange={(value) => setInstallRiskAcknowledged(value === true)}
-                  />
-                  <Label htmlFor="pipe-risk-ack" className="text-xs leading-relaxed">
-                    I understand this pipe can access all my data.
-                  </Label>
-                </div>
-              </div>
-            )}
-          </div>
+          <InstallRiskSummary
+            title={pendingInstall.title}
+            author={pendingInstall.author}
+            authorVerified={pendingInstall.author_verified}
+            permissions={pendingInstall.permissions}
+            onReviewSource={reviewPendingInstallSource}
+            acknowledgeId="pipe-risk-ack"
+            acknowledged={installRiskAcknowledged}
+            onAcknowledgedChange={setInstallRiskAcknowledged}
+          />
         ) : null}
 
         <DialogFooter className="gap-2 sm:gap-0">
           <Button variant="ghost" onClick={closeInstallGate}>
-            cancel
-          </Button>
-          <Button
-            variant="outline"
-            data-testid="pipe-risk-review-source"
-            onClick={reviewPendingInstallSource}
-          >
-            review source
+            not now
           </Button>
           <Button
             data-testid="pipe-risk-install-confirm"
@@ -771,17 +790,17 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
               (getPipeInstallRisk(pendingInstall) === "high" && !installRiskAcknowledged)
             }
             onClick={confirmPendingInstall}
-          >
-            {pendingInstall && installing === pendingInstall.slug ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
-                installing...
-              </>
-            ) : (
-              "install anyway"
-            )}
-          </Button>
-        </DialogFooter>
+            >
+              {pendingInstall && installing === pendingInstall.slug ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-1.5" />
+                  installing...
+                </>
+              ) : (
+                "install pipe"
+              )}
+            </Button>
+          </DialogFooter>
       </DialogContent>
     </Dialog>
   );
@@ -1906,6 +1925,88 @@ export function PermissionsReview({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+export function InstallRiskSummary({
+  title,
+  author,
+  authorVerified,
+  permissions,
+  onReviewSource,
+  acknowledgeId,
+  acknowledged,
+  onAcknowledgedChange,
+}: {
+  title: string;
+  author?: string;
+  authorVerified: boolean;
+  permissions?: PipePermissions;
+  onReviewSource?: () => void;
+  acknowledgeId?: string;
+  acknowledged?: boolean;
+  onAcknowledgedChange?: (checked: boolean) => void;
+}) {
+  const risk = getPipeInstallRisk({
+    permissions,
+    author_verified: authorVerified,
+  });
+  const unrestricted = isUnrestricted(permissions);
+  const accessLabels = unrestricted ? [] : getAllowedAccessLabels(permissions);
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            {risk === "high" || unrestricted ? (
+              <AlertTriangle className="h-4 w-4" />
+            ) : (
+              <Shield className="h-4 w-4" />
+            )}
+            {unrestricted ? "Can access all your screen data" : "Requested access"}
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            {unrestricted
+              ? "screen text, audio, keyboard input, screenshots, and raw queries."
+              : getPipeAccessSummary(permissions)}{" "}
+            {onReviewSource ? (
+              <button
+                data-testid="pipe-risk-review-source"
+                onClick={onReviewSource}
+                className="underline underline-offset-2 hover:text-foreground transition-colors"
+              >
+                review source
+              </button>
+            ) : null}
+          </p>
+        </div>
+
+        {accessLabels.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {accessLabels.map((label) => (
+              <Badge key={label} variant="secondary" className="rounded-none text-[10px] lowercase">
+                {label}
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        {risk === "high" && acknowledgeId && onAcknowledgedChange ? (
+          <div className="flex items-start gap-2 pt-3 border-t border-border">
+            <Checkbox
+              id={acknowledgeId}
+              data-testid="pipe-risk-ack"
+              checked={acknowledged === true}
+              onCheckedChange={(value) => onAcknowledgedChange(value === true)}
+            />
+            <Label htmlFor={acknowledgeId} className="text-xs leading-relaxed">
+              I understand this pipe can access all my data.
+            </Label>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/screenpipe-app-tauri/e2e/specs/pipes.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/pipes.spec.ts
@@ -19,6 +19,18 @@ import { saveScreenshot } from '../helpers/screenshot-utils.js';
 let installedPipeName = '';
 let connectionPipeSlug = '';
 
+async function confirmRiskGateIfPresent(): Promise<void> {
+  const confirmBtn = await $('[data-testid="pipe-risk-install-confirm"]');
+  if (!(await confirmBtn.isExisting())) return;
+
+  const ack = await $('[data-testid="pipe-risk-ack"]');
+  if (await ack.isExisting()) {
+    await ack.click();
+  }
+
+  await confirmBtn.click();
+}
+
 async function fetchWithTimeout(
   url: string,
   init: RequestInit,
@@ -127,9 +139,11 @@ describe('Pipes: discover → install → play', function () {
         { timeout: 15_000, timeoutMsg: 'No pipe-install-btn found — store API unreachable or Discover grid not loaded' }
       );
 
-      // Click any GET button — interceptor makes it fail inside handleInstall
-      const anyGetBtn = await $('[data-testid="pipe-install-btn"]');
+      // Click a real GET button — some cards may require source review first.
+      const anyGetBtn = await browser.$('//button[@data-testid="pipe-install-btn" and normalize-space()="GET"]');
+      await anyGetBtn.waitForExist({ timeout: 8_000 });
       await anyGetBtn.click();
+      await confirmRiskGateIfPresent();
 
       // handleInstall catches the 503 and calls toast({ variant: "destructive" }).
       // toaster.tsx sets data-testid="toast-error" on the inner <div> for
@@ -198,6 +212,7 @@ describe('Pipes: discover → install → play', function () {
     }
 
     await installBtn.click();
+    await confirmRiskGateIfPresent();
 
     // After install, the connection modal OR "My Pipes" tab should appear.
     // Either the modal opens (PostInstallConnectionsModal) or the tab switches.
@@ -290,6 +305,7 @@ describe('Pipes: discover → install → play', function () {
       console.log(`[pipes-spec] "${slug}" already installed (button=${btnText}); skipping install click`);
     } else {
       await installBtn.click();
+      await confirmRiskGateIfPresent();
 
       // After GET click the app auto-switches to My Pipes (onInstalled
       // callback). Wait for an unambiguous marker: the My Pipes section


### PR DESCRIPTION
This PR improves the pipe installation flow by replacing the confusing disabled install button with a unified safety warning dialog for high-risk pipes.

### Before
- Unverified pipes with full access had an active **GET** button in the grid view but a disabled **GET** button in the detail view.
- To enable it, users had to find and check an "I have reviewed the source code" checkbox inside the detail page.
- This created a broken-looking UX and forced unnecessary friction on users who just wanted to install a pipe.

https://github.com/user-attachments/assets/a267c35e-3ad3-4deb-abf4-84fc51761697


### After
- The **GET** button is always active and clickable from both the grid and detail views.
- Clicking **GET** on any risky pipe (unverified or requesting full access) now opens a clear, helpful confirmation dialog.
- For high-risk pipes (unverified + full access), users must explicitly check "I understand this pipe can access all my data" before installing.
- E2E tests and deep-link install dialogs are updated to handle the new confirmation flow seamlessly.


https://github.com/user-attachments/assets/6abf0e23-e2f4-40fb-bf1e-2b5385919577


