### PR TITLE
Reduce UI recorder idle wakeups

### DIFF
--- a/crates/screenpipe-a11y/src/platform/windows.rs
+++ b/crates/screenpipe-a11y/src/platform/windows.rs
@@ -275,32 +275,30 @@ impl UiRecorder {
         let tx4 = tx.clone();
         let stop4 = stop.clone();
         threads.push(thread::spawn(move || {
-            while !stop4.load(Ordering::Relaxed) {
-                match element_rx.recv_timeout(std::time::Duration::from_millis(100)) {
-                    Ok((req, ctx)) => {
-                        // Send a supplementary event with the element context for the click
-                        let event = UiEvent {
-                            id: None,
-                            timestamp: req.timestamp,
-                            relative_ms: 0,
-                            data: EventData::Click {
-                                x: req.x,
-                                y: req.y,
-                                button: 0,
-                                click_count: 0, // Marker: this is an element-context-only event
-                                modifiers: 0,
-                            },
-                            app_name: None,
-                            window_title: None,
-                            browser_url: None,
-                            element: Some(ctx),
-                            frame_id: None,
-                        };
-                        let _ = tx4.try_send(event);
-                    }
-                    Err(crossbeam_channel::RecvTimeoutError::Timeout) => continue,
-                    Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+            while let Ok((req, ctx)) = element_rx.recv() {
+                if stop4.load(Ordering::Relaxed) {
+                    break;
                 }
+
+                // Send a supplementary event with the element context for the click
+                let event = UiEvent {
+                    id: None,
+                    timestamp: req.timestamp,
+                    relative_ms: 0,
+                    data: EventData::Click {
+                        x: req.x,
+                        y: req.y,
+                        button: 0,
+                        click_count: 0, // Marker: this is an element-context-only event
+                        modifiers: 0,
+                    },
+                    app_name: None,
+                    window_title: None,
+                    browser_url: None,
+                    element: Some(ctx),
+                    frame_id: None,
+                };
+                let _ = tx4.try_send(event);
             }
         }));
 

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1897,7 +1897,7 @@ async fn do_capture(
                 let new_hash = snap.content_hash as i64;
                 if let Some(prev) = previous_content_hash {
                     if prev == new_hash && new_hash != 0 {
-                        info!(
+                        debug!(
                             "content dedup: skipping capture for monitor {} (hash={}, trigger={})",
                             params.monitor_id,
                             new_hash,

--- a/crates/screenpipe-engine/src/frame_linker_actor.rs
+++ b/crates/screenpipe-engine/src/frame_linker_actor.rs
@@ -19,7 +19,7 @@ use std::time::{Duration, Instant};
 use screenpipe_db::DatabaseManager;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use crate::frame_linker::{
     CorrelationId, DropReason, EventPersisted, FrameCaptured, FrameLinker, FrameLinkerConfig,
@@ -151,7 +151,7 @@ pub fn spawn_frame_linker(
                                 linker.on_event_persisted(e, Instant::now())
                             {
                                 PAIRS_EMITTED.fetch_add(1, Ordering::Relaxed);
-                                info!(
+                                debug!(
                                     corr_id,
                                     row_id = update.row_id,
                                     frame_id = update.frame_id,
@@ -176,7 +176,7 @@ pub fn spawn_frame_linker(
                             let updates = linker.on_frame_captured(c, Instant::now());
                             if !updates.is_empty() {
                                 PAIRS_EMITTED.fetch_add(updates.len() as u64, Ordering::Relaxed);
-                                info!(
+                                debug!(
                                     frame_id,
                                     paired = updates.len(),
                                     still_pending = n_corr - updates.len(),

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -12,12 +12,15 @@ use screenpipe_core::window_pattern::{self, WindowPattern};
 use screenpipe_db::{DatabaseManager, InsertUiEvent};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::frame_linker::{CorrelationId, EventPersisted};
 use crate::frame_linker_actor::{next_correlation_id, LinkerMessage, LinkerSender};
+
+const UI_RECORDER_IDLE_RECV_TIMEOUT: Duration = Duration::from_secs(1);
+const UI_RECORDER_MIN_RECV_TIMEOUT: Duration = Duration::from_millis(1);
 
 /// A batched UI event plus an optional correlation id. Events that
 /// won't trigger a capture (Move, Idle, filtered-out targets) leave
@@ -567,8 +570,10 @@ pub async fn start_ui_recording(
                 break;
             }
 
-            // Try to receive events with timeout
-            match handle.recv_timeout(Duration::from_millis(100)) {
+            let recv_timeout =
+                next_ui_event_recv_timeout(&batch, last_flush, batch_timeout, &scroll_burst);
+
+            match handle.recv_timeout(recv_timeout) {
                 Some(event) => {
                     let db_event = event.to_db_insert(Some(session_id.clone()));
                     let app_lower = db_event
@@ -971,6 +976,55 @@ impl ScrollBurstTracker {
             None
         }
     }
+
+    fn time_until_burst_end_at(&self, now: Instant) -> Option<Duration> {
+        let last = self.last_scroll_at?;
+        Some(min_positive_timeout(
+            self.delay
+                .saturating_sub(now.saturating_duration_since(last)),
+        ))
+    }
+}
+
+fn min_positive_timeout(timeout: Duration) -> Duration {
+    timeout.max(UI_RECORDER_MIN_RECV_TIMEOUT)
+}
+
+fn next_ui_event_recv_timeout(
+    batch: &EventBatch,
+    last_flush: Instant,
+    batch_timeout: Duration,
+    scroll_burst: &ScrollBurstTracker,
+) -> Duration {
+    next_ui_event_recv_timeout_at(
+        batch,
+        last_flush,
+        batch_timeout,
+        scroll_burst,
+        Instant::now(),
+    )
+}
+
+fn next_ui_event_recv_timeout_at(
+    batch: &EventBatch,
+    last_flush: Instant,
+    batch_timeout: Duration,
+    scroll_burst: &ScrollBurstTracker,
+    now: Instant,
+) -> Duration {
+    let mut timeout = UI_RECORDER_IDLE_RECV_TIMEOUT;
+
+    if !batch.is_empty() {
+        timeout = timeout.min(min_positive_timeout(
+            batch_timeout.saturating_sub(now.saturating_duration_since(last_flush)),
+        ));
+    }
+
+    if let Some(scroll_timeout) = scroll_burst.time_until_burst_end_at(now) {
+        timeout = timeout.min(scroll_timeout);
+    }
+
+    timeout
 }
 
 #[cfg(test)]
@@ -1040,6 +1094,70 @@ mod event_batch_tests {
         assert!(b.is_empty());
         assert_eq!(b.events.len(), 0);
         assert_eq!(b.correlation_ids.len(), 0);
+    }
+
+    #[test]
+    fn idle_recv_timeout_uses_long_backoff_without_pending_work() {
+        let batch = EventBatch::with_capacity(0);
+        let scroll = ScrollBurstTracker::new(Duration::from_millis(300));
+        let now = Instant::now();
+
+        let timeout =
+            next_ui_event_recv_timeout_at(&batch, now, Duration::from_secs(1), &scroll, now);
+
+        assert_eq!(timeout, UI_RECORDER_IDLE_RECV_TIMEOUT);
+    }
+
+    #[test]
+    fn recv_timeout_tracks_batch_flush_deadline() {
+        let mut batch = EventBatch::with_capacity(1);
+        batch.push(evt(), None);
+        let scroll = ScrollBurstTracker::new(Duration::from_millis(300));
+        let now = Instant::now();
+
+        let timeout = next_ui_event_recv_timeout_at(
+            &batch,
+            now - Duration::from_millis(750),
+            Duration::from_secs(1),
+            &scroll,
+            now,
+        );
+
+        assert_eq!(timeout, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn recv_timeout_tracks_scroll_burst_deadline() {
+        let batch = EventBatch::with_capacity(0);
+        let now = Instant::now();
+        let scroll = ScrollBurstTracker {
+            last_scroll_at: Some(now - Duration::from_millis(250)),
+            last_scroll_corr_id: Some(1),
+            delay: Duration::from_millis(300),
+        };
+
+        let timeout =
+            next_ui_event_recv_timeout_at(&batch, now, Duration::from_secs(1), &scroll, now);
+
+        assert_eq!(timeout, Duration::from_millis(50));
+    }
+
+    #[test]
+    fn recv_timeout_never_returns_zero_for_due_work() {
+        let mut batch = EventBatch::with_capacity(1);
+        batch.push(evt(), None);
+        let scroll = ScrollBurstTracker::new(Duration::from_millis(300));
+        let now = Instant::now();
+
+        let timeout = next_ui_event_recv_timeout_at(
+            &batch,
+            now - Duration::from_secs(2),
+            Duration::from_secs(1),
+            &scroll,
+            now,
+        );
+
+        assert_eq!(timeout, UI_RECORDER_MIN_RECV_TIMEOUT);
     }
 }
 


### PR DESCRIPTION
## Summary
- make the UI recorder event loop compute its receive timeout from actual pending work instead of waking every 100ms while idle
- remove the Windows element-context bridge polling loop by blocking on the UIA result channel until data or disconnect
- downgrade hot success/skip logs (`frame_linker` successful pairs and content-dedup skips) from INFO to DEBUG to avoid default stdout work during normal input bursts

## CPU / wakeup notes
- UI recorder idle receive wakeups drop from 10/sec to about 1/sec when there is no pending batch or scroll-stop deadline.
- Batch flush and scroll-stop latency are preserved by waking at the nearest pending deadline.
- Element-context bridge idle wakeups drop from 10/sec to zero; it now wakes only on click-context messages or UIA sender disconnect.
- Final local profile (`screenpipe record`, audio/telemetry/keyboard/clipboard/snapshot-compaction/meeting-detector disabled) stayed low in typing/scrolling and quieted the prior default INFO spam:
  - typing avg: 1.689% of one core
  - scrolling avg: 1.153% of one core
  - idle_post avg: 0.354% of one core

## Test plan
- `cargo fmt`
- `ORT_SKIP_DOWNLOAD=1 cargo test -p screenpipe-a11y platform::windows::tests::test_permission_check --lib`
- `ORT_SKIP_DOWNLOAD=1 cargo test -p screenpipe-engine ui_recorder::event_batch_tests --lib`
- `ORT_SKIP_DOWNLOAD=1 cargo test -p screenpipe-engine frame_linker::tests --lib`
- `ORT_SKIP_DOWNLOAD=1 cargo build --release -p screenpipe-engine --bin screenpipe`