### PR TITLE
fix(settings): keep logout visible in narrow/adaptive account view

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -218,14 +218,15 @@ export function AccountSection() {
 
   return (
     <div className="space-y-6">
-      {/* Header + login status */}
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground" data-testid="account-login-status">
+      {/* Header + login status. Wrap + truncate so the email never pushes the
+          manage/logout buttons off-screen in narrow/adaptive layouts (#3587). */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-sm text-muted-foreground" data-testid="account-login-status">
           {settings.user?.token
             ? `logged in as ${settings.user.email}`
             : "not logged in"}
         </p>
-        <div className="flex gap-2">
+        <div className="flex shrink-0 gap-2">
           {settings.user?.token ? (
             <>
               <Button


### PR DESCRIPTION
![before vs after](https://raw.githubusercontent.com/screenpipe/screenpipe/pr-assets/3587.png)

## Problem

Closes #3587.

In the account/profile view, the header row puts the login status on the left and the **manage / logout** buttons on the right via `flex justify-between`. The status text could not shrink, so with a long email and a narrow window (reporter: MacBook 14" at 50% width) it pushed the buttons past the right edge. They were clipped, with no scrollbar and no way to reach **logout**.

## Fix (CSS-only, `account-section.tsx`)

```
narrow account view (~460px content)

BEFORE  (flex justify-between, no wrap)        AFTER  (flex-wrap + truncate + shrink-0)
┌──────────────────────────────────┐          ┌──────────────────────────────────┐
│ logged in as alex.thompson@some-c…│ [manage] │ logged in as alex.thompson@so…     │
│                                   │ [logout] │              [⚙ manage] [logout]   │
└──────────────────────────────────┘  ▲        └──────────────────────────────────┘
                            clipped off-screen          both buttons always visible
```

Three changes to the header container:
- `flex-wrap` + `gap-2` so the buttons wrap to a second line instead of overflowing off-screen
- `min-w-0 truncate` on the status text so a long email ellipsizes instead of shoving the buttons out
- `shrink-0` on the button group so the buttons keep full size

An empty list / short email is unchanged; this only kicks in when space is tight.

## Testing

- `bun run typecheck` passes.
- Layout verified against a standalone reproduction at 460px content width (the reporter's ~50%-screen case): before clips `logout`, after keeps both buttons reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
