### PR TITLE
fix(ui): render native scrollbars/controls dark in dark theme (Windows)

### DIFF
--- a/apps/screenpipe-app-tauri/app/globals.css
+++ b/apps/screenpipe-app-tauri/app/globals.css
@@ -4,6 +4,10 @@
 
 @layer base {
   :root {
+    /* Tell the engine the UI is light by default so native scrollbars and form
+       controls render correctly. Overridden by `.dark` below. (#3746) */
+    color-scheme: light;
+
     /*
      * Screenpipe Brand Style Guide
      * Black & White Geometric Minimalism
@@ -117,6 +121,12 @@
   }
 
   .dark {
+    /* Match native scrollbars and form controls to the dark UI even when the OS
+       is in light mode. The theme is class-based (`.dark` on <html>), not
+       prefers-color-scheme, so without this the WebView keeps painting a light
+       scrollbar/controls in dark mode (most visible on Windows). (#3746) */
+    color-scheme: dark;
+
     /* Base colors - Slightly lifted black */
     --background: 0 0% 7%; /* #121212 */
     --foreground: 0 0% 100%; /* #FFFFFF */


### PR DESCRIPTION
![before vs after](https://raw.githubusercontent.com/screenpipe/screenpipe/pr-assets/3746.png)

## Problem

Closes #3746.

On Windows in dark theme, the scrollbar and some native controls render light and look broken against the dark UI.

Root cause: the app theme is **class-based** (`.dark` on `<html>`, toggled by the theme provider), but the `color-scheme` CSS property was only ever set inside `@media (prefers-color-scheme: …)` fallbacks. So when a user selects the dark theme while their **OS is in light mode** (extremely common on Windows), `color-scheme` stays `light` and the WebView keeps painting the default light scrollbar / native controls.

```
OS = light, app theme = dark

BEFORE                                   AFTER
┌───────────────────────────┬─┐         ┌───────────────────────────┬─┐
│ dark app content          │█│ ← light │ dark app content          │▓│ ← dark
│                           │ │   track │                           │ │   track
│                           │░│ on dark │                           │▒│ matches
└───────────────────────────┴─┘         └───────────────────────────┴─┘
```

## Fix (CSS-only)

Bind `color-scheme` to the theme classes in `globals.css`:
- `:root { color-scheme: light; }`
- `.dark { color-scheme: dark; }`

Chromium/WebView2 then paints native scrollbars and form controls to match the **selected** theme, independent of the OS setting. `.dark` follows `:root` in source order at equal specificity, so dark wins when `html.dark` is set.

## Testing

CSS-only change using a standard property. I don't have a Windows box in this environment to capture the before/after, so this is verified by inspection: `color-scheme` is the documented mechanism for theming native scrollbars/controls on Chromium, and the bug is precisely that it was gated behind `prefers-color-scheme` instead of the app's theme class. Worth a quick visual confirmation on a Windows build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
