### PR TITLE
fix(meetings): avoid false audio stalled warning

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/live-capture-state.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/live-capture-state.test.ts
@@ -110,12 +110,45 @@ describe("computeLiveCaptureState", () => {
     ).toBe("audio-not-started");
   });
 
-  it("surfaces stalled audio statuses", () => {
+  it("surfaces stale audio as stalled", () => {
+    expect(
+      computeLiveCaptureState({
+        isLive: true,
+        health: { ...healthyHealth, audio_status: "stale" },
+        devices: [activeMic],
+      }).kind,
+    ).toBe("audio-stalled");
+  });
+
+  it("does not surface recovered active_no_data as stalled", () => {
+    const nowMs = Date.parse("2026-06-11T11:20:30.000Z");
+
+    expect(
+      computeLiveCaptureState({
+        isLive: true,
+        health: {
+          ...healthyHealth,
+          audio_status: "active_no_data",
+          audio_pipeline: {
+            ...healthyHealth.audio_pipeline,
+            audio_level_rms: 0,
+          },
+        },
+        devices: [activeMic],
+        nowMs,
+      }).kind,
+    ).toBe("waiting-for-voice");
+  });
+
+  it("surfaces active_no_data as stalled when audio is not recent", () => {
+    const nowMs = Date.parse("2026-06-11T11:22:00.000Z");
+
     expect(
       computeLiveCaptureState({
         isLive: true,
         health: { ...healthyHealth, audio_status: "active_no_data" },
         devices: [activeMic],
+        nowMs,
       }).kind,
     ).toBe("audio-stalled");
   });

--- a/apps/screenpipe-app-tauri/lib/utils/live-capture-state.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/live-capture-state.ts
@@ -58,9 +58,11 @@ export interface ComputeLiveCaptureStateInput {
   health?: LiveCaptureHealth | null;
   devices?: LiveCaptureDevice[];
   hasTranscriptContent?: boolean;
+  nowMs?: number;
 }
 
 const SILENT_RMS_THRESHOLD = 0.001;
+const RECENT_AUDIO_WINDOW_MS = 60_000;
 
 const STATES: Record<LiveCaptureKind, LiveCaptureState> = {
   idle: {
@@ -174,6 +176,7 @@ export function computeLiveCaptureState({
   health,
   devices = [],
   hasTranscriptContent = false,
+  nowMs = Date.now(),
 }: ComputeLiveCaptureStateInput): LiveCaptureState {
   if (!isLive) return STATES.idle;
 
@@ -196,7 +199,14 @@ export function computeLiveCaptureState({
   }
 
   if (audioStatus === "not_started") return STATES["audio-not-started"];
-  if (audioStatus === "stale" || audioStatus === "active_no_data") {
+  const hasRecentAudio = isRecentAudioTimestamp(
+    health?.last_audio_timestamp,
+    nowMs,
+  );
+  if (
+    audioStatus === "stale" ||
+    (audioStatus === "active_no_data" && !hasRecentAudio)
+  ) {
     return STATES["audio-stalled"];
   }
 
@@ -222,6 +232,17 @@ export function computeLiveCaptureState({
   }
 
   return STATES.recording;
+}
+
+function isRecentAudioTimestamp(
+  timestamp: string | null | undefined,
+  nowMs: number,
+): boolean {
+  if (!timestamp) return false;
+  const parsed = Date.parse(timestamp);
+  if (Number.isNaN(parsed)) return false;
+  const ageMs = nowMs - parsed;
+  return ageMs >= 0 && ageMs < RECENT_AUDIO_WINDOW_MS;
 }
 
 export function isLiveCaptureDegraded(state: LiveCaptureState): boolean {

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -92,7 +92,9 @@ fn capture_status(
     audio_level_rms: f64,
     chunks_sent: u64,
     last_audio_ts: u64,
+    now_ts: u64,
 ) -> CaptureStatusInfo {
+    let audio_recent = last_audio_ts > 0 && now_ts.saturating_sub(last_audio_ts) < 60;
     let (status, severity, reason) = if audio_disabled {
         (
             "disabled",
@@ -111,7 +113,7 @@ fn capture_status(
             "warning",
             "audio capture has not produced data yet",
         )
-    } else if audio_status == "stale" || audio_status == "active_no_data" {
+    } else if audio_status == "stale" || (audio_status == "active_no_data" && !audio_recent) {
         (
             "audio_stalled",
             "warning",
@@ -129,9 +131,9 @@ fn capture_status(
             "waiting",
             "audio is queued for transcription",
         )
-    } else if audio_status == "ok"
+    } else if (audio_status == "ok" || audio_status == "active_no_data")
         && active_audio_devices > 0
-        && (chunks_sent > 0 || last_audio_ts > 0)
+        && (chunks_sent > 0 || audio_recent)
         && audio_level_rms <= SILENT_AUDIO_RMS_THRESHOLD
     {
         (
@@ -757,7 +759,8 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
         pending_transcription_segments,
         audio_snap.audio_level_rms,
         audio_snap.chunks_sent,
-        last_audio_ts,
+        last_audio_ts.max(most_recent_audio_timestamp),
+        now_ts,
     );
 
     // Format device statuses as a string for a more detailed view
@@ -1235,6 +1238,48 @@ mod tests {
             hostname: None,
             version: None,
         }
+    }
+
+    #[test]
+    fn capture_status_does_not_show_stalled_for_recovered_active_no_data() {
+        let state = capture_status(
+            false,
+            "active_no_data",
+            1,
+            1,
+            0,
+            0,
+            false,
+            None,
+            0.0,
+            4,
+            120,
+            121,
+        );
+
+        assert_eq!(state.status, "waiting_for_voice");
+        assert_eq!(state.severity, "waiting");
+    }
+
+    #[test]
+    fn capture_status_still_warns_for_active_no_data_without_fresh_audio() {
+        let state = capture_status(
+            false,
+            "active_no_data",
+            1,
+            1,
+            0,
+            0,
+            false,
+            None,
+            0.0,
+            4,
+            1,
+            120,
+        );
+
+        assert_eq!(state.status, "audio_stalled");
+        assert_eq!(state.severity, "warning");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Description:

- before:

https://github.com/user-attachments/assets/5a7477ce-853b-49df-ad5b-bcf221c69dd1


- after:


https://github.com/user-attachments/assets/57c583c4-696a-4084-bd8f-a4e4393595a9



Ref: https://github.com/screenpipe/screenpipe/pull/3998#issuecomment-4684236313

<img width="1102" height="394" alt="image" src="https://github.com/user-attachments/assets/04afd3e4-6b14-495a-92d0-39b41bb24024" />


Fixes a bug where live meeting notes could show Audio stalled even after audio had recovered and was still being captured.