### PR TITLE
feat(app): remove "Book a call" from settings feedback

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { ShareLogsButton } from "@/components/share-logs-button";
-import { MessageSquare, Github, Lightbulb, Calendar, FileText, Youtube, BookOpen, Play } from "lucide-react";
+import { MessageSquare, Github, Lightbulb, FileText, Youtube, BookOpen, Play } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
 
 function DiscordIcon(props: React.SVGProps<SVGSVGElement>) {
@@ -180,24 +180,6 @@ export function FeedbackSection() {
               className="text-xs text-muted-foreground hover:text-foreground transition-colors duration-150"
             >
               screenpipe.com/changelog →
-            </button>
-          </div>
-        </div>
-
-        <div className="px-3 py-2.5 bg-card border border-border">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2.5">
-              <Calendar className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground">Book a call</h3>
-                <p className="text-xs text-muted-foreground">talk with the founder</p>
-              </div>
-            </div>
-            <button
-              onClick={() => open("https://cal.com/team/screenpipe/chat")}
-              className="text-xs text-muted-foreground hover:text-foreground transition-colors duration-150"
-            >
-              schedule →
             </button>
           </div>
         </div>


### PR DESCRIPTION
## what

Remove the **Settings → Feedback → "Book a call"** row entirely. It linked any user (including individuals/consumers) straight to a 1:1 founder call.

People who want to talk now go through **Settings → Team** ("Bring your team to Screenpipe"), which has its own "Book a call" for the team / business path. This keeps the call path self-selecting for business without a separate consumer gate in the app.

## change

```
Settings → Feedback
  ...
  Changelog            screenpipe.com/changelog →
- Book a call          schedule →          (removed)
-   talk with the founder  → cal.com
```

Two-line removal of the row + the now-unused `Calendar` import. Nothing else in feedback touched.

## not changed
- **Settings → Team** "Book a call" (team/business path users are routed to) — unchanged.
- **Support** paths — onboarding `engine-startup` and overlay "send logs / schedule call" — unchanged.