### PR TITLE
fix(store): scope "screenpipe" ignore-pattern to app name only

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1330,6 +1330,17 @@ impl SettingsStore {
                 );
             }
 
+            // Migrate unscoped "screenpipe" ignore-pattern to app-scoped "screenpipe::"
+            // so browser tabs whose title contains "screenpipe" are no longer falsely
+            // excluded from SCK capture and rendered black.
+            if let Some(Value::Array(windows)) = obj.get_mut("ignoredWindows") {
+                for entry in windows.iter_mut() {
+                    if entry.as_str() == Some("screenpipe") {
+                        *entry = Value::String("screenpipe::".to_string());
+                    }
+                }
+            }
+
             // Sanitize unknown provider types in aiPresets to prevent deserialization failures
             let known_providers = [
                 "openai",

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1165,7 +1165,7 @@ impl Default for SettingsStore {
             "Recorder".to_string(),
             "vault".to_string(),
             "OBS Studio".to_string(),
-            "screenpipe".to_string(),
+            "screenpipe::".to_string(),
         ];
 
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Root cause

The default `ignored_windows` list contained the unscoped entry `"screenpipe"`. Unscoped patterns match when the substring appears in either the app name **or** the window title. This caused any browser tab whose title contained "screenpipe" (e.g. `screenpipe/screenpipe — GitHub`) to be resolved as an excluded SCK window ID and rendered black in capture.

## Fix

Changed `"screenpipe"` → `"screenpipe::"`. The `::` scope syntax constrains the match to the app name only, leaving the title unchecked. The screenpipe app window is still excluded from self-capture; browser tabs are unaffected.

## Reference

https://github.com/screenpipe/screenpipe/blob/55aa0e6fed2c63388376f5eb1736bf42b8a8c608/crates/screenpipe-core/src/window_pattern.rs#L13-L22



## Before

<img width="1470" height="956" alt="Screenshot 2026-06-12 at 2 40 28 AM" src="https://github.com/user-attachments/assets/a88cbeb5-026b-4e7c-84ac-c0e9c1f506ef" />


## After

<img width="1470" height="956" alt="Screenshot 2026-06-12 at 2 45 56 AM" src="https://github.com/user-attachments/assets/39e266dd-0de7-4814-aa47-13522cda941c" />