### PR TITLE
[codex] Skip active audio device restart checks

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -1165,6 +1165,10 @@ pub async fn start_device_monitor(
                             continue;
                         }
 
+                        if is_device_actively_streaming(&device_manager, &device) {
+                            continue;
+                        }
+
                         match audio_manager.start_device(&device).await {
                             Ok(()) => {
                                 //


### PR DESCRIPTION
## Summary
- skip the audio device monitor's per-cycle `start_device` call when the parsed device already has a live, non-disconnected stream
- keep the existing 2s monitor cadence and recovery paths for stale, missing, disconnected, or user-disabled devices

## Why
The monitor sweep runs continuously while audio is active. Calling `start_device` on already-active devices every pass adds avoidable async/lock work in the idle path even though recovery is only needed when the stream is not active.

## Validation
- `cargo fmt --package screenpipe-audio -- --check`
- `cargo test -p screenpipe-audio device_monitor --lib`
- `cargo check -p screenpipe-audio` (passes; pre-existing unused `mut` warning in `core/stream.rs`)