### PR TITLE
fix(updates): unblock restart to apply update on macOS

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -73,28 +73,24 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
     const os = platform();
 
     try {
-      // #3622: gate restart on boot-ready. Windows downloadAndInstall calls
-      // process::exit internally, and relaunch() does the same on macOS —
-      // both race onnxruntime teardown against still-initializing native
-      // sessions if startup hasn't finished. Backend waits up to 60s and
-      // returns one of "proceed" | "errored" | "pending".
-      const gate = await commands.awaitSafeRestart(60);
-      if (gate !== "proceed") {
-        setIsInstalling(false);
-        toast({
-          title: "screenpipe is still starting up",
-          description:
-            gate === "errored"
-              ? "startup error — open settings to see details before restarting"
-              : "finish startup first, then click update again",
-          variant: "destructive",
-        });
-        return;
-      }
-
-      // On Windows, the update is not pre-downloaded by the backend (unlike macOS/Linux)
-      // We need to check for update, download, and install it before relaunching
+      // Windows: NSIS installer calls process::exit directly, bypassing our
+      // ExitRequested handler — plain relaunch is fine. macOS/Linux go through
+      // restart_for_update which sets QUIT_REQUESTED so the exit isn't blocked
+      // by main.rs (2026-06-10 "stuck on still starting" report).
       if (os === "windows") {
+        const gate = await commands.awaitSafeRestart(60);
+        if (gate !== "proceed") {
+          setIsInstalling(false);
+          toast({
+            title: "screenpipe is still starting up",
+            description:
+              gate === "errored"
+                ? "startup error — open settings to see details before restarting"
+                : "finish startup first, then click update again",
+            variant: "destructive",
+          });
+          return;
+        }
         toast({
           title: "downloading update...",
           description: "please wait while the update is downloaded",
@@ -128,16 +124,35 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
             duration: 3000,
           });
         }
+
+        // Fallback relaunch only if installer didn't run (no update available
+        // at click time); normal path: downloadAndInstall already exited.
+        await relaunch();
       } else {
-        // On macOS/Linux, the update was already downloaded by the backend
+        // macOS/Linux: bundle already staged by backend. `restart_for_update`
+        // gates internally, so no separate `awaitSafeRestart` call needed.
         toast({
           title: "installing update...",
           description: "screenpipe will restart automatically",
           duration: 10000,
         });
+        const res = await commands.restartForUpdate(60);
+        const outcome = res.status === "ok" ? res.data : "errored";
+        if (outcome !== "proceed") {
+          setIsInstalling(false);
+          toast({
+            title: "screenpipe is still starting up",
+            description:
+              outcome === "errored"
+                ? "startup error — open settings to see details before restarting"
+                : "finish startup first, then click update again",
+            variant: "destructive",
+          });
+          return;
+        }
+        // restart scheduled off-thread; runtime will tear down shortly.
+        // Leave button on "restarting…" until the process is replaced.
       }
-
-      await relaunch();
     } catch (error) {
       console.error("failed to update:", error);
       setIsInstalling(false);

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -260,6 +260,43 @@ pub async fn await_safe_restart(timeout_secs: Option<u64>) -> String {
         .to_string()
 }
 
+/// Banner-click restart. plugin-process `relaunch()` fires
+/// `ExitRequested` which `main.rs` blocks unless `QUIT_REQUESTED` is set —
+/// banner never set it, so the exit was silently cancelled and the button
+/// hung on "restarting…". Mirror the auto-update path: gate, stop server,
+/// set `QUIT_REQUESTED`, then `app.restart()`. See 2026-06-10 report.
+#[tauri::command]
+#[specta::specta]
+pub async fn restart_for_update(
+    app: tauri::AppHandle,
+    timeout_secs: Option<u64>,
+) -> Result<String, String> {
+    let cap = Duration::from_secs(timeout_secs.unwrap_or(BANNER_GATE_TIMEOUT_SECS));
+    let gate = await_restart_gate(cap, "banner-triggered restart").await;
+    if !gate.proceed() {
+        return Ok(gate.as_str().to_string());
+    }
+
+    info!("banner restart: gate passed, shutting down for update");
+
+    // Non-fatal: server.rs retries port bind if the next boot races teardown.
+    if let Err(err) = stop_screenpipe(app.state::<RecordingState>(), app.clone()).await {
+        warn!("banner restart: stop_screenpipe failed (continuing): {}", err);
+    }
+
+    QUIT_REQUESTED.store(true, Ordering::SeqCst);
+
+    // Off-thread so the IPC reply flushes before runtime teardown; also
+    // `app.restart()` from a non-main thread blocks forever once it succeeds.
+    let app_clone = app.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(250));
+        app_clone.restart();
+    });
+
+    Ok("proceed".to_string())
+}
+
 fn auto_update_enabled_from_settings(settings: Result<Option<SettingsStore>, String>) -> bool {
     settings
         .ok()
@@ -1055,5 +1092,57 @@ mod tests {
         assert!(!auto_update_enabled_from_settings(Err(
             "store unavailable".to_string()
         )));
+    }
+
+    // Banner-restart gate contract (2026-06-10 report). Full end-to-end isn't
+    // unit-testable (`app.restart()` needs a real AppHandle); we lock down the
+    // gate's return values so the frontend string-match path can't drift.
+    use crate::health::{set_boot_error, set_boot_phase};
+
+    #[tokio::test]
+    async fn await_safe_restart_returns_proceed_when_boot_ready() {
+        set_boot_phase("ready", None);
+        let result = await_safe_restart(Some(1)).await;
+        set_boot_phase("idle", None);
+        assert_eq!(
+            result, "proceed",
+            "banner gate must return proceed when boot phase is ready"
+        );
+    }
+
+    #[tokio::test]
+    async fn await_safe_restart_returns_errored_on_boot_error() {
+        set_boot_error("simulated boot failure for banner-gate test");
+        let result = await_safe_restart(Some(1)).await;
+        set_boot_phase("idle", None);
+        assert_eq!(
+            result, "errored",
+            "banner gate must surface errored so frontend toasts instead of restarting"
+        );
+    }
+
+    #[tokio::test]
+    async fn await_safe_restart_returns_pending_on_timeout() {
+        set_boot_phase("starting", None);
+        let result = await_safe_restart(Some(1)).await;
+        set_boot_phase("idle", None);
+        assert_eq!(result, "pending");
+    }
+
+    #[test]
+    fn restart_gate_proceed_is_the_only_truthy_variant() {
+        // Guards against a new variant accidentally mapping to true and
+        // shipping a process::exit race.
+        assert!(RestartGate::Proceed.proceed());
+        assert!(!RestartGate::Errored.proceed());
+        assert!(!RestartGate::DeferPending.proceed());
+    }
+
+    #[test]
+    fn restart_gate_as_str_matches_frontend_contract() {
+        // update-banner.tsx string-matches these exact values.
+        assert_eq!(RestartGate::Proceed.as_str(), "proceed");
+        assert_eq!(RestartGate::Errored.as_str(), "errored");
+        assert_eq!(RestartGate::DeferPending.as_str(), "pending");
     }
 }


### PR DESCRIPTION
### Description:

Fixes #3973 
                                                                                                         
   - macOS user report (2026-06-10): clicking "restart to apply update" hangs on "restarting…", requires manual tray Quit, then    
 app relaunches into a stuck "Screenpipe is still starting" screen.                                                                
   - Root cause: `relaunch()` fires `ExitRequested`, which `main.rs` blocks via `prevent_exit()` unless `QUIT_REQUESTED=true`.     
 Banner click never set the flag, so the exit was silently cancelled. Linux had the same bug; Windows didn't (NSIS installer calls 
 `process::exit` directly).                                                                                                        
                                                                                                                                   
   ### Fix                                                                                                                         
   - New `restart_for_update` Tauri command mirrors the auto-update path: gate → `stop_screenpipe()` → `QUIT_REQUESTED=true` →     
 `app.restart()` off-thread.                                                                                                       
   - `update-banner.tsx` routes macOS/Linux through the new command. Windows path unchanged.