### PR TITLE
Fix Windows capture startup stalls and reduce active-work CPU

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -29,6 +29,8 @@ use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, watch};
 use tracing::{debug, error, info, warn};
 
+const CAPTURE_OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
+
 /// Stable configuration for a single capture invocation.
 ///
 /// Groups parameters that don't change between captures on the same monitor,
@@ -43,6 +45,16 @@ pub struct CaptureParams<'a> {
     pub use_pii_removal: bool,
     pub pause_on_drm_content: bool,
     pub languages: &'a [screenpipe_core::Language],
+}
+
+async fn capture_with_timeout<F, T>(
+    duration: Duration,
+    future: F,
+) -> std::result::Result<T, tokio::time::error::Elapsed>
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::time::timeout(duration, future).await
 }
 
 /// Types of events that trigger a capture.
@@ -197,6 +209,30 @@ fn trigger_reduce_priority(trigger: &CaptureTrigger) -> u8 {
     } else {
         1
     }
+}
+
+fn quiet_activity_window_ms(visual_check_interval: Duration) -> u64 {
+    let quiet_ms = visual_check_interval.as_millis().saturating_mul(2);
+    quiet_ms.min(u64::MAX as u128) as u64
+}
+
+fn should_run_visual_check(
+    trigger: &Option<CaptureTrigger>,
+    visual_check_enabled: bool,
+    can_capture: bool,
+    drm_paused: bool,
+    schedule_paused: bool,
+    elapsed_since_visual_check: Duration,
+    visual_check_interval: Duration,
+    keyboard_idle_ms: u64,
+) -> bool {
+    trigger.is_none()
+        && visual_check_enabled
+        && can_capture
+        && !drm_paused
+        && !schedule_paused
+        && elapsed_since_visual_check >= visual_check_interval
+        && keyboard_idle_ms >= quiet_activity_window_ms(visual_check_interval)
 }
 
 impl CaptureTrigger {
@@ -654,19 +690,22 @@ pub async fn event_driven_capture_loop(
         state.last_capture = Instant::now()
             .checked_sub(Duration::from_millis(500))
             .unwrap_or(Instant::now()); // allow capture
-        match do_capture(
-            &capture_params,
-            &CaptureTrigger::Manual,
-            None, // first capture — no previous hash
-            last_db_write,
-            None, // first capture — no elements ref
-            &mut walk_budget,
-            false, // screenshot enabled on startup
-            false, // hd not active at startup (Manual is dedup-exempt anyway)
+        match capture_with_timeout(
+            CAPTURE_OPERATION_TIMEOUT,
+            do_capture(
+                &capture_params,
+                &CaptureTrigger::Manual,
+                None, // first capture — no previous hash
+                last_db_write,
+                None, // first capture — no elements ref
+                &mut walk_budget,
+                false, // screenshot enabled on startup
+                false, // hd not active at startup (Manual is dedup-exempt anyway)
+            ),
         )
         .await
         {
-            Ok(output) => {
+            Ok(Ok(output)) => {
                 state.mark_captured();
                 if let Some(ref mut comparer) = frame_comparer {
                     let _ = comparer.compare(&output.image);
@@ -697,8 +736,14 @@ pub async fn event_driven_capture_loop(
                     vision_metrics.record_dedup_skip();
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!("startup capture failed for monitor {}: {}", monitor_id, e);
+            }
+            Err(_timeout) => {
+                warn!(
+                    "startup capture timed out after {:?} for monitor {}; continuing with live capture loop",
+                    CAPTURE_OPERATION_TIMEOUT, monitor_id
+                );
             }
         }
     } else {
@@ -1122,13 +1167,16 @@ pub async fn event_driven_capture_loop(
         // Use the same window exclusions as the full capture so the diff image
         // matches what we'd actually store — avoids triggering on excluded
         // windows and seeing phantom "visual changes" from their pixels.
-        if trigger.is_none()
-            && visual_check_enabled
-            && state.can_capture()
-            && !crate::drm_detector::drm_content_paused()
-            && !crate::schedule_monitor::schedule_paused()
-            && last_visual_check.elapsed() >= visual_check_interval
-        {
+        if should_run_visual_check(
+            &trigger,
+            visual_check_enabled,
+            state.can_capture(),
+            crate::drm_detector::drm_content_paused(),
+            crate::schedule_monitor::schedule_paused(),
+            last_visual_check.elapsed(),
+            visual_check_interval,
+            activity_feed.keyboard_idle_ms(),
+        ) {
             last_visual_check = Instant::now();
             let vc_filters = WindowFilters::new(
                 &capture_params.tree_walker_config.ignored_windows,
@@ -1240,8 +1288,8 @@ pub async fn event_driven_capture_loop(
                 // if the DB is truly stuck. 15s is generous — normal captures take
                 // 1-3s on debug builds. The semaphore serializes writes so they
                 // don't pile up, but each write still needs time.
-                let capture_result = tokio::time::timeout(
-                    Duration::from_secs(15),
+                let capture_result = capture_with_timeout(
+                    CAPTURE_OPERATION_TIMEOUT,
                     do_capture(
                         &capture_params,
                         &trigger,
@@ -2490,6 +2538,51 @@ mod tests {
         assert_eq!(corrs, vec![1, 2]);
     }
 
+    #[test]
+    fn visual_check_skips_while_keyboard_activity_is_recent() {
+        let interval = Duration::from_secs(3);
+        assert!(!should_run_visual_check(
+            &None,
+            true,
+            true,
+            false,
+            false,
+            Duration::from_secs(4),
+            interval,
+            quiet_activity_window_ms(interval) - 1,
+        ));
+    }
+
+    #[test]
+    fn visual_check_runs_after_keyboard_activity_is_quiet() {
+        let interval = Duration::from_secs(3);
+        assert!(should_run_visual_check(
+            &None,
+            true,
+            true,
+            false,
+            false,
+            Duration::from_secs(4),
+            interval,
+            quiet_activity_window_ms(interval),
+        ));
+    }
+
+    #[test]
+    fn visual_check_keeps_existing_trigger_gate() {
+        let interval = Duration::from_secs(3);
+        assert!(!should_run_visual_check(
+            &Some(CaptureTrigger::Click { x: 10, y: 20 }),
+            true,
+            true,
+            false,
+            false,
+            Duration::from_secs(4),
+            interval,
+            quiet_activity_window_ms(interval),
+        ));
+    }
+
     #[tokio::test]
     async fn test_trigger_receiver_recv_async() {
         let (tx, mut rx) = trigger_channel();
@@ -2500,6 +2593,16 @@ mod tests {
         .unwrap();
         let got = rx.recv().await.unwrap();
         assert_eq!(got.trigger, CaptureTrigger::Click { x: 10, y: 20 });
+    }
+
+    #[tokio::test]
+    async fn capture_timeout_returns_elapsed_for_stuck_future() {
+        let result = capture_with_timeout(Duration::from_millis(10), async {
+            std::future::pending::<Result<CaptureOutput>>().await
+        })
+        .await;
+
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Wrap startup capture in the same 15s timeout used by live captures so a stuck first Windows/UIA capture cannot block the monitor loop forever.
- Gate visual-change screenshots while keyboard activity is still recent, avoiding redundant background frame-diff captures during typing-driven full captures.
- Keep visual checks active after keyboard activity goes quiet, so mouse-only movement does not suppress passive visual capture.

## Verification
- `cargo fmt --package screenpipe-engine`
- `cargo build -p screenpipe-engine --profile release-dev --no-default-features`
- 5-minute Windows CLI benchmark with simulated Notepad typing, audio/telemetry/meeting detector disabled:
  - before startup timeout fix: UI events persisted but 0 frames
  - after startup timeout fix: 77 frames / 77 UI events
  - after keyboard-only visual gate: mean CPU 3.579%, median 2.972%, p90 7.411%, max 12.394%, with 77 frames / 77 UI events / 77 non-empty accessibility frames

## Notes
- Focused `cargo test` did not complete in this local workspace: debug target filled the system drive, and release-dev test harness compilation timed out. The release-dev build and runtime benchmark completed successfully.