### PR TITLE
[codex] Gate analytics reporter timers

### DIFF
--- a/crates/screenpipe-engine/src/analytics.rs
+++ b/crates/screenpipe-engine/src/analytics.rs
@@ -54,6 +54,11 @@ pub fn init(telemetry_enabled: bool) {
     );
 }
 
+/// Whether telemetry-backed analytics are currently enabled.
+pub fn is_enabled() -> bool {
+    TELEMETRY_ENABLED.load(Ordering::SeqCst)
+}
+
 /// Get the current distinct_id
 pub fn get_distinct_id() -> &'static str {
     ANALYTICS.distinct_id()
@@ -61,7 +66,7 @@ pub fn get_distinct_id() -> &'static str {
 
 /// Capture an analytics event
 pub async fn capture_event(event: &str, properties: Value) {
-    if !TELEMETRY_ENABLED.load(Ordering::SeqCst) {
+    if !is_enabled() {
         return;
     }
 
@@ -95,7 +100,7 @@ pub async fn capture_event(event: &str, properties: Value) {
 
 /// Capture event without blocking (fire and forget)
 pub fn capture_event_nonblocking(event: &'static str, properties: Value) {
-    if !TELEMETRY_ENABLED.load(Ordering::SeqCst) {
+    if !is_enabled() {
         return;
     }
 
@@ -118,7 +123,7 @@ fn parse_macos_major_version(version_str: &str) -> Option<u32> {
 /// - Below 14 (Sonoma): sck-rs may have issues, recommended to upgrade
 #[cfg(target_os = "macos")]
 pub fn check_macos_version() {
-    if !TELEMETRY_ENABLED.load(Ordering::SeqCst) {
+    if !is_enabled() {
         return;
     }
 

--- a/crates/screenpipe-engine/src/server.rs
+++ b/crates/screenpipe-engine/src/server.rs
@@ -405,106 +405,110 @@ impl SCServer {
 
     pub async fn create_router(&self) -> Router {
         let api_request_count = Arc::new(AtomicUsize::new(0));
+        let analytics_enabled = analytics::is_enabled();
+        let api_usage_counter = analytics_enabled.then(|| api_request_count.clone());
 
-        // Spawn periodic API usage reporter (every 5 minutes)
-        let counter_clone = api_request_count.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(300));
-            loop {
-                interval.tick().await;
-                let count = counter_clone.swap(0, Ordering::Relaxed);
-                if count > 0 {
-                    info!("api_usage_5min: {} requests", count);
-                    // Fire analytics event for API usage tracking
-                    analytics::track_api_usage(count);
+        if analytics_enabled {
+            // Spawn periodic API usage reporter (every 5 minutes)
+            let counter_clone = api_request_count.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(300));
+                loop {
+                    interval.tick().await;
+                    let count = counter_clone.swap(0, Ordering::Relaxed);
+                    if count > 0 {
+                        info!("api_usage_5min: {} requests", count);
+                        // Fire analytics event for API usage tracking
+                        analytics::track_api_usage(count);
+                    }
                 }
-            }
-        });
+            });
 
-        // Spawn periodic vision pipeline metrics reporter (every 60 seconds)
-        let metrics_for_posthog = self.vision_metrics.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(60));
-            loop {
-                interval.tick().await;
-                let snap = metrics_for_posthog.snapshot();
-                // Only report if the pipeline has captured any frames
-                if snap.frames_captured > 0 {
-                    analytics::capture_event_nonblocking(
-                        "vision_pipeline_health",
-                        json!({
-                            "uptime_secs": snap.uptime_secs,
-                            "frames_captured": snap.frames_captured,
-                            "frames_skipped": snap.frames_skipped,
-                            "ocr_completed": snap.ocr_completed,
-                            "ocr_cache_hits": snap.ocr_cache_hits,
-                            "ocr_cache_misses": snap.ocr_cache_misses,
-                            "avg_ocr_latency_ms": snap.avg_ocr_latency_ms,
-                            "frames_video_written": snap.frames_video_written,
-                            "frames_db_written": snap.frames_db_written,
-                            "frames_dropped": snap.frames_dropped,
-                            "avg_db_latency_ms": snap.avg_db_latency_ms,
-                            "frame_drop_rate": snap.frame_drop_rate,
-                            "capture_fps_actual": snap.capture_fps_actual,
-                            "time_to_first_frame_ms": snap.time_to_first_frame_ms,
-                            "ocr_queue_depth": snap.ocr_queue_depth,
-                            "video_queue_depth": snap.video_queue_depth,
-                            "pipeline_stall_count": snap.pipeline_stall_count,
-                        }),
-                    );
+            // Spawn periodic vision pipeline metrics reporter (every 60 seconds)
+            let metrics_for_posthog = self.vision_metrics.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    let snap = metrics_for_posthog.snapshot();
+                    // Only report if the pipeline has captured any frames
+                    if snap.frames_captured > 0 {
+                        analytics::capture_event_nonblocking(
+                            "vision_pipeline_health",
+                            json!({
+                                "uptime_secs": snap.uptime_secs,
+                                "frames_captured": snap.frames_captured,
+                                "frames_skipped": snap.frames_skipped,
+                                "ocr_completed": snap.ocr_completed,
+                                "ocr_cache_hits": snap.ocr_cache_hits,
+                                "ocr_cache_misses": snap.ocr_cache_misses,
+                                "avg_ocr_latency_ms": snap.avg_ocr_latency_ms,
+                                "frames_video_written": snap.frames_video_written,
+                                "frames_db_written": snap.frames_db_written,
+                                "frames_dropped": snap.frames_dropped,
+                                "avg_db_latency_ms": snap.avg_db_latency_ms,
+                                "frame_drop_rate": snap.frame_drop_rate,
+                                "capture_fps_actual": snap.capture_fps_actual,
+                                "time_to_first_frame_ms": snap.time_to_first_frame_ms,
+                                "ocr_queue_depth": snap.ocr_queue_depth,
+                                "video_queue_depth": snap.video_queue_depth,
+                                "pipeline_stall_count": snap.pipeline_stall_count,
+                            }),
+                        );
+                    }
                 }
-            }
-        });
+            });
 
-        // Spawn periodic audio pipeline metrics reporter (every 60 seconds)
-        let audio_metrics_for_posthog = self.audio_metrics.clone();
-        let audio_manager_for_posthog = self.audio_manager.clone();
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(60));
-            loop {
-                interval.tick().await;
-                let snap = audio_metrics_for_posthog.snapshot();
-                // Only report if the pipeline has processed any chunks
-                if snap.chunks_sent > 0 || snap.vad_rejected > 0 {
-                    let devices: Vec<String> = audio_manager_for_posthog
-                        .current_devices()
-                        .iter()
-                        .map(|d| d.to_string())
-                        .collect();
-                    let device_count = devices.len();
-                    analytics::capture_event_nonblocking(
-                        "audio_pipeline_health",
-                        json!({
-                            "uptime_secs": snap.uptime_secs,
-                            "chunks_sent": snap.chunks_sent,
-                            "chunks_received": snap.chunks_received,
-                            "chunks_channel_full": snap.chunks_channel_full,
-                            "stream_timeouts": snap.stream_timeouts,
-                            "process_errors": snap.process_errors,
-                            "vad_passed": snap.vad_passed,
-                            "vad_rejected": snap.vad_rejected,
-                            "avg_speech_ratio": snap.avg_speech_ratio,
-                            "vad_passthrough_rate": snap.vad_passthrough_rate,
-                            "transcriptions_completed": snap.transcriptions_completed,
-                            "transcriptions_empty": snap.transcriptions_empty,
-                            "transcription_errors": snap.transcription_errors,
-                            "db_inserted": snap.db_inserted,
-                            "db_duplicates_blocked": snap.db_duplicates_blocked,
-                            "db_overlaps_trimmed": snap.db_overlaps_trimmed,
-                            "total_words": snap.total_words,
-                            "words_per_minute": snap.words_per_minute,
-                            "audio_level_rms": snap.audio_level_rms,
-                            "segments_deferred": snap.segments_deferred,
-                            "segments_batch_processed": snap.segments_batch_processed,
-                            "batch_pause_events": snap.batch_pause_events,
-                            "batch_resume_events": snap.batch_resume_events,
-                            "audio_devices": devices,
-                            "audio_device_count": device_count,
-                        }),
-                    );
+            // Spawn periodic audio pipeline metrics reporter (every 60 seconds)
+            let audio_metrics_for_posthog = self.audio_metrics.clone();
+            let audio_manager_for_posthog = self.audio_manager.clone();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    let snap = audio_metrics_for_posthog.snapshot();
+                    // Only report if the pipeline has processed any chunks
+                    if snap.chunks_sent > 0 || snap.vad_rejected > 0 {
+                        let devices: Vec<String> = audio_manager_for_posthog
+                            .current_devices()
+                            .iter()
+                            .map(|d| d.to_string())
+                            .collect();
+                        let device_count = devices.len();
+                        analytics::capture_event_nonblocking(
+                            "audio_pipeline_health",
+                            json!({
+                                "uptime_secs": snap.uptime_secs,
+                                "chunks_sent": snap.chunks_sent,
+                                "chunks_received": snap.chunks_received,
+                                "chunks_channel_full": snap.chunks_channel_full,
+                                "stream_timeouts": snap.stream_timeouts,
+                                "process_errors": snap.process_errors,
+                                "vad_passed": snap.vad_passed,
+                                "vad_rejected": snap.vad_rejected,
+                                "avg_speech_ratio": snap.avg_speech_ratio,
+                                "vad_passthrough_rate": snap.vad_passthrough_rate,
+                                "transcriptions_completed": snap.transcriptions_completed,
+                                "transcriptions_empty": snap.transcriptions_empty,
+                                "transcription_errors": snap.transcription_errors,
+                                "db_inserted": snap.db_inserted,
+                                "db_duplicates_blocked": snap.db_duplicates_blocked,
+                                "db_overlaps_trimmed": snap.db_overlaps_trimmed,
+                                "total_words": snap.total_words,
+                                "words_per_minute": snap.words_per_minute,
+                                "audio_level_rms": snap.audio_level_rms,
+                                "segments_deferred": snap.segments_deferred,
+                                "segments_batch_processed": snap.segments_batch_processed,
+                                "batch_pause_events": snap.batch_pause_events,
+                                "batch_resume_events": snap.batch_resume_events,
+                                "audio_devices": devices,
+                                "audio_device_count": device_count,
+                            }),
+                        );
+                    }
                 }
-            }
-        });
+            });
+        }
 
         // Use pre-set hot frame cache or create a new one, then warm from DB.
         // Spawn warm_from_db in the background — the cache starts empty but fills
@@ -1032,9 +1036,11 @@ impl SCServer {
             ))
             .layer(axum::middleware::from_fn(
                 move |req: axum::extract::Request, next: axum::middleware::Next| {
-                    let counter = app_state.api_request_count.clone();
+                    let counter = api_usage_counter.clone();
                     async move {
-                        counter.fetch_add(1, Ordering::Relaxed);
+                        if let Some(counter) = counter {
+                            counter.fetch_add(1, Ordering::Relaxed);
+                        }
                         next.run(req).await
                     }
                 },


### PR DESCRIPTION
## Summary
- expose `analytics::is_enabled()` for telemetry-gated work
- skip spawning API usage, vision pipeline, and audio pipeline telemetry reporter timers when analytics are disabled
- skip the per-request API usage atomic increment when analytics are disabled

## Why
These reporters woke every 60s/60s/300s even in telemetry-disabled runs, only to hit the analytics no-op path. The request middleware also incremented an API usage counter with no active reporter to consume it. Gating both paths removes idle timer wakeups and disabled-telemetry request accounting while leaving analytics-enabled reporting behavior unchanged.

## Validation
- `cargo fmt --package screenpipe-engine -- --check`
- `cargo test -p screenpipe-engine --lib analytics`
- `cargo test -p screenpipe-engine --lib server`
- `cargo check -p screenpipe-engine`