### PR TITLE
fix(macos): stage PermissionFlow resource bundle into .app

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/.gitignore
+++ b/apps/screenpipe-app-tauri/src-tauri/.gitignore
@@ -4,3 +4,6 @@
 
 # Commit the Cargo.lock file
 !Cargo.lock
+
+# Swift SPM resource bundle copied by build.rs for Tauri bundling
+/PermissionFlow_PermissionFlow.bundle/

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tauri-plugin-autostart = "=2.5.1"
 tauri-plugin-shell = "=2.3.5"
 tauri-plugin-store = "=2.4.2"
 tauri-plugin-http = "=2.5.7"
-tauri-plugin-permission-flow = { git = "https://github.com/divanshu-go/permission-flow", rev = "d7376a1b95acb78700e93505d8ca058e5ddb94ce", package = "tauri-plugin-permission-flow" }
+tauri-plugin-permission-flow = { git = "https://github.com/divanshu-go/permission-flow", rev = "38a64e3704aa32e692bab95cffe704859e191a51", package = "tauri-plugin-permission-flow" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -579,13 +579,12 @@ int shortcut_is_available(void) { return 0; }
 }
 
 /// Stage `PermissionFlow_PermissionFlow.bundle` into `src-tauri/` so Tauri
-/// bundles it into `Contents/Resources/`. Missing it crashes onboarding
-/// with `fatalError` on the first localized string.
+/// bundles it into `Contents/Resources/`. Missing it crashes onboarding with
+/// `fatalError` on the first localized string in a shipped `.app`.
 ///
 /// Source path comes from `DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR`,
 /// which the plugin's build.rs re-exports from upstream `permission-flow`
-/// via Cargo `links` metadata. Panics on miss — a silent warning previously
-/// let broken `.app`s ship.
+/// via Cargo `links` metadata.
 #[cfg(target_os = "macos")]
 fn copy_permission_flow_bundle() {
     let bundle_name = "PermissionFlow_PermissionFlow.bundle";
@@ -598,12 +597,21 @@ fn copy_permission_flow_bundle() {
             panic!("DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR not set")
         });
 
+    // Missing here means swift-rs's SwiftPM build didn't emit it. Hard-fail
+    // release (shippable .app must have it) and warn-only debug (e2e CI uses
+    // --no-bundle and doesn't assemble a .app).
     if !bundle_src.exists() {
-        panic!(
-            "{} missing at {}; swift-rs build failed (rerun with -vv)",
+        let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
+        let msg = format!(
+            "{} missing at {}; swift-rs didn't emit it",
             bundle_name,
-            bundle_src.display()
+            bundle_src.display(),
         );
+        if is_release {
+            panic!("{msg}");
+        }
+        println!("cargo:warning={msg} (debug build, skipping stage)");
+        return;
     }
 
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();

--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -371,6 +371,23 @@ fn main() {
 
         // Build SwiftUI shortcut reminder
         build_shortcut_reminder();
+
+        // Stage permission-flow's resource bundle for Tauri to pick up.
+        copy_permission_flow_bundle();
+    }
+
+    // Empty stub on non-macOS so the resource entry in every tauri*.conf.json
+    // resolves to something. The bundle is macOS-only at runtime; this just
+    // keeps the bundler glob from erroring on Linux/Windows builds.
+    #[cfg(not(target_os = "macos"))]
+    {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+        let stub = std::path::PathBuf::from(&manifest_dir)
+            .join("PermissionFlow_PermissionFlow.bundle");
+        if !stub.exists() {
+            std::fs::create_dir_all(&stub).ok();
+            std::fs::write(stub.join(".placeholder"), b"").ok();
+        }
     }
 
     // Copy mlx.metallib to a known location so Tauri can bundle it as a resource.
@@ -559,4 +576,64 @@ int shortcut_is_available(void) { return 0; }
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=static=shortcut_reminder");
+}
+
+/// Stage `PermissionFlow_PermissionFlow.bundle` into `src-tauri/` so Tauri
+/// bundles it into `Contents/Resources/`. Missing it crashes onboarding
+/// with `fatalError` on the first localized string.
+///
+/// Source path comes from `DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR`,
+/// which the plugin's build.rs re-exports from upstream `permission-flow`
+/// via Cargo `links` metadata. Panics on miss — a silent warning previously
+/// let broken `.app`s ship.
+#[cfg(target_os = "macos")]
+fn copy_permission_flow_bundle() {
+    let bundle_name = "PermissionFlow_PermissionFlow.bundle";
+
+    println!("cargo:rerun-if-env-changed=DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR");
+
+    let bundle_src = std::env::var("DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            panic!(
+                "DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR not set; \
+                 plugin rev is too old to forward bundle-dir metadata"
+            )
+        });
+
+    if !bundle_src.exists() {
+        panic!(
+            "{} missing at {}; swift-rs build failed (rerun with -vv)",
+            bundle_name,
+            bundle_src.display()
+        );
+    }
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let bundle_dst = std::path::PathBuf::from(&manifest_dir).join(bundle_name);
+
+    if bundle_dst.exists() {
+        let _ = std::fs::remove_dir_all(&bundle_dst);
+    }
+
+    if let Err(e) = copy_dir_all(&bundle_src, &bundle_dst) {
+        panic!("copy {} → {}: {e}", bundle_src.display(), bundle_dst.display());
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn copy_dir_all(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)?.flatten() {
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path)?;
+        } else {
+            std::fs::copy(entry.path(), dst_path)?;
+        }
+    }
+    Ok(())
 }

--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -595,10 +595,7 @@ fn copy_permission_flow_bundle() {
     let bundle_src = std::env::var("DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
-            panic!(
-                "DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR not set; \
-                 plugin rev is too old to forward bundle-dir metadata"
-            )
+            panic!("DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR not set")
         });
 
     if !bundle_src.exists() {

--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -597,9 +597,14 @@ fn copy_permission_flow_bundle() {
             panic!("DEP_TAURI_PLUGIN_PERMISSION_FLOW_BUNDLE_DIR not set")
         });
 
-    // Missing here means swift-rs's SwiftPM build didn't emit it. Hard-fail
-    // release (shippable .app must have it) and warn-only debug (e2e CI uses
-    // --no-bundle and doesn't assemble a .app).
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let bundle_dst = std::path::PathBuf::from(&manifest_dir).join(bundle_name);
+
+    // Missing source means swift-rs's SwiftPM build didn't emit the bundle
+    // (CI cache layering, scratch-path mismatch, etc.). Release builds must
+    // ship the real bundle — hard-fail. Debug builds (e2e CI) only need the
+    // path to exist so tauri-build's resource validation passes; same
+    // empty-stub trick mlx.metallib uses above.
     if !bundle_src.exists() {
         let is_release = std::env::var("PROFILE").as_deref() == Ok("release");
         let msg = format!(
@@ -610,12 +615,13 @@ fn copy_permission_flow_bundle() {
         if is_release {
             panic!("{msg}");
         }
-        println!("cargo:warning={msg} (debug build, skipping stage)");
+        println!("cargo:warning={msg} (debug build, staging empty stub)");
+        if !bundle_dst.exists() {
+            let _ = std::fs::create_dir_all(&bundle_dst);
+            let _ = std::fs::write(bundle_dst.join(".placeholder"), b"");
+        }
         return;
     }
-
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let bundle_dst = std::path::PathBuf::from(&manifest_dir).join(bundle_name);
 
     if bundle_dst.exists() {
         let _ = std::fs::remove_dir_all(&bundle_dst);

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
@@ -39,7 +39,8 @@
       "icons/screenpipe-logo-tray-beta.png"
     ],
     "resources": [
-      "assets/*"
+      "assets/*",
+      "PermissionFlow_PermissionFlow.bundle"
     ],
     "macOS": {
       "entitlements": "entitlements.plist"

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -37,7 +37,8 @@
     ],
     "resources": [
       "assets/*",
-      "mlx.metallib"
+      "mlx.metallib",
+      "PermissionFlow_PermissionFlow.bundle"
     ],
     "macOS": {
       "entitlements": "entitlements.plist",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
@@ -39,7 +39,8 @@
       "icons/screenpipe-logo-tray-black.png"
     ],
     "resources": [
-      "assets/*"
+      "assets/*",
+      "PermissionFlow_PermissionFlow.bundle"
     ],
     "macOS": {
       "entitlements": "entitlements.plist"

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
@@ -40,7 +40,8 @@
     ],
     "resources": [
       "assets/*",
-      "mlx.metallib"
+      "mlx.metallib",
+      "PermissionFlow_PermissionFlow.bundle"
     ],
     "macOS": {
       "entitlements": "entitlements.plist",


### PR DESCRIPTION
## Description

Fixes the SIGTRAP that crashed onboarding on fresh macOS installs when users clicked Screen Recording or Accessibility. The PermissionFlow resource bundle now reaches `Contents/Resources/` of the shipped `.app`, so localized strings load successfully and the native permission flow runs end-to-end on user machines

## Root cause

`swift-rs` linked the plugin's Swift code but did not copy the SwiftPM-generated `PermissionFlow_PermissionFlow.bundle` into the consuming `.app`. At runtime, `Bundle.module`'s generated accessor walked its candidate paths, found nothing, and ran `Swift.fatalError("unable to find bundle named PermissionFlow_PermissionFlow")`. The trap fired on the main thread inside SwiftUI body evaluation, so the Tauri command never returned and the JS-side `try/catch` fallback in `permission-flow.ts` was unreachable.

Closes #3975

