### PR TITLE
[codex] Cache a11y excluded app filters

### DIFF
--- a/crates/screenpipe-a11y/src/config.rs
+++ b/crates/screenpipe-a11y/src/config.rs
@@ -83,6 +83,11 @@ pub struct UiCaptureConfig {
     /// Apps to exclude from capture (case-insensitive substring match)
     pub excluded_apps: Vec<String>,
 
+    /// Cached lowercase parse of `excluded_apps`.
+    /// Populated by `compile_patterns()` for hot-path app filtering.
+    #[serde(skip)]
+    pub excluded_app_patterns: Vec<String>,
+
     /// Window title patterns to exclude (regex)
     #[serde(skip)]
     pub excluded_window_patterns: Vec<Regex>,
@@ -214,6 +219,7 @@ impl Default for UiCaptureConfig {
                 "Keychain Access".to_string(),
                 "Credential Manager".to_string(),
             ],
+            excluded_app_patterns: Vec::new(),
             excluded_window_patterns: Vec::new(),
             // Incognito / private browsing detection is handled by the
             // `crate::incognito` module with comprehensive localized matching
@@ -261,8 +267,27 @@ impl UiCaptureConfig {
             .iter()
             .filter_map(|s| Regex::new(s).ok())
             .collect();
+        self.excluded_app_patterns = self
+            .excluded_apps
+            .iter()
+            .map(|app| app.to_lowercase())
+            .collect();
         self.ignored_window_patterns = WindowPattern::parse_list(&self.ignored_windows);
         self.included_window_patterns = WindowPattern::parse_list(&self.included_windows);
+    }
+
+    /// Lazily resolve lowercased excluded-app patterns.
+    fn resolved_excluded_apps(&self) -> std::borrow::Cow<'_, [String]> {
+        if self.excluded_app_patterns.is_empty() && !self.excluded_apps.is_empty() {
+            std::borrow::Cow::Owned(
+                self.excluded_apps
+                    .iter()
+                    .map(|app| app.to_lowercase())
+                    .collect(),
+            )
+        } else {
+            std::borrow::Cow::Borrowed(&self.excluded_app_patterns)
+        }
     }
 
     /// Lazily resolve the parsed ignore patterns. Returns the cache if it's
@@ -297,9 +322,9 @@ impl UiCaptureConfig {
 
         let app_lower = app_name.to_lowercase();
         if self
-            .excluded_apps
+            .resolved_excluded_apps()
             .iter()
-            .any(|excluded| app_lower.contains(&excluded.to_lowercase()))
+            .any(|excluded| app_lower.contains(excluded))
         {
             return false;
         }
@@ -394,6 +419,7 @@ impl UiCaptureConfig {
     /// Builder pattern: set excluded apps
     pub fn with_excluded_apps(mut self, apps: Vec<String>) -> Self {
         self.excluded_apps = apps;
+        self.compile_patterns();
         self
     }
 

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -199,15 +199,10 @@ impl UiRecorderConfig {
             config.excluded_apps.push(app.to_lowercase());
         }
 
-        // Add excluded window patterns
-        for pattern in &self.excluded_windows {
-            if let Ok(re) = regex::Regex::new(pattern) {
-                config.excluded_window_patterns.push(re);
-            }
-        }
-
+        config.excluded_window_pattern_strings = self.excluded_windows.clone();
         config.ignored_windows = self.ignored_windows.clone();
         config.included_windows = self.included_windows.clone();
+        config.compile_patterns();
 
         config
     }
@@ -1449,6 +1444,21 @@ mod tests {
 
         assert!(ui_config.capture_clipboard);
         assert!(!ui_config.capture_clipboard_content);
+    }
+
+    #[test]
+    fn to_ui_config_refreshes_filter_caches() {
+        let config = UiRecorderConfig {
+            excluded_apps: vec!["SecretApp".to_string()],
+            excluded_windows: vec![r"(?i)private window".to_string()],
+            ..Default::default()
+        };
+
+        let ui_config = config.to_ui_config();
+
+        assert!(!ui_config.excluded_app_patterns.is_empty());
+        assert!(!ui_config.should_capture_app("secretapp helper"));
+        assert!(!ui_config.should_capture_window("Private Window - Browser"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cache lowercased `UiCaptureConfig::excluded_apps` alongside the existing window filter caches
- use the cached excluded-app patterns in `should_capture_app` instead of lowercasing every pattern per call
- make `UiRecorderConfig::to_ui_config()` feed excluded-window strings into `compile_patterns()` so excluded-window regex behavior is preserved while refreshing the new cache

## Why
`should_capture_app` runs in platform capture paths before app/window events are accepted. Excluded app filters are stable config, so lowercasing every excluded-app pattern on each check adds avoidable allocation and CPU churn.

## Validation
- `cargo fmt --package screenpipe-a11y --package screenpipe-engine -- --check`
- `git diff --check`
- `cargo check -p screenpipe-a11y --lib`
- `cargo check -p screenpipe-engine`
- `cargo test -p screenpipe-engine --lib ui_recorder::tests::to_ui_config_refreshes_filter_caches`

Existing warnings observed only: rand deprecations in secrets/vault/sync/core, unused `mut` in audio stream, and unused import in meeting_export.