### PR TITLE
fix(e2e): re-expand sidebar so nav-* testids exist (fixes red E2E on main)

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/helpers/test-utils.ts
+++ b/apps/screenpipe-app-tauri/e2e/helpers/test-utils.ts
@@ -107,6 +107,27 @@ async function finishOpenHomeWindow(): Promise<void> {
     }
   );
   await browser.pause(t(1500));
+
+  // The Home window persists across specs and `sidebarCollapsed` is in-memory
+  // React state — a prior spec may have collapsed the sidebar (e.g. via the
+  // focused-meeting auto-collapse) without navigating away, so the force-/home
+  // reload above never fires and the collapsed state survives. Since #4017
+  // ("declutter sidebar corner") a collapsed sidebar is hidden entirely — the
+  // whole <AppSidebar> and every nav-* item vanish — so any spec that clicks
+  // nav-pipes / nav-timeline / nav-settings would fail with "element still not
+  // existing". Re-expand here so each spec starts from a known-expanded state.
+  // The toggle is the only chrome left when collapsed; aria-label flips to
+  // "expand sidebar" in that state, so its presence is the collapse signal.
+  try {
+    const expandBtn = await $('[aria-label="expand sidebar"]');
+    if (await expandBtn.isExisting()) {
+      await expandBtn.click();
+      await browser.pause(t(500));
+    }
+  } catch {
+    // Best-effort — if the toggle can't be found/clicked, the spec's own
+    // waitForExist on the nav item still reports the real failure.
+  }
 }
 
 /**


### PR DESCRIPTION
## what

E2E Tests has been red on `main` across **all three platforms** (Windows, macOS, Linux) since `3aaca4c3b` (#4017, *declutter sidebar corner*). The same 5 specs fail deterministically every run:

`pipes` · `privacy-api-auth` · `privacy-installed-apps` · `settings-sections` · `timeline`

```
Error: element ("[data-testid=\"nav-pipes\"]") still not existing after 20000ms
```

## root cause

#4017 made a **collapsed sidebar hide the entire `<AppSidebar>`** (no icon-rail fallback) — so every `nav-*` testid disappears when collapsed. The Home window and its `sidebarCollapsed` React state **persist across the shared e2e session**. Once an earlier spec collapses the sidebar (e.g. the focused-meeting auto-collapse) *without navigating away*, `finishOpenHomeWindow`'s force-`/home` reload never fires (already on `/home`), so the collapsed state survives into the next spec. Every later spec that clicks a nav item then can't find it.

`privacy-api-auth-enforcement` and `tray-search` run in the same window between the failures and pass — they don't click sidebar nav, which confirms the diagnosis.

## fix

Test-infra only — no product code touched (the collapse behavior from #4017 is intentional). After the Home page renders in `finishOpenHomeWindow`, re-expand the sidebar if it's collapsed (best-effort click on the `expand sidebar` toggle), so every spec starts from a known-expanded state.

```
BEFORE (red)                              AFTER (green)
------------                              -------------
meeting spec auto-collapses sidebar       home page renders
  -> sidebarCollapsed=true persists       if [aria-label="expand sidebar"] exists:
next spec already on /home -> no reload        click it  (sidebar back, nav-* in DOM)
collapsed = whole nav hidden              spec clicks its nav item normally
  X nav-pipes / nav-timeline / nav-       ✓ pipes ✓ privacy-* ✓ settings ✓ timeline
    settings "still not existing"
```

Best-effort: if the toggle can't be found/clicked, the spec's own `waitForExist` still surfaces the real failure.

## test

- `tsc` clean against `e2e/tsconfig.json` types (`node` / `mocha` / `@wdio/globals`).
- Change uses only WDIO globals already used throughout the helper (`$`, `browser`, `isExisting`, `click`, `pause`, `t`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)