### PR TITLE
[codex] improve desktop feedback follow-up UX

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
@@ -633,7 +633,7 @@ export function TranscriptPanel({
       if (!isLive) return "no transcript was captured for this meeting";
       return (
         captureState?.transcriptEmptyCopy ??
-        "listening — transcript will appear when the first segment arrives"
+        "no transcript yet — audio can take a minute to appear; keep the meeting open"
       );
     }
     if (filteredBlocks.length === 0 && query.trim()) {

--- a/apps/screenpipe-app-tauri/components/share-logs-button.tsx
+++ b/apps/screenpipe-app-tauri/components/share-logs-button.tsx
@@ -267,7 +267,7 @@ export const ShareLogsButton = ({
       const os_version = osVersion();
       const app_version = await getVersion();
 
-      await fetch(`${BASE_URL}/api/logs/confirm`, {
+      const confirmResponse = await fetch(`${BASE_URL}/api/logs/confirm`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -283,10 +283,20 @@ export const ShareLogsButton = ({
           screenpipe_id: settings.analyticsId,
         }),
       });
+      if (!confirmResponse.ok) {
+        throw new Error("failed to confirm log upload");
+      }
+      const confirmPayload = await confirmResponse.json().catch(() => null);
+      const supportId = confirmPayload?.data?.id;
+      const followUpChannel = confirmPayload?.data?.follow_up;
+      const reference = supportId ? ` #${supportId}` : "";
 
       toast({
         title: "feedback sent",
-        description: "thanks — we'll follow up by email or discord.",
+        description:
+          followUpChannel === "email"
+            ? `we emailed you a receipt${reference} and will reply there.`
+            : `we posted it to support${reference}; mention that ID in Discord if you need an update.`,
       });
       setFeedbackText("");
       setScreenshot(null);

--- a/apps/screenpipe-app-tauri/src-tauri/src/meeting_stall_notifications.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/meeting_stall_notifications.rs
@@ -103,7 +103,7 @@ fn handle_transcript_stall(app: &AppHandle, event: StallEvent) {
 
     client::send_typed_with_actions(
         "live transcript not flowing",
-        format!("audio is being captured but no transcript has arrived in {elapsed}s — retrying in the background"),
+        format!("audio is still being captured, but the transcript is delayed by {elapsed}s — keep the meeting open while screenpipe retries"),
         "meeting",
         Some(30_000),
         Vec::new(),


### PR DESCRIPTION
## Summary

- Make the desktop `send logs` flow wait for `/api/logs/confirm`, fail visibly if confirmation fails, and show the returned support ID/follow-up channel in the toast.
- Clarify the live transcript empty state and transcript-stall notification so users know audio can still be captured while transcript segments are delayed.

Pairs with website PR: https://github.com/screenpipe/website/pull/260

## Validation

- `bunx tsc --noEmit --pretty false`
- `rustfmt --edition 2021 apps/screenpipe-app-tauri/src-tauri/src/meeting_stall_notifications.rs`
- `cargo check -p screenpipe-app --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml` passed with existing unrelated warnings in `screenpipe-engine`, `owned_browser.rs`, and `enterprise_policy.rs`.