### PR TITLE
Preserve browser sidebar collapsed state when switching chats

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -324,12 +324,20 @@ export function BrowserSidebar({ conversationId }: BrowserSidebarProps) {
         setSessionAccessRequest(null);
         setSessionAccessAnswer(null);
         setV20CookieBlock(null);
-        setVisible(true);
-        setCollapsed(false);
         setCurrentUrl(url);
         setCurrentTitle(null);
         setLoading(true);
-        persistState({ url, collapsed: false });
+        // Agent-driven navigations (owner is set) always open the panel.
+        // Ownerless events (restore/reload after chat switch) must not
+        // override the persisted collapsed state — otherwise switching
+        // away from a chat with a collapsed sidebar and back re-opens it.
+        if (owner) {
+          setVisible(true);
+          setCollapsed(false);
+          persistState({ url, collapsed: false });
+        } else {
+          persistState({ url });
+        }
       },
     );
     return () => {


### PR DESCRIPTION
This PR fixes the browser sidebar ignoring collapsed state when switching between chats. Toggling off the sidebar, switching to another chat, and switching back would re-open it.

The navigate event listener was unconditionally setting `collapsed: false` on restore events, overriding the persisted collapsed state that the restore effect had just correctly applied.

Now ownerless (restore/reload) events only persist the URL without touching collapsed state.

Before -


https://github.com/user-attachments/assets/6073dbf8-6189-4cce-b091-f0c2fcb49375



After - 

https://github.com/user-attachments/assets/954bda85-922f-4245-8966-6b00e258daf9

