### PR TITLE
fix(vision): recover capture after locked-screen startup and wedged capture loops

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1186,10 +1186,21 @@ async fn main() -> anyhow::Result<()> {
         let h = runtime.spawn(async move {
             let mut shutdown_rx = shutdown_tx_clone2.subscribe();
 
-            // Start VisionManager
+            // Start VisionManager. A failed start here is NOT fatal and must not
+            // abort this task: the common cause is the screen being locked at
+            // startup (auto-update restart, reboot into the lock screen, sleep),
+            // where macOS enumerates 0 monitors, so start() returns Err and rolls
+            // status back to Stopped. We must still start the monitor watcher
+            // below — its retry loop waits on the screen-unlock notification and
+            // is exactly what recovers vision once the screen unlocks. Returning
+            // here instead stranded vision dead until the next process restart.
+            // (#3702 — PR #3705 fixed the Tauri app path; this CLI binary path
+            // was left with the original `return`.)
             if let Err(e) = vm_clone.start().await {
-                error!("Failed to start VisionManager: {:?}", e);
-                return;
+                warn!(
+                    "VisionManager initial start failed ({:?}); monitor watcher will retry (e.g. once the screen unlocks)",
+                    e
+                );
             }
 
             // Start MonitorWatcher for dynamic detection (with audio DRM pause support)

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -23,7 +23,7 @@ use screenpipe_screen::monitor::{list_monitors, SafeMonitor};
 use screenpipe_screen::snapshot_writer::SnapshotWriter;
 use screenpipe_screen::utils::capture_monitor_image;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, watch};
@@ -573,6 +573,10 @@ pub async fn event_driven_capture_loop(
     // The loop polls `effective_interval_ms()` each tick; `None` here means
     // the override is fully disabled (no auto, no manual, no detector).
     high_fps_controller: Option<Arc<crate::high_fps_controller::HighFpsController>>,
+    // Shared cross-task "last successful capture" stamp (epoch-ms), owned by
+    // VisionManager. Stamped on every completed capture cycle (full write OR
+    // dedup-skip) so the monitor watcher can detect a wedged-but-Running loop.
+    last_capture_ms: Arc<AtomicU64>,
 ) -> Result<()> {
     info!(
         "event-driven capture started for monitor {} (device: {})",
@@ -704,6 +708,9 @@ pub async fn event_driven_capture_loop(
         {
             Ok(Ok(output)) => {
                 state.mark_captured();
+                // Cross-task liveness stamp: the pipeline cycled successfully
+                // (this is the startup capture). See the live-loop site below.
+                last_capture_ms.store(Utc::now().timestamp_millis().max(0) as u64, Ordering::Relaxed);
                 if let Some(ref mut comparer) = frame_comparer {
                     let _ = comparer.compare(&output.image);
                 }
@@ -1298,6 +1305,15 @@ pub async fn event_driven_capture_loop(
                 match capture_result {
                     Ok(Ok(output)) => {
                         state.mark_captured();
+                        // Cross-task liveness stamp for the monitor watcher.
+                        // Stamped on EVERY successful cycle — full write and
+                        // dedup-skip alike — so a static screen (Zoom call,
+                        // slide deck, IDE) stays "alive" and is never mistaken
+                        // for a wedge. The wedge signal is the ABSENCE of this
+                        // stamp (repeated CAPTURE_OPERATION_TIMEOUTs), not the
+                        // absence of a DB write.
+                        last_capture_ms
+                            .store(Utc::now().timestamp_millis().max(0) as u64, Ordering::Relaxed);
 
                         if consecutive_capture_errors > 0 {
                             info!(

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -5,11 +5,12 @@
 //! VisionManager - Core manager for per-monitor recording tasks
 
 use anyhow::Result;
+use chrono::Utc;
 use dashmap::DashMap;
 use screenpipe_db::DatabaseManager;
 use screenpipe_screen::monitor::{get_monitor_by_id, list_monitors};
 use screenpipe_screen::PipelineMetrics;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::{watch, RwLock};
@@ -112,6 +113,53 @@ pub struct VisionManager {
     /// Set when the user's monitor allowlist matched zero connected displays and
     /// we fell back to recording every monitor. Clears the filter for hot-plug too.
     stale_allowlist_fallback: Arc<AtomicBool>,
+    /// Epoch-ms of the last successful capture cycle across all monitors. Each
+    /// capture loop stamps this whenever `do_capture` completes (full write OR
+    /// dedup-skip — both mean the pipeline cycled). The monitor watcher reads it
+    /// to detect a wedged-but-`Running` loop that has stopped producing frames
+    /// after a DB/disk I/O stall (repeated `CAPTURE_OPERATION_TIMEOUT`s) — a
+    /// condition no per-loop-local `Instant` could surface to a supervisor.
+    last_capture_ms: Arc<AtomicU64>,
+}
+
+/// Threshold past which a `Running` VisionManager that has produced no
+/// successful capture is treated as wedged and force-restarted by the monitor
+/// watcher. Fixed at 180s: long enough to clear the longest idle-capture
+/// interval (30s default) with generous margin for slow OCR / DB writes and
+/// legitimate transient stalls, so a healthy-but-quiet pipeline is never
+/// restarted; short enough that a real wedge (DB/disk stall) self-heals within
+/// a few minutes instead of silently losing the rest of a session.
+pub(crate) const VISION_WEDGE_THRESHOLD_MS: u64 = 180_000;
+
+/// Wall-clock epoch milliseconds. Used for the cross-task last-capture stamp
+/// (a monotonic `Instant` can't be shared as an atomic across the loop /
+/// watcher boundary the way an epoch-ms `u64` can).
+fn now_epoch_ms() -> u64 {
+    Utc::now().timestamp_millis().max(0) as u64
+}
+
+/// Pure staleness decision for the vision-wedge watchdog. Returns true only
+/// when the manager is `Running`, capture is NOT legitimately paused (DRM /
+/// schedule / screen-lock), monitors are present, and the last successful
+/// capture is older than `threshold_ms`. Side-effect-free so it can be
+/// unit-tested without a `VisionManager`; the actual DB/disk stall that wedges
+/// the loop can only be exercised by the e2e-macos workflow or manual testing.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn should_restart_wedged_vision(
+    is_running: bool,
+    drm_paused: bool,
+    schedule_paused: bool,
+    screen_locked: bool,
+    monitors_present: bool,
+    capture_age_ms: u64,
+    threshold_ms: u64,
+) -> bool {
+    is_running
+        && !drm_paused
+        && !schedule_paused
+        && !screen_locked
+        && monitors_present
+        && capture_age_ms >= threshold_ms
 }
 
 impl VisionManager {
@@ -163,6 +211,9 @@ impl VisionManager {
             focus_controller,
             high_fps_controller: None,
             stale_allowlist_fallback: Arc::new(AtomicBool::new(false)),
+            // Seed with "now" so a freshly-started manager isn't immediately
+            // judged stale before the first capture lands.
+            last_capture_ms: Arc::new(AtomicU64::new(now_epoch_ms())),
         }
     }
 
@@ -204,6 +255,16 @@ impl VisionManager {
     /// Get current status
     pub async fn status(&self) -> VisionManagerStatus {
         *self.status.read().await
+    }
+
+    /// Milliseconds since the last successful capture cycle on any monitor.
+    /// Saturates at 0 if the clock went backwards. The monitor watcher uses
+    /// this with [`should_restart_wedged_vision`] to detect a wedged loop.
+    pub fn capture_age_ms(&self) -> u64 {
+        let last = self
+            .last_capture_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        now_epoch_ms().saturating_sub(last)
     }
 
     /// Check whether a monitor is allowed by the user's monitor filter settings.
@@ -504,6 +565,7 @@ impl VisionManager {
         let focus_controller = self.focus_controller.clone();
         let linker_tx = Some(self.linker_tx.clone());
         let high_fps_controller = self.high_fps_controller.clone();
+        let last_capture_ms = self.last_capture_ms.clone();
 
         // Spawn the decoupled high-fps HD recorder alongside this monitor's
         // capture loop. It idles until an HD session is active, then records a
@@ -559,6 +621,7 @@ impl VisionManager {
                 focus_controller,
                 linker_tx,
                 high_fps_controller,
+                last_capture_ms,
             )
             .await
             {
@@ -791,6 +854,83 @@ mod tests {
             // the important thing is we didn't hang.
             let _ = result;
         }
+    }
+
+    // --- Vision wedge watchdog decision tests (#3939) ---
+
+    const T: u64 = VISION_WEDGE_THRESHOLD_MS;
+
+    #[test]
+    fn wedge_restarts_when_running_and_capture_stale() {
+        // The core wedge case: Running, nothing paused, monitors present, and
+        // no successful capture for longer than the threshold.
+        assert!(should_restart_wedged_vision(
+            true, false, false, false, true, T + 1, T
+        ));
+    }
+
+    #[test]
+    fn wedge_no_restart_when_capture_fresh() {
+        // Healthy pipeline — a recent capture (or static-screen dedup-skip,
+        // which still stamps the clock) keeps the age below threshold.
+        assert!(!should_restart_wedged_vision(
+            true,
+            false,
+            false,
+            false,
+            true,
+            T - 1,
+            T
+        ));
+    }
+
+    #[test]
+    fn wedge_no_restart_when_not_running() {
+        // Already Stopped / ShuttingDown — the not-Running recovery path owns it.
+        assert!(!should_restart_wedged_vision(
+            false, false, false, false, true, T + 1, T
+        ));
+    }
+
+    #[test]
+    fn wedge_no_restart_while_drm_paused() {
+        // DRM pause intentionally halts capture — not a wedge.
+        assert!(!should_restart_wedged_vision(
+            true, true, false, false, true, T + 1, T
+        ));
+    }
+
+    #[test]
+    fn wedge_no_restart_while_schedule_paused() {
+        // Outside work-hours schedule — capture is intentionally stopped.
+        assert!(!should_restart_wedged_vision(
+            true, false, true, false, true, T + 1, T
+        ));
+    }
+
+    #[test]
+    fn wedge_no_restart_while_screen_locked() {
+        // Screen locked — the loop skips captures on purpose.
+        assert!(!should_restart_wedged_vision(
+            true, false, false, true, true, T + 1, T
+        ));
+    }
+
+    #[test]
+    fn wedge_no_restart_when_no_monitors_present() {
+        // No active monitors (undock / wake) — the not-Running / start-retry
+        // path handles this; don't thrash a stop()+start() over nothing.
+        assert!(!should_restart_wedged_vision(
+            true, false, false, false, false, T + 1, T
+        ));
+    }
+
+    #[test]
+    fn wedge_threshold_boundary_is_inclusive() {
+        // Exactly at the threshold counts as stale (>=).
+        assert!(should_restart_wedged_vision(
+            true, false, false, false, true, T, T
+        ));
     }
 
     /// Verify that an already-finished task completes instantly on stop_monitor.

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -224,6 +224,56 @@ pub async fn start_monitor_watcher(
                 continue;
             }
 
+            // ── Wedge watchdog ──────────────────────────────────────────────
+            // A capture loop can keep its status `Running` yet stop producing
+            // frames entirely — e.g. repeated `CAPTURE_OPERATION_TIMEOUT`s under
+            // a DB/disk I/O stall. The reconnect logic below only restarts a
+            // monitor whose task already exited, so a wedged-but-Running loop is
+            // never recovered. Detect it via the shared last-successful-capture
+            // stamp and force a stop()+start() to rebuild the pipeline. Gated by
+            // `should_restart_wedged_vision` so legitimate pauses (DRM / schedule
+            // / screen-lock) and a no-monitor state never false-trigger; a static
+            // screen also can't trigger it because dedup-skips still stamp the
+            // capture clock.
+            {
+                let active_count = vision_manager.active_monitors().await.len();
+                #[cfg(target_os = "macos")]
+                let screen_locked = crate::sleep_monitor::screen_is_locked();
+                #[cfg(not(target_os = "macos"))]
+                let screen_locked = false;
+                if super::manager::should_restart_wedged_vision(
+                    vision_manager.status().await == VisionManagerStatus::Running,
+                    drm_detector::drm_content_paused(),
+                    crate::schedule_monitor::schedule_paused(),
+                    screen_locked,
+                    active_count > 0,
+                    vision_manager.capture_age_ms(),
+                    super::manager::VISION_WEDGE_THRESHOLD_MS,
+                ) {
+                    warn!(
+                        "vision capture wedged ({}ms since last successful capture, {} monitor(s) active) — restarting VisionManager",
+                        vision_manager.capture_age_ms(),
+                        active_count
+                    );
+                    if let Err(e) = vision_manager.stop().await {
+                        warn!("failed to stop wedged VisionManager: {:?}", e);
+                    }
+                    if let Err(e) = vision_manager.start().await {
+                        warn!("failed to restart VisionManager after wedge: {:?}", e);
+                    } else {
+                        info!("VisionManager restarted after capture wedge");
+                        if let Ok(monitors) = list_monitors_detailed().await {
+                            known_monitors = monitors
+                                .iter()
+                                .map(|m| (m.id(), m.name().to_string()))
+                                .collect();
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    continue;
+                }
+            }
+
             // Get currently connected monitors with detailed error info
             let current_monitors = match list_monitors_detailed().await {
                 Ok(monitors) => {


### PR DESCRIPTION
Two related fixes that keep CLI vision capture alive when it would otherwise
silently die while the process keeps running.

## 1. Recover CLI capture after a locked-screen startup
The standalone `screenpipe record` binary aborted its vision task when the
initial `VisionManager::start()` failed — most commonly because the screen was
locked at startup (auto-update restart, reboot, sleep), where macOS enumerates
0 monitors and `start()` returns `Err`. The early `return` ran before
`start_monitor_watcher()`, so the watcher's retry loop (which waits on the
screen-unlock notification) never started; vision stayed dead until the next
process restart while audio and the process kept running, so nothing surfaced it.

Fix: fall through to start the monitor watcher even when the initial start
fails; its existing retry loop brings vision up once the screen unlocks.

## 2. Restart a wedged capture loop via a last-capture watchdog
A per-monitor event-driven capture loop wraps each `do_capture` in a 15s
`CAPTURE_OPERATION_TIMEOUT`. Under a DB/disk I/O stall the loop can hit repeated
timeouts and stop producing frames while `VisionManager` status stays `Running`.
The monitor watcher only restarts a monitor whose task already exited, so a
wedged-but-`Running` loop was never recovered, and `last_capture` was a
per-loop-local `Instant` invisible to any supervisor — capture silently died
for the rest of the session.

Fix: expose a shared `Arc<AtomicU64>` last-successful-capture stamp (epoch-ms)
from `VisionManager`, stamped wherever each loop already calls
`state.mark_captured()` (full write and dedup-skip alike). The watchdog restarts
a monitor whose status is `Running` but whose last capture is older than the
staleness threshold — and only when it should be capturing (not while
screen-locked, DRM-paused, schedule-paused, or with no monitors present).

## Testing
8 new unit tests cover the wedge-restart decision (restart when running + stale;
no restart when not running / capture fresh / screen-locked / DRM-paused /
schedule-paused / no monitors / threshold boundary). All `vision_manager` tests
pass (14).
