### PR TITLE
fix(ci): cargo fmt pipes_api.rs (unbreak Code Quality)

### DIFF
--- a/crates/screenpipe-engine/src/pipes_api.rs
+++ b/crates/screenpipe-engine/src/pipes_api.rs
@@ -393,4 +393,3 @@ pub async fn set_pipe_favorite(
         Err(e) => Json(json!({ "error": e.to_string() })),
     }
 }
-


### PR DESCRIPTION
## what

`cargo fmt --all -- --check` was failing on main, reding the **Code Quality & Optimization** workflow since #4072. A trailing blank line at the end of `crates/screenpipe-engine/src/pipes_api.rs` slipped through.

## fix

Ran `cargo fmt -p screenpipe-engine`. One-line deletion. `cargo fmt --all -- --check` now exits 0.

## flow

```
pipes_api.rs (end of file)
  } 
- <trailing blank line>   <-- removed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)