### PR TITLE
perf(db): index the snapshot-compaction scan to stop full-table scans

### DIFF
--- a/crates/screenpipe-db/src/migrations/20260610000000_index_frames_snapshot_compaction.sql
+++ b/crates/screenpipe-db/src/migrations/20260610000000_index_frames_snapshot_compaction.sql
@@ -1,0 +1,20 @@
+-- Speed up the background snapshot-compaction scan.
+-- snapshot_compaction.rs runs this query every compaction cycle:
+--   SELECT id, snapshot_path, device_name, timestamp FROM frames
+--   WHERE snapshot_path IS NOT NULL AND timestamp < ?1
+--   ORDER BY device_name, timestamp ASC LIMIT 5000
+--
+-- None of the existing indexes match it: idx_frames_snapshot_path is ordered by
+-- snapshot_path (so the device_name,timestamp ORDER BY needs a temp B-tree sort),
+-- and idx_frames_timestamp_device leads with timestamp (wrong order for the
+-- ORDER BY). With weeks of data this degrades into a multi-second full table
+-- scan + sort that runs on a timer and contends with the HTTP/API runtime,
+-- contributing to the high-CPU / unresponsive-server behavior in #183.
+--
+-- This partial index matches the query exactly: it indexes only not-yet-compacted
+-- frames (snapshot_path IS NOT NULL) in (device_name, timestamp) order, so SQLite
+-- satisfies both the WHERE filter and the ORDER BY directly from the index with no
+-- sort, scanning only the small uncompacted subset instead of the whole table.
+CREATE INDEX IF NOT EXISTS idx_frames_snapshot_compaction
+  ON frames(device_name, timestamp)
+  WHERE snapshot_path IS NOT NULL;

--- a/crates/screenpipe-db/tests/query_plan_test.rs
+++ b/crates/screenpipe-db/tests/query_plan_test.rs
@@ -581,6 +581,42 @@ mod query_plan_tests {
     }
 
     // ──────────────────────────────────────────────────────────
+    // Background snapshot-compaction scan (#183)
+    // Must use the partial (device_name, timestamp) WHERE
+    // snapshot_path IS NOT NULL index and avoid a temp B-tree sort,
+    // so it scans only uncompacted frames instead of the whole table.
+    // ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_snapshot_compaction_scan_uses_partial_index() {
+        let db = setup_test_db().await;
+        seed_data(&db, 200).await;
+
+        let plan = explain(
+            &db,
+            r#"SELECT id, snapshot_path, device_name, timestamp
+            FROM frames
+            WHERE snapshot_path IS NOT NULL
+              AND timestamp < '2030-01-01'
+            ORDER BY device_name, timestamp ASC
+            LIMIT 5000"#,
+        )
+        .await;
+
+        let joined = plan.join("\n");
+        assert!(
+            joined.contains("idx_frames_snapshot_compaction"),
+            "snapshot-compaction scan does not use the partial index.\nPlan:\n{}",
+            joined
+        );
+        assert!(
+            !joined.to_uppercase().contains("TEMP B-TREE"),
+            "snapshot-compaction scan still sorts via a temp B-tree (index ORDER BY unused).\nPlan:\n{}",
+            joined
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────
     // Dedup query (runs before every audio insert)
     // ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What
Adds a partial composite index so the background snapshot-compaction scan uses
an index instead of a full-table scan + sort.

## Why (refs #183)
`snapshot_compaction.rs` runs this every compaction cycle, on a timer:

    SELECT id, snapshot_path, device_name, timestamp FROM frames
    WHERE snapshot_path IS NOT NULL AND timestamp < ?1
    ORDER BY device_name, timestamp ASC LIMIT 5000

No existing index matches it:
- `idx_frames_snapshot_path` orders by `snapshot_path`, so the
  `device_name, timestamp` ORDER BY needs a temp B-tree sort.
- `idx_frames_timestamp_device` leads with `timestamp` — wrong order for the
  ORDER BY.

On a database with weeks of data this degrades into a multi-second full-table
scan + sort that runs repeatedly on a timer and contends with the HTTP/API
runtime — part of the high-CPU / unresponsive-server behavior in #183.

## Change
A partial composite index that matches the query exactly:

    CREATE INDEX IF NOT EXISTS idx_frames_snapshot_compaction
      ON frames(device_name, timestamp)
      WHERE snapshot_path IS NOT NULL;

It indexes only not-yet-compacted frames in `(device_name, timestamp)` order, so
SQLite serves both the WHERE filter and the ORDER BY from the index with no
sort, scanning only the small uncompacted subset.

## Testing
Adds `test_snapshot_compaction_scan_uses_partial_index` asserting the scan uses
`idx_frames_snapshot_compaction` and does no temp B-tree sort. Passing.
