### PR TITLE
fix(connections): hide Apple Calendar tile on Windows

### DIFF
--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -290,23 +290,23 @@ async fn list_connections(State(state): State<ConnectionsState>) -> Json<Value> 
 
     let mut data = serde_json::to_value(&list).unwrap_or(json!([]));
     if let Some(arr) = data.as_array_mut() {
-        // Native calendar (macOS / Windows)
-        let cal_available = tokio::task::spawn_blocking(is_native_calendar_available)
-            .await
-            .unwrap_or(false);
-        arr.push(json!({
-            "id": "apple-calendar",
-            "name": "Apple Calendar",
-            "icon": "apple-calendar",
-            "category": "calendar",
-            "description": format!(
-                "Read-only access to your native {} calendar. \
-                Query events via GET /connections/calendar/events?hours_back=1&hours_ahead=8",
-                std::env::consts::OS
-            ),
-            "fields": [],
-            "connected": cal_available,
-        }));
+        // Native calendar — macOS only (EventKit). Windows/Linux have no equivalent.
+        #[cfg(target_os = "macos")]
+        {
+            let cal_available = tokio::task::spawn_blocking(is_native_calendar_available)
+                .await
+                .unwrap_or(false);
+            arr.push(json!({
+                "id": "apple-calendar",
+                "name": "Apple Calendar",
+                "icon": "apple-calendar",
+                "category": "calendar",
+                "description": "Read-only access to your Apple Calendar. \
+                    Query events via GET /connections/calendar/events?hours_back=1&hours_ahead=8",
+                "fields": [],
+                "connected": cal_available,
+            }));
+        }
 
         let (ics_feed_count, ics_enabled_count, ics_error) =
             match screenpipe_connect::ics_calendar::load_ics_calendar_settings_from_store(


### PR DESCRIPTION
### Description: 

<img width="1112" height="456" alt="image" src="https://github.com/user-attachments/assets/d14cd823-d79f-4f8e-9159-8403e281efc5" />
<img width="1907" height="1078" alt="image" src="https://github.com/user-attachments/assets/2f79fa4e-037a-433d-8440-f5019445f1b4" />


Fixes #3967 

Apple Calendar was showing in "Suggested for this device" on Windows because the backend pushed the tile unconditionally for all platforms. Wrapped the injection in `#[cfg(target_os = "macos")]` so it only appears where EventKit exists.