### PR TITLE
fix(pi): wait for active turn before respawning a session

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -1438,6 +1438,53 @@ pub async fn pi_start_inner(
     };
 
     let sid = session_id.to_string();
+
+    // Defense against killing a Pi mid-turn. A prompt that's currently
+    // streaming holds `agent_active=true` on its `PiQueueState`. If we
+    // proceeded straight to `m.stop()` below, any caller that re-invokes
+    // `pi_start` during a streaming response (preset watcher,
+    // connections-change effect, `pi-reauth` listener in
+    // `standalone-chat.tsx`) would silently truncate the user's reply and
+    // trigger the auto-restart-after-crash cascade.
+    //
+    // Wait briefly for the active turn to finish before respawning. The wait
+    // happens outside the main pool lock so other sessions (and the stdout
+    // reader that signals `done`) can keep operating. On timeout we fall
+    // through to the original kill-and-respawn behavior with a warning so
+    // the regression is visible in logs.
+    //
+    // 120s aligns with typical max turn length (most replies finish in
+    // <60s; long tool-using turns can take ~2 min). The queue itself uses a
+    // 300s safety timeout for waiting on `done` after a single command, so
+    // 120s here is a deliberately tighter cap — at 120s something is wrong
+    // enough that respawning is the lesser evil.
+    {
+        let queue_state = {
+            let pool = state.0.lock().await;
+            pool.sessions
+                .get(&sid)
+                .and_then(|m| m.queue_state.clone())
+        };
+        if let Some(qs) = queue_state {
+            if qs.is_agent_active() {
+                info!(
+                    "pi_start for session '{}' deferred — waiting for active turn to finish before respawn",
+                    sid
+                );
+                if !qs
+                    .wait_for_idle(std::time::Duration::from_secs(120))
+                    .await
+                {
+                    warn!(
+                        "pi_start for session '{}' proceeding despite active turn — \
+                         wait_for_idle timed out after 120s; respawn will truncate the in-flight reply",
+                        sid
+                    );
+                }
+            }
+        }
+    }
+
     let mut pool = state.0.lock().await;
 
     // Stop existing instance for this session if running

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi_command_queue.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi_command_queue.rs
@@ -208,7 +208,16 @@ impl PiQueueState {
     /// follow-up prompt can flip `agent_active` back to true before we
     /// finish — the loop guarantees we observe a true "idle" window before
     /// returning success.
+    ///
+    /// `done_notify` uses `notify_waiters()`, which stores no permit: a wake
+    /// fired in the window between our `is_agent_active()` check and the
+    /// `notified()` registration is lost. Capping each wait at `POLL_STEP` so
+    /// the loop re-checks the flag keeps a lost wake from stalling the full
+    /// `timeout` (and then truncating the reply anyway — the very regression
+    /// this guards against). The real deadline is still enforced at the top of
+    /// the loop; mirrors the bounded retry the queue's steer-wait already uses.
     pub async fn wait_for_idle(&self, timeout: std::time::Duration) -> bool {
+        const POLL_STEP: std::time::Duration = std::time::Duration::from_secs(1);
         if !self.is_agent_active() {
             return true;
         }
@@ -218,10 +227,11 @@ impl PiQueueState {
             if remaining.is_zero() {
                 return false;
             }
+            let step = remaining.min(POLL_STEP);
             tokio::select! {
                 _ = self.done_notify.notified() => {}
                 _ = self.terminated_notify.notified() => return true,
-                _ = tokio::time::sleep(remaining) => return false,
+                _ = tokio::time::sleep(step) => {}
             }
         }
         true
@@ -970,6 +980,36 @@ mod tests {
 
         let ok = state.wait_for_idle(std::time::Duration::from_secs(2)).await;
         assert!(ok, "should keep waiting until agent is genuinely idle");
+        signaller.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_idle_recovers_when_done_wake_is_lost() {
+        // `done_notify` uses notify_waiters() (no stored permit), so a wake
+        // delivered before the waiter registers is lost. Simulate the worst
+        // case by flipping the agent idle WITHOUT signalling done: the periodic
+        // poll must still observe idle well before the timeout. Without the
+        // POLL_STEP cap this stalled the entire timeout and then truncated the
+        // reply — the exact bug this change guards against.
+        let state = PiQueueState::new();
+        state.mark_agent_active();
+
+        let state_clone = state.clone();
+        let signaller = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            state_clone.mark_agent_idle(); // deliberately NO signal_done()
+        });
+
+        let start = std::time::Instant::now();
+        let ok = state
+            .wait_for_idle(std::time::Duration::from_secs(10))
+            .await;
+        assert!(ok, "poll must observe idle even when the done wake is lost");
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "should detect idle within ~1 poll step, not stall to timeout (got {:?})",
+            start.elapsed()
+        );
         signaller.await.unwrap();
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi_command_queue.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi_command_queue.rs
@@ -191,6 +191,42 @@ impl PiQueueState {
         self.steer_in_flight.load(Ordering::SeqCst)
     }
 
+    /// Wait until the agent stops streaming a turn (`agent_active` flips to
+    /// false), or until `timeout` elapses, whichever comes first. Returns
+    /// `true` if the session became idle in time, `false` on timeout.
+    ///
+    /// This extends the queue's existing prompt-level serialization
+    /// (`wait_for_done_or_terminated`) to *process-level* operations: callers
+    /// of `pi_start` use this to avoid killing a Pi that's currently
+    /// streaming a reply. Without it, any caller that re-invokes `pi_start`
+    /// during an active turn (preset watcher, connections-change effect,
+    /// `pi-reauth` listener) silently truncates the user's response and
+    /// triggers the auto-restart-after-crash cascade in
+    /// `standalone-chat.tsx`.
+    ///
+    /// Loops on every `done_notify` wake-up because a freshly-arrived
+    /// follow-up prompt can flip `agent_active` back to true before we
+    /// finish — the loop guarantees we observe a true "idle" window before
+    /// returning success.
+    pub async fn wait_for_idle(&self, timeout: std::time::Duration) -> bool {
+        if !self.is_agent_active() {
+            return true;
+        }
+        let deadline = tokio::time::Instant::now() + timeout;
+        while self.is_agent_active() {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            tokio::select! {
+                _ = self.done_notify.notified() => {}
+                _ = self.terminated_notify.notified() => return true,
+                _ = tokio::time::sleep(remaining) => return false,
+            }
+        }
+        true
+    }
+
     /// Called by the stdout reader when the process terminates (EOF).
     pub fn signal_terminated(&self) {
         let _ = self.alive.send(false);
@@ -845,6 +881,96 @@ mod tests {
 
         let result = h.await.unwrap();
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_idle_returns_immediately_when_idle() {
+        let state = PiQueueState::new();
+        let start = std::time::Instant::now();
+        let ok = state.wait_for_idle(std::time::Duration::from_secs(5)).await;
+        assert!(ok, "should return true when already idle");
+        assert!(
+            start.elapsed() < std::time::Duration::from_millis(50),
+            "should not block when already idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_idle_blocks_then_returns_on_done() {
+        let state = PiQueueState::new();
+        state.mark_agent_active();
+
+        let state_clone = state.clone();
+        let signaller = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            state_clone.mark_agent_idle();
+            state_clone.signal_done();
+        });
+
+        let ok = state.wait_for_idle(std::time::Duration::from_secs(2)).await;
+        assert!(ok, "should return true once agent becomes idle");
+        signaller.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_idle_returns_false_on_timeout() {
+        let state = PiQueueState::new();
+        state.mark_agent_active();
+
+        let start = std::time::Instant::now();
+        let ok = state
+            .wait_for_idle(std::time::Duration::from_millis(120))
+            .await;
+        assert!(!ok, "should return false when timeout elapses while busy");
+        assert!(
+            start.elapsed() >= std::time::Duration::from_millis(100),
+            "should actually wait the timeout (got {:?})",
+            start.elapsed()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_idle_returns_true_on_termination() {
+        let state = PiQueueState::new();
+        state.mark_agent_active();
+
+        let state_clone = state.clone();
+        let signaller = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            state_clone.signal_terminated();
+        });
+
+        let ok = state.wait_for_idle(std::time::Duration::from_secs(2)).await;
+        assert!(
+            ok,
+            "should return true when process terminates (no point waiting further)"
+        );
+        signaller.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_idle_loops_on_spurious_done() {
+        // A follow-up prompt can flip agent_active back to true between the
+        // moment `done_notify` fires and the moment we re-check the flag.
+        // The loop must observe a real idle window before returning true.
+        let state = PiQueueState::new();
+        state.mark_agent_active();
+
+        let state_clone = state.clone();
+        let signaller = tokio::spawn(async move {
+            // First done — but the agent is "still active" from the perspective
+            // of the wait loop (simulating: prompt N finished, prompt N+1
+            // already streaming).
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+            state_clone.signal_done(); // wakes the wait, but flag is still true
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+            state_clone.mark_agent_idle();
+            state_clone.signal_done();
+        });
+
+        let ok = state.wait_for_idle(std::time::Duration::from_secs(2)).await;
+        assert!(ok, "should keep waiting until agent is genuinely idle");
+        signaller.await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`pi_start` unconditionally calls `m.stop()` on an already-running session before respawning. When a caller re-invokes `pi_start` while a reply is still streaming — the preset watcher, the connections-change effect, or the `pi-reauth` listener in `standalone-chat.tsx` — the Pi is killed mid-turn. The user's response is silently truncated and the auto-restart-after-crash cascade fires.

The eviction path already guards *other* sessions from being killed mid-turn (via `pending_responses`), but the **same-session respawn** path has no such guard.

## Fix

Add `PiQueueState::wait_for_idle(timeout)` and gate the same-session respawn on it: if the session is mid-turn, wait up to 120s for the turn to finish before stopping. On timeout, fall through to the original kill-and-respawn with a `warn!` so the regression stays visible in logs. The wait happens outside the pool lock so other sessions keep operating.

## Tests

Unit tests for idle / blocking-then-done / timeout / termination / spurious-wakeup. All pass:

```
test pi_command_queue::tests::test_wait_for_idle_returns_immediately_when_idle ... ok
test pi_command_queue::tests::test_wait_for_idle_returns_true_on_termination ... ok
test pi_command_queue::tests::test_wait_for_idle_blocks_then_returns_on_done ... ok
test pi_command_queue::tests::test_wait_for_idle_loops_on_spurious_done ... ok
test pi_command_queue::tests::test_wait_for_idle_returns_false_on_timeout ... ok
test result: ok. 5 passed; 0 failed
```