### PR TITLE
Use full-height layout so virtual scroll works with  many artifacts

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -913,7 +913,8 @@ function HomeContent() {
     activeSection === "home" ||
     activeSection === "timeline" ||
     activeSection === "meetings" ||
-    activeSection === "history";
+    activeSection === "history" ||
+    activeSection === "brain";
 
   return (
     <div className={cn("bg-transparent", isFullHeight ? "h-screen overflow-hidden" : "min-h-screen")} data-testid="home-page">

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -653,8 +653,8 @@ export function BrainSection() {
   const isStale = staleDays >= 1;
 
   return (
-    <div data-testid="section-brain" className="h-full overflow-y-auto">
-    <div className="max-w-4xl mx-auto px-6 py-6 pb-12 space-y-4 h-full flex flex-col">
+    <div data-testid="section-brain" className="h-full overflow-hidden">
+    <div className="max-w-4xl mx-auto px-6 py-6 space-y-4 h-full flex flex-col">
       <p className="text-muted-foreground text-sm mb-4">
         what the AI has learned from your activity and what it has generated for you
       </p>

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -653,7 +653,8 @@ export function BrainSection() {
   const isStale = staleDays >= 1;
 
   return (
-    <div data-testid="section-brain" className="space-y-4 h-full flex flex-col">
+    <div data-testid="section-brain" className="h-full overflow-y-auto">
+    <div className="max-w-4xl mx-auto px-6 py-6 pb-12 space-y-4 h-full flex flex-col">
       <p className="text-muted-foreground text-sm mb-4">
         what the AI has learned from your activity and what it has generated for you
       </p>
@@ -1297,6 +1298,7 @@ export function BrainSection() {
           </div>
         </div>
       )}
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
This pr fixes the brain section layout breaking when many artifacts are loaded.

brain section used the non-full-height layout path, wrapping content in `max-w-4xl` without a fixed height constraint. `h-full` on the brain root never resolved, `flex-1` on the scroll container grew unbounded, and the `IntersectionObserver` sentinel fired repeatedly — dumping all items into the DOM at once and breaking layout with many artifacts.

switches brain to `isFullHeight` (like meetings) and moves `max-w-4xl` centering in to the component itself so the flex or scroll chain resolves correctly and `RENDER_WINDOW` virtualization works as intended.

https://github.com/user-attachments/assets/473ea99c-e786-4335-8a58-7de776ce6e6b
