### PR TITLE
fix(health): report idle audio as healthy; gate tap rebuild on audio actually playing

### DIFF
--- a/crates/screenpipe-audio/src/core/mod.rs
+++ b/crates/screenpipe-audio/src/core/mod.rs
@@ -59,6 +59,23 @@ pub fn get_device_capture_time(device_name: &str) -> u64 {
         .unwrap_or_else(|| LAST_AUDIO_CAPTURE.load(Ordering::Relaxed))
 }
 
+/// True when the system's current default output device is being driven by some
+/// process right now (i.e. audio is actually playing). macOS-only signal via
+/// `kAudioDevicePropertyDeviceIsRunningSomewhere`; returns `false` on other
+/// platforms and on any CoreAudio error (fail-safe).
+///
+/// Used by the health endpoint to tell legitimate idle silence (nothing playing)
+/// apart from a genuine capture stall (audio playing but nothing captured).
+#[cfg(target_os = "macos")]
+pub fn default_output_is_running() -> bool {
+    process_tap::default_output_running_somewhere()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn default_output_is_running() -> bool {
+    false
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod e2e_ghost_word_silent_room;
 

--- a/crates/screenpipe-audio/src/core/process_tap.rs
+++ b/crates/screenpipe-audio/src/core/process_tap.rs
@@ -464,6 +464,60 @@ extern "C" fn tap_io_proc(
 }
 
 // ---------------------------------------------------------------------------
+// Silence watchdog (shared tuning + decision logic)
+// ---------------------------------------------------------------------------
+
+/// If the tap delivers only near-silent buffers for this long *while audio is
+/// actually playing on the default output*, rebuild the aggregate once. This
+/// catches the "tap anchored to a device whose aggregate sub-device has gone
+/// mute" failure mode without firing on an idle machine. Module-scoped so
+/// [`silence_rebuild_decision`] and its tests share the value.
+const WATCHDOG_SILENCE_SECS: u64 = 45;
+
+/// After a rebuild, wait at least this long before considering another — avoids
+/// ping-ponging when the real cause is that nothing is playing.
+const REBUILD_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// True when the system's current default output device is actively being
+/// driven by some process right now (`kAudioDevicePropertyDeviceIsRunningSomewhere`).
+///
+/// This is the signal that separates a genuine capture stall (audio IS playing
+/// but our aggregate delivers zeros, so a rebuild may help) from legitimate
+/// idle silence (nothing is playing, so a rebuild is pointless and — left
+/// ungated — churns the tap every ~minute forever on a quiet machine).
+///
+/// Any error reading the property yields `false` (fail-safe: prefer a missed
+/// rebuild over an infinite rebuild loop — the device-switch and exclusion-
+/// drift paths still handle real reconfiguration).
+fn default_output_running_somewhere() -> bool {
+    ca::System::default_output_device()
+        .and_then(|d| d.bool_prop(&ca::PropSelector::DEVICE_IS_RUNNING_SOMEWHERE.global_addr()))
+        .unwrap_or(false)
+}
+
+/// Pure decision for the silence watchdog: rebuild only when we've been silent
+/// long enough, the rebuild cooldown has elapsed, AND audio is actually playing
+/// (so the silence is a capture failure, not an idle machine). `audio_playing`
+/// is evaluated lazily — only once the timing gates pass — so the CoreAudio
+/// query in [`default_output_running_somewhere`] never runs on a routine tick.
+///
+/// `cooldown` is supplied by the caller (rather than read from `REBUILD_COOLDOWN`
+/// directly) so the watchdog loop can grow it with the consecutive-silence
+/// backoff streak; see `SILENCE_BACKOFF_CAP`.
+fn silence_rebuild_decision(
+    silence_elapsed: Option<std::time::Duration>,
+    since_last_rebuild: Option<std::time::Duration>,
+    cooldown: std::time::Duration,
+    audio_playing: impl FnOnce() -> bool,
+) -> bool {
+    let silent_long_enough = silence_elapsed
+        .map(|d| d.as_secs() >= WATCHDOG_SILENCE_SECS)
+        .unwrap_or(false);
+    let cooldown_ok = since_last_rebuild.map(|d| d >= cooldown).unwrap_or(true);
+    silent_long_enough && cooldown_ok && audio_playing()
+}
+
+// ---------------------------------------------------------------------------
 // Capture lifecycle
 // ---------------------------------------------------------------------------
 
@@ -740,32 +794,27 @@ pub fn spawn_process_tap_capture(
         // enough that we don't hammer CoreAudio.
         const POLL: std::time::Duration = std::time::Duration::from_millis(500);
 
-        // Silence watchdog — if the tap runs for this long with zero non-
-        // silent audio (AND the callback is firing, so it's not just that
-        // the IO proc stalled), rebuild the aggregate once. This catches
-        // the "tap anchored to BuiltInSpeaker while all app audio is
-        // routed to AirPods" failure mode reported on v2.4.46. The
-        // tap runs happily, the callback fires, but every buffer is
-        // zeros because the aggregate's sub-device has no signal and the
-        // global-tap → aggregate delivery path stays mute. See the
-        // pseudo-silent-for-a-whole-call reports around 2026-04-24.
-        const WATCHDOG_SILENCE_SECS: u64 = 45;
-        // Peak f32 amplitude below this counts as "silent enough to
-        // rebuild". Legit call audio peaks at ~0.05–0.5; this threshold
-        // only fires on truly zeroed buffers, not quiet speech.
+        // Silence watchdog — if the tap runs for WATCHDOG_SILENCE_SECS with
+        // zero non-silent audio (AND the callback is firing, AND audio is
+        // actually playing on the default output), rebuild the aggregate once.
+        // This catches the "tap anchored to a device whose aggregate sub-device
+        // has gone mute while audio plays" failure mode (pseudo-silent-for-a-
+        // whole-call reports around 2026-04-24) without churning on an idle
+        // machine. Tuning (WATCHDOG_SILENCE_SECS, REBUILD_COOLDOWN) and the
+        // decision live at module scope; see silence_rebuild_decision.
+        //
+        // Peak f32 amplitude below this counts as "silent enough to rebuild".
+        // Legit call audio peaks at ~0.05–0.5; this threshold only fires on
+        // truly zeroed buffers, not quiet speech.
         const SILENCE_AMP_EPS: f32 = 0.002;
-        // After a rebuild, give the tap this long to deliver real audio
-        // before we consider another rebuild. Avoids ping-pong when the
-        // actual cause is that nothing is playing (e.g. user isn't in a
-        // call) rather than a broken anchor.
-        const REBUILD_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60);
         // Exponential backoff for silence-driven rebuilds: if rebuilding doesn't
         // restore audio, the cause is usually "nothing is playing" rather than a
         // broken anchor, so doubling the cooldown each consecutive silence
         // rebuild stops the once-a-minute teardown/start churn (and the extra
         // CoreAudio teardown windows that go with it). Capped so the tap still
         // recovers within a few minutes once audio resumes. Reset on real audio
-        // or any non-silence rebuild (device switch / exclusion change).
+        // or any non-silence rebuild (device switch / exclusion change). The base
+        // REBUILD_COOLDOWN lives at module scope (shared with silence_rebuild_decision).
         const SILENCE_BACKOFF_CAP: u32 = 4; // 60s → 120 → 240 → 480 → 960s max
 
         let mut silence_started: Option<std::time::Instant> = None;
@@ -795,16 +844,22 @@ pub fn spawn_process_tap_capture(
             // device-change path already covers it, and rebuilding when
             // the device is genuinely asleep will just fail.
 
-            // Cooldown grows with the consecutive-silence-rebuild streak.
+            // Rebuild for silence only when the timing gates pass AND audio is
+            // ACTUALLY playing on the default output — otherwise the silence is
+            // legitimate (nothing is playing) and a rebuild would churn the tap
+            // on an idle machine. The cooldown grows with the consecutive-
+            // silence-rebuild streak (exponential backoff); the CoreAudio
+            // running-somewhere query is lazy, running only once the timing
+            // gates pass (see silence_rebuild_decision).
             let silence_cooldown = REBUILD_COOLDOWN
                 .checked_mul(1u32 << silence_rebuild_streak.min(SILENCE_BACKOFF_CAP))
                 .unwrap_or(REBUILD_COOLDOWN);
-            let should_rebuild_for_silence = silence_started
-                .map(|t| t.elapsed().as_secs() >= WATCHDOG_SILENCE_SECS)
-                .unwrap_or(false)
-                && last_rebuild
-                    .map(|t| t.elapsed() >= silence_cooldown)
-                    .unwrap_or(true);
+            let should_rebuild_for_silence = silence_rebuild_decision(
+                silence_started.map(|t| t.elapsed()),
+                last_rebuild.map(|t| t.elapsed()),
+                silence_cooldown,
+                default_output_running_somewhere,
+            );
 
             // Check the current default output device UID.
             let new_uid = match ca::System::default_output_device().and_then(|d| d.uid()) {
@@ -985,5 +1040,111 @@ mod tests {
         // Timed out, so the full deadline must have elapsed and the caller
         // (Drop) would leak the ctx instead of freeing it.
         assert!(start.elapsed() >= std::time::Duration::from_millis(50));
+    }
+
+    // --- silence watchdog decision ---------------------------------------
+    // These pin the regression fix: on an idle machine (audio not playing)
+    // the watchdog must NOT rebuild, no matter how long the silence runs.
+    // `cooldown` is passed explicitly so the same helper covers the
+    // exponential backoff the watchdog loop layers on top.
+
+    use std::cell::Cell;
+    use std::time::Duration;
+
+    #[test]
+    fn silence_rebuild_skips_when_not_silent_long_enough() {
+        // Timing gate fails → audio_playing must not even be consulted.
+        let consulted = Cell::new(false);
+        let decision = silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS - 1)),
+            None,
+            REBUILD_COOLDOWN,
+            || {
+                consulted.set(true);
+                true
+            },
+        );
+        assert!(!decision);
+        assert!(!consulted.get(), "audio_playing must be evaluated lazily");
+    }
+
+    #[test]
+    fn silence_rebuild_skips_when_no_silence_window() {
+        // silence_started == None (we just saw real audio) → never rebuild.
+        assert!(!silence_rebuild_decision(
+            None,
+            None,
+            REBUILD_COOLDOWN,
+            || true
+        ));
+    }
+
+    #[test]
+    fn silence_rebuild_skips_during_cooldown() {
+        let decision = silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS)),
+            Some(REBUILD_COOLDOWN - Duration::from_secs(1)),
+            REBUILD_COOLDOWN,
+            || true,
+        );
+        assert!(!decision);
+    }
+
+    #[test]
+    fn silence_rebuild_skips_on_idle_machine() {
+        // THE regression: silent long enough, cooldown ok, but nothing is
+        // playing → must NOT rebuild (otherwise it churns the tap forever).
+        let decision = silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS + 10)),
+            None,
+            REBUILD_COOLDOWN,
+            || false,
+        );
+        assert!(!decision);
+    }
+
+    #[test]
+    fn silence_rebuild_fires_on_genuine_stall() {
+        // Silent long enough, no prior rebuild, audio IS playing → rebuild.
+        let decision = silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS)),
+            None,
+            REBUILD_COOLDOWN,
+            || true,
+        );
+        assert!(decision);
+    }
+
+    #[test]
+    fn silence_rebuild_fires_after_cooldown_elapsed() {
+        let decision = silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS)),
+            Some(REBUILD_COOLDOWN + Duration::from_secs(1)),
+            REBUILD_COOLDOWN,
+            || true,
+        );
+        assert!(decision);
+    }
+
+    #[test]
+    fn silence_rebuild_honors_backed_off_cooldown() {
+        // Layering check: with a backed-off cooldown (4× base), a gap that
+        // would clear the BASE cooldown must still be held off, even though
+        // audio is playing and we've been silent long enough.
+        let backed_off = REBUILD_COOLDOWN * 4;
+        let since_last = REBUILD_COOLDOWN * 2; // > base, < backed-off
+        assert!(!silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS)),
+            Some(since_last),
+            backed_off,
+            || true,
+        ));
+        // Once the backed-off interval elapses, it fires.
+        assert!(silence_rebuild_decision(
+            Some(Duration::from_secs(WATCHDOG_SILENCE_SECS)),
+            Some(backed_off + Duration::from_secs(1)),
+            backed_off,
+            || true,
+        ));
     }
 }

--- a/crates/screenpipe-audio/src/core/process_tap.rs
+++ b/crates/screenpipe-audio/src/core/process_tap.rs
@@ -489,7 +489,7 @@ const REBUILD_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(60)
 /// Any error reading the property yields `false` (fail-safe: prefer a missed
 /// rebuild over an infinite rebuild loop — the device-switch and exclusion-
 /// drift paths still handle real reconfiguration).
-fn default_output_running_somewhere() -> bool {
+pub(crate) fn default_output_running_somewhere() -> bool {
     ca::System::default_output_device()
         .and_then(|d| d.bool_prop(&ca::PropSelector::DEVICE_IS_RUNNING_SOMEWHERE.global_addr()))
         .unwrap_or(false)

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -749,7 +749,16 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
     } else if now.timestamp() as u64 - last_audio_ts < threshold_secs {
         "ok".to_string()
     } else {
-        "stale".to_string()
+        // No real audio captured recently. This is the normal state of a quiet
+        // machine (content only ticks the capture clock on non-silent buffers),
+        // so only treat it as a fault ("stale") when the output device is
+        // actively playing yet we captured nothing. Otherwise it's "idle".
+        classify_silent_audio(
+            screenpipe_audio::core::default_output_is_running(),
+            crate::sleep_monitor::screen_is_locked(),
+            crate::sleep_monitor::recently_woke_from_sleep(),
+        )
+        .to_string()
     };
 
     let transcription_paused = if !state.audio_disabled {
@@ -868,7 +877,7 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
 
     let (overall_status, message, verbose_instructions, status_code) = if (frame_status == "ok"
         || frame_status == "disabled")
-        && (audio_status == "ok" || audio_status == "disabled")
+        && (audio_status == "ok" || audio_status == "disabled" || audio_status == "idle")
         && !vision_degraded
         && !audio_degraded
     {
@@ -886,7 +895,7 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
         if vision_degraded && !unhealthy_systems.contains(&"vision") {
             unhealthy_systems.push("vision");
         }
-        if audio_status != "ok" && audio_status != "disabled" {
+        if audio_status != "ok" && audio_status != "disabled" && audio_status != "idle" {
             // active_no_data is a degraded state (device hijacked but watchdog recovering)
             unhealthy_systems.push("audio");
         }
@@ -1437,5 +1446,27 @@ mod tests {
     fn silent_audio_is_idle_just_after_wake() {
         // Recently woke from sleep — capture re-initializing, grace period.
         assert_eq!(super::classify_silent_audio(true, false, true), "idle");
+    }
+
+    // Models the audio clause of the overall-status rollup: which audio_status
+    // values keep the endpoint healthy (200) vs. degraded (503).
+    fn audio_status_is_healthy(audio_status: &str) -> bool {
+        audio_status == "ok" || audio_status == "disabled" || audio_status == "idle"
+    }
+
+    #[test]
+    fn idle_audio_is_healthy() {
+        // "idle" (quiet machine, nothing playing) must NOT degrade the endpoint.
+        assert!(audio_status_is_healthy(super::classify_silent_audio(
+            false, false, false
+        )));
+    }
+
+    #[test]
+    fn stale_audio_is_degraded() {
+        // "stale" (output playing but capture silent) MUST degrade the endpoint.
+        assert!(!audio_status_is_healthy(super::classify_silent_audio(
+            true, false, false
+        )));
     }
 }

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -318,6 +318,28 @@ pub struct AudioPipelineHealthInfo {
 /// killed by a watchdog).
 const HEALTH_RESPONSE_BUDGET: std::time::Duration = std::time::Duration::from_secs(2);
 
+/// Classify a stretch of "no real audio captured recently."
+///
+/// Audio content only ticks the capture timestamp on non-silent buffers
+/// (a deliberate anti-hijack measure), so "no recent audio" is the normal state
+/// of a quiet machine — NOT evidence of a fault. The only case that is a genuine
+/// fault, and that no other health signal already covers, is: the default output
+/// device is actively being driven (something is playing) yet we captured nothing.
+///
+/// * `output_running` — default output device is being driven right now.
+/// * `screen_locked`  — capture is intentionally paused (screen lock / display sleep).
+/// * `recently_woke`  — within the post-wake grace window; capture re-initializing.
+///
+/// Returns `"stale"` (a degraded fault) only for output-playing-but-silent;
+/// everything else is `"idle"` (healthy).
+fn classify_silent_audio(output_running: bool, screen_locked: bool, recently_woke: bool) -> &'static str {
+    if output_running && !screen_locked && !recently_woke {
+        "stale"
+    } else {
+        "idle"
+    }
+}
+
 #[oasgen]
 pub async fn health_check(State(state): State<Arc<AppState>>) -> JsonResponse<HealthCheckResponse> {
     let now_ts = std::time::SystemTime::now()
@@ -1391,5 +1413,29 @@ mod tests {
             audio_status_2, "ok",
             "audio_status should be 'ok' when stream_timeouts == 0 and device is active"
         );
+    }
+
+    #[test]
+    fn silent_audio_is_stale_only_when_output_playing() {
+        // Output is being driven but we captured nothing — genuine capture stall.
+        assert_eq!(super::classify_silent_audio(true, false, false), "stale");
+    }
+
+    #[test]
+    fn silent_audio_is_idle_when_nothing_playing() {
+        // Nothing playing — legitimate idle, not a fault.
+        assert_eq!(super::classify_silent_audio(false, false, false), "idle");
+    }
+
+    #[test]
+    fn silent_audio_is_idle_when_screen_locked() {
+        // Screen locked — capture paused, silence expected even if output "runs".
+        assert_eq!(super::classify_silent_audio(true, true, false), "idle");
+    }
+
+    #[test]
+    fn silent_audio_is_idle_just_after_wake() {
+        // Recently woke from sleep — capture re-initializing, grace period.
+        assert_eq!(super::classify_silent_audio(true, false, true), "idle");
     }
 }


### PR DESCRIPTION
A quiet Mac (nothing playing, or asleep/locked) was reported as
`degraded`/`stale` even though nothing was wrong. Two coupled changes fix the
root cause and the symptom. Built on top of the existing `SILENCE_BACKOFF_CAP`
silence-rebuild backoff — it is extended, not replaced.

## 1. Gate the Process Tap silence-rebuild on audio actually playing
The silence watchdog rebuilds the aggregate when the tap delivers only
near-silent buffers for `WATCHDOG_SILENCE_SECS`. The existing exponential
backoff stretches the interval between rebuilds but still rebuilds forever on a
quiet machine — churning capture and opening a brief gap each time when nothing
is wrong.

Add `kAudioDevicePropertyDeviceIsRunningSomewhere` for the default output as an
additional precondition, **layered on top of the backoff**: only rebuild when
audio is actually being driven through the output. Idle machine → gate is false
→ no rebuild at all; audio playing but aggregate delivers zeros (the real
failure) → timing/backoff gates and the running-somewhere gate all pass → it
rebuilds. The CoreAudio query is lazy (runs only after the timing gates pass).
The decision is factored into the pure, unit-tested `silence_rebuild_decision`
helper, which takes the (possibly backed-off) cooldown explicitly.

## 2. Report idle audio as healthy; reserve `stale` for a real fault
`/health` mapped any silent audio to `stale` → `degraded`/503. But
`update_device_capture_time` is only stamped on non-silent buffers (deliberate
anti-hijack design), so "no recent data" is the normal state of a quiet machine,
not a fault. A 503 should require positive evidence of a fault, never mere
absence of recent data.

Add `classify_silent_audio(output_running, screen_locked, recently_woke)`:
report `stale` (→ degraded) only when the default output is actively playing
while we capture silence (and the screen isn't locked / we didn't just wake);
otherwise report `idle`, which rolls up as healthy. Mic-stream death is still
caught separately via `stream_timeouts` → `active_no_data`.

## Testing
- `process_tap`: 20 tests pass — backoff (`drain_active_*`) and the layered gate
  (`silence_rebuild_*`, including idle-machine, cooldown, and a backed-off-cooldown
  case) coexist.
- `routes::health`: 12 tests pass — 4 `classify_silent_audio` cases plus
  `idle_audio_is_healthy` and `stale_audio_is_degraded`.