### PR TITLE
[codex] Cache a11y ignored URL patterns

### DIFF
--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -561,10 +561,7 @@ pub fn create_tree_walker(config: TreeWalkerConfig) -> Box<dyn TreeWalkerPlatfor
     if ignored_urls.is_empty() {
         walker
     } else {
-        Box::new(UrlFilteredWalker {
-            inner: walker,
-            ignored_urls,
-        })
+        Box::new(UrlFilteredWalker::new(walker, ignored_urls))
     }
 }
 
@@ -573,7 +570,16 @@ pub fn create_tree_walker(config: TreeWalkerConfig) -> Box<dyn TreeWalkerPlatfor
 /// platform walker) applies the filter uniformly across macOS/Windows/Linux.
 struct UrlFilteredWalker {
     inner: Box<dyn TreeWalkerPlatform>,
-    ignored_urls: Vec<String>,
+    ignored_url_patterns: Vec<String>,
+}
+
+impl UrlFilteredWalker {
+    fn new(inner: Box<dyn TreeWalkerPlatform>, ignored_urls: Vec<String>) -> Self {
+        Self {
+            inner,
+            ignored_url_patterns: crate::url_filter::normalize_blocked_patterns(&ignored_urls),
+        }
+    }
 }
 
 impl TreeWalkerPlatform for UrlFilteredWalker {
@@ -581,7 +587,10 @@ impl TreeWalkerPlatform for UrlFilteredWalker {
         let result = self.inner.walk_focused_window()?;
         if let TreeWalkResult::Found(ref snapshot) = result {
             if let Some(ref url) = snapshot.browser_url {
-                if crate::url_filter::is_url_blocked(url, &self.ignored_urls) {
+                if crate::url_filter::is_url_blocked_by_normalized_patterns(
+                    url,
+                    &self.ignored_url_patterns,
+                ) {
                     return Ok(TreeWalkResult::Skipped(SkipReason::BlockedUrl));
                 }
             }
@@ -633,10 +642,10 @@ mod tests {
 
     #[test]
     fn test_url_filtered_walker_blocks_matching_url() {
-        let walker = UrlFilteredWalker {
-            inner: Box::new(FakeWalker(Some("https://www.chase.com/login".into()))),
-            ignored_urls: vec!["chase.com".into()],
-        };
+        let walker = UrlFilteredWalker::new(
+            Box::new(FakeWalker(Some("https://www.chase.com/login".into()))),
+            vec!["chase.com".into()],
+        );
         assert!(matches!(
             walker.walk_focused_window().unwrap(),
             TreeWalkResult::Skipped(SkipReason::BlockedUrl)
@@ -645,10 +654,10 @@ mod tests {
 
     #[test]
     fn test_url_filtered_walker_passes_other_urls() {
-        let walker = UrlFilteredWalker {
-            inner: Box::new(FakeWalker(Some("https://example.com".into()))),
-            ignored_urls: vec!["chase.com".into()],
-        };
+        let walker = UrlFilteredWalker::new(
+            Box::new(FakeWalker(Some("https://example.com".into()))),
+            vec!["chase.com".into()],
+        );
         assert!(matches!(
             walker.walk_focused_window().unwrap(),
             TreeWalkResult::Found(_)
@@ -657,10 +666,7 @@ mod tests {
 
     #[test]
     fn test_url_filtered_walker_passes_non_browser_windows() {
-        let walker = UrlFilteredWalker {
-            inner: Box::new(FakeWalker(None)),
-            ignored_urls: vec!["chase.com".into()],
-        };
+        let walker = UrlFilteredWalker::new(Box::new(FakeWalker(None)), vec!["chase.com".into()]);
         assert!(matches!(
             walker.walk_focused_window().unwrap(),
             TreeWalkResult::Found(_)

--- a/crates/screenpipe-a11y/src/url_filter.rs
+++ b/crates/screenpipe-a11y/src/url_filter.rs
@@ -3,6 +3,7 @@
 //! Lives here because the dependency direction is screen → a11y: an ignored
 //! URL must produce neither frames nor accessibility snapshots.
 
+use std::borrow::Cow;
 use url::Url;
 
 /// Check if a URL should be filtered out for privacy.
@@ -21,28 +22,49 @@ pub fn is_url_blocked(url: &str, blocked_patterns: &[String]) -> bool {
         return false;
     }
 
+    let normalized_patterns = normalize_blocked_patterns(blocked_patterns);
+    is_url_blocked_by_normalized_patterns(url, &normalized_patterns)
+}
+
+/// Lowercase ignored URL patterns once before entering repeated match loops.
+pub(crate) fn normalize_blocked_patterns(blocked_patterns: &[String]) -> Vec<String> {
+    blocked_patterns
+        .iter()
+        .map(|blocked| blocked.to_lowercase())
+        .collect()
+}
+
+/// Check if a URL should be filtered using already-lowercased patterns.
+pub(crate) fn is_url_blocked_by_normalized_patterns(
+    url: &str,
+    blocked_patterns_lower: &[String],
+) -> bool {
+    if blocked_patterns_lower.is_empty() {
+        return false;
+    }
+
     // Normalize so bare hosts ("wellsfargo.com") parse too.
     let url_to_parse = if !url.starts_with("http://") && !url.starts_with("https://") {
-        format!("https://{}", url)
+        Cow::Owned(format!("https://{}", url))
     } else {
-        url.to_string()
+        Cow::Borrowed(url)
     };
 
-    if let Ok(parsed) = Url::parse(&url_to_parse) {
+    if let Ok(parsed) = Url::parse(url_to_parse.as_ref()) {
         if let Some(host) = parsed.host_str() {
             let host_lower = host.to_lowercase();
-            return blocked_patterns
+            return blocked_patterns_lower
                 .iter()
-                .any(|blocked| host_matches_pattern(&host_lower, &blocked.to_lowercase()));
+                .any(|blocked| host_matches_pattern(&host_lower, blocked));
         }
     }
 
     // Fallback to simple contains check if URL parsing fails.
     // Less precise, but ensures we don't miss obvious matches.
     let url_lower = url.to_lowercase();
-    blocked_patterns
+    blocked_patterns_lower
         .iter()
-        .any(|blocked| url_lower.contains(&blocked.to_lowercase()))
+        .any(|blocked| url_lower.contains(blocked))
 }
 
 /// Domain-boundary match of one lowercased host against one lowercased pattern.
@@ -53,7 +75,10 @@ fn host_matches_pattern(host_lower: &str, blocked: &str) -> bool {
     }
 
     // Subdomain match: host ends with ".blocked"
-    if host_lower.ends_with(&format!(".{}", blocked)) {
+    if host_lower.len() > blocked.len()
+        && host_lower.ends_with(blocked)
+        && host_lower.as_bytes()[host_lower.len() - blocked.len() - 1] == b'.'
+    {
         return true;
     }
 
@@ -136,5 +161,24 @@ mod tests {
         assert!(is_url_blocked("https://chase.com/login", &b));
         assert!(is_url_blocked("https://www.bankofamerica.com", &b));
         assert!(!is_url_blocked("https://google.com", &b));
+    }
+
+    #[test]
+    fn test_normalized_patterns_match_public_api() {
+        let b = blocked(&["WellsFargo.com", "CHASE"]);
+        let normalized = normalize_blocked_patterns(&b);
+
+        assert!(is_url_blocked_by_normalized_patterns(
+            "https://www.wellsfargo.com/login",
+            &normalized
+        ));
+        assert!(is_url_blocked_by_normalized_patterns(
+            "https://online.chase.co.uk",
+            &normalized
+        ));
+        assert!(!is_url_blocked_by_normalized_patterns(
+            "https://purchase.com",
+            &normalized
+        ));
     }
 }


### PR DESCRIPTION
﻿## Summary
- pre-normalize ignored URL patterns once in the accessibility tree walker's URL-filter wrapper
- reuse normalized patterns for every browser snapshot URL match
- avoid allocating a copied URL string for already-schemed URLs and avoid per-pattern `format!(".{pattern}")` during subdomain checks

## Why
Ignored URL filters are stable for a tree walker, but every snapshot previously lowercased every configured ignored URL pattern. That adds avoidable allocation/CPU churn on the browser snapshot path, especially for users with multiple ignored domains.

## Validation
- `cargo fmt --package screenpipe-a11y -- --check`
- `git diff --check`
- `cargo check -p screenpipe-a11y --lib` passed on Windows; existing `screenpipe-core` rand deprecation warnings only
- `cargo test -p screenpipe-a11y --lib url_filter::tests` and `tree::tests::test_url_filtered_walker` are blocked on this Windows host by the existing all-OS `zbus` dev-dependency feature error before crate tests run
