### PR TITLE
Fix owned browser lifecycle events leaking into the wrong chat

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -57,6 +57,7 @@ import { localFetch } from "@/lib/api";
 import { useSettings } from "@/lib/hooks/use-settings";
 import {
   isForeignNavigation,
+  isMismatchedNavigation,
   parseNavigatePayload,
   type OwnedBrowserNavigatePayload,
 } from "@/lib/owned-browser-ownership";
@@ -89,6 +90,7 @@ interface SessionAccessEvent {
   host: string;
   already_granted?: boolean;
   alreadyGranted?: boolean;
+  navigationId?: string | null;
   /** Conversation that issued the navigation (see `owner` on the navigate
    *  event). Ownerless payloads are treated as stale/legacy and ignored. */
   owner?: string | null;
@@ -99,6 +101,7 @@ interface ActiveSessionAccessRequest {
   url: string;
   host: string;
   alreadyGranted: boolean;
+  navigationId: string;
   owner: string | null;
 }
 
@@ -110,6 +113,7 @@ interface V20CookieBlockEvent {
   v20_count?: number;
   sources?: string[];
   reason?: string;
+  navigationId?: string | null;
   owner?: string | null;
 }
 
@@ -120,6 +124,7 @@ interface ActiveV20CookieBlock {
   v20Count: number;
   sources: string[];
   reason: string;
+  navigationId: string;
   owner: string | null;
 }
 
@@ -127,6 +132,7 @@ interface OwnedBrowserStateEvent {
   url?: string | null;
   title?: string | null;
   loading?: boolean | null;
+  navigationId?: string | null;
   owner?: string | null;
 }
 
@@ -152,6 +158,7 @@ export function BrowserSidebar({
   const [collapsed, setCollapsed] = useState(false);
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
   const [currentOwner, setCurrentOwner] = useState<string | null>(null);
+  const [currentNavigationId, setCurrentNavigationId] = useState<string | null>(null);
   const [currentTitle, setCurrentTitle] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [sessionAccessRequest, setSessionAccessRequest] =
@@ -338,7 +345,7 @@ export function BrowserSidebar({
     const unlistenPromise = listen<OwnedBrowserNavigatePayload>(
       NAVIGATE_EVENT,
       (e) => {
-        const { url, owner } = parseNavigatePayload(e.payload);
+        const { url, owner, navigationId } = parseNavigatePayload(e.payload);
         if (!url) return;
         // The owned browser is a singleton shared across every chat and
         // background pipe. Ignore navigations owned by a *different*
@@ -349,11 +356,13 @@ export function BrowserSidebar({
         // themselves with the foreground conversation id; ownerless events are
         // treated as stale/legacy and ignored.
         if (isForeignNavigation(owner, conversationId)) return;
+        if (!navigationId) return;
         setSessionAccessRequest(null);
         setSessionAccessAnswer(null);
         setV20CookieBlock(null);
         setCurrentUrl(url);
         setCurrentOwner(owner);
+        setCurrentNavigationId(navigationId);
         setCurrentTitle(null);
         setLoading(true);
         setVisible(true);
@@ -376,12 +385,14 @@ export function BrowserSidebar({
         // Same ownership gate as the navigate event — a background pipe's
         // cookie-consent prompt must not surface in another chat.
         if (isForeignNavigation(payload.owner, conversationId)) return;
+        if (isMismatchedNavigation(payload.navigationId, currentNavigationId)) return;
         const request = {
           requestId,
           url: payload.url,
           host: payload.host,
           alreadyGranted:
             payload.alreadyGranted ?? payload.already_granted ?? false,
+          navigationId: payload.navigationId!,
           owner: payload.owner ?? null,
         };
         setSessionAccessRequest(request);
@@ -391,6 +402,7 @@ export function BrowserSidebar({
         setCollapsed(false);
         setCurrentUrl(request.url);
         setCurrentOwner(request.owner);
+        setCurrentNavigationId(request.navigationId);
         setCurrentTitle(null);
         setLoading(true);
         persistState({ url: request.url, collapsed: false });
@@ -400,7 +412,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [persistState, conversationId]);
+  }, [persistState, conversationId, currentNavigationId]);
 
   useEffect(() => {
     const unlistenPromise = listen<V20CookieBlockEvent>(
@@ -409,6 +421,7 @@ export function BrowserSidebar({
         const payload = e.payload;
         if (!payload?.url || !payload?.host) return;
         if (isForeignNavigation(payload.owner, conversationId)) return;
+        if (isMismatchedNavigation(payload.navigationId, currentNavigationId)) return;
         const block = {
           url: payload.url,
           host: payload.host,
@@ -416,6 +429,7 @@ export function BrowserSidebar({
           v20Count: payload.v20Count ?? payload.v20_count ?? 0,
           sources: payload.sources ?? [],
           reason: payload.reason ?? "v20",
+          navigationId: payload.navigationId!,
           owner: payload.owner ?? null,
         };
         setSessionAccessRequest(null);
@@ -425,6 +439,7 @@ export function BrowserSidebar({
         setCollapsed(false);
         setCurrentUrl(block.url);
         setCurrentOwner(block.owner);
+        setCurrentNavigationId(block.navigationId);
         setCurrentTitle(null);
         setLoading(false);
         persistState({ url: block.url, collapsed: false });
@@ -434,7 +449,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [persistState, conversationId]);
+  }, [persistState, conversationId, currentNavigationId]);
 
   useEffect(() => {
     sessionAccessActiveRef.current =
@@ -500,6 +515,7 @@ export function BrowserSidebar({
       // sticky half of the leak: without this the URL is restored on reopen
       // even though the panel never visibly popped).
       if (isForeignNavigation(payload.owner, conversationId)) return;
+      if (isMismatchedNavigation(payload.navigationId, currentNavigationId)) return;
 
       if (typeof payload.url === "string" && payload.url.length > 0) {
         if (payload.url !== currentUrl) {
@@ -507,6 +523,7 @@ export function BrowserSidebar({
         }
         setCurrentUrl(payload.url);
         setCurrentOwner(payload.owner ?? conversationId ?? null);
+        setCurrentNavigationId(payload.navigationId!);
         persistState({ url: payload.url });
       }
       if (typeof payload.title === "string") {
@@ -520,7 +537,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [currentUrl, persistState, conversationId]);
+  }, [currentNavigationId, currentUrl, persistState, conversationId]);
 
   // ---------------------------------------------------------------------------
   // Per-conversation restore
@@ -533,6 +550,7 @@ export function BrowserSidebar({
       setCollapsed(false);
       setCurrentUrl(null);
       setCurrentOwner(null);
+      setCurrentNavigationId(null);
       setCurrentTitle(null);
       setLoading(false);
       setSessionAccessRequest(null);
@@ -561,6 +579,7 @@ export function BrowserSidebar({
         setCollapsed(wasCollapsed);
         setCurrentUrl(url);
         setCurrentOwner(conversationId);
+        setCurrentNavigationId(null);
         setCurrentTitle(null);
         setLoading(!wasCollapsed);
         // The webview install runs on a background task that retries
@@ -589,6 +608,7 @@ export function BrowserSidebar({
         setCollapsed(false);
         setCurrentUrl(null);
         setCurrentOwner(null);
+        setCurrentNavigationId(null);
         setCurrentTitle(null);
         setLoading(false);
         setV20CookieBlock(null);

--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -90,7 +90,7 @@ interface SessionAccessEvent {
   already_granted?: boolean;
   alreadyGranted?: boolean;
   /** Conversation that issued the navigation (see `owner` on the navigate
-   *  event). Null for the sidebar's own restore/reload. */
+   *  event). Ownerless payloads are treated as stale/legacy and ignored. */
   owner?: string | null;
 }
 
@@ -99,6 +99,7 @@ interface ActiveSessionAccessRequest {
   url: string;
   host: string;
   alreadyGranted: boolean;
+  owner: string | null;
 }
 
 interface V20CookieBlockEvent {
@@ -119,6 +120,7 @@ interface ActiveV20CookieBlock {
   v20Count: number;
   sources: string[];
   reason: string;
+  owner: string | null;
 }
 
 interface OwnedBrowserStateEvent {
@@ -149,6 +151,7 @@ export function BrowserSidebar({
   const [visible, setVisible] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [currentUrl, setCurrentUrl] = useState<string | null>(null);
+  const [currentOwner, setCurrentOwner] = useState<string | null>(null);
   const [currentTitle, setCurrentTitle] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [sessionAccessRequest, setSessionAccessRequest] =
@@ -342,26 +345,20 @@ export function BrowserSidebar({
         // conversation than the one on screen — otherwise a background pipe
         // (or another chat's agent) pops its page into whatever chat the user
         // is looking at, and `persistState` writes that URL into the wrong
-        // chat's file so it sticks on reopen. Untagged events (owner == null)
-        // are the sidebar's own restore/reload and are always honored.
+        // chat's file so it sticks on reopen. Restore/reload paths now tag
+        // themselves with the foreground conversation id; ownerless events are
+        // treated as stale/legacy and ignored.
         if (isForeignNavigation(owner, conversationId)) return;
         setSessionAccessRequest(null);
         setSessionAccessAnswer(null);
         setV20CookieBlock(null);
         setCurrentUrl(url);
+        setCurrentOwner(owner);
         setCurrentTitle(null);
         setLoading(true);
-        // Agent-driven navigations (owner is set) always open the panel.
-        // Ownerless events (restore/reload after chat switch) must not
-        // override the persisted collapsed state — otherwise switching
-        // away from a chat with a collapsed sidebar and back re-opens it.
-        if (owner) {
-          setVisible(true);
-          setCollapsed(false);
-          persistState({ url, collapsed: false });
-        } else {
-          persistState({ url });
-        }
+        setVisible(true);
+        setCollapsed(false);
+        persistState({ url, collapsed: false });
       },
     );
     return () => {
@@ -385,6 +382,7 @@ export function BrowserSidebar({
           host: payload.host,
           alreadyGranted:
             payload.alreadyGranted ?? payload.already_granted ?? false,
+          owner: payload.owner ?? null,
         };
         setSessionAccessRequest(request);
         setSessionAccessAnswer(null);
@@ -392,6 +390,7 @@ export function BrowserSidebar({
         setVisible(true);
         setCollapsed(false);
         setCurrentUrl(request.url);
+        setCurrentOwner(request.owner);
         setCurrentTitle(null);
         setLoading(true);
         persistState({ url: request.url, collapsed: false });
@@ -417,6 +416,7 @@ export function BrowserSidebar({
           v20Count: payload.v20Count ?? payload.v20_count ?? 0,
           sources: payload.sources ?? [],
           reason: payload.reason ?? "v20",
+          owner: payload.owner ?? null,
         };
         setSessionAccessRequest(null);
         setSessionAccessAnswer(null);
@@ -424,6 +424,7 @@ export function BrowserSidebar({
         setVisible(true);
         setCollapsed(false);
         setCurrentUrl(block.url);
+        setCurrentOwner(block.owner);
         setCurrentTitle(null);
         setLoading(false);
         persistState({ url: block.url, collapsed: false });
@@ -466,7 +467,12 @@ export function BrowserSidebar({
             // Extension is now connected — retry the navigation, which will
             // go through the extension cookie path.
             setV20CookieBlock(null);
-            commands.ownedBrowserNavigate(retryUrl).catch(() => {});
+            commands
+              .ownedBrowserNavigate(
+                retryUrl,
+                v20CookieBlock.owner ?? currentOwner ?? conversationId ?? null,
+              )
+              .catch(() => {});
           }
         } else {
           setExtensionConnected(false);
@@ -500,6 +506,7 @@ export function BrowserSidebar({
           setCurrentTitle(null);
         }
         setCurrentUrl(payload.url);
+        setCurrentOwner(payload.owner ?? conversationId ?? null);
         persistState({ url: payload.url });
       }
       if (typeof payload.title === "string") {
@@ -525,6 +532,7 @@ export function BrowserSidebar({
       setVisible(false);
       setCollapsed(false);
       setCurrentUrl(null);
+      setCurrentOwner(null);
       setCurrentTitle(null);
       setLoading(false);
       setSessionAccessRequest(null);
@@ -552,6 +560,7 @@ export function BrowserSidebar({
         setVisible(true);
         setCollapsed(wasCollapsed);
         setCurrentUrl(url);
+        setCurrentOwner(conversationId);
         setCurrentTitle(null);
         setLoading(!wasCollapsed);
         // The webview install runs on a background task that retries
@@ -562,7 +571,7 @@ export function BrowserSidebar({
         // browser silently fails to restore. Retry once when Rust emits
         // `owned-browser:ready` so the saved state survives app quit.
         const tryNavigate = () =>
-          commands.ownedBrowserNavigate(url).catch((e) => {
+          commands.ownedBrowserNavigate(url, conversationId).catch((e) => {
             const msg = typeof e === "string" ? e : String(e);
             return msg.includes("not initialized") ? "retry" : null;
           });
@@ -579,6 +588,7 @@ export function BrowserSidebar({
         setVisible(false);
         setCollapsed(false);
         setCurrentUrl(null);
+        setCurrentOwner(null);
         setCurrentTitle(null);
         setLoading(false);
         setV20CookieBlock(null);
@@ -684,11 +694,14 @@ export function BrowserSidebar({
     if (!currentUrl) return;
     try {
       setLoading(true);
-      await commands.ownedBrowserNavigate(currentUrl);
+      await commands.ownedBrowserNavigate(
+        currentUrl,
+        currentOwner ?? conversationId ?? null,
+      );
     } catch (e) {
       console.error("reload failed", e);
     }
-  }, [currentUrl]);
+  }, [conversationId, currentOwner, currentUrl]);
 
   const setCookieAccessGranted = useCallback(
     async (granted: boolean) => {
@@ -702,10 +715,12 @@ export function BrowserSidebar({
     if (!currentUrl) return;
     await commands.confirmBrowserCookieAccessForSession();
     setLoading(true);
-    await commands.ownedBrowserNavigate(currentUrl).catch((e) => {
-      console.error("retry cookie navigation failed", e);
-    });
-  }, [currentUrl]);
+    await commands
+      .ownedBrowserNavigate(currentUrl, currentOwner ?? conversationId ?? null)
+      .catch((e) => {
+        console.error("retry cookie navigation failed", e);
+      });
+  }, [conversationId, currentOwner, currentUrl]);
 
   const clearBrowserData = useCallback(async () => {
     try {
@@ -715,12 +730,15 @@ export function BrowserSidebar({
       await commands.ownedBrowserClearBrowsingData();
       if (currentUrl) {
         setLoading(true);
-        await commands.ownedBrowserNavigate(currentUrl);
+        await commands.ownedBrowserNavigate(
+          currentUrl,
+          currentOwner ?? conversationId ?? null,
+        );
       }
     } catch (e) {
       console.error("clear owned-browser browsing data failed", e);
     }
-  }, [currentUrl, setCookieAccessGranted]);
+  }, [conversationId, currentOwner, currentUrl, setCookieAccessGranted]);
 
   const enableAndRetryWithCookies = useCallback(async () => {
     await setCookieAccessGranted(true);

--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -490,6 +490,7 @@ export function BrowserSidebar({
               .ownedBrowserNavigate(
                 retryUrl,
                 v20CookieBlock.owner ?? currentOwner ?? conversationId ?? null,
+                true,
               )
               .catch(() => {});
           }
@@ -721,6 +722,7 @@ export function BrowserSidebar({
       await commands.ownedBrowserNavigate(
         currentUrl,
         currentOwner ?? conversationId ?? null,
+        true,
       );
     } catch (e) {
       console.error("reload failed", e);
@@ -740,7 +742,11 @@ export function BrowserSidebar({
     await commands.confirmBrowserCookieAccessForSession();
     setLoading(true);
     await commands
-      .ownedBrowserNavigate(currentUrl, currentOwner ?? conversationId ?? null)
+      .ownedBrowserNavigate(
+        currentUrl,
+        currentOwner ?? conversationId ?? null,
+        true,
+      )
       .catch((e) => {
         console.error("retry cookie navigation failed", e);
       });
@@ -757,6 +763,7 @@ export function BrowserSidebar({
         await commands.ownedBrowserNavigate(
           currentUrl,
           currentOwner ?? conversationId ?? null,
+          true,
         );
       }
     } catch (e) {

--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -345,7 +345,7 @@ export function BrowserSidebar({
     const unlistenPromise = listen<OwnedBrowserNavigatePayload>(
       NAVIGATE_EVENT,
       (e) => {
-        const { url, owner, navigationId } = parseNavigatePayload(e.payload);
+        const { url, owner, navigationId, reveal } = parseNavigatePayload(e.payload);
         if (!url) return;
         // The owned browser is a singleton shared across every chat and
         // background pipe. Ignore navigations owned by a *different*
@@ -365,9 +365,13 @@ export function BrowserSidebar({
         setCurrentNavigationId(navigationId);
         setCurrentTitle(null);
         setLoading(true);
-        setVisible(true);
-        setCollapsed(false);
-        persistState({ url, collapsed: false });
+        if (reveal) {
+          setVisible(true);
+          setCollapsed(false);
+          persistState({ url, collapsed: false });
+        } else {
+          persistState({ url });
+        }
       },
     );
     return () => {
@@ -590,7 +594,7 @@ export function BrowserSidebar({
         // browser silently fails to restore. Retry once when Rust emits
         // `owned-browser:ready` so the saved state survives app quit.
         const tryNavigate = () =>
-          commands.ownedBrowserNavigate(url, conversationId).catch((e) => {
+          commands.ownedBrowserNavigate(url, conversationId, false).catch((e) => {
             const msg = typeof e === "string" ? e : String(e);
             return msg.includes("not initialized") ? "retry" : null;
           });

--- a/apps/screenpipe-app-tauri/e2e/specs/zz-owned-browser-background-nav.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-owned-browser-background-nav.spec.ts
@@ -13,11 +13,14 @@
  * session (see harness note below) — and that handle never re-enumerates, so
  * `openHomeWindow()` can't recover it. If any spec ran after this one it would
  * fail its `before` hook with "Could not get home window handle" and cascade.
- * The `zz-` prefix sorts it after every other spec (incl. `windows-*`) so
- * nothing depends on `home` afterwards. Do NOT rename it back / un-prefix it.
- * (An earlier revision filed this as macOS-only "Windows is also fine"; in CI
- * it poisoned the session on BOTH macOS and Windows — Linux only escaped
- * because it skips the spec entirely.)
+ * The `zz-` prefix sorts it after the normal app-window specs so nothing that
+ * still depends on `home` runs afterwards. The one intentional exception is
+ * the later `zzz-browser-state-chat-switch` spec, which is search-driven and
+ * does not need a recoverable `home` handle. Inside THIS file, keep the
+ * destructive attach-to-`home` block last for the same reason. Do NOT rename
+ * it back / un-prefix it. (An earlier revision filed this as macOS-only
+ * "Windows is also fine"; in CI it poisoned the session on BOTH macOS and
+ * Windows — Linux only escaped because it skips the spec entirely.)
  *
  * Bug: the owned browser is a native child Webview parented to the `home`
  * window, behind the chat sidebar. The meeting-notes section lives in the SAME
@@ -43,7 +46,13 @@
  * fallout to the end of the run.
  */
 
-import { existsSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
@@ -92,6 +101,11 @@ const OWN_CHAT = "33333333-cccc-cccc-cccc-cccccccccccc";
 const FOREIGN_OWNER = "pipe:e2e-background-poster";
 const CHATS_DIR = join(homedir(), ".screenpipe", "chats");
 const FOREIGN_URL = "https://example.com/e2e-foreign-pipe";
+const BROWSER_CHAT_A = "44444444-dddd-dddd-dddd-dddddddddddd";
+const BROWSER_CHAT_B = "55555555-eeee-eeee-eeee-eeeeeeeeeeee";
+const PLAIN_CHAT = "66666666-ffff-ffff-ffff-ffffffffffff";
+const BROWSER_URL_A = "https://example.com/e2e-browser-chat-a";
+const BROWSER_URL_B = "https://example.com/e2e-browser-chat-b";
 
 function removeChatFile(id: string): void {
   try {
@@ -100,6 +114,73 @@ function removeChatFile(id: string): void {
   } catch {
     /* ignore */
   }
+}
+
+function writeSeedChatFile(
+  id: string,
+  userText: string,
+  browserState?: { url: string; collapsed?: boolean; width?: number },
+): void {
+  if (!existsSync(CHATS_DIR)) mkdirSync(CHATS_DIR, { recursive: true });
+  const now = Date.now();
+  writeFileSync(
+    join(CHATS_DIR, `${id}.json`),
+    JSON.stringify({
+      id,
+      title: "e2e",
+      messages: [
+        {
+          id: `e2e-seed-${id.slice(0, 12)}`,
+          role: "user",
+          content: userText,
+          timestamp: now,
+        },
+      ],
+      createdAt: now,
+      updatedAt: now,
+      ...(browserState
+        ? {
+            browserState: {
+              url: browserState.url,
+              updatedAt: now,
+              ...(typeof browserState.width === "number"
+                ? { width: browserState.width }
+                : {}),
+              ...(browserState.collapsed === true ? { collapsed: true } : {}),
+            },
+          }
+        : {}),
+    }),
+  );
+}
+
+function loadChatFile(
+  id: string,
+): { id: string; messages: any[]; browserState?: { url?: string } } | null {
+  const p = join(CHATS_DIR, `${id}.json`);
+  if (!existsSync(p)) return null;
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+async function clearBrowserStateCache(chatId: string): Promise<void> {
+  await browser.execute((key: string) => {
+    window.localStorage.removeItem(key);
+  }, `screenpipe:browser-state:${chatId}`);
+}
+
+async function readBrowserStateCacheUrl(
+  chatId: string,
+): Promise<string | null> {
+  return (await browser.execute((key: string) => {
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      return parsed?.url ?? null;
+    } catch {
+      return null;
+    }
+  }, `screenpipe:browser-state:${chatId}`)) as string | null;
 }
 
 async function waitForChatSeedHook(): Promise<void> {
@@ -316,6 +397,105 @@ describe("Owned browser — per-chat navigation ownership", function () {
       expect(await invokeOrThrow<boolean>("e2e_owned_browser_visible")).toBe(
         false,
       );
+    },
+  );
+});
+
+describe("Owned browser — fast chat switching keeps pipe state out of other chats", function () {
+  this.timeout(180_000);
+
+  before(async () => {
+    await waitForAppReady();
+    await openHomeWindow();
+    await showWindow({ Search: { query: null } });
+    await waitForWindowHandle("search", t(10_000));
+    await browser.switchToWindow("search");
+    await browser.pause(t(800));
+
+    for (const id of [BROWSER_CHAT_A, BROWSER_CHAT_B, PLAIN_CHAT]) {
+      removeChatFile(id);
+      await clearBrowserStateCache(id);
+    }
+  });
+
+  after(async () => {
+    await invoke("owned_browser_hide").catch(() => {});
+    for (const id of [BROWSER_CHAT_A, BROWSER_CHAT_B, PLAIN_CHAT]) {
+      removeChatFile(id);
+      await clearBrowserStateCache(id);
+    }
+  });
+
+  (canDriveOwnedBrowser ? it : it.skip)(
+    "does not persist a pipe-driven browser URL into another browser chat or a plain chat during fast switching",
+    async () => {
+      await installSessionCapture();
+      writeSeedChatFile(
+        BROWSER_CHAT_A,
+        "(e2e) browser chat A",
+        { url: BROWSER_URL_A, collapsed: true, width: 420 },
+      );
+      writeSeedChatFile(
+        BROWSER_CHAT_B,
+        "(e2e) browser chat B",
+        { url: BROWSER_URL_B, collapsed: true, width: 420 },
+      );
+      writeSeedChatFile(PLAIN_CHAT, "(e2e) plain chat");
+
+      await loadChatIntoHome(BROWSER_CHAT_A);
+      await waitForActiveConversation(BROWSER_CHAT_A);
+      await browser.pause(t(800));
+      await invokeOrThrow("owned_browser_hide");
+      expect(await invokeOrThrow<boolean>("e2e_owned_browser_visible")).toBe(
+        false,
+      );
+
+      const { port, key } = await getLocalApiConfig();
+
+      await loadChatIntoHome(PLAIN_CHAT);
+      await waitForActiveConversation(PLAIN_CHAT);
+      const navigateStatus = await postNavigateAs(
+        port,
+        key,
+        FOREIGN_URL,
+        FOREIGN_OWNER,
+      );
+      expect(navigateStatus).toBe(200);
+      await browser.pause(t(1_200));
+      expect(await invokeOrThrow<boolean>("e2e_owned_browser_visible")).toBe(
+        false,
+      );
+
+      await loadChatIntoHome(BROWSER_CHAT_B);
+      await waitForActiveConversation(BROWSER_CHAT_B);
+      await loadChatIntoHome(PLAIN_CHAT);
+      await waitForActiveConversation(PLAIN_CHAT);
+      await postEvalWithUrlAs(port, key, FOREIGN_URL, FOREIGN_OWNER);
+      await browser.pause(t(1_200));
+      expect(await invokeOrThrow<boolean>("e2e_owned_browser_visible")).toBe(
+        false,
+      );
+      await loadChatIntoHome(BROWSER_CHAT_A);
+      await waitForActiveConversation(BROWSER_CHAT_A);
+      await loadChatIntoHome(BROWSER_CHAT_B);
+      await waitForActiveConversation(BROWSER_CHAT_B);
+      await browser.pause(t(1_000));
+
+      const chatA = loadChatFile(BROWSER_CHAT_A);
+      const chatB = loadChatFile(BROWSER_CHAT_B);
+      const plain = loadChatFile(PLAIN_CHAT);
+
+      if (!chatA || !chatB || !plain) {
+        throw new Error("expected all seeded chat files to exist");
+      }
+
+      expect(chatA.browserState?.url).toBe(BROWSER_URL_A);
+      expect(chatB.browserState?.url).toBe(BROWSER_URL_B);
+      expect(plain.browserState).toBeUndefined();
+
+      expect(await readBrowserStateCacheUrl(BROWSER_CHAT_A)).toBe(BROWSER_URL_A);
+      expect(await readBrowserStateCacheUrl(BROWSER_CHAT_B)).toBe(BROWSER_URL_B);
+      expect(await readBrowserStateCacheUrl(PLAIN_CHAT)).toBeNull();
     },
   );
 });

--- a/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isForeignNavigation,
+  isMismatchedNavigation,
   parseNavigatePayload,
 } from "@/lib/owned-browser-ownership";
 
@@ -54,14 +55,23 @@ describe("owned-browser ownership", () => {
   describe("parseNavigatePayload", () => {
     it("parses the object payload with an owner", () => {
       expect(
-        parseNavigatePayload({ url: "https://example.com", owner: "pipe:x" }),
-      ).toEqual({ url: "https://example.com", owner: "pipe:x" });
+        parseNavigatePayload({
+          url: "https://example.com",
+          owner: "pipe:x",
+          navigationId: "nav-1",
+        }),
+      ).toEqual({
+        url: "https://example.com",
+        owner: "pipe:x",
+        navigationId: "nav-1",
+      });
     });
 
     it("treats a bare string (legacy/stale emit) as un-owned", () => {
       expect(parseNavigatePayload("https://example.com")).toEqual({
         url: "https://example.com",
         owner: null,
+        navigationId: null,
       });
     });
 
@@ -69,9 +79,34 @@ describe("owned-browser ownership", () => {
       expect(parseNavigatePayload({ url: "https://example.com" })).toEqual({
         url: "https://example.com",
         owner: null,
+        navigationId: null,
       });
-      expect(parseNavigatePayload({})).toEqual({ url: null, owner: null });
-      expect(parseNavigatePayload("")).toEqual({ url: null, owner: null });
+      expect(parseNavigatePayload({})).toEqual({
+        url: null,
+        owner: null,
+        navigationId: null,
+      });
+      expect(parseNavigatePayload("")).toEqual({
+        url: null,
+        owner: null,
+        navigationId: null,
+      });
+    });
+  });
+
+  describe("isMismatchedNavigation", () => {
+    it("rejects missing navigation ids", () => {
+      expect(isMismatchedNavigation(null, "nav-1")).toBe(true);
+      expect(isMismatchedNavigation(undefined, null)).toBe(true);
+    });
+
+    it("accepts the first adopted navigation when none is active yet", () => {
+      expect(isMismatchedNavigation("nav-1", null)).toBe(false);
+    });
+
+    it("rejects a different navigation once one is active", () => {
+      expect(isMismatchedNavigation("nav-2", "nav-1")).toBe(true);
+      expect(isMismatchedNavigation("nav-1", "nav-1")).toBe(false);
     });
   });
 });

--- a/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
@@ -59,11 +59,13 @@ describe("owned-browser ownership", () => {
           url: "https://example.com",
           owner: "pipe:x",
           navigationId: "nav-1",
+          reveal: false,
         }),
       ).toEqual({
         url: "https://example.com",
         owner: "pipe:x",
         navigationId: "nav-1",
+        reveal: false,
       });
     });
 
@@ -72,6 +74,7 @@ describe("owned-browser ownership", () => {
         url: "https://example.com",
         owner: null,
         navigationId: null,
+        reveal: true,
       });
     });
 
@@ -80,16 +83,19 @@ describe("owned-browser ownership", () => {
         url: "https://example.com",
         owner: null,
         navigationId: null,
+        reveal: true,
       });
       expect(parseNavigatePayload({})).toEqual({
         url: null,
         owner: null,
         navigationId: null,
+        reveal: true,
       });
       expect(parseNavigatePayload("")).toEqual({
         url: null,
         owner: null,
         navigationId: null,
+        reveal: true,
       });
     });
   });

--- a/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
@@ -34,13 +34,11 @@ describe("owned-browser ownership", () => {
       expect(isForeignNavigation("conv-C", "conv-C")).toBe(false);
     });
 
-    it("honors untagged navigations (the sidebar's own restore/reload)", () => {
-      expect(isForeignNavigation(null, "conv-C")).toBe(false);
-      expect(isForeignNavigation(undefined, "conv-C")).toBe(false);
-      expect(isForeignNavigation("", "conv-C")).toBe(false);
-      // Untagged is honored even when no chat is bound — that's a fresh
-      // chat's own restore/reload, not a foreign pipe.
-      expect(isForeignNavigation(null, null)).toBe(false);
+    it("drops ownerless navigations (stale/legacy emits)", () => {
+      expect(isForeignNavigation(null, "conv-C")).toBe(true);
+      expect(isForeignNavigation(undefined, "conv-C")).toBe(true);
+      expect(isForeignNavigation("", "conv-C")).toBe(true);
+      expect(isForeignNavigation(null, null)).toBe(true);
     });
 
     it("gates a tagged navigation when no chat is bound (fresh/unsaved chat)", () => {

--- a/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
+++ b/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
@@ -38,22 +38,23 @@ export function parseNavigatePayload(payload: OwnedBrowserNavigatePayload): {
  * True when a navigation belongs to a DIFFERENT chat than the one on screen, so
  * the sidebar must ignore it (no reveal, no persist).
  *
- * - owner null/empty → the sidebar's own restore/reload, always honored
- *   (regardless of whether a chat is bound).
- * - owner === conversationId → this chat's own agent, honored.
+ * - owner === conversationId → this chat's own browser lifecycle event,
+ *   honored.
+ * - owner null/empty → foreign/stale, ignored. All supported restore/reload
+ *   paths now send the real `conversationId`; leaving ownerless events
+ *   writable lets the singleton browser leak into whichever chat is open.
  * - otherwise (a different owner, INCLUDING when no chat is bound) → foreign,
- *   ignored. A null/empty conversationId means a fresh, unsaved chat: a tagged
- *   navigation there can only come from a background pipe (`pipe:<name>`) or
- *   another chat's agent, never from this surface, so a background pipe must
- *   not pop into it. (Previously a null conversationId let any tagged
- *   navigation through — the hole this closes.)
+ *   ignored. A null/empty conversationId means a fresh chat: any tagged event
+ *   necessarily belongs to another chat or a background pipe.
  */
 export function isForeignNavigation(
   owner: string | null | undefined,
   conversationId: string | null | undefined,
 ): boolean {
-  // The sidebar's own restore/reload is untagged — always honor it.
-  if (!owner) return false;
+  // Ownerless events are stale/legacy and must not mutate whichever chat is
+  // currently open. Every supported restore/reload path now tags itself with
+  // the foreground conversation id.
+  if (!owner) return true;
   // A tagged navigation is honored only by the chat that issued it. When no
   // chat is bound (conversationId null/empty), `owner !== conversationId` is
   // true, so the navigation is treated as foreign and dropped.

--- a/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
+++ b/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
@@ -21,24 +21,31 @@
  *  upgrade still navigates. */
 export type OwnedBrowserNavigatePayload =
   | string
-  | { url?: string | null; owner?: string | null; navigationId?: string | null };
+  | {
+      url?: string | null;
+      owner?: string | null;
+      navigationId?: string | null;
+      reveal?: boolean | null;
+    };
 
 export function parseNavigatePayload(payload: OwnedBrowserNavigatePayload): {
   url: string | null;
   owner: string | null;
   navigationId: string | null;
+  reveal: boolean;
 } {
   if (typeof payload === "string") {
-    return { url: payload || null, owner: null, navigationId: null };
+    return { url: payload || null, owner: null, navigationId: null, reveal: true };
   }
   if (payload && typeof payload === "object") {
     return {
       url: payload.url ?? null,
       owner: payload.owner ?? null,
       navigationId: payload.navigationId ?? null,
+      reveal: payload.reveal !== false,
     };
   }
-  return { url: null, owner: null, navigationId: null };
+  return { url: null, owner: null, navigationId: null, reveal: true };
 }
 
 /**

--- a/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
+++ b/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
@@ -21,17 +21,24 @@
  *  upgrade still navigates. */
 export type OwnedBrowserNavigatePayload =
   | string
-  | { url?: string | null; owner?: string | null };
+  | { url?: string | null; owner?: string | null; navigationId?: string | null };
 
 export function parseNavigatePayload(payload: OwnedBrowserNavigatePayload): {
   url: string | null;
   owner: string | null;
+  navigationId: string | null;
 } {
-  if (typeof payload === "string") return { url: payload || null, owner: null };
-  if (payload && typeof payload === "object") {
-    return { url: payload.url ?? null, owner: payload.owner ?? null };
+  if (typeof payload === "string") {
+    return { url: payload || null, owner: null, navigationId: null };
   }
-  return { url: null, owner: null };
+  if (payload && typeof payload === "object") {
+    return {
+      url: payload.url ?? null,
+      owner: payload.owner ?? null,
+      navigationId: payload.navigationId ?? null,
+    };
+  }
+  return { url: null, owner: null, navigationId: null };
 }
 
 /**
@@ -59,4 +66,13 @@ export function isForeignNavigation(
   // chat is bound (conversationId null/empty), `owner !== conversationId` is
   // true, so the navigation is treated as foreign and dropped.
   return owner !== conversationId;
+}
+
+export function isMismatchedNavigation(
+  navigationId: string | null | undefined,
+  currentNavigationId: string | null | undefined,
+): boolean {
+  if (!navigationId) return true;
+  if (!currentNavigationId) return false;
+  return navigationId !== currentNavigationId;
 }

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1059,14 +1059,17 @@ async ownedBrowserHide() : Promise<Result<null, string>> {
 }
 },
 /**
- * Navigate the embedded webview to `url`. Used by the sidebar when restoring
- * per-chat state or on user reload — i.e. always an action of the chat that's
- * on screen, so it carries no owner (`None`) and the frontend always honors
- * it. The agent/pipe path is the connect-trait `navigate` (owner-tagged).
+ * Navigate the embedded webview to `url`.
+ *
+ * Frontend restore/reload calls pass the foreground conversation id as
+ * `owner`, so the entire browser lifecycle stays scoped to that chat. Retry
+ * paths that are continuing a pipe/chat-owned navigation (for example after an
+ * extension or cookie-consent flow) can pass the original `owner` through so
+ * the follow-up navigate does not look like a fresh restore in every chat.
  */
-async ownedBrowserNavigate(url: string) : Promise<Result<null, string>> {
+async ownedBrowserNavigate(url: string, owner: string | null) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("owned_browser_navigate", { url }) };
+    return { status: "ok", data: await TAURI_INVOKE("owned_browser_navigate", { url, owner }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1067,9 +1067,9 @@ async ownedBrowserHide() : Promise<Result<null, string>> {
  * extension or cookie-consent flow) can pass the original `owner` through so
  * the follow-up navigate does not look like a fresh restore in every chat.
  */
-async ownedBrowserNavigate(url: string, owner: string | null) : Promise<Result<null, string>> {
+async ownedBrowserNavigate(url: string, owner: string | null, reveal: boolean | null) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("owned_browser_navigate", { url, owner }) };
+    return { status: "ok", data: await TAURI_INVOKE("owned_browser_navigate", { url, owner, reveal }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -379,6 +379,27 @@ impl OwnedBrowserState {
             })
     }
 
+    fn remember_committed_url_for_context(&self, url: &str, context: &NavigationContext) {
+        if let Ok(mut guard) = self.recent_navigations.lock() {
+            if guard
+                .iter()
+                .rev()
+                .any(|ctx| ctx.navigation_id == context.navigation_id && ctx.requested_url == url)
+            {
+                return;
+            }
+            guard.push(NavigationContext {
+                navigation_id: context.navigation_id.clone(),
+                owner: context.owner.clone(),
+                requested_url: url.to_string(),
+            });
+            if guard.len() > RECENT_NAVIGATION_CONTEXT_LIMIT {
+                let drop_count = guard.len() - RECENT_NAVIGATION_CONTEXT_LIMIT;
+                guard.drain(0..drop_count);
+            }
+        }
+    }
+
     fn current_context(&self) -> Option<NavigationContext> {
         let navigation_id = self.pending_navigation_id();
         let owner = self.pending_owner();
@@ -464,10 +485,24 @@ fn emit_state_event(
     loading: Option<bool>,
 ) {
     let state = browser_state();
-    let context = url
-        .as_deref()
-        .and_then(|u| state.context_for_url(u))
-        .or_else(|| state.current_context());
+    let context = if let Some(ref current_url) = url {
+        if let Some(context) = state.context_for_url(current_url) {
+            Some(context)
+        } else {
+            let fallback = state.current_context();
+            if let Some(ref context) = fallback {
+                // Redirects commit a different main-document URL than the one
+                // we originally requested. Bind that committed URL onto the
+                // same navigation context so later title/state events resolve
+                // by exact URL instead of depending on the mutable pending
+                // fallback.
+                state.remember_committed_url_for_context(current_url, context);
+            }
+            fallback
+        }
+    } else {
+        state.current_context()
+    };
     let payload = OwnedBrowserStateEvent {
         url,
         title,
@@ -1104,7 +1139,7 @@ fn normalize_url(raw: &str) -> Result<url::Url, String> {
 
 #[cfg(test)]
 mod normalize_url_tests {
-    use super::{normalize_url, title_after_eval_marker};
+    use super::{normalize_url, title_after_eval_marker, OwnedBrowserState};
 
     #[test]
     fn keeps_fully_qualified() {
@@ -1171,6 +1206,37 @@ mod normalize_url_tests {
         assert_eq!(
             title_after_eval_marker("Example Domain", "not json"),
             "Example Domain"
+        );
+    }
+
+    #[test]
+    fn redirect_committed_url_keeps_same_navigation_context() {
+        let state = OwnedBrowserState::new();
+        let context =
+            state.remember_navigation("http://example.com".to_string(), Some("conv-1".to_string()));
+
+        assert_eq!(
+            state
+                .context_for_url("http://example.com")
+                .as_ref()
+                .map(|ctx| ctx.navigation_id.as_str()),
+            Some(context.navigation_id.as_str())
+        );
+        assert!(state.context_for_url("https://www.example.com").is_none());
+
+        state.remember_committed_url_for_context("https://www.example.com", &context);
+
+        let redirected = state
+            .context_for_url("https://www.example.com")
+            .expect("redirect target should resolve to the original navigation context");
+        assert_eq!(redirected.navigation_id, context.navigation_id);
+        assert_eq!(redirected.owner, context.owner);
+        assert_eq!(
+            state
+                .context_for_url("http://example.com")
+                .as_ref()
+                .map(|ctx| ctx.navigation_id.as_str()),
+            Some(context.navigation_id.as_str())
         );
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -129,17 +129,18 @@ struct OwnedBrowserStateEvent {
     title: Option<String>,
     loading: Option<bool>,
     /// Conversation/session that issued the navigation currently in flight.
-    /// See [`OwnedBrowserNavigateEvent::owner`]. `None` for the sidebar's own
-    /// restore/reload; the frontend always honors those.
+    /// See [`OwnedBrowserNavigateEvent::owner`]. `None` means stale/legacy;
+    /// supported restore/reload paths now send the foreground conversation id.
     owner: Option<String>,
 }
 
 /// Payload of [`NAVIGATE_EVENT`]. `owner` is the chat/session id that drove the
 /// navigation — `sid` for a chat agent (equals the frontend `conversationId`),
-/// `pipe:<name>` for a background pipe, `None` for the sidebar's own
-/// restore/reload. The owned browser is a singleton broadcast to every window,
-/// so the frontend uses `owner` to ignore navigations that belong to a chat
-/// other than the one on screen.
+/// `pipe:<name>` for a background pipe. `None` means stale/legacy; supported
+/// restore/reload paths now send the foreground conversation id. The owned
+/// browser is a singleton broadcast to every window, so the frontend uses
+/// `owner` to ignore navigations that belong to a chat other than the one on
+/// screen.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct OwnedBrowserNavigateEvent {
@@ -1089,17 +1090,24 @@ mod normalize_url_tests {
     }
 }
 
-/// Navigate the embedded webview to `url`. Used by the sidebar when restoring
-/// per-chat state or on user reload — i.e. always an action of the chat that's
-/// on screen, so it carries no owner (`None`) and the frontend always honors
-/// it. The agent/pipe path is the connect-trait `navigate` (owner-tagged).
+/// Navigate the embedded webview to `url`.
+///
+/// Frontend restore/reload calls pass the foreground conversation id as
+/// `owner`, so the entire browser lifecycle stays scoped to that chat. Retry
+/// paths that are continuing a pipe/chat-owned navigation (for example after an
+/// extension or cookie-consent flow) can pass the original `owner` through so
+/// the follow-up navigate does not look like a fresh restore in every chat.
 #[specta::specta]
 #[tauri::command]
-pub async fn owned_browser_navigate(app: AppHandle, url: String) -> Result<(), String> {
+pub async fn owned_browser_navigate(
+    app: AppHandle,
+    url: String,
+    owner: Option<String>,
+) -> Result<(), String> {
     let state = browser_state();
     let parsed: url::Url = normalize_url(&url)?;
 
-    prepare_navigation(&app, &state, &parsed, None).await;
+    prepare_navigation(&app, &state, &parsed, owner.as_deref()).await;
     inject_cookies_for_url(&app, &parsed).await;
     if let Some(active) = state.active().await {
         // Visibility is owned by the frontend sidebar — never force-show here

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -47,6 +47,8 @@ use tokio::sync::{oneshot, Mutex};
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
+const RECENT_NAVIGATION_CONTEXT_LIMIT: usize = 16;
+
 /// Embedded webview label — also used by the frontend Tauri commands.
 pub const WEBVIEW_LABEL: &str = "owned-browser";
 
@@ -147,6 +149,7 @@ struct OwnedBrowserStateEvent {
 struct OwnedBrowserNavigateEvent {
     url: String,
     navigation_id: String,
+    reveal: bool,
     owner: Option<String>,
 }
 
@@ -309,9 +312,17 @@ struct OwnedBrowserInner {
     visible: bool,
 }
 
+#[derive(Clone)]
+struct NavigationContext {
+    navigation_id: String,
+    owner: Option<String>,
+    requested_url: String,
+}
+
 struct OwnedBrowserState {
     inner: Mutex<OwnedBrowserInner>,
     last_title: StdMutex<String>,
+    recent_navigations: StdMutex<Vec<NavigationContext>>,
     pending_navigation_id: StdMutex<Option<String>>,
     /// Owner (chat/session id) of the most recent navigation. Set by
     /// `prepare_navigation` and read by the native page-state / cookie event
@@ -329,9 +340,53 @@ impl OwnedBrowserState {
         Self {
             inner: Mutex::new(OwnedBrowserInner::default()),
             last_title: StdMutex::new(String::new()),
+            recent_navigations: StdMutex::new(Vec::new()),
             pending_navigation_id: StdMutex::new(None),
             pending_owner: StdMutex::new(None),
         }
+    }
+
+    fn remember_navigation(
+        &self,
+        requested_url: String,
+        owner: Option<String>,
+    ) -> NavigationContext {
+        let context = NavigationContext {
+            navigation_id: Uuid::new_v4().to_string(),
+            owner,
+            requested_url,
+        };
+        if let Ok(mut guard) = self.recent_navigations.lock() {
+            guard.push(context.clone());
+            if guard.len() > RECENT_NAVIGATION_CONTEXT_LIMIT {
+                let drop_count = guard.len() - RECENT_NAVIGATION_CONTEXT_LIMIT;
+                guard.drain(0..drop_count);
+            }
+        }
+        context
+    }
+
+    fn context_for_url(&self, url: &str) -> Option<NavigationContext> {
+        self.recent_navigations
+            .lock()
+            .ok()
+            .and_then(|guard| {
+                guard
+                    .iter()
+                    .rev()
+                    .find(|ctx| ctx.requested_url == url)
+                    .cloned()
+            })
+    }
+
+    fn current_context(&self) -> Option<NavigationContext> {
+        let navigation_id = self.pending_navigation_id();
+        let owner = self.pending_owner();
+        navigation_id.map(|navigation_id| NavigationContext {
+            navigation_id,
+            owner,
+            requested_url: String::new(),
+        })
     }
 
     fn set_pending_navigation_id(&self, navigation_id: Option<String>) {
@@ -408,15 +463,17 @@ fn emit_state_event(
     title: Option<String>,
     loading: Option<bool>,
 ) {
+    let state = browser_state();
+    let context = url
+        .as_deref()
+        .and_then(|u| state.context_for_url(u))
+        .or_else(|| state.current_context());
     let payload = OwnedBrowserStateEvent {
         url,
         title,
         loading,
-        navigation_id: browser_state().pending_navigation_id(),
-        // Native page-load/title callbacks don't know which navigation they
-        // belong to; tag with the owner of the most recent navigate so the
-        // frontend can drop state for a chat other than the one on screen.
-        owner: browser_state().pending_owner(),
+        navigation_id: context.as_ref().map(|ctx| ctx.navigation_id.clone()),
+        owner: context.and_then(|ctx| ctx.owner),
     };
     if let Err(e) = app.emit(STATE_EVENT, payload) {
         debug!("owned-browser: failed to emit state event: {e}");
@@ -555,7 +612,7 @@ impl TauriOwnedHandle {
             // is `None` for the plain `eval` entry point (snapshot, code-only
             // eval), which is fine — those don't pass a url, so this branch and
             // its navigate event don't fire.
-            prepare_navigation(&self.app, &self.state, parsed, owner).await;
+            prepare_navigation(&self.app, &self.state, parsed, owner, true).await;
         }
 
         let active = match self.state.active().await {
@@ -753,7 +810,7 @@ impl OwnedWebviewHandle for TauriOwnedHandle {
         // hook the agent always lands on the logged-out version of the
         // site even though the Tauri-command-driven sidebar restore
         // path was injecting correctly.
-        prepare_navigation(&self.app, &self.state, &parsed, owner).await;
+        prepare_navigation(&self.app, &self.state, &parsed, owner, true).await;
         inject_cookies_for_url(&self.app, &parsed).await;
 
         if let Some(active) = self.state.active().await {
@@ -926,21 +983,26 @@ async fn prepare_navigation(
     state: &OwnedBrowserState,
     parsed: &url::Url,
     owner: Option<&str>,
+    reveal: bool,
 ) {
-    let navigation_id = Uuid::new_v4().to_string();
+    let context = state.remember_navigation(
+        parsed.as_str().to_string(),
+        owner.map(|s| s.to_string()),
+    );
     // Record the owner before emitting anything so the provisional state event
     // below — and the native page-load/title callbacks that follow — carry the
     // same tag. `owner` is the chat/session that issued this navigation; the
     // frontend uses it to keep a background pipe's page out of whatever chat is
     // on screen.
-    state.set_pending_navigation_id(Some(navigation_id.clone()));
-    state.set_pending_owner(owner.map(|s| s.to_string()));
+    state.set_pending_navigation_id(Some(context.navigation_id.clone()));
+    state.set_pending_owner(context.owner.clone());
     let _ = app.emit(
         NAVIGATE_EVENT,
         OwnedBrowserNavigateEvent {
             url: parsed.as_str().to_string(),
-            navigation_id,
-            owner: owner.map(|s| s.to_string()),
+            navigation_id: context.navigation_id,
+            reveal,
+            owner: context.owner,
         },
     );
     // Provisional omnibox URL while a top-level navigation is in flight
@@ -1126,11 +1188,19 @@ pub async fn owned_browser_navigate(
     app: AppHandle,
     url: String,
     owner: Option<String>,
+    reveal: Option<bool>,
 ) -> Result<(), String> {
     let state = browser_state();
     let parsed: url::Url = normalize_url(&url)?;
 
-    prepare_navigation(&app, &state, &parsed, owner.as_deref()).await;
+    prepare_navigation(
+        &app,
+        &state,
+        &parsed,
+        owner.as_deref(),
+        reveal.unwrap_or(true),
+    )
+    .await;
     inject_cookies_for_url(&app, &parsed).await;
     if let Some(active) = state.active().await {
         // Visibility is owned by the frontend sidebar — never force-show here
@@ -1250,6 +1320,7 @@ async fn inject_cookies_for_url(app: &AppHandle, url: &url::Url) {
                     }
                 }
                 if cookies.is_empty() {
+                    let context = browser_state().context_for_url(url.as_str());
                     // Extension couldn't supply cookies — show the v20 card.
                     let payload = V20CookieBlockPayload {
                         url: url.as_str().to_string(),
@@ -1258,8 +1329,8 @@ async fn inject_cookies_for_url(app: &AppHandle, url: &url::Url) {
                         v20_count: block.v20_count,
                         sources: block.sources,
                         reason: "v20".to_string(),
-                        navigation_id: browser_state().pending_navigation_id(),
-                        owner: browser_state().pending_owner(),
+                        navigation_id: context.as_ref().map(|ctx| ctx.navigation_id.clone()),
+                        owner: context.and_then(|ctx| ctx.owner),
                     };
                     if let Err(e) = app.emit(V20_COOKIE_BLOCK_EVENT, payload) {
                         warn!("owned-browser cookies: failed to emit v20 block event: {e}");
@@ -1471,6 +1542,7 @@ async fn browser_session_decision_for_url(
                 );
                 return BrowserSessionDecision::UseBrowserSession;
             }
+            let context = browser_state().context_for_url(url.as_str());
             let payload = V20CookieBlockPayload {
                 url: url.as_str().to_string(),
                 host: block.host,
@@ -1478,8 +1550,8 @@ async fn browser_session_decision_for_url(
                 v20_count: 0,
                 sources: block.sources,
                 reason: "locked".to_string(),
-                navigation_id: browser_state().pending_navigation_id(),
-                owner: browser_state().pending_owner(),
+                navigation_id: context.as_ref().map(|ctx| ctx.navigation_id.clone()),
+                owner: context.and_then(|ctx| ctx.owner),
             };
             if let Err(e) = app.emit(V20_COOKIE_BLOCK_EVENT, payload) {
                 warn!("owned-browser: failed to emit locked-browser event: {e}");
@@ -1579,13 +1651,14 @@ async fn browser_session_decision_for_url(
         .await
         .insert(request_id.clone(), tx);
 
+    let context = browser_state().context_for_url(url.as_str());
     let payload = BrowserSessionAccessRequestPayload {
         request_id: request_id.clone(),
         url: url.as_str().to_string(),
         host: host_key.clone(),
         already_granted,
-        navigation_id: browser_state().pending_navigation_id(),
-        owner: browser_state().pending_owner(),
+        navigation_id: context.as_ref().map(|ctx| ctx.navigation_id.clone()),
+        owner: context.and_then(|ctx| ctx.owner),
     };
 
     if let Err(e) = app.emit(SESSION_ACCESS_REQUEST_EVENT, payload) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -128,6 +128,7 @@ struct OwnedBrowserStateEvent {
     url: Option<String>,
     title: Option<String>,
     loading: Option<bool>,
+    navigation_id: Option<String>,
     /// Conversation/session that issued the navigation currently in flight.
     /// See [`OwnedBrowserNavigateEvent::owner`]. `None` means stale/legacy;
     /// supported restore/reload paths now send the foreground conversation id.
@@ -145,6 +146,7 @@ struct OwnedBrowserStateEvent {
 #[serde(rename_all = "camelCase")]
 struct OwnedBrowserNavigateEvent {
     url: String,
+    navigation_id: String,
     owner: Option<String>,
 }
 
@@ -161,6 +163,7 @@ struct BrowserSessionAccessRequestPayload {
     url: String,
     host: String,
     already_granted: bool,
+    navigation_id: Option<String>,
     /// Owner of the navigation that triggered this prompt — see
     /// [`OwnedBrowserNavigateEvent::owner`].
     owner: Option<String>,
@@ -178,6 +181,7 @@ struct V20CookieBlockPayload {
     /// "v20" = app-bound encryption blocked decrypt; "locked" = browser running, DB inaccessible
     #[serde(default)]
     reason: String,
+    navigation_id: Option<String>,
     /// Owner of the navigation that triggered this block — see
     /// [`OwnedBrowserNavigateEvent::owner`].
     owner: Option<String>,
@@ -308,6 +312,7 @@ struct OwnedBrowserInner {
 struct OwnedBrowserState {
     inner: Mutex<OwnedBrowserInner>,
     last_title: StdMutex<String>,
+    pending_navigation_id: StdMutex<Option<String>>,
     /// Owner (chat/session id) of the most recent navigation. Set by
     /// `prepare_navigation` and read by the native page-state / cookie event
     /// emitters, which fire from sync callbacks that don't carry the owner.
@@ -324,8 +329,22 @@ impl OwnedBrowserState {
         Self {
             inner: Mutex::new(OwnedBrowserInner::default()),
             last_title: StdMutex::new(String::new()),
+            pending_navigation_id: StdMutex::new(None),
             pending_owner: StdMutex::new(None),
         }
+    }
+
+    fn set_pending_navigation_id(&self, navigation_id: Option<String>) {
+        if let Ok(mut guard) = self.pending_navigation_id.lock() {
+            *guard = navigation_id;
+        }
+    }
+
+    fn pending_navigation_id(&self) -> Option<String> {
+        self.pending_navigation_id
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
     }
 
     fn set_pending_owner(&self, owner: Option<String>) {
@@ -393,6 +412,7 @@ fn emit_state_event(
         url,
         title,
         loading,
+        navigation_id: browser_state().pending_navigation_id(),
         // Native page-load/title callbacks don't know which navigation they
         // belong to; tag with the owner of the most recent navigate so the
         // frontend can drop state for a chat other than the one on screen.
@@ -907,23 +927,26 @@ async fn prepare_navigation(
     parsed: &url::Url,
     owner: Option<&str>,
 ) {
+    let navigation_id = Uuid::new_v4().to_string();
     // Record the owner before emitting anything so the provisional state event
     // below — and the native page-load/title callbacks that follow — carry the
     // same tag. `owner` is the chat/session that issued this navigation; the
     // frontend uses it to keep a background pipe's page out of whatever chat is
     // on screen.
+    state.set_pending_navigation_id(Some(navigation_id.clone()));
     state.set_pending_owner(owner.map(|s| s.to_string()));
-    // Provisional omnibox URL while a top-level navigation is in flight
-    // (agent or sidebar initiated). Committed URL comes from `webview.url()`
-    // on main-document load finish / title change.
-    emit_state_event(app, Some(parsed.as_str().to_string()), None, Some(true));
     let _ = app.emit(
         NAVIGATE_EVENT,
         OwnedBrowserNavigateEvent {
             url: parsed.as_str().to_string(),
+            navigation_id,
             owner: owner.map(|s| s.to_string()),
         },
     );
+    // Provisional omnibox URL while a top-level navigation is in flight
+    // (agent or sidebar initiated). Committed URL comes from `webview.url()`
+    // on main-document load finish / title change.
+    emit_state_event(app, Some(parsed.as_str().to_string()), None, Some(true));
     state.store_pending_url(parsed.clone()).await;
 }
 
@@ -1235,6 +1258,7 @@ async fn inject_cookies_for_url(app: &AppHandle, url: &url::Url) {
                         v20_count: block.v20_count,
                         sources: block.sources,
                         reason: "v20".to_string(),
+                        navigation_id: browser_state().pending_navigation_id(),
                         owner: browser_state().pending_owner(),
                     };
                     if let Err(e) = app.emit(V20_COOKIE_BLOCK_EVENT, payload) {
@@ -1454,6 +1478,7 @@ async fn browser_session_decision_for_url(
                 v20_count: 0,
                 sources: block.sources,
                 reason: "locked".to_string(),
+                navigation_id: browser_state().pending_navigation_id(),
                 owner: browser_state().pending_owner(),
             };
             if let Err(e) = app.emit(V20_COOKIE_BLOCK_EVENT, payload) {
@@ -1559,6 +1584,7 @@ async fn browser_session_decision_for_url(
         url: url.as_str().to_string(),
         host: host_key.clone(),
         already_granted,
+        navigation_id: browser_state().pending_navigation_id(),
         owner: browser_state().pending_owner(),
     };
 


### PR DESCRIPTION
This PR fixes a race where the shared owned browser could leak state into the wrong chat.

Previously, the initial browser navigation could be tagged with the correct owner, but later lifecycle events like restore, state updates, retry flows, and cookie/session prompts could lose or overwrite that ownership. When that happened, the currently open chat could accept and persist browser state it never actually opened.

This showed up most clearly when switching quickly between chats or while a pipe was driving the owned browser in the background.

Fixes #3915 

### Changes

- restores/reloads now use the real `conversationId` as browser owner
- ownerless browser events are treated as stale/foreign instead of being auto-accepted
- retry/reload paths preserve the active owner
- each owned-browser navigation now carries a stable `navigationId`
- follow-up browser events carry that same `navigationId`
- the browser sidebar only accepts state/prompt/block events when both:
  - the `owner` matches the current chat
  - the `navigationId` matches the active navigation adopted by that chat
  
