### PR TITLE
Fix mid-text click in meeting notes and chat selection

### DIFF
--- a/apps/screenpipe-app-tauri/app/layout.tsx
+++ b/apps/screenpipe-app-tauri/app/layout.tsx
@@ -318,8 +318,11 @@ export default function RootLayout({
     const SELECTABLE =
       '.prose, .selectable-text-layer, input, textarea, [contenteditable="true"], [contenteditable=""]';
     const onSelectStart = (e: Event) => {
-      const target = e.target as Element | null;
-      if (target?.closest?.(SELECTABLE)) return; // allow selecting real content
+      // e.target may be a Text node (when clicking mid-text), which lacks
+      // .closest(). Walk up to the nearest Element so the check works.
+      const node = e.target as Node | null;
+      const el = node instanceof Element ? node : node?.parentElement;
+      if (el?.closest?.(SELECTABLE)) return; // allow selecting real content
       e.preventDefault();
     };
     document.addEventListener("selectstart", onSelectStart);


### PR DESCRIPTION
This PR fixes cursor placement and text selection being broken when clicking mid-sentence across the app in meeting notes editor, chat messages, and any `.prose` or `contenteditable` area.

The cursor would jump to the end of the line instead of landing where you clicked, and drag-selection from mid-sentence didn't work either.

Root cause: the `selectstart` handler in `layout.tsx` assumed `e.target` is always an Element, but mid-text clicks produce Text nodes which lack `.closest()`, so `preventDefault()` fired and blocked all mid-text selections.

Fixed by walking up to the parent Element for Text nodes before checking `.closest()`


fixes #3906 
fixes #3772 


https://github.com/user-attachments/assets/b5fef2ca-866f-49a2-bd34-54ec2b679d13

https://github.com/user-attachments/assets/89ea4372-32ad-4428-a0e7-811747ab20fa



