### PR TITLE
fix(pi): isolate pi agent config from global ~/.pi/agent + prefix bundled tool names

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/custom-mcp-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/custom-mcp-card.tsx
@@ -203,7 +203,7 @@ export function CustomMcpCard() {
               like Brave Search, Linear, Notion, or local stdio processes like{" "}
               <code className="text-xs bg-muted px-1 rounded">uvx mcp-server-brave</code>
               {" "}— so pipes and chat can call their tools via{" "}
-              <code className="text-xs bg-muted px-1 rounded">mcp_call</code>
+              <code className="text-xs bg-muted px-1 rounded">sp_mcp_call</code>
               .
             </p>
 

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -221,7 +221,9 @@ function buildCreatePipeDisplayLabel(prompt: string): string {
 }
 
 function buildOptimizePrompt(pipeName: string): string {
-  const sessionDir = `~/.pi/agent/sessions/`;
+  // Screenpipe's isolated pi agent dir (legacy sessions before the isolation
+  // lived in ~/.pi/agent/sessions/ and were copied over on first run).
+  const sessionDir = `~/.screenpipe/pi-config/sessions/`;
   return `i need help optimizing my screenpipe pipe "${pipeName}".
 
 ## your task

--- a/apps/screenpipe-app-tauri/lib/__tests__/source-citations.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/source-citations.test.ts
@@ -226,6 +226,7 @@ describe("source citations", () => {
     expect(citations[0].title).toBe("Local file: standalone-chat.tsx");
   });
 
+  // legacy name from sessions recorded before the sp_ rename
   it("extracts web links from web_search results and dedupes duplicates", () => {
     const citations = sourceCitationsFromMessage({
       contentBlocks: [
@@ -250,13 +251,13 @@ describe("source citations", () => {
     });
   });
 
-  it("uses structured web_search sources when available", () => {
+  it("uses structured sp_web_search sources when available", () => {
     const citations = sourceCitationsFromMessage({
       contentBlocks: [
         {
           type: "tool",
           toolCall: {
-            toolName: "web_search",
+            toolName: "sp_web_search",
             args: { query: "screenpipe docs" },
             result: {
               content: [{ type: "text", text: "See the docs." }],

--- a/apps/screenpipe-app-tauri/lib/source-citations.ts
+++ b/apps/screenpipe-app-tauri/lib/source-citations.ts
@@ -165,7 +165,8 @@ function sourceCitationsFromToolCall(toolCall: ToolCallLike | undefined): Source
   const resultText = resultToText(toolCall.result);
 
   // "sp_web_search" is the current bundled tool; bare "web_search" still
-  // appears when replaying sessions recorded before the sp_ rename (#3812).
+  // appears when replaying sessions recorded before the sp_ rename
+  // (https://github.com/screenpipe/screenpipe/issues/3812).
   if (toolName === "sp_web_search" || toolName === "web_search") {
     return webSearchCitations(args, toolCall.result, resultText);
   }

--- a/apps/screenpipe-app-tauri/lib/source-citations.ts
+++ b/apps/screenpipe-app-tauri/lib/source-citations.ts
@@ -164,7 +164,9 @@ function sourceCitationsFromToolCall(toolCall: ToolCallLike | undefined): Source
   const args = isObject(toolCall.args) ? toolCall.args : {};
   const resultText = resultToText(toolCall.result);
 
-  if (toolName === "web_search") {
+  // "sp_web_search" is the current bundled tool; bare "web_search" still
+  // appears when replaying sessions recorded before the sp_ rename (#3812).
+  if (toolName === "sp_web_search" || toolName === "web_search") {
     return webSearchCitations(args, toolCall.result, resultText);
   }
 

--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/mcp-bridge.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/mcp-bridge.ts
@@ -8,8 +8,8 @@
 // tool individually burns ~7-9% of the model's context per server in
 // tool descriptions and runs into Anthropic's per-turn tool count cap
 // after 3-4 verbose servers. With this design the model spends ~200
-// tokens total and calls `mcp_list_tools` lazily before invoking
-// `mcp_call`. Same trade-off the `pi-mcp-adapter` extension makes.
+// tokens total and calls `sp_mcp_list_tools` lazily before invoking
+// `sp_mcp_call`. Same trade-off the `pi-mcp-adapter` extension makes.
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
@@ -66,7 +66,7 @@ const callParams = {
   properties: {
     server_id: {
       type: "string",
-      description: "The MCP server id (from mcp_list_tools).",
+      description: "The MCP server id (from sp_mcp_list_tools).",
     },
     tool: {
       type: "string",
@@ -82,10 +82,10 @@ const callParams = {
 
 export default function (pi: ExtensionAPI) {
   pi.registerTool({
-    name: "mcp_list_tools",
+    name: "sp_mcp_list_tools",
     label: "List MCP tools",
     description:
-      "List the tools exposed by user-registered MCP (Model Context Protocol) servers. Call this BEFORE mcp_call so you know which server to target and what arguments each tool expects. Cheap to call. Returns server_id, server_name, and a list of { name, description } per server.",
+      "List the tools exposed by user-registered MCP (Model Context Protocol) servers. Call this BEFORE sp_mcp_call so you know which server to target and what arguments each tool expects. Cheap to call. Returns server_id, server_name, and a list of { name, description } per server.",
     parameters: listToolsParams,
 
     async execute(
@@ -171,7 +171,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text" as const,
-              text: `mcp_list_tools failed: ${e?.message ?? String(e)}`,
+              text: `sp_mcp_list_tools failed: ${e?.message ?? String(e)}`,
             },
           ],
         };
@@ -180,10 +180,10 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerTool({
-    name: "mcp_call",
+    name: "sp_mcp_call",
     label: "Call MCP tool",
     description:
-      "Invoke a tool on a user-registered MCP server. Always call mcp_list_tools FIRST to find the server_id and tool name. The arguments object must match the tool's schema. Returns the raw MCP `content` array — typically text blocks but may include resources.",
+      "Invoke a tool on a user-registered MCP server. Always call sp_mcp_list_tools FIRST to find the server_id and tool name. The arguments object must match the tool's schema. Returns the raw MCP `content` array — typically text blocks but may include resources.",
     parameters: callParams,
 
     async execute(
@@ -214,7 +214,7 @@ export default function (pi: ExtensionAPI) {
             content: [
               {
                 type: "text" as const,
-                text: `mcp_call failed (${res.status}): ${bodyText.slice(0, 800)}`,
+                text: `sp_mcp_call failed (${res.status}): ${bodyText.slice(0, 800)}`,
               },
             ],
           };
@@ -267,7 +267,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text" as const,
-              text: `mcp_call failed: ${e?.message ?? String(e)}`,
+              text: `sp_mcp_call failed: ${e?.message ?? String(e)}`,
             },
           ],
         };

--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/web-search.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/web-search.ts
@@ -8,7 +8,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     // "sp_" prefix: a generic name like "web_search" collides with the user's
     // global pi packages (e.g. pi-web-access registers "web_search") and a
-    // tool-name conflict aborts non-interactive pi runs (#3812).
+    // tool-name conflict aborts non-interactive pi runs
+    // (https://github.com/screenpipe/screenpipe/issues/3812).
     name: "sp_web_search",
     label: "Web Search",
     description:

--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/web-search.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/web-search.ts
@@ -6,7 +6,10 @@ import { Type } from "@sinclair/typebox";
 
 export default function (pi: ExtensionAPI) {
   pi.registerTool({
-    name: "web_search",
+    // "sp_" prefix: a generic name like "web_search" collides with the user's
+    // global pi packages (e.g. pi-web-access registers "web_search") and a
+    // tool-name conflict aborts non-interactive pi runs (#3812).
+    name: "sp_web_search",
     label: "Web Search",
     description:
       "Search the public internet via Google Search. Use ONLY for public, external information the user explicitly asks about — current events, news, public people or companies, or public product documentation. Do NOT use it for the user's own screenpipe data (recordings, meetings, activity) or the local screenpipe API at localhost:3030 — that data is private and not on the web; use your screenpipe skills and the local tools for it. When unsure, do not search. Returns search results with sources.",

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -3309,7 +3309,8 @@ pub async fn list_cache_files() -> Result<Vec<CacheFile>, String> {
 
     // Pi config (~/.screenpipe/pi-config/). Never list the user's global
     // ~/.pi/agent here — that belongs to their standalone pi install and
-    // offering to delete it was a footgun (see PRD-AGENT-001).
+    // offering to delete it risked destroying the user's own setup
+    // (https://github.com/screenpipe/screenpipe/issues/4002).
     let pi_config = data_dir.join("pi-config");
     if pi_config.exists() {
         let size = dir_size(&pi_config);

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -1720,7 +1720,8 @@ pub async fn set_window_always_on_top_native(
                 if let raw_window_handle::RawWindowHandle::AppKit(appkit_handle) = handle.as_raw() {
                     use objc::{msg_send, sel, sel_impl};
                     let ns_view = appkit_handle.ns_view.as_ptr() as *mut objc::runtime::Object;
-                    let ns_window: *mut objc::runtime::Object = unsafe { msg_send![ns_view, window] };
+                    let ns_window: *mut objc::runtime::Object =
+                        unsafe { msg_send![ns_view, window] };
                     if !ns_window.is_null() {
                         // NSNormalWindowLevel = 0. NSFloatingWindowLevel = 3.
                         // Floating keeps recovery/onboarding above normal app
@@ -2207,7 +2208,10 @@ fn shortcut_reminder_label(
     setting_key: &str,
     disabled_shortcuts: &[String],
 ) -> String {
-    if disabled_shortcuts.iter().any(|disabled| disabled == setting_key) {
+    if disabled_shortcuts
+        .iter()
+        .any(|disabled| disabled == setting_key)
+    {
         String::new()
     } else if value.trim().is_empty() {
         String::new()
@@ -3290,7 +3294,6 @@ pub struct CacheFile {
 #[specta::specta]
 pub async fn list_cache_files() -> Result<Vec<CacheFile>, String> {
     let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
-    let home_dir = dirs::home_dir().ok_or("no home directory")?;
     let mut files = Vec::new();
 
     // Pi agent node_modules (~/.screenpipe/pi-agent/)
@@ -3304,13 +3307,15 @@ pub async fn list_cache_files() -> Result<Vec<CacheFile>, String> {
         });
     }
 
-    // Pi config (~/.pi/agent/)
-    let pi_config = home_dir.join(".pi").join("agent");
+    // Pi config (~/.screenpipe/pi-config/). Never list the user's global
+    // ~/.pi/agent here — that belongs to their standalone pi install and
+    // offering to delete it was a footgun (see PRD-AGENT-001).
+    let pi_config = data_dir.join("pi-config");
     if pi_config.exists() {
         let size = dir_size(&pi_config);
         files.push(CacheFile {
             path: pi_config.to_string_lossy().to_string(),
-            label: "AI agent config (.pi/agent)".to_string(),
+            label: "AI agent config (pi-config)".to_string(),
             size_bytes: size,
         });
     }

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -468,10 +468,12 @@ impl PiManager {
     }
 }
 
-/// Get the Pi config directory (~/.pi/agent)
+/// Get the Pi config directory — screenpipe's isolated agent dir
+/// (`~/.screenpipe/pi-config`), never the user's global `~/.pi/agent`.
+/// Delegates to screenpipe-core, which also runs the one-time seed
+/// migration from the global dir. See PRD-AGENT-001.
 fn get_pi_config_dir() -> Result<PathBuf, String> {
-    let home_dir = dirs::home_dir().ok_or_else(|| "Could not find home directory".to_string())?;
-    Ok(home_dir.join(".pi").join("agent"))
+    screenpipe_core::agents::pi::pi_config_dir().map_err(|e| e.to_string())
 }
 
 /// Parse the output of `where pi` on Windows, preferring .cmd files
@@ -991,7 +993,7 @@ fn ensure_web_search_extension(
 }
 
 /// Install the MCP bridge extension. Registers proxy tools that route
-/// `mcp_call` / `mcp_list_tools` requests through the local
+/// `sp_mcp_call` / `sp_mcp_list_tools` requests through the local
 /// `/mcp-servers/*` API. Always installed — does nothing when zero
 /// servers are registered.
 fn ensure_mcp_bridge_extension(project_dir: &str) -> Result<(), String> {
@@ -1686,6 +1688,11 @@ pub async fn pi_start_inner(
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         cmd.creation_flags(CREATE_NO_WINDOW);
     }
+
+    // Scope pi to screenpipe's isolated agent dir (never ~/.pi/agent).
+    screenpipe_core::agents::pi::apply_pi_isolation_env(&mut |k, v| {
+        cmd.env(k, v);
+    });
 
     if let Some(ref token) = user_token {
         cmd.env("SCREENPIPE_API_KEY", token);

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -471,7 +471,9 @@ impl PiManager {
 /// Get the Pi config directory — screenpipe's isolated agent dir
 /// (`~/.screenpipe/pi-config`), never the user's global `~/.pi/agent`.
 /// Delegates to screenpipe-core, which also runs the one-time seed
-/// migration from the global dir. See PRD-AGENT-001.
+/// migration from the global dir.
+/// See https://github.com/screenpipe/screenpipe/issues/4002
+/// and https://github.com/screenpipe/screenpipe/issues/3812.
 fn get_pi_config_dir() -> Result<PathBuf, String> {
     screenpipe_core::agents::pi::pi_config_dir().map_err(|e| e.to_string())
 }

--- a/crates/screenpipe-connect/src/mcp_servers.rs
+++ b/crates/screenpipe-connect/src/mcp_servers.rs
@@ -1995,7 +1995,7 @@ pub async fn render_context(screenpipe_dir: &Path, api_port: u16) -> String {
 
     let base = format!("http://localhost:{}/mcp-servers", api_port);
     let mut out = String::from(
-        "\nUser-registered MCP servers — invoke their tools via the `mcp_call` and `mcp_list_tools` bridge tools.\n\
+        "\nUser-registered MCP servers — invoke their tools via the `sp_mcp_call` and `sp_mcp_list_tools` bridge tools.\n\
          These are HTTP MCP endpoints registered by the user; the bridge handles auth.\n",
     );
     for cfg in enabled {

--- a/crates/screenpipe-core/assets/extensions/mcp-bridge.ts
+++ b/crates/screenpipe-core/assets/extensions/mcp-bridge.ts
@@ -8,8 +8,8 @@
 // tool individually burns ~7-9% of the model's context per server in
 // tool descriptions and runs into Anthropic's per-turn tool count cap
 // after 3-4 verbose servers. With this design the model spends ~200
-// tokens total and calls `mcp_list_tools` lazily before invoking
-// `mcp_call`. Same trade-off the `pi-mcp-adapter` extension makes.
+// tokens total and calls `sp_mcp_list_tools` lazily before invoking
+// `sp_mcp_call`. Same trade-off the `pi-mcp-adapter` extension makes.
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
@@ -66,7 +66,7 @@ const callParams = {
   properties: {
     server_id: {
       type: "string",
-      description: "The MCP server id (from mcp_list_tools).",
+      description: "The MCP server id (from sp_mcp_list_tools).",
     },
     tool: {
       type: "string",
@@ -82,10 +82,10 @@ const callParams = {
 
 export default function (pi: ExtensionAPI) {
   pi.registerTool({
-    name: "mcp_list_tools",
+    name: "sp_mcp_list_tools",
     label: "List MCP tools",
     description:
-      "List the tools exposed by user-registered MCP (Model Context Protocol) servers. Call this BEFORE mcp_call so you know which server to target and what arguments each tool expects. Cheap to call. Returns server_id, server_name, and a list of { name, description } per server.",
+      "List the tools exposed by user-registered MCP (Model Context Protocol) servers. Call this BEFORE sp_mcp_call so you know which server to target and what arguments each tool expects. Cheap to call. Returns server_id, server_name, and a list of { name, description } per server.",
     parameters: listToolsParams,
 
     async execute(
@@ -171,7 +171,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text" as const,
-              text: `mcp_list_tools failed: ${e?.message ?? String(e)}`,
+              text: `sp_mcp_list_tools failed: ${e?.message ?? String(e)}`,
             },
           ],
         };
@@ -180,10 +180,10 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerTool({
-    name: "mcp_call",
+    name: "sp_mcp_call",
     label: "Call MCP tool",
     description:
-      "Invoke a tool on a user-registered MCP server. Always call mcp_list_tools FIRST to find the server_id and tool name. The arguments object must match the tool's schema. Returns the raw MCP `content` array — typically text blocks but may include resources.",
+      "Invoke a tool on a user-registered MCP server. Always call sp_mcp_list_tools FIRST to find the server_id and tool name. The arguments object must match the tool's schema. Returns the raw MCP `content` array — typically text blocks but may include resources.",
     parameters: callParams,
 
     async execute(
@@ -214,7 +214,7 @@ export default function (pi: ExtensionAPI) {
             content: [
               {
                 type: "text" as const,
-                text: `mcp_call failed (${res.status}): ${bodyText.slice(0, 800)}`,
+                text: `sp_mcp_call failed (${res.status}): ${bodyText.slice(0, 800)}`,
               },
             ],
           };
@@ -267,7 +267,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             {
               type: "text" as const,
-              text: `mcp_call failed: ${e?.message ?? String(e)}`,
+              text: `sp_mcp_call failed: ${e?.message ?? String(e)}`,
             },
           ],
         };

--- a/crates/screenpipe-core/assets/extensions/web-search.ts
+++ b/crates/screenpipe-core/assets/extensions/web-search.ts
@@ -17,7 +17,10 @@ const params = {
 
 export default function (pi: ExtensionAPI) {
   pi.registerTool({
-    name: "web_search",
+    // "sp_" prefix: a generic name like "web_search" collides with the user's
+    // global pi packages (e.g. pi-web-access registers "web_search") and a
+    // tool-name conflict aborts non-interactive pi runs (#3812).
+    name: "sp_web_search",
     label: "Web Search",
     description:
       "Search the public internet via Google Search. Use ONLY for public, external information the user explicitly asks about — current events, news, public people or companies, or public product documentation. Do NOT use it for the user's own screenpipe data (recordings, meetings, activity) or the local screenpipe API at localhost:3030 — that data is private and not on the web; use your screenpipe skills and the local tools for it. When unsure, do not search. Returns search results with sources.",

--- a/crates/screenpipe-core/assets/extensions/web-search.ts
+++ b/crates/screenpipe-core/assets/extensions/web-search.ts
@@ -19,7 +19,8 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     // "sp_" prefix: a generic name like "web_search" collides with the user's
     // global pi packages (e.g. pi-web-access registers "web_search") and a
-    // tool-name conflict aborts non-interactive pi runs (#3812).
+    // tool-name conflict aborts non-interactive pi runs
+    // (https://github.com/screenpipe/screenpipe/issues/3812).
     name: "sp_web_search",
     label: "Web Search",
     description:

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1952,20 +1952,33 @@ fn seed_from_global(global: &Path, dest: &Path, data_dir: &Path) -> bool {
         }
     }
 
-    // settings.json minus `packages` (global pi packages stay global).
+    // settings.json: copy run-affecting settings (thinking level, budgets,
+    // compaction, …) so behavior matches pre-isolation, but drop:
+    // - `packages`: global pi packages are the #3812 conflict vector;
+    // - `defaultProvider`/`defaultModel`: those are the *user's* personal pi
+    //   defaults. Screenpipe passes --provider/--model on every spawn, so
+    //   they'd never be read — except by a future flagless spawn, which must
+    //   not silently land on the user's BYOK provider. Pin screenpipe's own
+    //   safe fallback instead ("screenpipe"/"auto": the gateway picks a
+    //   model server-side; on a BYOK-only setup it fails loudly rather than
+    //   billing the user's personal key).
     let settings_src = global.join("settings.json");
-    if settings_src.exists() {
-        if let Ok(content) = std::fs::read_to_string(&settings_src) {
-            if let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&content) {
-                if let Some(obj) = settings.as_object_mut() {
-                    obj.remove("packages");
-                }
-                let pretty = serde_json::to_string_pretty(&settings).unwrap_or(content);
-                if let Err(e) = std::fs::write(dest.join("settings.json"), pretty) {
-                    warn!("pi config seed: failed to write settings.json: {}", e);
-                }
+    let mut settings: serde_json::Value = std::fs::read_to_string(&settings_src)
+        .ok()
+        .and_then(|c| serde_json::from_str(&c).ok())
+        .unwrap_or_else(|| json!({}));
+    if let Some(obj) = settings.as_object_mut() {
+        obj.remove("packages");
+        obj.insert("defaultProvider".to_string(), json!("screenpipe"));
+        obj.insert("defaultModel".to_string(), json!("auto"));
+    }
+    match serde_json::to_string_pretty(&settings) {
+        Ok(pretty) => {
+            if let Err(e) = std::fs::write(dest.join("settings.json"), pretty) {
+                warn!("pi config seed: failed to write settings.json: {}", e);
             }
         }
+        Err(e) => warn!("pi config seed: failed to serialize settings.json: {}", e),
     }
 
     // Sessions for screenpipe-owned cwds. Pi encodes a session dir name as
@@ -2856,7 +2869,9 @@ mod tests {
         std::fs::write(global.join("auth.json"), r#"{"screenpipe":"tok"}"#).unwrap();
         std::fs::write(
             global.join("settings.json"),
-            r#"{"theme":"dark","packages":["npm:pi-web-access"]}"#,
+            // The user's personal pi defaults must NOT leak into screenpipe's
+            // config; run-affecting settings (theme, thinking, …) must.
+            r#"{"theme":"dark","packages":["npm:pi-web-access"],"defaultProvider":"anthropic","defaultModel":"claude-opus-4-8"}"#,
         )
         .unwrap();
 
@@ -2887,6 +2902,10 @@ mod tests {
                 .unwrap();
         assert_eq!(settings["theme"], "dark");
         assert!(settings.get("packages").is_none());
+        // Personal defaults replaced by screenpipe's safe fallback: a future
+        // flagless spawn must never silently run on the user's BYOK provider.
+        assert_eq!(settings["defaultProvider"], "screenpipe");
+        assert_eq!(settings["defaultModel"], "auto");
 
         // Only the screenpipe-owned session dir came over.
         assert!(dest

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1797,9 +1797,11 @@ impl AgentExecutor for PiExecutor {
 /// Screenpipe's private pi agent dir (models.json, auth.json, sessions, …).
 ///
 /// Isolated from the user's global `~/.pi/agent` so screenpipe never rewrites
-/// config a standalone pi install owns (#4002) and never loads the user's
+/// config a standalone pi install owns
+/// (https://github.com/screenpipe/screenpipe/issues/4002) and never loads the user's
 /// global pi packages — whose tools can collide with ours and abort the run —
-/// into pipe/chat runs (#3812). Every pi spawn must pass this dir via the
+/// into pipe/chat runs (https://github.com/screenpipe/screenpipe/issues/3812).
+/// Every pi spawn must pass this dir via the
 /// `PI_CODING_AGENT_DIR` env var (see [`apply_pi_isolation_env`]).
 ///
 /// Escape hatch: `SCREENPIPE_PI_AGENT_DIR` overrides the location; setting it
@@ -1854,7 +1856,8 @@ const PI_MIGRATION_MARKER: &str = ".migrated-from-global";
 ///
 /// - `models.json` / `auth.json` / `trust.json`: copied verbatim (auth 0600).
 /// - `settings.json`: copied with the `packages` key stripped — globally
-///   installed pi packages are exactly the #3812 conflict vector.
+///   installed pi packages are exactly the conflict vector from
+///   https://github.com/screenpipe/screenpipe/issues/3812.
 /// - `sessions/<encoded-cwd>/`: copied only for cwds under the screenpipe
 ///   data dir (pi-chat, pi-title, pipes/*) so `--continue` keeps history.
 ///
@@ -1954,7 +1957,8 @@ fn seed_from_global(global: &Path, dest: &Path, data_dir: &Path) -> bool {
 
     // settings.json: copy run-affecting settings (thinking level, budgets,
     // compaction, …) so behavior matches pre-isolation, but drop:
-    // - `packages`: global pi packages are the #3812 conflict vector;
+    // - `packages`: global pi packages are the conflict vector from
+    //   https://github.com/screenpipe/screenpipe/issues/3812;
     // - `defaultProvider`/`defaultModel`: those are the *user's* personal pi
     //   defaults. Screenpipe passes --provider/--model on every spawn, so
     //   they'd never be read — except by a future flagless spawn, which must

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -649,7 +649,7 @@ impl PiExecutor {
     }
 
     /// Install the MCP bridge extension. Registers two proxy tools
-    /// (`mcp_list_tools`, `mcp_call`) that the model uses to talk to
+    /// (`sp_mcp_list_tools`, `sp_mcp_call`) that the model uses to talk to
     /// user-registered MCP servers via the local `/mcp-servers/*` API.
     /// Always installed — does nothing harmful when zero servers are
     /// registered (the tools return a helpful "none registered" message).
@@ -714,8 +714,9 @@ impl PiExecutor {
     /// pi's existing config files.
     ///
     /// Unlike the old `write_pi_config`, this preserves any existing providers
-    /// and auth credentials the user set up via `pi /login` or by editing
-    /// `~/.pi/agent/auth.json` directly.
+    /// and auth credentials already present in the config dir (e.g. entries
+    /// seeded from the user's global `~/.pi/agent` on first run, or edits the
+    /// user made to the isolated `pi-config/` files directly).
     ///
     /// When a pipe uses a non-screenpipe provider (e.g. ollama, openai), pass
     /// the resolved `provider`, `model`, and optional `provider_url` so the
@@ -896,7 +897,7 @@ impl PiExecutor {
                     }
 
                     info!(
-                        "pi config: merged provider '{}' (model '{}') into ~/.pi/agent/models.json",
+                        "pi config: merged provider '{}' (model '{}') into pi-config/models.json",
                         pi_provider_name, mdl
                     );
                 }
@@ -1133,6 +1134,9 @@ impl PiExecutor {
     ) -> Result<AgentOutput> {
         let mut cmd = build_async_command(pi_path);
         cmd.current_dir(working_dir);
+        apply_pi_isolation_env(&mut |k, v| {
+            cmd.env(k, v);
+        });
         // Flags MUST come before -p on Windows (see spawn_pi_streaming comment)
         if continue_session {
             cmd.arg("--continue");
@@ -1256,6 +1260,9 @@ impl PiExecutor {
     ) -> Result<AgentOutput> {
         let mut cmd = build_async_command(pi_path);
         cmd.current_dir(working_dir);
+        apply_pi_isolation_env(&mut |k, v| {
+            cmd.env(k, v);
+        });
         // Flags MUST come before -p on Windows: cmd.exe /C passes everything
         // as a single string, and the long prompt text can break arg parsing
         // if flags come after it.
@@ -1787,9 +1794,214 @@ impl AgentExecutor for PiExecutor {
 // Helpers (extracted from apps/screenpipe-app-tauri/src-tauri/src/pi.rs)
 // ---------------------------------------------------------------------------
 
+/// Screenpipe's private pi agent dir (models.json, auth.json, sessions, …).
+///
+/// Isolated from the user's global `~/.pi/agent` so screenpipe never rewrites
+/// config a standalone pi install owns (#4002) and never loads the user's
+/// global pi packages — whose tools can collide with ours and abort the run —
+/// into pipe/chat runs (#3812). Every pi spawn must pass this dir via the
+/// `PI_CODING_AGENT_DIR` env var (see [`apply_pi_isolation_env`]).
+///
+/// Escape hatch: `SCREENPIPE_PI_AGENT_DIR` overrides the location; setting it
+/// to `~/.pi/agent` restores the old shared-config behavior.
+pub fn pi_config_dir() -> Result<PathBuf> {
+    let dir = match std::env::var("SCREENPIPE_PI_AGENT_DIR") {
+        Ok(v) if !v.trim().is_empty() => {
+            let v = v.trim();
+            if v == "~" || v.starts_with("~/") || v.starts_with("~\\") {
+                let home =
+                    dirs::home_dir().ok_or_else(|| anyhow!("could not find home directory"))?;
+                if v == "~" {
+                    home
+                } else {
+                    home.join(&v[2..])
+                }
+            } else {
+                PathBuf::from(v)
+            }
+        }
+        _ => crate::paths::default_screenpipe_data_dir().join("pi-config"),
+    };
+    seed_pi_config_from_global(&dir);
+    Ok(dir)
+}
+
 fn get_pi_config_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow!("could not find home directory"))?;
-    Ok(home.join(".pi").join("agent"))
+    pi_config_dir()
+}
+
+/// Set the env vars that scope a pi subprocess to screenpipe's private agent
+/// dir. Applied to every spawn (pipes, chat, title-gen); child processes that
+/// pi itself spawns (e.g. sub-agent runs) inherit them.
+pub fn apply_pi_isolation_env(apply: &mut dyn FnMut(&str, &str)) {
+    if let Ok(dir) = pi_config_dir() {
+        apply("PI_CODING_AGENT_DIR", &dir.to_string_lossy());
+    }
+    // We pin the pi version ourselves (ensure_installed); don't let the
+    // subprocess phone pi.dev for update checks on every run.
+    apply("PI_SKIP_VERSION_CHECK", "1");
+}
+
+/// Marker file recording that the one-time seed from `~/.pi/agent` ran.
+const PI_MIGRATION_MARKER: &str = ".migrated-from-global";
+
+/// One-time seed of the isolated pi dir from the user's global `~/.pi/agent`.
+///
+/// Earlier releases wrote screenpipe's provider/auth into the global config
+/// and stored chat sessions there, and some users deliberately configured
+/// BYOK providers (ollama/openai) there for their pipes. Copy that state once
+/// so the switch to an isolated dir is invisible:
+///
+/// - `models.json` / `auth.json` / `trust.json`: copied verbatim (auth 0600).
+/// - `settings.json`: copied with the `packages` key stripped — globally
+///   installed pi packages are exactly the #3812 conflict vector.
+/// - `sessions/<encoded-cwd>/`: copied only for cwds under the screenpipe
+///   data dir (pi-chat, pi-title, pipes/*) so `--continue` keeps history.
+///
+/// Never deletes or modifies anything under `~/.pi/agent`. Concurrent callers
+/// (parallel pipes, app + CLI) are serialized via an exclusive-create lock;
+/// losers proceed without waiting — `ensure_pi_config` rewrites models.json
+/// and auth.json before every spawn anyway, so a half-seeded dir self-heals.
+fn seed_pi_config_from_global(dest: &Path) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    // Fast path: skip the fs checks after the first call in this process.
+    static DONE: AtomicBool = AtomicBool::new(false);
+    if DONE.load(Ordering::Relaxed) {
+        return;
+    }
+    let Some(home) = dirs::home_dir() else { return };
+    let global = home.join(".pi").join("agent");
+    let data_dir = crate::paths::default_screenpipe_data_dir();
+    if seed_from_global(&global, dest, &data_dir) {
+        DONE.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Inner seed step (no process-wide statics so it's unit-testable).
+/// Returns `true` when the dest dir is fully seeded (marker present).
+fn seed_from_global(global: &Path, dest: &Path, data_dir: &Path) -> bool {
+    let marker = dest.join(PI_MIGRATION_MARKER);
+    if marker.exists() {
+        return true;
+    }
+
+    // Nothing to migrate, or the escape hatch points us *at* the global dir.
+    if !global.exists() || dest == global {
+        let _ = std::fs::create_dir_all(dest);
+        let _ = std::fs::write(&marker, "no global config to seed\n");
+        return true;
+    }
+
+    if std::fs::create_dir_all(dest).is_err() {
+        return false;
+    }
+    // Exclusive-create lock so concurrent first runs seed exactly once.
+    let lock = dest.join(".migration.lock");
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock)
+    {
+        Ok(_) => {}
+        Err(_) => {
+            // A crashed earlier attempt leaves the lock behind with no
+            // marker; reclaim it once it's clearly stale so we don't stay
+            // unseeded forever. Otherwise someone is actively seeding —
+            // proceed without waiting (ensure_pi_config rewrites the files
+            // that matter before every spawn).
+            let stale = std::fs::metadata(&lock)
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.elapsed().ok())
+                .map(|age| age.as_secs() > 600)
+                .unwrap_or(false);
+            if !stale {
+                return false;
+            }
+            let _ = std::fs::remove_file(&lock);
+            if std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock)
+                .is_err()
+            {
+                return false;
+            }
+        }
+    }
+
+    info!(
+        "seeding isolated pi config at {:?} from global {:?}",
+        dest, global
+    );
+
+    for name in ["models.json", "auth.json", "trust.json"] {
+        let src = global.join(name);
+        if src.exists() {
+            if let Err(e) = std::fs::copy(&src, dest.join(name)) {
+                warn!("pi config seed: failed to copy {}: {}", name, e);
+            }
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let auth = dest.join("auth.json");
+        if auth.exists() {
+            let _ = std::fs::set_permissions(&auth, std::fs::Permissions::from_mode(0o600));
+        }
+    }
+
+    // settings.json minus `packages` (global pi packages stay global).
+    let settings_src = global.join("settings.json");
+    if settings_src.exists() {
+        if let Ok(content) = std::fs::read_to_string(&settings_src) {
+            if let Ok(mut settings) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(obj) = settings.as_object_mut() {
+                    obj.remove("packages");
+                }
+                let pretty = serde_json::to_string_pretty(&settings).unwrap_or(content);
+                if let Err(e) = std::fs::write(dest.join("settings.json"), pretty) {
+                    warn!("pi config seed: failed to write settings.json: {}", e);
+                }
+            }
+        }
+    }
+
+    // Sessions for screenpipe-owned cwds. Pi encodes a session dir name as
+    // `--<cwd with leading separator stripped and [/\:] replaced by ->--`
+    // (see pi's session-manager); match dirs whose decoded cwd lives under
+    // the screenpipe data dir.
+    let encoded_data_dir = data_dir
+        .to_string_lossy()
+        .trim_start_matches(['/', '\\'])
+        .replace(['/', '\\', ':'], "-");
+    let sessions_src = global.join("sessions");
+    if let Ok(entries) = std::fs::read_dir(&sessions_src) {
+        let exact = format!("--{}--", encoded_data_dir);
+        let prefix = format!("--{}-", encoded_data_dir);
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !entry.path().is_dir() || !(name == exact || name.starts_with(&prefix)) {
+                continue;
+            }
+            let to = dest.join("sessions").join(&name);
+            if let Err(e) = crate::paths::copy_dir_all(&entry.path(), &to) {
+                warn!("pi config seed: failed to copy sessions {}: {}", name, e);
+            }
+        }
+    }
+
+    if let Err(e) = std::fs::write(
+        &marker,
+        format!("seeded from {}\n", global.to_string_lossy()),
+    ) {
+        warn!("pi config seed: failed to write marker: {}", e);
+        return false;
+    }
+    let _ = std::fs::remove_file(&lock);
+    info!("pi config seed complete at {:?}", dest);
+    true
 }
 
 pub fn find_bun_executable() -> Option<String> {
@@ -2623,6 +2835,117 @@ mod tests {
             "invalid bytes should become replacement chars"
         );
         assert_eq!(lines[1], "OK");
+    }
+
+    /// First-run seed copies config + screenpipe-owned sessions from the
+    /// global `~/.pi/agent`, strips `packages` from settings.json, and never
+    /// touches the global dir. A second call is a no-op via the marker.
+    #[test]
+    fn seed_from_global_copies_config_and_screenpipe_sessions() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let global = tmp.path().join("global");
+        let dest = tmp.path().join("isolated");
+        let data_dir = tmp.path().join("home").join(".screenpipe");
+
+        std::fs::create_dir_all(&global).unwrap();
+        std::fs::write(
+            global.join("models.json"),
+            r#"{"providers":{"ollama":{"baseUrl":"http://homelab:11434/v1"}}}"#,
+        )
+        .unwrap();
+        std::fs::write(global.join("auth.json"), r#"{"screenpipe":"tok"}"#).unwrap();
+        std::fs::write(
+            global.join("settings.json"),
+            r#"{"theme":"dark","packages":["npm:pi-web-access"]}"#,
+        )
+        .unwrap();
+
+        // Session dirs: one for a screenpipe cwd (copied), one for an
+        // unrelated project (left behind). Encoding mirrors pi's
+        // session-manager: leading separator stripped, [/\:] → '-'.
+        let encoded = data_dir
+            .to_string_lossy()
+            .trim_start_matches(['/', '\\'])
+            .replace(['/', '\\', ':'], "-");
+        let ours = global
+            .join("sessions")
+            .join(format!("--{}-pi-chat--", encoded));
+        let theirs = global.join("sessions").join("--Users-x-other-project--");
+        std::fs::create_dir_all(&ours).unwrap();
+        std::fs::write(ours.join("s1.jsonl"), "{}").unwrap();
+        std::fs::create_dir_all(&theirs).unwrap();
+        std::fs::write(theirs.join("s2.jsonl"), "{}").unwrap();
+
+        assert!(seed_from_global(&global, &dest, &data_dir));
+
+        // Config copied; settings stripped of `packages`.
+        let models = std::fs::read_to_string(dest.join("models.json")).unwrap();
+        assert!(models.contains("homelab"));
+        assert!(dest.join("auth.json").exists());
+        let settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(dest.join("settings.json")).unwrap())
+                .unwrap();
+        assert_eq!(settings["theme"], "dark");
+        assert!(settings.get("packages").is_none());
+
+        // Only the screenpipe-owned session dir came over.
+        assert!(dest
+            .join("sessions")
+            .join(format!("--{}-pi-chat--", encoded))
+            .join("s1.jsonl")
+            .exists());
+        assert!(!dest
+            .join("sessions")
+            .join("--Users-x-other-project--")
+            .exists());
+
+        // Marker written; global untouched; rerun is a no-op even if the
+        // global gains new files afterwards.
+        assert!(dest.join(PI_MIGRATION_MARKER).exists());
+        assert!(global.join("settings.json").exists());
+        std::fs::write(global.join("trust.json"), "{}").unwrap();
+        assert!(seed_from_global(&global, &dest, &data_dir));
+        assert!(!dest.join("trust.json").exists());
+    }
+
+    /// No global pi install: the dest dir is created and marked seeded
+    /// without copying anything (fresh-user path). Pointing the escape
+    /// hatch at the global dir itself must never self-copy.
+    #[test]
+    fn seed_from_global_handles_missing_global_and_self_target() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let global = tmp.path().join("no-such-global");
+        let dest = tmp.path().join("isolated");
+        let data_dir = tmp.path().join(".screenpipe");
+
+        assert!(seed_from_global(&global, &dest, &data_dir));
+        assert!(dest.join(PI_MIGRATION_MARKER).exists());
+
+        // dest == global (SCREENPIPE_PI_AGENT_DIR=~/.pi/agent escape hatch):
+        // marked seeded, nothing else happens.
+        let shared = tmp.path().join("shared");
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::write(shared.join("models.json"), "{}").unwrap();
+        assert!(seed_from_global(&shared, &shared, &data_dir));
+        assert!(shared.join(PI_MIGRATION_MARKER).exists());
+    }
+
+    /// A fresh (non-stale) lock from a concurrent seeder makes the call
+    /// back off without seeding; the marker stays absent so a later call
+    /// retries.
+    #[test]
+    fn seed_from_global_backs_off_on_active_lock() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let global = tmp.path().join("global");
+        let dest = tmp.path().join("isolated");
+        std::fs::create_dir_all(&global).unwrap();
+        std::fs::write(global.join("models.json"), "{}").unwrap();
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join(".migration.lock"), "").unwrap();
+
+        assert!(!seed_from_global(&global, &dest, tmp.path()));
+        assert!(!dest.join("models.json").exists());
+        assert!(!dest.join(PI_MIGRATION_MARKER).exists());
     }
 
     #[test]


### PR DESCRIPTION


## Summary

- Gives Screenpipe's embedded pi coding agent its own private configuration directory, `~/.screenpipe/pi-config`, instead of sharing the user's global `~/.pi/agent` directory.
- Renames the tools registered by Screenpipe's bundled pi extensions with an `sp_` prefix so they can never collide with tools from the user's own pi extensions.

## The problem

Screenpipe runs pipes and the in-app chat through the pi coding agent. Until now, every pi subprocess used the user's **global** pi configuration directory (`~/.pi/agent`). That caused two distinct problems:

1. **Screenpipe modified configuration it does not own** ([#4002](https://github.com/screenpipe/screenpipe/issues/4002))
   - On every pipe or chat run, Screenpipe merged its own model provider and auth token into the user's global `models.json` and `auth.json`.
   - People who use pi independently for other work found Screenpipe's models and credentials mixed into their personal setup.
   - Screenpipe could overwrite settings they maintain by hand.

2. **The user's global pi extensions could break every Screenpipe run** ([#3812](https://github.com/screenpipe/screenpipe/issues/3812))
   - Pi loads all globally installed extension packages into each run. If one of them registers a tool with the same name as a Screenpipe-bundled tool, pi reports a conflict.
   - In the non-interactive modes Screenpipe uses (`-p` and `--mode json`), that conflict is treated as a fatal error and pi exits before the agent starts. Verified against pi 0.75.4: `main.js` exits with code 1 on any error diagnostic in non-interactive mode.
   - This is exactly what happened with the `pi-web-access` package: both it and our bundled web-search extension registered a tool named `web_search`, so affected users' pipes failed on every run.
   
   
<img width="863" height="173" alt="image" src="https://github.com/user-attachments/assets/032b41cf-b37d-477d-b128-7573e973db1b" />


https://github.com/user-attachments/assets/500a1403-d788-495f-af69-7b20fa192548


## What is changed / added

1. **Private configuration directory**
   - Every pi subprocess now receives `PI_CODING_AGENT_DIR=~/.screenpipe/pi-config`, an environment variable pi supports and documents for exactly this purpose.
   - Pi resolves *everything* through this directory: provider config, credentials, settings, sessions, and extension package discovery.
   - Screenpipe no longer reads or writes anything under `~/.pi/agent`, and the user's global extension packages are no longer loaded into Screenpipe runs.
   - Users who deliberately want the old shared behavior can set `SCREENPIPE_PI_AGENT_DIR=~/.pi/agent`.

2. **One-time migration so existing users lose nothing**
   - On the first run after this change, Screenpipe copies the relevant state from `~/.pi/agent` into the new directory (details below).
   - The global directory is only read during this copy and is never modified or deleted.

3. **Prefixed tool names**
   - `web_search` → `sp_web_search`, `mcp_list_tools` → `sp_mcp_list_tools`, `mcp_call` → `sp_mcp_call`.
   - With the prefix, a name collision cannot happen even if a user installs a conflicting extension directly inside a pipe's project directory, which the isolation alone would not prevent.

## What the migration copies

- Runs once and writes a `.migrated-from-global` marker when done.
- Uses a lock file so concurrent pipe runs cannot trigger it twice; a stale lock from a crashed run is reclaimed after 10 minutes.
- Fresh installs (no `~/.pi` directory) skip the copy entirely; Screenpipe never creates `~/.pi`.

| File / directory in `~/.pi/agent` | Copied? | Notes |
|---|---|---|
| `models.json` | Yes, unchanged | Preserves providers the user configured for their pipes (for example, a local Ollama server or their own OpenAI key). |
| `auth.json` | Yes, unchanged | File permissions set to `0600`. |
| `trust.json` | Yes, unchanged | Avoids re-prompting for directories the user already trusted. |
| `settings.json` | Yes, with two edits | See the list below the table. |
| `sessions/` | Partially | Only the session directories belonging to Screenpipe working directories (the chat, title generation, and pipe directories under `~/.screenpipe`) are copied, so `--continue` chat history carries over. Sessions from the user's other projects stay where they are. |
| `npm/`, `git/`, `extensions/`, `skills/`, `bin/` | No | Global packages stay global by design. The `fd`/`rg` helper binaries are re-extracted by pi automatically. |

The two edits made to the copied `settings.json`:

- The `packages` list is removed — globally installed packages are the source of the tool conflicts in [#3812](https://github.com/screenpipe/screenpipe/issues/3812).
- `defaultProvider` and `defaultModel` are replaced with `"screenpipe"` / `"auto"`:
  - Screenpipe passes `--provider` and `--model` explicitly on every spawn, so these defaults are normally never read.
  - If a future code path ever spawned pi without flags, it must not silently fall back to the user's personal provider and bill their API key.
- All other settings (thinking level, token budgets, compaction) are copied as-is so behavior matches what users had before.




https://github.com/user-attachments/assets/4849a950-b016-4b5a-b484-9063be5b08d5




## Backward compatibility

| Scenario | Outcome |
|---|---|
| Default Screenpipe cloud user | No visible change. |
| Uses pi independently for other work ([#4002](https://github.com/screenpipe/screenpipe/issues/4002)) | Screenpipe stops writing into their configuration, and their pi extensions no longer load into Screenpipe runs. Entries Screenpipe wrote in the past are left in place; they can be removed by hand. |
| Has the global `pi-web-access` package ([#3812](https://github.com/screenpipe/screenpipe/issues/3812)) | Pipe runs no longer crash. |
| Configured their own providers (Ollama, OpenAI, etc.) in the global `models.json` | Settings carry over via the migration. Future edits belong in `~/.screenpipe/pi-config/models.json`. |
| Existing chat history | Carries over; `--continue` works as before. |
| Custom extensions inside a pipe's own `.pi/` directory | Unaffected. |
| Old recorded sessions that show `web_search` calls | Still render correctly. |
| Wants the previous shared-configuration behavior | Set `SCREENPIPE_PI_AGENT_DIR=~/.pi/agent`. |

Closes [#4002](https://github.com/screenpipe/screenpipe/issues/4002)
Closes [#3812](https://github.com/screenpipe/screenpipe/issues/3812)
