### PR TITLE
test(e2e): fix multi-window auth-signout flake (zz-logout-resurrect) + tray-search reuse race

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/tray-search.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/tray-search.spec.ts
@@ -121,6 +121,17 @@ describe("Tray: Search window", function () {
 
     await invokeOrThrow("open_search_window", { query: null });
     await waitForWindowHandle("search", t(20_000));
+    // Wait for the first search window to finish its initial /search load before
+    // reusing it. The reuse path re-seeds the query by eval-ing
+    // window.location.replace("/search/?q=…") (src-tauri window/show.rs); if that
+    // fires before the initial load has committed, the replace is lost and the
+    // ?q= query never seeds — the source of this spec's flake on slow CI.
+    // Switching in and waiting for the input guarantees the webview is ready.
+    await browser.switchToWindow("search");
+    await (
+      await $('input[placeholder*="search memory"]')
+    ).waitForExist({ timeout: t(20_000) });
+
     await invokeOrThrow("open_search_window", { query: "?q=tray-e2e" });
     await waitForWindowHandle("search", t(20_000));
 

--- a/apps/screenpipe-app-tauri/e2e/specs/zz-logout-resurrect.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-logout-resurrect.spec.ts
@@ -141,6 +141,49 @@ async function restoreFetch(): Promise<void> {
   });
 }
 
+/** Install the /api/user mock in EVERY open window, not just home.
+ *
+ *  The emitTo("home") deep-link targeting above keeps the LOGIN loadUser in the
+ *  mocked home window. But that only covers the deep-link path. After Phase A
+ *  writes the fake token into the SHARED settings store, the auto-refresh effect
+ *  (lib/hooks/use-settings.tsx, the effect keyed on settings.user?.token) fires
+ *  loadUser(fakeToken) in EVERY window. Non-home windows have no mock, so they
+ *  hit the real network, 401, and the global auth interceptor broadcasts
+ *  "screenpipe-auth-signout" — which clears the freshly-logged-in home window,
+ *  flaking Phase A (Linux/Windows worst, ~50%).
+ *
+ *  Mocking the endpoint in every window keeps those auto-refresh loadUsers on a
+ *  200 fake user: no 401, no cross-window sign-out. Restored per-window in
+ *  after() (restoreFetchAllWindows) so the patch can't leak into later specs. */
+async function tuneUserFetchMockAllWindows(delayMs: number, email: string): Promise<void> {
+  const start = await browser.getWindowHandle();
+  for (const handle of await browser.getWindowHandles()) {
+    try {
+      await browser.switchToWindow(handle);
+      await tuneUserFetchMock(delayMs, email);
+    } catch {
+      // window may have closed mid-iteration; best-effort
+    }
+  }
+  await browser.switchToWindow(start).catch(() => {});
+}
+
+/** Undo tuneUserFetchMockAllWindows: restore window.fetch in every window so a
+ *  fake /api/user response cannot leak into later specs in the shared session. */
+async function restoreFetchAllWindows(): Promise<void> {
+  const start = await browser.getWindowHandle().catch(() => null);
+  const handles = await browser.getWindowHandles().catch(() => [] as string[]);
+  for (const handle of handles) {
+    try {
+      await browser.switchToWindow(handle);
+      await restoreFetch();
+    } catch {
+      // best-effort
+    }
+  }
+  if (start) await browser.switchToWindow(start).catch(() => {});
+}
+
 async function userFetchCalls(): Promise<number> {
   return (await browser.execute(
     () => ((window as unknown as Record<string, unknown>).__E2E_USER_CALLS as number) || 0,
@@ -169,7 +212,10 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
   before(async () => {
     await waitForAppReady();
     await openHomeWindow();
-    await tuneUserFetchMock(0, FAKE_EMAIL);
+    // Mock /api/user in every window (not just home) so non-home windows'
+    // auto-refresh loadUser can't 401 and broadcast a session-clearing
+    // sign-out mid-test. See tuneUserFetchMockAllWindows.
+    await tuneUserFetchMockAllWindows(0, FAKE_EMAIL);
     await openAccountSettings();
   });
 
@@ -184,7 +230,7 @@ describe("Logout is not resurrected by an in-flight loadUser", function () {
     } catch {
       // best-effort
     }
-    await restoreFetch().catch(() => {});
+    await restoreFetchAllWindows().catch(() => {});
     await browser.execute(() => window.location.reload());
     await browser
       .waitUntil(


### PR DESCRIPTION
## What

Fixes the two specs that have been intermittently reddening the **E2E Tests** workflow on `main` (Linux + Windows; macOS was unaffected). Both fixes are **test-only**, no product code changes.

This is the durable fix for the `zz-logout-resurrect` flake. Note: skipping/quarantining that spec was tried twice before and reverted, so this fixes the test harness instead.

## Flake 1: `zz-logout-resurrect` (the dominant one, ~40% of runs)

The failure was always in **Phase A (login setup)**, not in the in-flight-loadUser regression guard the spec exists to protect. The product code is correct; this was a multi-window test artifact.

```mermaid
sequenceDiagram
    participant T as Test
    participant H as Home window (mocked)
    participant O as Other window (NOT mocked)
    participant S as Shared settings store
    participant N as Real network

    T->>H: emitTo("home") deep-link login (fake token)
    H->>H: loadUser -> mock 200 -> user written
    H->>S: write user + token
    S-->>O: token changed (cross-window broadcast)
    O->>N: auto-refresh loadUser(fakeToken)
    N-->>O: 401 (fake token, real server)
    O->>S: auth interceptor -> user=null + emit("screenpipe-auth-signout")
    S-->>H: home session cleared
    Note over H: Phase A now sees "not logged in" -> FLAKE
```

The earlier `emitTo("home")` fix only kept the **deep-link** `loadUser` in the mocked home window. But the **auto-refresh** effect in `lib/hooks/use-settings.tsx` (keyed on `settings.user?.token`) fires `loadUser` in *every* window when the shared token changes, and those non-home calls hit the real network and 401.

**Fix:** mock `/api/user` in **every** window (`tuneUserFetchMockAllWindows`), restored per-window in `after()` (`restoreFetchAllWindows`) so the patch cannot leak into later specs in the shared session. Every auto-refresh `loadUser` now gets a 200 fake user, so no 401 and no cross-window sign-out.

## Flake 2: `tray-search` "reuses the Search handle" (intermittent)

The product re-seeds the query on window reuse via `window.location.replace("/search/?q=...")` (`src-tauri/.../window/show.rs`). The second `open_search_window` could fire that `replace` before the first window finished its initial `/search` load, so the navigation was lost and `?q=` never seeded.

**Fix:** wait for the first search window's input to exist (initial load committed) before reusing it.

## Verification

The flake is Linux/Windows-specific, so it cannot be reproduced on a macOS dev box. Verification is this PR's **E2E Tests** run across all three platforms. I will re-run the E2E job a few times to confirm the flake is gone (a single green pass is not proof for a ~40% flake) before this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
