### PR TITLE
fix(tray): show "Stop HD recording" when an HD session is active

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -383,6 +383,17 @@ struct MenuState {
     cloud_subscribed: bool,
     /// Plan id (Free/Basic/Business/…) so plan-label changes also rebuild the menu
     subscription_plan: Option<String>,
+    /// HD high-fps session state, for change detection. Without these, starting
+    /// or stopping an HD session changes nothing in MenuState, so
+    /// update_menu_if_needed computes should_update=false and never re-queues
+    /// the menu — the "Stop HD recording" item then never replaces the "Record
+    /// HD" submenu (and the countdown never ticks). Mirrors what
+    /// create_dynamic_menu renders into the HD label so any visible change
+    /// triggers a rebuild.
+    hd_active: bool,
+    hd_remaining_secs: u64,
+    hd_session_kind: String,
+    hd_interval_ms: u64,
 }
 
 pub fn setup_tray(app: &AppHandle, update_item: Option<&tauri::menu::MenuItem<Wry>>) -> Result<()> {
@@ -1392,6 +1403,7 @@ async fn update_menu_if_needed(
 
     let recording_info = get_recording_info();
     let effective_status = get_effective_recording_status();
+    let hd = get_high_fps_status();
     let new_state = MenuState {
         shortcuts: {
             let mut m = HashMap::new();
@@ -1410,6 +1422,10 @@ async fn update_menu_if_needed(
             .collect(),
         cloud_subscribed: data.cloud_subscribed,
         subscription_plan: data.subscription_plan.clone(),
+        hd_active: hd.active,
+        hd_remaining_secs: hd.remaining_secs,
+        hd_session_kind: hd.session_kind,
+        hd_interval_ms: hd.interval_ms,
     };
 
     // Compare with last state (poison-safe: run handler must not panic)


### PR DESCRIPTION
## What

When an HD session is active, the tray menu kept showing the **"Record HD"** duration submenu instead of **"Stop HD recording (… left)"**, so there was no way to see HD was running or stop it early. Reported on v2.5.27 (macOS).

## Root cause

The macOS tray avoids background `set_menu` (muda use-after-free), so the poller queues "pending" menu inputs and the **mouse-down handler installs them on open**. A pending refresh is only queued when `should_update` fires, and `should_update` is driven entirely by the `MenuState` change-detection struct.

`MenuState` tracked shortcuts, recording status, devices, subscription, etc. but **no HD/high-fps state**. So toggling HD changed nothing in `MenuState`:

```mermaid
sequenceDiagram
    participant U as User
    participant Eng as Engine (/capture/hd)
    participant Poll as update_menu_if_needed (~1s)
    participant MS as MenuState (change-detect)
    participant Tray as tray menu (on open)

    U->>Eng: Record HD -> 15 min
    Eng-->>Eng: active=true (verified live)
    Poll->>MS: build new_state (no HD field)
    MS-->>Poll: new_state == last_state
    Note over Poll: should_update = false -> NO pending queued
    U->>Tray: click tray
    Note over Tray: pending is None -> keep stale menu
    Tray-->>U: still shows "Record HD" ❌
```

Confirmed live while the bug reproduced: `GET /capture/hd` returned `{"active":true,"session":{"kind":"timer"},"remainingSecs":453}` while the tray still showed "Record HD". `create_dynamic_menu` already reads `get_high_fps_status()` live, so the only gap was the rebuild trigger.

## Fix

Add the HD fields to `MenuState` and populate them from `get_high_fps_status()`, so any visible HD label change (start, stop, countdown, fps, meeting-vs-timer) re-queues the menu:

```
hd_active / hd_remaining_secs / hd_session_kind / hd_interval_ms
```

The 3 `MenuState::default()` sites are unaffected (new fields default to false/0/""). Net: starting HD now flips the menu to "Stop HD recording (… left)" on the next open, the countdown ticks, and stopping returns it to the "Record HD" submenu.

## Test

1. Tray > Record HD > 15 minutes.
2. Reopen the tray menu: it now shows **"Stop HD recording (~10 fps, 14m left)"** plus **"Extend HD by +30 min"** (was: "Record HD" submenu).
3. Click Stop HD: menu returns to the "Record HD" submenu.

Compilation verified by Rust CI + the Release App build on this PR (the tauri crate's `build.rs` needs sidecars, so it builds in CI rather than locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
