### PR TITLE
fix(audio): recover dead System Audio output and fall back to Process Tap

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -61,6 +61,39 @@ fn is_device_type_running(
     })
 }
 
+/// Inputs to [`should_recover_output`]. Snapshot of the output-device state at
+/// the start of a monitor cycle. Mirrors the input-recovery decision but for
+/// the System Audio (output) ScreenCaptureKit stream, which dies silently on
+/// lid-close / clamshell / screen-lock without ever flipping `is_disconnected`
+/// in a way the input recovery path observes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct OutputRecoveryInputs {
+    /// An output device is enrolled in the user's `enabled_devices` set.
+    pub output_enrolled: bool,
+    /// An enrolled output device currently has a live, non-disconnected stream.
+    pub output_streaming: bool,
+    /// Output (SCK) capture is intentionally paused for DRM content. When true
+    /// the monitor must NOT recover — doing so fights the DRM pause.
+    pub drm_paused: bool,
+    /// The user explicitly disabled the output device (privacy / preference).
+    pub output_user_disabled: bool,
+}
+
+/// Pure recovery-decision predicate for the System Audio (output) stream.
+///
+/// Returns true only when an output device is enrolled, is NOT actively
+/// streaming (stale / dead handle), is NOT paused for DRM, and was NOT disabled
+/// by the user. Kept side-effect-free so the decision can be exhaustively
+/// unit-tested without an `AudioManager` (the actual lid-close / clamshell SCK
+/// death that triggers it can only be exercised by the e2e-macos workflow or
+/// manual testing).
+pub(crate) fn should_recover_output(inputs: OutputRecoveryInputs) -> bool {
+    inputs.output_enrolled
+        && !inputs.output_streaming
+        && !inputs.drm_paused
+        && !inputs.output_user_disabled
+}
+
 use super::{AudioManager, AudioManagerStatus};
 
 /// Exponential backoff for output device recovery.
@@ -917,6 +950,100 @@ pub async fn start_device_monitor(
                     }
                 }
 
+                // Manual-mode output (System Audio) liveness recovery.
+                //
+                // The follow-system-default branch above already re-arms a dead
+                // output stream, but in MANUAL device mode nothing did — so when
+                // the SCK output stream dies silently on lid-close / clamshell /
+                // screen-lock (it never flips `is_disconnected` the way an input
+                // disconnect does), `/health` stayed "ok" (the mic was alive) and
+                // meetings were captured mic-only. Mirror the input-recovery path
+                // for the output device here. DRM-pause-aware via
+                // `should_recover_output` so it does not fight an intentional DRM
+                // pause. Uses the stream-liveness signal (`is_device_type_running`
+                // → live, non-disconnected handle), NOT mere silence, so genuine
+                // quiet periods are not treated as failures.
+                if !audio_manager.use_system_default_audio().await {
+                    let current_enabled = audio_manager.enabled_devices().await;
+                    let user_disabled = audio_manager.user_disabled_devices().await;
+                    let output_enrolled = current_enabled.iter().any(|name| {
+                        parse_audio_device(name)
+                            .map(|d| d.device_type == DeviceType::Output)
+                            .unwrap_or(false)
+                    });
+                    let output_streaming = is_device_type_running(
+                        &device_manager,
+                        &current_enabled,
+                        DeviceType::Output,
+                    );
+                    let output_user_disabled = match default_output_device().await {
+                        Ok(d) => user_disabled.contains(&d.to_string()),
+                        Err(_) => false,
+                    };
+                    let drm_paused = audio_manager.output_paused_for_drm().await;
+
+                    let recover = should_recover_output(OutputRecoveryInputs {
+                        output_enrolled,
+                        output_streaming,
+                        drm_paused,
+                        output_user_disabled,
+                    });
+
+                    if recover {
+                        // Reuse the shared backoff so a permanently-unavailable
+                        // output (no display) does not spam logs every 2s.
+                        let backoff_secs = output_recovery_backoff.next_delay_secs();
+                        if output_recovery_backoff.last_attempt.elapsed()
+                            >= Duration::from_secs(backoff_secs)
+                        {
+                            output_recovery_backoff.last_attempt = Instant::now();
+                            match default_output_device().await {
+                                Ok(default_output) => {
+                                    let device_name = default_output.to_string();
+                                    info!(
+                                        "[DEVICE_RECOVERY] output stream not live (attempt {}), restarting System Audio: {}",
+                                        output_recovery_backoff.attempts, device_name
+                                    );
+                                    match audio_manager.start_device(&default_output).await {
+                                        Ok(()) => {
+                                            failed_devices.remove(&device_name);
+                                            output_recovery_backoff.reset();
+                                            info!(
+                                                "[DEVICE_RECOVERY] output device restored, device={}",
+                                                device_name
+                                            );
+                                        }
+                                        Err(e) => {
+                                            output_recovery_backoff.record_failure(false);
+                                            warn!(
+                                                "[DEVICE_RECOVERY] failed to restart output device {} (attempt {}, next retry in {}s): {}",
+                                                device_name, output_recovery_backoff.attempts,
+                                                output_recovery_backoff.next_delay_secs(), e
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    let is_permanent = is_permanent_output_error(&e);
+                                    output_recovery_backoff.record_failure(is_permanent);
+                                    if output_recovery_backoff.attempts <= 3
+                                        || output_recovery_backoff.attempts.is_multiple_of(30)
+                                    {
+                                        warn!(
+                                            "[DEVICE_RECOVERY] no output device available for recovery (attempt {}, {}, next retry in {}s): {}",
+                                            output_recovery_backoff.attempts,
+                                            if is_permanent { "permanent" } else { "transient" },
+                                            output_recovery_backoff.next_delay_secs(), e
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        output_recovery_backoff.reset();
+                    }
+                }
+
                 // Check for stale recording handles (tasks that have finished/crashed)
                 // This handles cases where audio stream was hijacked by another app
                 let stale_devices = audio_manager.check_stale_recording_handles().await;
@@ -1571,6 +1698,65 @@ mod tests {
         // With a 0s window, the old timestamps are immediately evicted,
         // so we never accumulate 3 within the window
         assert!(!cd.exhausted);
+    }
+
+    // --- Output recovery decision tests (#3901) ---
+
+    #[test]
+    fn output_recovers_when_enrolled_dead_and_not_drm_paused() {
+        // The core lid-close / clamshell case: output enrolled, stream dead,
+        // no DRM pause, user did not disable it → recover.
+        assert!(should_recover_output(OutputRecoveryInputs {
+            output_enrolled: true,
+            output_streaming: false,
+            drm_paused: false,
+            output_user_disabled: false,
+        }));
+    }
+
+    #[test]
+    fn output_no_recover_while_streaming() {
+        // Healthy live stream — quiet periods are not failures.
+        assert!(!should_recover_output(OutputRecoveryInputs {
+            output_enrolled: true,
+            output_streaming: true,
+            drm_paused: false,
+            output_user_disabled: false,
+        }));
+    }
+
+    #[test]
+    fn output_no_recover_while_drm_paused() {
+        // Output intentionally stopped for DRM content — recovering here would
+        // fight the pause and log false "restored" events.
+        assert!(!should_recover_output(OutputRecoveryInputs {
+            output_enrolled: true,
+            output_streaming: false,
+            drm_paused: true,
+            output_user_disabled: false,
+        }));
+    }
+
+    #[test]
+    fn output_no_recover_when_not_enrolled() {
+        // No output device in the enabled set — nothing to recover.
+        assert!(!should_recover_output(OutputRecoveryInputs {
+            output_enrolled: false,
+            output_streaming: false,
+            drm_paused: false,
+            output_user_disabled: false,
+        }));
+    }
+
+    #[test]
+    fn output_no_recover_when_user_disabled() {
+        // User explicitly disabled the output device — respect that.
+        assert!(!should_recover_output(OutputRecoveryInputs {
+            output_enrolled: true,
+            output_streaming: false,
+            drm_paused: false,
+            output_user_disabled: true,
+        }));
     }
 
     // --- Pinned input fallback decider tests ---

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -1089,6 +1089,14 @@ impl AudioManager {
             .remove(device_name);
     }
 
+    /// True when output (SCK) devices are currently stopped for a DRM pause.
+    /// The device monitor consults this so its output-liveness recovery does
+    /// not fight the intentional DRM pause (which would otherwise log false
+    /// "restored" events and re-arm SCK while protected content is playing).
+    pub async fn output_paused_for_drm(&self) -> bool {
+        !self.drm_stopped_devices.read().await.is_empty()
+    }
+
     /// Stop all SCK-based (Output) audio devices for DRM pause.
     /// Input (microphone) devices are left running. Unlike `stop_device()`,
     /// this does NOT remove devices from `enabled_devices` since DRM pause

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -209,17 +209,60 @@ impl AudioStream {
                     unreachable!()
                 }
             } else {
-                Self::start_cpal_stream(
-                    &device,
-                    tx,
-                    stream_control_rx,
-                    &is_running,
-                    &is_disconnected,
-                    &stream_control_tx,
-                    windows_input_aec,
-                    macos_input_vpio,
-                )
-                .await?
+                #[cfg(target_os = "macos")]
+                {
+                    use super::device::{DeviceType, MACOS_OUTPUT_AUDIO_DEVICE_NAME};
+                    let is_system_audio = device.device_type == DeviceType::Output
+                        && device.name == MACOS_OUTPUT_AUDIO_DEVICE_NAME;
+                    match Self::start_cpal_stream(
+                        &device,
+                        tx.clone(),
+                        stream_control_rx,
+                        &is_running,
+                        &is_disconnected,
+                        &stream_control_tx,
+                        windows_input_aec,
+                        macos_input_vpio,
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        // ScreenCaptureKit's System Audio enumeration is unreliable under
+                        // sustained GPU/Metal load (e.g. Parakeet on MLX): it returns empty
+                        // displays → "device not found" and never recovers. The CoreAudio
+                        // Process Tap doesn't touch the GPU, so fall back to it automatically.
+                        // (Mirrors the reverse tap→SCK fallback in the `use_process_tap` arm.)
+                        Err(e)
+                            if is_system_audio
+                                && super::process_tap::is_process_tap_available() =>
+                        {
+                            tracing::warn!(
+                                "SCK System Audio capture failed ({}); falling back to CoreAudio Process Tap",
+                                e
+                            );
+                            super::process_tap::spawn_process_tap_capture(
+                                tx,
+                                is_running.clone(),
+                                is_disconnected.clone(),
+                            )?
+                        }
+                        Err(e) => return Err(e),
+                    }
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    Self::start_cpal_stream(
+                        &device,
+                        tx,
+                        stream_control_rx,
+                        &is_running,
+                        &is_disconnected,
+                        &stream_control_tx,
+                        windows_input_aec,
+                        macos_input_vpio,
+                    )
+                    .await?
+                }
             }
         };
 


### PR DESCRIPTION
Two related System Audio robustness fixes for manual-device mode on macOS.

## 1. Recover a dead System Audio output stream (refs #3901)
On lid-close, clamshell, or screen-lock the System Audio (output)
ScreenCaptureKit stream dies silently: it never flips `is_disconnected` the way
an input disconnect does, so the device monitor never noticed. The existing
output-liveness recovery only ran inside the follow-system-default branch, so in
MANUAL device mode nothing re-armed the stream. `/health` stayed "ok" because
the mic was still alive and a dead output is indistinguishable from "nothing
playing" — and meetings were captured mic-only.

Add an output-liveness recovery pass that also runs in manual mode, mirroring
the input-recovery path. It keys off stream liveness (a live, non-disconnected
handle), not mere silence, so genuine quiet periods are not treated as failures,
and reuses the shared exponential backoff so a permanently-unavailable output
does not spam logs. The decision is factored into the pure, unit-tested
`should_recover_output` predicate, and is DRM-pause-aware via the new
`AudioManager::output_paused_for_drm` accessor (recovery is skipped during a DRM
pause so it does not fight the pause or log false "restored" events).

## 2. Fall back to CoreAudio Process Tap when SCK System Audio fails
ScreenCaptureKit's System Audio enumeration is unreliable under sustained
GPU/Metal load (verified: Parakeet on MLX makes SCK return empty displays →
"device not found" with no recovery; on CPU/ONNX, SCK starts on the first try).
The CoreAudio Process Tap doesn't use the GPU, so when SCK System Audio capture
fails and the tap is available (macOS 14.4+), fall back to it automatically —
mirroring the existing reverse tap→SCK fallback. No manual flag needed.

## Testing
`should_recover_output` is unit-tested across the recover / streaming /
DRM-paused / not-enrolled / user-disabled cases — all 5 pass (28 device_monitor
tests total). The lid-close / clamshell SCK death that triggers recovery, and
the under-load SCK fallback, can only be exercised by the e2e-macos workflow or
manual testing.