### PR TITLE
fix(meetings): keep the full meeting transcript surfaced (don't drop live segments) + audio-capture + doc fixes

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -694,8 +694,8 @@ function createSettingsStore() {
 		// cancellation — so the tap silently captured zeroed buffers on every
 		// meeting. Users who explicitly want the tap (e.g. to dodge SCK's
 		// sleep/wake display-enumeration bug) can re-enable it in Settings.
-		// Reported by Ruark Ferreira on 2026-04-24 after his v2.4.46 calls
-		// kept dropping other participants.
+		// Reported on 2026-04-24 after v2.4.46 calls kept dropping
+		// other participants.
 		if (!(settings as any).coreaudioTapMigrationV2) {
 			settings.experimentalCoreaudioSystemAudio = false;
 			(settings as any).coreaudioTapMigrationV2 = true;

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -67,7 +67,7 @@ async calendarGetEvents(hoursBack: number | null, hoursAhead: number | null) : P
 /**
  * Reset TCC (privacy) permission for Calendars on this app's bundle ID.
  *
- * Why: users (Mike, Jarad, Ruark, Louis's own Mac mini) clicked
+ * Why: multiple users (including Louis's own Mac mini) clicked
  * "Fix Calendar Permission" → macOS opened the Calendars privacy pane
  * with an EMPTY app list, so they had no way to grant access. Root cause
  * is a stale TCC record (dev-build → prod-build reinstall, OS update,
@@ -2376,17 +2376,19 @@ audioDevices: string[];
 useSystemDefaultAudio: boolean;
 /**
  * Experimental: capture System Audio via the CoreAudio Process Tap API
- * (macOS 14.4+) instead of ScreenCaptureKit. Avoids SCK's display
- * enumeration failures after sleep/wake, the GPU/compositor wake
- * overhead, and — most importantly — captures audio that's been
- * routed to a Bluetooth headset via HFP (which SCK can't see; see
- * Ruark Ferreira's 2026-04-24 Zoom call where AirPods-as-input
- * silently routed output away from the SCK-visible mixer).
+ * (macOS 14.4+) instead of ScreenCaptureKit. The tap sidesteps SCK's
+ * display-enumeration failures after sleep/wake and the GPU/compositor
+ * wake overhead, but it cannot see audio rendered through a
+ * VoiceProcessing AudioUnit (Zoom / Google Meet / Microsoft Teams all
+ * use one for echo cancellation), so on meeting audio it silently
+ * captures zeroed buffers even though tap creation succeeds.
  *
- * Default `true`: if tap creation fails for any reason (permission,
- * macOS <14.4, OS quirk), stream.rs falls back to the SCK path
- * automatically — so flipping the default on can't regress anyone.
- * Ignored on non-macOS platforms.
+ * Default `false` (see `default_experimental_coreaudio_system_audio`).
+ * SCK captures at the display compositor, which does see VoiceProcessing
+ * output, so it is the right default for anyone on calls. Users who hit
+ * SCK's sleep/wake display-enumeration bug can still opt in; when the tap
+ * is on and creation fails (permission, macOS <14.4, OS quirk), stream.rs
+ * falls back to the SCK path automatically. Ignored on non-macOS platforms.
  */
 experimentalCoreaudioSystemAudio?: boolean;
 /**

--- a/apps/screenpipe-app-tauri/src-tauri/src/calendar.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/calendar.rs
@@ -146,7 +146,7 @@ pub async fn calendar_status() -> Result<CalendarStatus, String> {
 
 /// Reset TCC (privacy) permission for Calendars on this app's bundle ID.
 ///
-/// Why: users (Mike, Jarad, Ruark, Louis's own Mac mini) clicked
+/// Why: multiple users (including Louis's own Mac mini) clicked
 /// "Fix Calendar Permission" → macOS opened the Calendars privacy pane
 /// with an EMPTY app list, so they had no way to grant access. Root cause
 /// is a stale TCC record (dev-build → prod-build reinstall, OS update,

--- a/crates/screenpipe-audio/src/core/process_tap.rs
+++ b/crates/screenpipe-audio/src/core/process_tap.rs
@@ -602,7 +602,7 @@ pub fn spawn_process_tap_capture(
         // silent audio (AND the callback is firing, so it's not just that
         // the IO proc stalled), rebuild the aggregate once. This catches
         // the "tap anchored to BuiltInSpeaker while all app audio is
-        // routed to AirPods" failure mode that Ruark hit on v2.4.46 — the
+        // routed to AirPods" failure mode reported on v2.4.46. The
         // tap runs happily, the callback fires, but every buffer is
         // zeros because the aggregate's sub-device has no signal and the
         // global-tap → aggregate delivery path stays mute. See the

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -82,17 +82,19 @@ pub struct RecordingSettings {
     pub use_system_default_audio: bool,
 
     /// Experimental: capture System Audio via the CoreAudio Process Tap API
-    /// (macOS 14.4+) instead of ScreenCaptureKit. Avoids SCK's display
-    /// enumeration failures after sleep/wake, the GPU/compositor wake
-    /// overhead, and — most importantly — captures audio that's been
-    /// routed to a Bluetooth headset via HFP (which SCK can't see; see
-    /// Ruark Ferreira's 2026-04-24 Zoom call where AirPods-as-input
-    /// silently routed output away from the SCK-visible mixer).
+    /// (macOS 14.4+) instead of ScreenCaptureKit. The tap sidesteps SCK's
+    /// display-enumeration failures after sleep/wake and the GPU/compositor
+    /// wake overhead, but it cannot see audio rendered through a
+    /// VoiceProcessing AudioUnit (Zoom / Google Meet / Microsoft Teams all
+    /// use one for echo cancellation), so on meeting audio it silently
+    /// captures zeroed buffers even though tap creation succeeds.
     ///
-    /// Default `true`: if tap creation fails for any reason (permission,
-    /// macOS <14.4, OS quirk), stream.rs falls back to the SCK path
-    /// automatically — so flipping the default on can't regress anyone.
-    /// Ignored on non-macOS platforms.
+    /// Default `false` (see `default_experimental_coreaudio_system_audio`).
+    /// SCK captures at the display compositor, which does see VoiceProcessing
+    /// output, so it is the right default for anyone on calls. Users who hit
+    /// SCK's sleep/wake display-enumeration bug can still opt in; when the tap
+    /// is on and creation fails (permission, macOS <14.4, OS quirk), stream.rs
+    /// falls back to the SCK path automatically. Ignored on non-macOS platforms.
     #[serde(
         rename = "experimentalCoreaudioSystemAudio",
         default = "default_experimental_coreaudio_system_audio"

--- a/crates/screenpipe-db/tests/db.rs
+++ b/crates/screenpipe-db/tests/db.rs
@@ -110,7 +110,7 @@ mod tests {
     async fn test_recent_output_audio_ignores_input_chunk() {
         let db = setup_test_db().await;
 
-        db.insert_audio_chunk("Ruark’s AirPods (input)_recent.mp4", Some(Utc::now()))
+        db.insert_audio_chunk("AirPods (input)_recent.mp4", Some(Utc::now()))
             .await
             .unwrap();
 

--- a/crates/screenpipe-db/tests/meeting_transcript_dedup_test.rs
+++ b/crates/screenpipe-db/tests/meeting_transcript_dedup_test.rs
@@ -32,7 +32,7 @@ mod tests {
 
     fn input_device() -> AudioDevice {
         AudioDevice {
-            name: "Ruark’s AirPods".to_string(),
+            name: "AirPods".to_string(),
             device_type: DeviceType::Input,
         }
     }
@@ -71,7 +71,7 @@ mod tests {
                 "screenpipe-cloud",
                 Some("nova-3"),
                 &format!("deepgram:0:{}", i * 1000),
-                "Ruark’s AirPods",
+                "AirPods",
                 "input",
                 None,
                 &format!("me talking part {i}"),
@@ -109,7 +109,7 @@ mod tests {
         // SHOULD still be deduped away (same direction, real duplicate).
         let in_chunk = db
             .insert_audio_chunk(
-                "Ruark’s AirPods (input)_dupe.mp4",
+                "AirPods (input)_dupe.mp4",
                 Some(base + Duration::seconds(4)),
             )
             .await

--- a/crates/screenpipe-db/tests/timeline_live_meeting_test.rs
+++ b/crates/screenpipe-db/tests/timeline_live_meeting_test.rs
@@ -280,7 +280,7 @@ mod timeline_live_meeting_tests {
         let base = Utc::now();
 
         let mic_chunk_id = db
-            .insert_audio_chunk("Ruark's AirPods (input)_meeting.mp4", Some(base))
+            .insert_audio_chunk("AirPods (input)_meeting.mp4", Some(base))
             .await
             .unwrap();
         let meeting_id = db


### PR DESCRIPTION
Three commits from one investigation into a paid user's report: a 40-min meeting "recorded both sides for the first ~5 min, then stopped, detection stayed green the whole time." I pulled his attached engine log to ground each step.

## What the log proved (so we stop guessing)
- He is on **ScreenCaptureKit** (default), not the experimental tap.
- In the ~18 min the log covers (it was truncated to the last 100KB, cutting off the 5-min mark), **both sides were captured and transcribed**: live Deepgram finals for `System Audio` and his mic ran continuously to teardown, 90 successful batch transcriptions of `System Audio (output)`, and 494 live segments mirrored into `audio_transcriptions`.
- So the data exists on three paths. **His "stopped recording" is a surfacing problem, not a capture problem.**

## Commit 3 (the most likely fix for his report): don't drop live transcript segments
The post-call meeting view reads `audio_transcriptions`, which only gets a live segment if `mirror_live_meeting_to_audio_transcriptions` copies it in. That mirror **silently dropped** any segment whose nearest same-device audio chunk fell outside a fixed ±15s window:

```
live final "captured_at" drifts (provider finalizes a turn seconds late,
long chunks, capture gaps) ──► no chunk within ±15s ──► segment SKIPPED
                                                          (continue;)
   ──► never written to audio_transcriptions
   ──► gone from meeting notes / timeline / search after the call
```

Fix: fall back to the nearest **same-device** chunk regardless of window instead of dropping (the row keeps the segment's real timestamp, so search/timeline stay correct; device attribution stays strict). Also aligned a case-**sensitive** device match in `mark_chunks_covered_by_live` to the case-**insensitive** match its sibling mirror already used (a casing difference left meeting chunks pending and inconsistent). Two regression tests added; all coverage/mirror/dedup tests pass.

## Commit 2: tap-only aggregate (separate audio-capture improvement)
The CoreAudio Process Tap anchored its aggregate to the system default output, so when call audio routed elsewhere (AirPods/HFP/per-app) it captured zeros. Switched to a tap-only aggregate so capture follows the app's audio. **This is NOT his bug** (he's on SCK, and the log shows SCK capturing both sides) — it's a real fix for users who opt into the tap, behind the experimental flag, default unchanged. Not hardware-verified (needs a Bluetooth headset on a live call).

## Commit 1: doc + PII cleanup
Corrected the stale `experimental_coreaudio_system_audio` doc and removed real customer names that had leaked into this public repo (comments + test fixtures), generated `tauri.ts` kept in sync.

## Honest status
- Commit 3 is tested (db crate, no hardware) and is the diagnosis-driven fix for the surfacing class his log points to. I could not pin the single dropped row because his log was truncated past the failure and his DB is on his machine — but the mechanism (mirror dropping segments on a window miss) is real and fixed.
- The "froze live during the call" half of his symptom likely also wants a frontend change: the live transcript panel builds only from push events and never reconciles against the persisted segments, so a stalled event stream leaves a gap until reload. Flagging as the companion follow-up; not in this PR.
- These are three distinct concerns on one branch for review convenience. Happy to split commit 3 into its own PR if you'd rather merge it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
