### PR TITLE
[codex] Reuse a11y window filter patterns

### DIFF
--- a/crates/screenpipe-a11y/src/tree/linux.rs
+++ b/crates/screenpipe-a11y/src/tree/linux.rs
@@ -998,7 +998,8 @@ pub struct LinuxTreeWalker {
 unsafe impl Send for LinuxTreeWalker {}
 
 impl LinuxTreeWalker {
-    pub fn new(config: TreeWalkerConfig) -> Self {
+    pub fn new(mut config: TreeWalkerConfig) -> Self {
+        config.compile_patterns();
         Self {
             config,
             inner: UnsafeCell::new(WalkerInner {
@@ -1057,15 +1058,15 @@ impl TreeWalkerPlatform for LinuxTreeWalker {
 
         // Apply user-configured ignored windows. Supports legacy unscoped
         // patterns and scoped `App::Title` patterns.
-        let ignored_patterns = WindowPattern::parse_list(&self.config.ignored_windows);
-        let included_patterns = WindowPattern::parse_list(&self.config.included_windows);
-        if window_pattern::matches_any(&ignored_patterns, &app_lower, &window_lower) {
+        let ignored_patterns = self.config.resolved_ignored();
+        let included_patterns = self.config.resolved_included();
+        if window_pattern::matches_any(ignored_patterns.as_ref(), &app_lower, &window_lower) {
             return Ok(TreeWalkResult::Skipped(SkipReason::UserIgnored));
         }
 
         // Scoped includes act as per-app whitelists — see
         // `window_pattern::passes_includes`.
-        if !window_pattern::passes_includes(&included_patterns, &app_lower, &window_lower) {
+        if !window_pattern::passes_includes(included_patterns.as_ref(), &app_lower, &window_lower) {
             return Ok(TreeWalkResult::Skipped(SkipReason::NotInIncludeList));
         }
 
@@ -1073,7 +1074,7 @@ impl TreeWalkerPlatform for LinuxTreeWalker {
         let mut state = WalkState::new(
             &self.config,
             start,
-            ignored_patterns.clone(),
+            ignored_patterns.to_vec(),
             app_lower.clone(),
         );
         if let Some((wx, wy, ww, wh)) = get_component_extents(conn, &window_ref) {

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -295,7 +295,8 @@ pub struct MacosTreeWalker {
 }
 
 impl MacosTreeWalker {
-    pub fn new(config: TreeWalkerConfig) -> Self {
+    pub fn new(mut config: TreeWalkerConfig) -> Self {
+        config.compile_patterns();
         Self {
             config,
             incognito_detector: crate::incognito::create_detector(),
@@ -350,9 +351,9 @@ impl MacosTreeWalker {
         // Apply user-configured ignored windows (app-name pre-check).
         // Scoped patterns (`App::Title`) defer to the post-title check below
         // since the window title isn't known yet — see `window_pattern`.
-        let ignored_patterns = WindowPattern::parse_list(&self.config.ignored_windows);
-        let included_patterns = WindowPattern::parse_list(&self.config.included_windows);
-        if window_pattern::matches_any(&ignored_patterns, &app_lower, "") {
+        let ignored_patterns = self.config.resolved_ignored();
+        let included_patterns = self.config.resolved_included();
+        if window_pattern::matches_any(ignored_patterns.as_ref(), &app_lower, "") {
             return Ok(TreeWalkResult::Skipped(SkipReason::UserIgnored));
         }
 
@@ -450,14 +451,14 @@ impl MacosTreeWalker {
         // Full app + title check — scoped patterns (`App::Title`) and any
         // legacy pattern matching the title are evaluated here.
         let window_lower = window_name.to_lowercase();
-        if window_pattern::matches_any(&ignored_patterns, &app_lower, &window_lower) {
+        if window_pattern::matches_any(ignored_patterns.as_ref(), &app_lower, &window_lower) {
             return Ok(TreeWalkResult::Skipped(SkipReason::UserIgnored));
         }
 
         // Apply user-configured included windows. Scoped includes act as
         // per-app whitelists; apps without a scoped include rule fall back to
         // global semantics — see `window_pattern::passes_includes`.
-        if !window_pattern::passes_includes(&included_patterns, &app_lower, &window_lower) {
+        if !window_pattern::passes_includes(included_patterns.as_ref(), &app_lower, &window_lower) {
             return Ok(TreeWalkResult::Skipped(SkipReason::NotInIncludeList));
         }
 
@@ -465,7 +466,7 @@ impl MacosTreeWalker {
         let mut state = WalkState::new(
             &self.config,
             start,
-            ignored_patterns.clone(),
+            ignored_patterns.to_vec(),
             app_lower.clone(),
         );
 

--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -29,7 +29,9 @@ pub mod enhanced_mode_cache;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use screenpipe_core::window_pattern::WindowPattern;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Duration;
@@ -414,6 +416,10 @@ pub struct TreeWalkerConfig {
     pub ignored_windows: Vec<String>,
     /// User-configured windows to include (whitelist — if non-empty, only these are captured).
     pub included_windows: Vec<String>,
+    /// Cached parse of `ignored_windows`, populated by `compile_patterns()`.
+    pub ignored_window_patterns: Vec<WindowPattern>,
+    /// Cached parse of `included_windows`, populated by `compile_patterns()`.
+    pub included_window_patterns: Vec<WindowPattern>,
     /// User-configured URLs to ignore (domain-level match on the focused
     /// browser tab's URL — see [`crate::url_filter::is_url_blocked`]).
     pub ignored_urls: Vec<String>,
@@ -463,6 +469,8 @@ impl Default for TreeWalkerConfig {
             element_timeout_secs: 0.2,
             ignored_windows: Vec::new(),
             included_windows: Vec::new(),
+            ignored_window_patterns: Vec::new(),
+            included_window_patterns: Vec::new(),
             ignored_urls: Vec::new(),
             monitor_x: 0.0,
             monitor_y: 0.0,
@@ -481,6 +489,30 @@ impl Default for TreeWalkerConfig {
 }
 
 impl TreeWalkerConfig {
+    /// Compile window filters once before the walker enters its hot path.
+    pub fn compile_patterns(&mut self) {
+        self.ignored_window_patterns = WindowPattern::parse_list(&self.ignored_windows);
+        self.included_window_patterns = WindowPattern::parse_list(&self.included_windows);
+    }
+
+    /// Lazily resolve parsed ignore patterns for defensive direct construction.
+    pub(crate) fn resolved_ignored(&self) -> Cow<'_, [WindowPattern]> {
+        if self.ignored_window_patterns.is_empty() && !self.ignored_windows.is_empty() {
+            Cow::Owned(WindowPattern::parse_list(&self.ignored_windows))
+        } else {
+            Cow::Borrowed(&self.ignored_window_patterns)
+        }
+    }
+
+    /// Lazily resolve parsed include patterns for defensive direct construction.
+    pub(crate) fn resolved_included(&self) -> Cow<'_, [WindowPattern]> {
+        if self.included_window_patterns.is_empty() && !self.included_windows.is_empty() {
+            Cow::Owned(WindowPattern::parse_list(&self.included_windows))
+        } else {
+            Cow::Borrowed(&self.included_window_patterns)
+        }
+    }
+
     /// Return the effective max_nodes (override if set, else default).
     pub fn effective_max_nodes(&self) -> usize {
         self.max_nodes_override.unwrap_or(self.max_nodes)

--- a/crates/screenpipe-a11y/src/tree/windows.rs
+++ b/crates/screenpipe-a11y/src/tree/windows.rs
@@ -102,7 +102,8 @@ pub struct WindowsTreeWalker {
 unsafe impl Send for WindowsTreeWalker {}
 
 impl WindowsTreeWalker {
-    pub fn new(config: TreeWalkerConfig) -> Self {
+    pub fn new(mut config: TreeWalkerConfig) -> Self {
+        config.compile_patterns();
         Self {
             config,
             state: UnsafeCell::new(WalkerState {
@@ -239,9 +240,9 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
         // Apply user-configured ignored windows. Supports both legacy
         // unscoped patterns ("Slack") and scoped `App::Title` patterns.
         let window_lower = window_name.to_lowercase();
-        let ignored_patterns = WindowPattern::parse_list(&self.config.ignored_windows);
-        let included_patterns = WindowPattern::parse_list(&self.config.included_windows);
-        if window_pattern::matches_any(&ignored_patterns, &app_lower, &window_lower) {
+        let ignored_patterns = self.config.resolved_ignored();
+        let included_patterns = self.config.resolved_included();
+        if window_pattern::matches_any(ignored_patterns.as_ref(), &app_lower, &window_lower) {
             debug!(
                 app = %app_name,
                 title = %window_name,
@@ -253,7 +254,7 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
 
         // Scoped includes act as per-app whitelists; other apps fall back to
         // global semantics — see `window_pattern::passes_includes`.
-        if !window_pattern::passes_includes(&included_patterns, &app_lower, &window_lower) {
+        if !window_pattern::passes_includes(included_patterns.as_ref(), &app_lower, &window_lower) {
             debug!(
                 app = %app_name,
                 title = %window_name,
@@ -301,7 +302,7 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
             &mut browser_url,
             &monitor_rect,
             &window_rect,
-            &ignored_patterns,
+            ignored_patterns.as_ref(),
             &app_lower,
             &mut hit_ignored_extension,
         );


### PR DESCRIPTION
﻿## Summary
- cache parsed `ignored_windows` / `included_windows` on `TreeWalkerConfig`
- compile those filters once in each platform tree walker constructor
- reuse the cached patterns in Windows, macOS, and Linux focused-window walks instead of reparsing on every walk

## Why
Accessibility walks run continuously while screenpipe records. The include/ignore window filters are stable per walker, so rebuilding `WindowPattern` lists inside every `walk_focused_window` adds avoidable CPU and allocation churn on the capture hot path.

## Validation
- `cargo fmt --package screenpipe-a11y -- --check`
- `git diff --check`
- `cargo check -p screenpipe-a11y --lib` passed on Windows; existing `screenpipe-core` rand deprecation warnings only
- `cargo test -p screenpipe-a11y --lib config::tests` is blocked on this Windows host by the existing all-OS `zbus` dev-dependency feature error before crate tests run
- `cargo check -p screenpipe-a11y --lib --target x86_64-unknown-linux-gnu` and `--target x86_64-apple-darwin` are blocked on this Windows host by missing cross C compiler shims for `ring` / `aws-lc-sys`
