### PR TITLE
[codex] Avoid resource monitor debug string allocation

### DIFF
--- a/crates/screenpipe-engine/src/resource_monitor.rs
+++ b/crates/screenpipe-engine/src/resource_monitor.rs
@@ -20,17 +20,21 @@ pub struct ResourceMonitor {
     posthog_client: Option<Client>,
     posthog_enabled: bool,
     distinct_id: String,
-    /// Cached hardware info (collected once at startup, never changes)
+    /// Cached host info (collected once at startup, never changes)
     hw_info: HardwareInfo,
 }
 
-/// Static hardware info collected once at startup.
-/// Only contains general model names — no serial numbers, UUIDs, or PII.
+/// Static host info collected once at startup.
+/// Only contains general OS/model names — no serial numbers, UUIDs, or PII.
 #[derive(Clone, Debug)]
 struct HardwareInfo {
     cpu_brand: String,
     cpu_arch: String,
+    cpu_count: usize,
     gpu_names: Vec<String>,
+    os_name: String,
+    os_version: String,
+    kernel_version: String,
 }
 
 impl HardwareInfo {
@@ -45,13 +49,21 @@ impl HardwareInfo {
             .unwrap_or_default();
 
         let cpu_arch = std::env::consts::ARCH.to_string();
+        let cpu_count = sys.cpus().len();
+        let os_name = sys.name().unwrap_or_default();
+        let os_version = sys.os_version().unwrap_or_default();
+        let kernel_version = sys.kernel_version().unwrap_or_default();
 
         let gpu_names = detect_gpus();
 
         Self {
             cpu_brand,
             cpu_arch,
+            cpu_count,
             gpu_names,
+            os_name,
+            os_version,
+            kernel_version,
         }
     }
 }
@@ -266,11 +278,17 @@ impl ResourceMonitor {
         let distinct_id = TelemetryContext::distinct_id_from_env()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
-        // Collect hardware info once (CPU brand, GPU names) — never panics
+        // Collect host info once (OS, CPU, GPU names) — never panics
         let hw_info = HardwareInfo::collect();
         debug!(
-            "hardware: cpu={:?} arch={} gpus={:?}",
-            hw_info.cpu_brand, hw_info.cpu_arch, hw_info.gpu_names
+            "host: os={:?} {:?} kernel={:?} cpu={:?} arch={} cores={} gpus={:?}",
+            hw_info.os_name,
+            hw_info.os_version,
+            hw_info.kernel_version,
+            hw_info.cpu_brand,
+            hw_info.cpu_arch,
+            hw_info.cpu_count,
+            hw_info.gpu_names
         );
 
         Arc::new(Self {
@@ -293,9 +311,6 @@ impl ResourceMonitor {
             return;
         };
 
-        // Create System only when needed
-        let sys = System::new();
-
         // Avoid unnecessary cloning by using references
         let mut properties = Map::new();
         properties.insert("distinct_id".to_string(), json!(&self.distinct_id));
@@ -314,16 +329,13 @@ impl ResourceMonitor {
             "runtime_seconds".to_string(),
             json!(self.start_time.elapsed().as_secs()),
         );
-        properties.insert("os_name".to_string(), json!(sys.name().unwrap_or_default()));
-        properties.insert(
-            "os_version".to_string(),
-            json!(sys.os_version().unwrap_or_default()),
-        );
+        properties.insert("os_name".to_string(), json!(&self.hw_info.os_name));
+        properties.insert("os_version".to_string(), json!(&self.hw_info.os_version));
         properties.insert(
             "kernel_version".to_string(),
-            json!(sys.kernel_version().unwrap_or_default()),
+            json!(&self.hw_info.kernel_version),
         );
-        properties.insert("cpu_count".to_string(), json!(sys.cpus().len()));
+        properties.insert("cpu_count".to_string(), json!(self.hw_info.cpu_count));
         properties.insert("cpu_brand".to_string(), json!(&self.hw_info.cpu_brand));
         properties.insert("cpu_arch".to_string(), json!(&self.hw_info.cpu_arch));
         properties.insert("gpu_count".to_string(), json!(self.hw_info.gpu_names.len()));
@@ -451,8 +463,9 @@ impl ResourceMonitor {
             runtime,
         ) = metrics;
 
-        // Log to console with virtual memory
-        let log_message = format!(
+        // Log to console with virtual memory. Let tracing format lazily so
+        // release builds with debug logging disabled avoid the String allocation.
+        debug!(
             "Runtime: {}s, Memory: {:.0}% ({:.2} GB / {:.2} GB), Virtual: {:.2} GB, CPU: {:.0}%",
             runtime.as_secs(),
             memory_usage_percent,
@@ -461,7 +474,6 @@ impl ResourceMonitor {
             total_virtual_memory_gb,
             total_cpu
         );
-        debug!("{}", log_message);
 
         // Log to file
         self.log_to_file(metrics).await;
@@ -482,6 +494,13 @@ impl ResourceMonitor {
         interval: Duration,
         posthog_interval: Option<Duration>,
     ) {
+        if !self.posthog_enabled
+            && self.resource_log_file.is_none()
+            && !tracing::enabled!(tracing::Level::DEBUG)
+        {
+            return;
+        }
+
         let monitor = Arc::clone(self);
         let posthog_interval = posthog_interval.unwrap_or(interval);
         let mut last_posthog_update = Instant::now();
@@ -556,8 +575,9 @@ impl ResourceMonitor {
             runtime,
         ) = metrics;
 
-        // Log to console with virtual memory
-        let log_message = format!(
+        // Log to console with virtual memory. Let tracing format lazily so
+        // release builds with debug logging disabled avoid the String allocation.
+        debug!(
             "Runtime: {}s, Memory: {:.0}% ({:.2} GB / {:.2} GB), Virtual: {:.2} GB, CPU: {:.0}%",
             runtime.as_secs(),
             memory_usage_percent,
@@ -566,7 +586,6 @@ impl ResourceMonitor {
             total_virtual_memory_gb,
             total_cpu
         );
-        debug!("{}", log_message);
 
         // Log to file
         self.log_to_file(metrics).await;


### PR DESCRIPTION
﻿## Summary
- replace eager `format!` debug messages in the resource monitor with direct `tracing::debug!` formatting
- cache static OS/CPU/GPU metadata at startup instead of creating a fresh `sysinfo::System` for every telemetry send
- skip spawning the 30s resource monitor sampler when analytics, resource-file logging, and debug logs are all disabled
- preserve the existing resource usage log text and PostHog payload fields when a sink is active

## Why
The resource monitor wakes every 30s for the life of the process. In normal release runs with analytics disabled and no resource log file, it had no observable output but still refreshed sysinfo and formatted/logged debug-only metrics. This removes that idle wake path, and trims allocations/lookups when telemetry is active.

## Validation
- `cargo fmt --package screenpipe-engine -- --check`
- `cargo test -p screenpipe-engine resource_monitor --lib`
- `cargo check -p screenpipe-engine`
