### PR TITLE
[codex] Avoid screenpipe app lowercase filters

### DIFF
--- a/crates/screenpipe-engine/src/hot_frame_cache.rs
+++ b/crates/screenpipe-engine/src/hot_frame_cache.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, watch, RwLock};
 use tracing::{info, warn};
 
+use crate::routes::search::is_screenpipe_app;
 use crate::video_cache::{AudioEntry, DeviceFrame, FrameMetadata, TimeSeriesFrame};
 
 /// Cached frame from the capture pipeline.
@@ -226,7 +227,7 @@ impl HotFrameCache {
                     // Convert FrameData to HotFrames
                     for ocr_entry in &frame_data.ocr_entries {
                         // Skip screenpipe's own frames
-                        if ocr_entry.app_name.to_lowercase().contains("screenpipe") {
+                        if is_screenpipe_app(&ocr_entry.app_name) {
                             continue;
                         }
                         let hot = HotFrame {

--- a/crates/screenpipe-engine/src/routes/search.rs
+++ b/crates/screenpipe-engine/src/routes/search.rs
@@ -244,7 +244,11 @@ pub fn truncate_middle(text: &str, max_chars: usize) -> String {
 /// Case-insensitive check for whether an app row should be filtered out
 /// because it belongs to screenpipe itself.
 pub fn is_screenpipe_app(app_name: &str) -> bool {
-    app_name.to_lowercase().contains("screenpipe")
+    const SCREENPIPE_APP_NEEDLE: &[u8] = b"screenpipe";
+    app_name
+        .as_bytes()
+        .windows(SCREENPIPE_APP_NEEDLE.len())
+        .any(|window| window.eq_ignore_ascii_case(SCREENPIPE_APP_NEEDLE))
 }
 
 /// Convert a `SearchResult` row into the public `ContentItem` shape used by
@@ -772,7 +776,7 @@ pub(crate) async fn keyword_search_handler(
 
         let filtered: Vec<_> = matches
             .into_iter()
-            .filter(|m| !m.app_name.to_lowercase().contains("screenpipe"))
+            .filter(|m| !is_screenpipe_app(&m.app_name))
             .collect();
 
         let groups = DatabaseManager::cluster_search_matches(filtered, 120);
@@ -802,7 +806,7 @@ pub(crate) async fn keyword_search_handler(
 
         let filtered: Vec<_> = matches
             .into_iter()
-            .filter(|m| !m.app_name.to_lowercase().contains("screenpipe"))
+            .filter(|m| !is_screenpipe_app(&m.app_name))
             .collect();
 
         Ok(JsonResponse(json!(filtered)))
@@ -1104,6 +1108,14 @@ mod tests {
     fn test_truncate_middle_short_text() {
         assert_eq!(truncate_middle("hello", 10), "hello");
         assert_eq!(truncate_middle("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_is_screenpipe_app_case_insensitive() {
+        assert!(is_screenpipe_app("screenpipe"));
+        assert!(is_screenpipe_app("ScreenPipe Desktop"));
+        assert!(is_screenpipe_app("com.screenpipe.capture"));
+        assert!(!is_screenpipe_app("pipe viewer"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/routes/streaming.rs
+++ b/crates/screenpipe-engine/src/routes/streaming.rs
@@ -21,6 +21,7 @@ use std::{sync::Arc, time::Duration};
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    routes::search::is_screenpipe_app,
     server::AppState,
     video_cache::{AudioEntry, DeviceFrame, FrameMetadata, TimeSeriesFrame},
 };
@@ -169,7 +170,7 @@ pub(crate) fn create_time_series_frame(chunk: FrameData) -> TimeSeriesFrame {
         .ocr_entries
         .into_iter()
         // Filter out screenpipe frames at display time
-        .filter(|device_data| !device_data.app_name.to_lowercase().contains("screenpipe"))
+        .filter(|device_data| !is_screenpipe_app(&device_data.app_name))
         .map(|device_data| DeviceFrame {
             device_id: device_data.device_name,
             frame_id: chunk.frame_id,
@@ -516,7 +517,7 @@ async fn handle_stream_frames_socket(
                             drop(sent);
 
                             // Skip screenpipe's own frames
-                            if hot_frame.app_name.to_lowercase().contains("screenpipe") {
+                            if is_screenpipe_app(&hot_frame.app_name) {
                                 continue;
                             }
 


### PR DESCRIPTION
﻿## Summary
- make `is_screenpipe_app` check for the ASCII `screenpipe` literal without allocating a lowercased app name
- reuse that helper in keyword search filters, streaming frame conversion, live hot-frame streaming, and hot-frame DB warmup
- add a focused regression test for mixed-case app names

## Why
These filters run over OCR/search/hot-frame rows to hide screenpipe's own frames. The previous implementation allocated a lowercased `String` for each app name before checking a fixed ASCII literal. This keeps the same case-insensitive behavior while avoiding that repeated allocation in hot display and cache paths.

## Validation
- `cargo fmt --package screenpipe-engine -- --check`
- `git diff --check`
- `cargo test -p screenpipe-engine --lib routes::search::tests::test_is_screenpipe_app_case_insensitive`
- `cargo check -p screenpipe-engine`

Existing warnings observed only: rand deprecations in secrets/vault/sync/core, an unused `mut` in audio stream, and an unused import in meeting_export.
