### PR TITLE
[codex] Cache event capture window filters

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -42,6 +42,7 @@ pub struct CaptureParams<'a> {
     pub device_name: &'a str,
     pub snapshot_writer: &'a SnapshotWriter,
     pub tree_walker_config: &'a TreeWalkerConfig,
+    pub window_filters: WindowFilters,
     pub use_pii_removal: bool,
     pub pause_on_drm_content: bool,
     pub languages: &'a [screenpipe_core::Language],
@@ -671,6 +672,11 @@ pub async fn event_driven_capture_loop(
         device_name: &device_name,
         snapshot_writer: &snapshot_writer,
         tree_walker_config: &tree_walker_config,
+        window_filters: WindowFilters::new(
+            &tree_walker_config.ignored_windows,
+            &tree_walker_config.included_windows,
+            &tree_walker_config.ignored_urls,
+        ),
         use_pii_removal,
         pause_on_drm_content,
         languages: &languages,
@@ -1178,12 +1184,7 @@ pub async fn event_driven_capture_loop(
             activity_feed.keyboard_idle_ms(),
         ) {
             last_visual_check = Instant::now();
-            let vc_filters = WindowFilters::new(
-                &capture_params.tree_walker_config.ignored_windows,
-                &capture_params.tree_walker_config.included_windows,
-                &capture_params.tree_walker_config.ignored_urls,
-            );
-            let mut fresh_ids = get_excluded_sck_window_ids(&vc_filters);
+            let mut fresh_ids = get_excluded_sck_window_ids(&capture_params.window_filters);
             fresh_ids.sort_unstable();
             fresh_ids.dedup();
             if fresh_ids != cached_excluded_ids {
@@ -1754,12 +1755,7 @@ async fn do_capture(
     // excludes them from the capture buffer (zero overhead, pixel-perfect).
     // Sort + dedup so the persistent stream isn't needlessly recreated when
     // transient windows (tooltips, popups) cause ordering changes.
-    let window_filters = WindowFilters::new(
-        &params.tree_walker_config.ignored_windows,
-        &params.tree_walker_config.included_windows,
-        &params.tree_walker_config.ignored_urls,
-    );
-    let mut excluded_ids = get_excluded_sck_window_ids(&window_filters);
+    let mut excluded_ids = get_excluded_sck_window_ids(&params.window_filters);
     excluded_ids.sort_unstable();
     excluded_ids.dedup();
 


### PR DESCRIPTION
## Summary
- build the event-driven capture `WindowFilters` once when the monitor loop starts
- reuse the cached filters for visual-change checks and full captures
- keep excluded SCK window IDs resolved freshly each check/capture so changing windows are still respected

## Why
The ignore/include/window URL config is stable for an event-driven capture loop, but the loop rebuilt parsed `WindowFilters` on every visual check and every full capture. Caching the parsed filters removes repeated pattern parsing and URL lowercasing from the steady capture path without changing capture behavior.

## Validation
- `cargo fmt --package screenpipe-engine -- --check`
- `cargo test -p screenpipe-engine event_driven_capture --lib`
- `cargo check -p screenpipe-engine`