### PR TITLE
fix(ci): re-sign Linux AppImage after GLib repack — Linux auto-update has been broken since v2.2.115

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -786,7 +786,27 @@ jobs:
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root
             echo "AppImage repacked successfully"
+
+            # Re-sign for the Tauri updater - the .sig from `tauri build` was made for
+            # the pre-repack bytes, so shipping it breaks auto-update on every Linux
+            # client ("The signature verification failed"). Same pattern as the macOS
+            # post-staple and Windows post-SSL.com re-signs. Reads the key from
+            # TAURI_SIGNING_PRIVATE_KEY(_PASSWORD) env, like the Windows step.
+            rm -f "$APPIMAGE.sig"
+            bunx tauri signer sign "$APPIMAGE"
+            echo "Updater signature regenerated for repacked AppImage"
           ' _ {} \;
+
+          # find -exec does not propagate failures from the inner bash, so fail the
+          # build hard if any AppImage ends up without a signature newer than itself -
+          # a stale (pre-repack) .sig bricks auto-update for every Linux user.
+          for f in src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage; do
+            [ -f "$f" ] || continue
+            if [ ! -f "$f.sig" ] || [ "$f" -nt "$f.sig" ]; then
+              echo "❌ missing or stale updater signature for $f - auto-update would be broken"
+              exit 1
+            fi
+          done
 
       - name: Install CodeSignTool for SSL.com EV signing (Windows)
         if: matrix.os_type == 'windows'


### PR DESCRIPTION
## Problem

**Auto-update is broken for every Linux user, since March (app-v2.2.115).**

Found while debugging a user feedback log bundle (Discord feedback 2026-06-12, user `0b3652c5`, stuck on 2.4.123):

```
WARN screenpipe_app::updates: Failed to check for updates: The signature verification failed
```

Reproduced independently of the user: downloading the live Linux artifact and verifying the manifest signature with minisign fails:

```
$ curl .../api/app-update/stable/linux-x86_64/2.4.123   # → offers 2.5.33
$ minisign -V -p app-pubkey.pub -x manifest-sig.minisig -m screenpipe_2.5.33_amd64.AppImage
Signature verification failed
```

Root cause: f688782d7 ("remove bundled GLib to fix Fedora ABI mismatch") repacks the AppImage with `appimagetool` **after** `tauri build` has already produced the updater `.sig`. The upload step then ships the pre-repack signature next to the post-repack bytes, so every client rejects the update and silently stays on its version forever.

```
 BEFORE (broken)                          AFTER (this PR)
 ───────────────                          ───────────────
 tauri build ──► AppImage + .sig          tauri build ──► AppImage + .sig
       │                                        │
 appimagetool repack                      appimagetool repack
   (bytes change,                               │
    .sig now stale) ──► upload both       rm stale .sig
       │                                  bunx tauri signer sign  ◄─ matches shipped bytes
       ▼                                        │
 client: "signature                       guard: fail build if any AppImage
 verification failed"                     has missing/older-than-binary .sig
 (stuck forever)                                │
                                                ▼
                                          client updates normally
```

## Fix

Mirrors the two existing precedents in this same workflow: the macOS post-staple tarball re-sign and the Windows post-SSL.com re-sign (whose comment literally says "auto-updater would be broken").

1. After the appimagetool repack, delete the stale `.sig` and run `bunx tauri signer sign "$APPIMAGE"` (key comes from `TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)` env already present on the step).
2. Add a hard post-`find` guard: the build fails if any AppImage lacks a `.sig` newer than itself — because `find -exec` swallows inner script failures, without this a future regression would ship silently again.

## Verification

Tested the exact sequence locally with a throwaway `tauri signer generate` key (CLI pinned `@tauri-apps/cli@2.11.2`, same as repo):

- build-time sig → simulated repack (bytes changed) → **guard catches stale sig** ✓
- re-sign snippet → **guard passes** ✓
- re-signed artifact **minisign-verifies against the pubkey** ✓
- `yaml.safe_load` + `bash -n` on outer and inner scripts ✓

First release cut after this merges un-bricks auto-update for all Linux installs (their pubkey never changed, so old clients verify the newly signed artifact fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)