### PR TITLE
fix: let pipes use OAuth GitHub connections via proxy

### DIFF
--- a/.claude/skills/screenpipe-api/SKILL.md
+++ b/.claude/skills/screenpipe-api/SKILL.md
@@ -277,20 +277,41 @@ Common patterns: `GROUP BY date(timestamp)` (daily), `GROUP BY strftime('%H:00',
 ## 8. Connections — `GET /connections`
 
 ```bash
-# List all integrations (Telegram, Slack, Discord, Email, Todoist, Teams)
+# List all integrations (Telegram, Slack, Discord, Email, Todoist, Teams, 40+)
 curl http://localhost:3030/connections
 
-# Get credentials for a connected service
+# Get saved credentials for a webhook/token integration
 curl http://localhost:3030/connections/telegram
 ```
 
-Returns credentials to use with service APIs directly:
+**Credential integrations** — `GET /connections/<id>` returns saved fields to use with the service API directly:
 - **Telegram**: `bot_token` + `chat_id` → `POST https://api.telegram.org/bot{token}/sendMessage`
 - **Slack**: `webhook_url` → `POST {webhook_url}` with `{"text": "..."}`
 - **Discord**: `webhook_url` → `POST {webhook_url}` with `{"content": "..."}`
 - **Todoist**: `api_token` → `POST https://api.todoist.com/api/v1/tasks` with Bearer auth
 - **Teams**: `webhook_url` → `POST {webhook_url}` with `{"text": "..."}`
 - **Email**: `smtp_host`, `smtp_port`, `smtp_user`, `smtp_pass`, `from_address`
+
+**OAuth/proxy integrations** — tokens are stored in SecretStore and are never exposed via `GET /connections/<id>`. Call the local proxy instead; it injects auth and forwards to the upstream API:
+
+```bash
+# GitHub — create an issue (repo owner/name from pipe settings)
+curl -X POST http://localhost:3030/connections/github/proxy/repos/OWNER/REPO/issues \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Found a bug","body":"Steps to reproduce..."}'
+
+# GitHub — comment on an issue
+curl -X POST http://localhost:3030/connections/github/proxy/repos/OWNER/REPO/issues/42/comments \
+  -H "Content-Type: application/json" \
+  -d '{"body":"Thanks for the report!"}'
+
+# Generic OAuth proxy pattern (Zoom, Vercel, Google Docs, Microsoft 365, etc.)
+curl -X POST http://localhost:3030/connections/<id>/proxy/<upstream-api-path> \
+  -H "Content-Type: application/json" \
+  -d '{...}'
+```
+
+Do **not** call `https://api.github.com/...` directly from a pipe — use `/connections/github/proxy/...` instead. There is no `/connections/<id>/token` endpoint.
 
 If not connected, tell user to set up in Settings > Connections.
 

--- a/crates/screenpipe-connect/src/connections/github_issues.rs
+++ b/crates/screenpipe-connect/src/connections/github_issues.rs
@@ -24,7 +24,9 @@ static DEF: IntegrationDef = IntegrationDef {
     icon: "github",
     category: Category::Productivity,
     description:
-        "Create GitHub issues and comments. Connected via OAuth, with repository selection handled by pipe-level settings.",
+        "Create GitHub issues and comments via OAuth proxy. Repository selection is handled by pipe-level settings. \
+        POST /connections/github/proxy/repos/{owner}/{repo}/issues with {\"title\":\"...\",\"body\":\"...\"} to create an issue. \
+        POST /connections/github/proxy/repos/{owner}/{repo}/issues/{issue_number}/comments with {\"body\":\"...\"} to comment.",
     fields: &[],
 };
 

--- a/crates/screenpipe-connect/src/connections/mod.rs
+++ b/crates/screenpipe-connect/src/connections/mod.rs
@@ -375,6 +375,37 @@ pub async fn load_connection(
     file_store.get(key).cloned()
 }
 
+/// Returns true when a connection id is configured and ready for pipes.
+/// OAuth integrations are checked via `oauth:<id>` tokens in SecretStore;
+/// credential-based integrations via `cred:<id>` / `connections.json`.
+pub async fn is_connection_configured(
+    secret_store: Option<&SecretStore>,
+    screenpipe_dir: &Path,
+    conn_id: &str,
+) -> bool {
+    let integration = all_integrations()
+        .into_iter()
+        .find(|i| i.def().id == conn_id);
+
+    let Some(integration) = integration else {
+        return false;
+    };
+
+    if integration.oauth_config().is_some() {
+        for inst in oauth::list_oauth_instances(secret_store, conn_id).await {
+            if oauth::is_oauth_instance_connected(secret_store, conn_id, inst.as_deref()).await {
+                return true;
+            }
+        }
+        false
+    } else {
+        load_connection(secret_store, screenpipe_dir, conn_id)
+            .await
+            .map(|c| c.enabled && !c.credentials.is_empty())
+            .unwrap_or(false)
+    }
+}
+
 /// Write a `SavedConnection` to SecretStore. Falls back to the legacy
 /// `connections.json` file only when no SecretStore is available.
 async fn save_connection(
@@ -933,6 +964,26 @@ mod tests {
         let context = render_context(&dir, 3030, None).await;
         assert!(context.contains("## Discord (discord, instance: work)"));
         assert!(context.contains("webhook_url: https://example.com/webhook"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn oauth_integration_counts_as_configured() {
+        use screenpipe_secrets::SecretStore;
+        use serde_json::json;
+        use sqlx::SqlitePool;
+
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        let store = SecretStore::new(pool, None).await.unwrap();
+        store
+            .set_json("oauth:github", &json!({"access_token": "gho_test"}))
+            .await
+            .unwrap();
+        let dir = temp_screenpipe_dir();
+
+        assert!(is_connection_configured(Some(&store), &dir, "github").await);
+        assert!(!is_connection_configured(Some(&store), &dir, "discord").await);
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
+++ b/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
@@ -254,11 +254,11 @@ Common patterns: `GROUP BY date(timestamp)` (daily), `GROUP BY strftime('%H:00',
 # List all integrations (Telegram, Slack, Discord, Email, Todoist, Teams, 40+)
 curl http://localhost:3030/connections
 
-# Get credentials for a connected service
+# Get saved credentials for a webhook/token integration
 curl http://localhost:3030/connections/telegram
 ```
 
-Returns credentials to use with service APIs directly:
+**Credential integrations** — `GET /connections/<id>` returns saved fields to use with the service API directly:
 - **Telegram**: `bot_token` + `chat_id` → `POST https://api.telegram.org/bot{token}/sendMessage`
 - **Slack**: `webhook_url` → `POST {webhook_url}` with `{"text": "..."}`
 - **Discord**: `webhook_url` → `POST {webhook_url}` with `{"content": "..."}`
@@ -266,10 +266,31 @@ Returns credentials to use with service APIs directly:
 - **Teams**: `webhook_url` → `POST {webhook_url}` with `{"text": "..."}`
 - **Email**: `smtp_host`, `smtp_port`, `smtp_user`, `smtp_pass`, `from_address`
 
+**OAuth/proxy integrations** — tokens are stored in SecretStore and are never exposed via `GET /connections/<id>`. Call the local proxy instead; it injects auth and forwards to the upstream API:
+
+```bash
+# GitHub — create an issue (repo owner/name from pipe settings)
+curl -X POST http://localhost:3030/connections/github/proxy/repos/OWNER/REPO/issues \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Found a bug","body":"Steps to reproduce..."}'
+
+# GitHub — comment on an issue
+curl -X POST http://localhost:3030/connections/github/proxy/repos/OWNER/REPO/issues/42/comments \
+  -H "Content-Type: application/json" \
+  -d '{"body":"Thanks for the report!"}'
+
+# Generic OAuth proxy pattern (Zoom, Vercel, Google Docs, Microsoft 365, etc.)
+curl -X POST http://localhost:3030/connections/<id>/proxy/<upstream-api-path> \
+  -H "Content-Type: application/json" \
+  -d '{...}'
+```
+
+Do **not** call `https://api.github.com/...` directly from a pipe — use `/connections/github/proxy/...` instead. There is no `/connections/<id>/token` endpoint.
+
 If not connected, tell user to set up in Settings > Connections.
 
 Each entry's `description` field is self-describing — for capabilities that
-need a control surface (browsers, gateways, etc.), the description includes
+need a control surface (browsers, gateways, OAuth proxies, etc.), the description includes
 the exact endpoint and body shape. Read it before guessing.
 
 ### Calendar Connections

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -96,8 +96,10 @@ pub struct PipeConfig {
     )]
     pub preset: Vec<String>,
 
-    /// Connections this pipe uses (e.g. `["obsidian", "slack"]`).
-    /// The AI can query `GET /connections/<id>` at runtime to get credentials.
+    /// Connections this pipe uses (e.g. `["obsidian", "slack", "github"]`).
+    /// Credential integrations: `GET /connections/<id>` returns saved fields.
+    /// OAuth/proxy integrations: call `POST /connections/<id>/proxy/<api-path>`
+    /// (the proxy injects auth; raw tokens are never exposed).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub connections: Vec<String>,
 
@@ -3396,7 +3398,7 @@ impl PipeManager {
                     }
 
                     // Setup-mode gate: pipes whose declared `connections` aren't
-                    // all configured (`enabled && credentials present`) must not
+                    // all configured (credentials or OAuth token present) must not
                     // run on schedule or event. Mirrors the manual-run gate in
                     // pipes_api::run_pipe_now. Placed after the schedule/queue
                     // checks so we only hit the SecretStore when the pipe would

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1431,14 +1431,12 @@ async fn main() -> anyhow::Result<()> {
             Box::pin(async move {
                 let mut missing = Vec::new();
                 for conn_id in required {
-                    let configured = screenpipe_connect::connections::load_connection(
+                    let configured = screenpipe_connect::connections::is_connection_configured(
                         ss.as_deref(),
                         &dir,
                         &conn_id,
                     )
-                    .await
-                    .map(|c| c.enabled && !c.credentials.is_empty())
-                    .unwrap_or(false);
+                    .await;
                     if !configured {
                         missing.push(conn_id);
                     }

--- a/crates/screenpipe-engine/src/pipes_api.rs
+++ b/crates/screenpipe-engine/src/pipes_api.rs
@@ -177,11 +177,12 @@ pub async fn run_pipe_now(
             let ss = secret_store.as_ref().map(|e| e.0.as_ref());
             let mut missing = Vec::new();
             for conn_id in required {
-                let configured =
-                    screenpipe_connect::connections::load_connection(ss, &screenpipe_dir, conn_id)
-                        .await
-                        .map(|c| c.enabled && !c.credentials.is_empty())
-                        .unwrap_or(false);
+                let configured = screenpipe_connect::connections::is_connection_configured(
+                    ss,
+                    &screenpipe_dir,
+                    conn_id,
+                )
+                .await;
                 if !configured {
                     missing.push(conn_id.as_str());
                 }


### PR DESCRIPTION
### Description:


https://github.com/user-attachments/assets/866b1cd2-285c-4e25-b511-ed9d2f0e9e45


Fixes #3972 

Fixes #3982


- GitHub shows as "Connected" after OAuth, but pipes with `connections: ["github"]` were blocked as "unconfigured" because the readiness check only looked at saved credentials, not OAuth tokens in SecretStore.
- `GET /connections/github` returns `{"credentials":{}}` by design — OAuth tokens are never exposed — so pipes/docs that expected a raw token could not authenticate to GitHub.
- Pipes trying to call `https://api.github.com/...` directly had no token and failed silently; the bundled skill still told agents to read credentials from `GET /connections/<id>`.

### Fix:

- Add `is_connection_configured()` to treat OAuth integrations as ready when a recoverable token exists in SecretStore; use it for manual and scheduled pipe connection gates.
- Update `screenpipe-api` skill, `PipeConfig.connections` docs, and GitHub connection description to document the proxy path: `POST /connections/github/proxy/repos/{owner}/{repo}/issues`.
- Regenerate `screenpipe-skills.ts` so agent-facing docs match the proxy contract.