### PR TITLE
fix(owned-browser): preserve eval title changes

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -109,6 +109,19 @@ const BRIDGE_INIT_SCRIPT: &str = r#"
 })();
 "#;
 
+fn title_after_eval_marker(original_title: &str, result_json: &str) -> String {
+    #[derive(serde::Deserialize)]
+    struct Payload {
+        #[serde(default)]
+        title: Option<String>,
+    }
+
+    serde_json::from_str::<Payload>(result_json)
+        .ok()
+        .and_then(|payload| payload.title)
+        .unwrap_or_else(|| original_title.to_string())
+}
+
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct OwnedBrowserStateEvent {
@@ -558,8 +571,9 @@ impl OwnedWebviewHandle for TauriOwnedHandle {
             tokio::time::sleep(Duration::from_millis(1_000)).await;
         }
 
-        // Snapshot the current title so we can restore it after we read
-        // our marker. Best-effort — we don't fail the eval if this fails.
+        // Snapshot the current title so the marker transport can be cleared
+        // after eval. If the user code changes document.title, the wrapper
+        // reports that post-eval title and we preserve it below.
         let original_title = self.state.latest_title();
 
         let id = Uuid::new_v4().to_string();
@@ -578,6 +592,7 @@ impl OwnedWebviewHandle for TauriOwnedHandle {
                         window.__SP_RESULT__({{
                             id: {id},
                             ok: true,
+                            title: document.title,
                             result: __sp_result === undefined ? null : __sp_result
                         }});
                     }}
@@ -586,6 +601,7 @@ impl OwnedWebviewHandle for TauriOwnedHandle {
                         window.__SP_RESULT__({{
                             id: {id},
                             ok: false,
+                            title: document.title,
                             error: String((e && e.message) || e)
                         }});
                     }}
@@ -622,9 +638,10 @@ impl OwnedWebviewHandle for TauriOwnedHandle {
             tokio::time::sleep(Duration::from_millis(50)).await;
         };
 
-        // Restore the page's prior title so user-facing chrome (history,
-        // tab labels in any embedding UI) doesn't keep our marker.
-        let restore_lit = serde_json::to_string(&original_title).unwrap_or_else(|_| "\"\"".into());
+        // Clear the marker without undoing a document.title mutation made by
+        // the caller's eval code.
+        let restore_title = title_after_eval_marker(&original_title, &result_json);
+        let restore_lit = serde_json::to_string(&restore_title).unwrap_or_else(|_| "\"\"".into());
         let _ = active.eval(format!("document.title = {restore_lit};"));
         if shown_for_eval && url.is_none() {
             let _ = active.hide();
@@ -966,7 +983,7 @@ fn normalize_url(raw: &str) -> Result<url::Url, String> {
 
 #[cfg(test)]
 mod normalize_url_tests {
-    use super::normalize_url;
+    use super::{normalize_url, title_after_eval_marker};
 
     #[test]
     fn keeps_fully_qualified() {
@@ -1008,6 +1025,32 @@ mod normalize_url_tests {
     fn preserves_data_url() {
         let u = normalize_url("data:text/plain,hello").unwrap();
         assert_eq!(u.scheme(), "data");
+    }
+
+    #[test]
+    fn restores_title_changed_by_eval_code() {
+        let payload = r#"{"id":"1","ok":true,"title":"changed","result":null}"#;
+        assert_eq!(
+            title_after_eval_marker("Example Domain", payload),
+            "changed"
+        );
+    }
+
+    #[test]
+    fn restores_original_title_when_payload_has_no_title() {
+        let payload = r#"{"id":"1","ok":true,"result":null}"#;
+        assert_eq!(
+            title_after_eval_marker("Example Domain", payload),
+            "Example Domain"
+        );
+    }
+
+    #[test]
+    fn restores_original_title_when_payload_is_malformed() {
+        assert_eq!(
+            title_after_eval_marker("Example Domain", "not json"),
+            "Example Domain"
+        );
     }
 }
 


### PR DESCRIPTION
## description

Preserve `document.title` changes made through owned-browser `/eval` after the internal title-marker transport is cleared.

related issue: #3676

## before

`POST /connections/browsers/owned-default/eval` with `document.title = "changed";` returned `success: true`, but the next snapshot still showed the previous title because the eval transport restored the pre-eval title after reading its marker.

## after

The eval wrapper includes the post-eval page title in the marker payload, and Rust restores that title instead of the stale pre-eval title. This keeps the marker hidden while preserving intentional title mutations from user code.

## how to test

1. Navigate `owned-default` to `https://example.com`.
2. POST `/connections/browsers/owned-default/eval` with `{ "code": "document.title = \"changed\";" }`.
3. GET `/connections/browsers/owned-default/snapshot` and confirm the title is `changed`.

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

No Tauri commands or exported Rust types changed.

Validation run locally:

- `git diff --check`
- `rustfmt +stable --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs`

Attempted but blocked before compilation by dependency fetch failure:

- `cargo +stable test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml normalize_url_tests --lib`
- Cargo failed while fetching the `audiopipe` git dependency submodule `antirez/qwen-asr` with an SSL handshake error before this crate compiled.
