### PR TITLE
fix(deps): restore zbus blocking-api + async-io so --all-targets builds on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,12 @@ ort = { version = "=2.0.0-rc.10", default-features = false }
 # Platform
 dirs = "6"
 which = "7"
-zbus = { version = "5.5", default-features = false, features = ["blocking"] }
+# zbus 5.x has no `blocking` feature — the blocking API lives behind `blocking-api`
+# (the module) plus a runtime (`async-io`). These are in zbus's default set; #3815 set
+# `default-features = false` and listed `blocking` (the optional crate dep, not the API),
+# which only compiled on Linux because atspi backfilled `tokio`. macOS has no atspi, so
+# the blocking API failed under `--all-targets` (G-1008). Name the real features here.
+zbus = { version = "5.5", default-features = false, features = ["blocking-api", "async-io"] }
 windows = "0.58"
 xcap = "0.9"
 keyring = "3"


### PR DESCRIPTION
## description

`zbus` fails to compile under `--all-targets` on macOS, breaking `cargo clippy --all-targets` for `screenpipe-a11y` and flooding rust-analyzer with phantom dependency errors. This is a silent regression from #3815 (Linux CI stays green).

### root cause

#3815 consolidated `zbus` to the workspace as `{ default-features = false, features = ["blocking"] }`. But zbus 5.x has **no `blocking` feature** — that name only enables zbus's optional `blocking` *crate dependency*, not its blocking API. The blocking API depends on two of zbus's **default** features that `default-features = false` dropped:

- `blocking-api` — gates `pub mod blocking` (`#[cfg(feature = "blocking-api")]`)
- `async-io` — supplies the runtime the blocking layer is built on

On Linux this still compiled because `atspi` (in `screenpipe-screen`) pulls in zbus's `tokio` feature, so feature-unification handed `screenpipe-a11y` a runtime and the default module set. macOS has no `atspi`, so nothing backfilled it:

```
cargo check -p screenpipe-a11y --all-targets
# before: 82 errors in zbus-5.15.0 (unresolved async_io/async_lock/async_process),
#         then `unresolved import zbus::blocking`
```

`screenpipe-a11y` keeps `zbus` as a non-target-gated dev-dependency (so the Linux debug examples compile under clippy on every dev OS), which is why this only bites `--all-targets` — exactly what the lefthook pre-commit clippy gate and rust-analyzer run. Net effect: macOS contributors editing `screenpipe-a11y` hit `exit 101` on commit, and the editor shows 116 phantom errors.

### fix

Name the real features explicitly so the blocking API compiles on every OS regardless of `atspi`. Restores pre-#3815 behavior.

```toml
zbus = { version = "5.5", default-features = false, features = ["blocking-api", "async-io"] }
```

## how to test

on macOS:

1. `git checkout main` → `cargo check -p screenpipe-a11y --all-targets` → **fails** (zbus 82 errors)
2. `git checkout` this branch → `cargo clippy -p screenpipe-a11y --all-targets -- -W clippy::all` → **exits 0**
3. confirm Linux is unaffected: `cargo check -p screenpipe-a11y --all-targets` still passes (atspi already supplied a runtime there)

## notes

build-config only (one line in `Cargo.toml`); no runtime/behavior change, so before/after recordings aren't applicable. Lockfile unaffected — feature changes don't alter resolved versions.