### PR TITLE
[codex] Borrow permission monitor reasons

### DIFF
--- a/crates/screenpipe-engine/src/permission_monitor.rs
+++ b/crates/screenpipe-engine/src/permission_monitor.rs
@@ -142,7 +142,7 @@ pub fn start() -> Option<JoinHandle<()>> {
 ///
 /// Skipped silently during the wake grace period to avoid spurious
 /// lost→restored flashes after sleep/wake.
-pub fn report_state(kind: PermissionKind, now_granted: bool, reason: Option<String>) {
+pub fn report_state(kind: PermissionKind, now_granted: bool, reason: Option<&str>) {
     let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
 
     // Suppress emissions during wake grace period. A real transition will
@@ -195,10 +195,10 @@ pub fn report_state(kind: PermissionKind, now_granted: bool, reason: Option<Stri
     } else {
         info!(
             ?kind,
-            reason = reason.as_deref().unwrap_or("(unknown)"),
+            reason = reason.unwrap_or("(unknown)"),
             "permission lost"
         );
-        PermissionEvent::lost(kind, reason)
+        PermissionEvent::lost(kind, reason.map(str::to_owned))
     };
     let _ = send_event(evt.event_name(), evt);
 }
@@ -226,22 +226,22 @@ async fn run() {
         report_state(
             PermissionKind::ScreenRecording,
             granted(perms.screen_recording),
-            Some("poll".to_string()),
+            Some("poll"),
         );
         report_state(
             PermissionKind::Microphone,
             granted(perms.microphone),
-            Some("poll".to_string()),
+            Some("poll"),
         );
         report_state(
             PermissionKind::Accessibility,
             granted(perms.accessibility),
-            Some("poll".to_string()),
+            Some("poll"),
         );
         report_state(
             PermissionKind::Keychain,
             keychain_accessible(),
-            Some("poll".to_string()),
+            Some("poll"),
         );
     }
 }

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -71,7 +71,7 @@ pub async fn start_monitor_watcher(
                 permission_monitor::report_state(
                     PermissionKind::ScreenRecording,
                     false,
-                    Some("list_monitors PermissionDenied (startup)".to_string()),
+                    Some("list_monitors PermissionDenied (startup)"),
                 );
             }
             Err(e) => {
@@ -245,7 +245,7 @@ pub async fn start_monitor_watcher(
                         permission_monitor::report_state(
                             PermissionKind::ScreenRecording,
                             false,
-                            Some("list_monitors PermissionDenied (runtime)".to_string()),
+                            Some("list_monitors PermissionDenied (runtime)"),
                         );
                     }
                     // Back off to 30s when permission is denied instead of 2s


### PR DESCRIPTION
## Summary
- change permission monitor transition reasons from owned `String`s to borrowed `&str`s
- remove four `poll.to_string()` allocations from the 5s permission reconcile loop
- keep owned allocation only when a real `permission_lost` event is emitted

## Why
The permission monitor usually polls and dedups without emitting anything. Allocating static reason strings before each dedup path adds steady background work with no user-visible benefit. Borrowing the reason preserves event payloads while keeping the normal no-transition path allocation-free.

## Validation
- `cargo fmt --package screenpipe-engine -- --check`
- `cargo test -p screenpipe-engine --lib permission_monitor`
- `cargo check -p screenpipe-engine`