### PR TITLE
fix(health): accurate audio hijack status and configured transcription mode

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/builder.rs
+++ b/crates/screenpipe-audio/src/audio_manager/builder.rs
@@ -77,6 +77,16 @@ pub enum TranscriptionMode {
     Batch,
 }
 
+impl TranscriptionMode {
+    /// Stable lowercase label for diagnostics / the health endpoint.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TranscriptionMode::Realtime => "realtime",
+            TranscriptionMode::Batch => "batch",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AudioManagerOptions {
     pub transcription_engine: Arc<AudioTranscriptionEngine>,

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -643,6 +643,18 @@ impl AudioManager {
         self.options.read().await.use_system_default_audio
     }
 
+    /// Best-effort, non-blocking read of the configured transcription mode.
+    ///
+    /// Uses `try_read` so the health endpoint never blocks on the options
+    /// lock; returns `None` if a writer momentarily holds it (the caller
+    /// can fall back to an activity-derived guess).
+    pub fn transcription_mode_hint(&self) -> Option<TranscriptionMode> {
+        self.options
+            .try_read()
+            .ok()
+            .map(|o| o.transcription_mode.clone())
+    }
+
     async fn record_device(&self, device: &AudioDevice) -> Result<JoinHandle<Result<()>>> {
         let options = self.options.read().await;
         let stream = self

--- a/crates/screenpipe-audio/src/metrics.rs
+++ b/crates/screenpipe-audio/src/metrics.rs
@@ -18,6 +18,11 @@ pub struct AudioPipelineMetrics {
     pub chunks_channel_full: AtomicU64,
     /// Device stream timeouts (no audio data received for >30s)
     pub stream_timeouts: AtomicU64,
+    /// Unix timestamp (secs) of the most recent stream timeout. Lets the health
+    /// check treat a hijack as *current* only when a timeout fired recently,
+    /// rather than letting one transient blip pin the status to degraded for
+    /// the rest of the run (the cumulative `stream_timeouts` count is sticky).
+    pub last_stream_timeout_ts: AtomicU64,
 
     // --- VAD stage ---
     /// Chunks that passed VAD (speech_ratio > threshold)
@@ -83,6 +88,7 @@ impl AudioPipelineMetrics {
             chunks_sent: AtomicU64::new(0),
             chunks_channel_full: AtomicU64::new(0),
             stream_timeouts: AtomicU64::new(0),
+            last_stream_timeout_ts: AtomicU64::new(0),
             vad_passed: AtomicU64::new(0),
             vad_rejected: AtomicU64::new(0),
             speech_ratio_sum_x1000: AtomicU64::new(0),
@@ -119,6 +125,11 @@ impl AudioPipelineMetrics {
 
     pub fn record_stream_timeout(&self) {
         self.stream_timeouts.fetch_add(1, Ordering::Relaxed);
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        self.last_stream_timeout_ts.store(now, Ordering::Relaxed);
     }
 
     // --- Consumer stage ---
@@ -264,6 +275,7 @@ impl AudioPipelineMetrics {
             chunks_sent,
             chunks_channel_full: self.chunks_channel_full.load(Ordering::Relaxed),
             stream_timeouts: self.stream_timeouts.load(Ordering::Relaxed),
+            last_stream_timeout_ts: self.last_stream_timeout_ts.load(Ordering::Relaxed),
             // Consumer
             chunks_received: self.chunks_received.load(Ordering::Relaxed),
             process_errors: self.process_errors.load(Ordering::Relaxed),
@@ -325,6 +337,8 @@ pub struct AudioMetricsSnapshot {
     pub chunks_sent: u64,
     pub chunks_channel_full: u64,
     pub stream_timeouts: u64,
+    /// Unix timestamp (secs) of the most recent stream timeout, or 0 if none.
+    pub last_stream_timeout_ts: u64,
 
     // Consumer stage
     pub chunks_received: u64,

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -707,9 +707,16 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
     // Detect "active_no_data" condition: device appears active (was selected and in
     // the device list) but the zero-fill watchdog has fired, indicating the stream
     // was hijacked by another app or went silent (Issue #3144). The watchdog
-    // automatically triggers a reconnect after 30s of no real audio, so this metric
-    // captures recovery attempts.
-    let stream_hijacked = audio_snap.stream_timeouts > 0;
+    // automatically triggers a reconnect after 30s of no real audio.
+    //
+    // Use a RECENT timeout, not the cumulative count: `stream_timeouts` is sticky
+    // (monotonic for the whole run), so a single transient blip — e.g. a mic
+    // reconnect during a device-monitor restart — would otherwise pin the status
+    // to "active_no_data"/degraded forever even after capture fully recovered.
+    // Only treat the stream as currently hijacked if a timeout fired within the
+    // staleness threshold; an ongoing hijack keeps re-firing and stays flagged.
+    let stream_hijacked = audio_snap.last_stream_timeout_ts > 0
+        && now_ts.saturating_sub(audio_snap.last_stream_timeout_ts) < threshold_secs;
 
     let audio_status = if state.audio_disabled {
         "disabled".to_string()
@@ -1345,51 +1352,43 @@ mod tests {
         assert!(!audio_backlog_is_stalled(200, freshness, false));
     }
 
+    // Models the time-bounded `stream_hijacked` decision from the health check.
+    // A timeout is only a *current* hijack if it fired within `threshold_secs`.
+    fn stream_hijacked(now_ts: u64, last_stream_timeout_ts: u64, threshold_secs: u64) -> bool {
+        last_stream_timeout_ts > 0 && now_ts.saturating_sub(last_stream_timeout_ts) < threshold_secs
+    }
+
+    fn audio_status(now_ts: u64, last_stream_timeout_ts: u64, global_active: bool) -> &'static str {
+        let threshold_secs = 60u64;
+        if stream_hijacked(now_ts, last_stream_timeout_ts, threshold_secs) && global_active {
+            "active_no_data"
+        } else if global_active {
+            "ok"
+        } else {
+            "not_started"
+        }
+    }
+
     #[test]
-    fn audio_status_active_no_data_when_stream_timeouts_nonzero() {
-        // This test verifies the fix for Issue #3144: detect when audio device
-        // is "active but producing no data" (hijacked or silent Bluetooth device).
-        // The stream_timeouts metric indicates the zero-fill watchdog has activated,
-        // which is the signal for active_no_data status.
+    fn audio_status_active_no_data_on_recent_timeout() {
+        // Issue #3144: a recent zero-fill watchdog timeout on an active device
+        // surfaces as "active_no_data".
+        let now = 10_000u64;
+        assert_eq!(audio_status(now, now - 5, true), "active_no_data");
+    }
 
-        // Simulate the logic in the health check: when stream_timeouts > 0 and
-        // the device is globally active, we should report "active_no_data" status.
+    #[test]
+    fn audio_status_recovers_after_stale_timeout() {
+        // Regression: a single transient timeout must NOT pin the status to
+        // degraded forever. Once it ages past the threshold, status returns to
+        // "ok" even though the cumulative stream_timeouts count is still > 0.
+        let now = 10_000u64;
+        assert_eq!(audio_status(now, now - 120, true), "ok");
+    }
 
-        let stream_timeouts = 1; // Watchdog has fired — device hijacked or silent
-        let is_global_active = true;
-
-        let stream_hijacked = stream_timeouts > 0;
-
-        // Validate: with stream_hijacked=true and is_global_active=true,
-        // audio_status should be "active_no_data", not "ok".
-        let audio_status = if stream_hijacked && is_global_active {
-            "active_no_data".to_string()
-        } else if is_global_active {
-            "ok".to_string()
-        } else {
-            "not_started".to_string()
-        };
-
-        assert_eq!(
-            audio_status, "active_no_data",
-            "audio_status should be 'active_no_data' when stream_timeouts > 0 and device is active (Issue #3144)"
-        );
-
-        // Also verify the converse: if stream_timeouts == 0, should be "ok"
-        let no_hijack = 0;
-        let is_still_active = true;
-        let stream_hijacked_2 = no_hijack > 0;
-        let audio_status_2 = if stream_hijacked_2 && is_still_active {
-            "active_no_data".to_string()
-        } else if is_still_active {
-            "ok".to_string()
-        } else {
-            "not_started".to_string()
-        };
-
-        assert_eq!(
-            audio_status_2, "ok",
-            "audio_status should be 'ok' when stream_timeouts == 0 and device is active"
-        );
+    #[test]
+    fn audio_status_ok_when_never_timed_out() {
+        let now = 10_000u64;
+        assert_eq!(audio_status(now, 0, true), "ok");
     }
 }

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -1061,14 +1061,27 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
                 } else {
                     Some(device_names)
                 },
-                // Batch/Smart mode
-                transcription_mode: if audio_snap.segments_deferred > 0
-                    || audio_snap.segments_batch_processed > 0
-                {
-                    Some("batch".to_string())
-                } else {
-                    Some("realtime".to_string())
-                },
+                // Report the CONFIGURED transcription mode, not a heuristic.
+                // The old behavior derived this from segment counters, so it
+                // reported "realtime" right after restart / during idle even
+                // when batch was configured. Observed batch *activity* is still
+                // available via segments_deferred / segments_batch_processed.
+                // Falls back to the activity-derived guess only if the options
+                // lock is momentarily contended (keeps health non-blocking).
+                transcription_mode: Some(
+                    match state.audio_manager.transcription_mode_hint() {
+                        Some(mode) => mode.as_str().to_string(),
+                        None => {
+                            if audio_snap.segments_deferred > 0
+                                || audio_snap.segments_batch_processed > 0
+                            {
+                                "batch".to_string()
+                            } else {
+                                "realtime".to_string()
+                            }
+                        }
+                    },
+                ),
                 transcription_paused: Some(transcription_paused),
                 segments_deferred: if audio_snap.segments_deferred > 0 {
                     Some(audio_snap.segments_deferred)


### PR DESCRIPTION
Two `/health` accuracy fixes.

## 1. Base audio hijack status on a recent timeout, not a cumulative count
`audio_status` was driven by `stream_timeouts > 0`, a monotonic run-lifetime
counter. A single transient timeout — e.g. a mic reconnect during a routine
device-monitor restart, or a wake/sleep blip — set it to 1 and pinned audio
health to "active_no_data"/degraded with an "appears hijacked or silent"
message for the rest of the process's life, even when capture had fully
recovered. (System Audio capture itself was fine throughout.)

Stamp `last_stream_timeout_ts` whenever a timeout is recorded and treat the
stream as currently hijacked only if one fired within the staleness threshold
(60s). A one-off blip now clears and the status returns to ok; a genuine ongoing
hijack keeps re-firing and stays flagged (preserves #3144).

## 2. Report the configured transcription mode (fixes #3989)
The `transcription_mode` field was derived from segment counters
(`segments_deferred` / `segments_batch_processed`), so it reported "realtime"
right after startup or during idle even when batch was configured — the label
lagged actual configuration. Report the configured mode directly via a
non-blocking `try_read` on the audio-manager options (falling back to the old
heuristic only if the lock is momentarily contended, keeping the endpoint
non-blocking). Observed batch activity remains available via the segment-count
fields.

## Testing
All 8 `routes::health` unit tests pass.