### PR TITLE
fix: drop double screenpipe- prefix in lefthook clippy hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,7 +28,7 @@ pre-commit:
         crates=$(echo "{staged_files}" | tr ' ' '\n' \
           | grep -oE 'crates/[^/]+' | sort -u | sed 's|crates/||')
         for c in $crates; do
-          cargo clippy -p "screenpipe-$c" --all-targets -- -W clippy::all
+          cargo clippy -p "$c" --all-targets -- -W clippy::all
         done
 
     biome:


### PR DESCRIPTION
## description

The `rust-clippy` pre-commit hook in `lefthook.yml` never passes: crate directories under `crates/` are already named `screenpipe-*`, so the hook's `sed 's|crates/||'` already yields the full package name (e.g. `screenpipe-core`). The loop then re-prefixes it, producing nonexistent package ids like `screenpipe-screenpipe-core`, and `cargo clippy` exits 101 ("did not match any packages") on every commit that stages a crate `.rs` file.

One-line fix: pass the bare extracted name to `-p`.

related issue: none open — found while setting up the local dev loop (hooks installed via `bunx lefthook install`).

## before

(terminal output instead of a recording — this is a git-hook config change, no app UI involved)

```
$ cargo clippy -p "screenpipe-screenpipe-core" --all-targets -- -W clippy::all
error: package ID specification `screenpipe-screenpipe-core` did not match any packages
# exit 101 → the clippy gate fails on any staged crates/**.rs file
```

## after

```
$ cargo clippy -p "screenpipe-core" --all-targets -- -W clippy::all
    Finished `dev` profile [unoptimized + debuginfo] target(s)
# hook passes; ~1s warm for a typical staged set
```

## how to test

1. `bunx lefthook install`
2. stage any crate file, e.g. `touch crates/screenpipe-core/src/lib.rs && git add crates/screenpipe-core/src/lib.rs`
3. `bunx lefthook run pre-commit` — on main, rust-clippy fails with exit 101 ("did not match any packages"); with this patch it resolves the real package and runs clippy

## desktop app checklist (if applicable)

n/a — no tauri commands or exported Rust types touched (git-hook config only).