### PR TITLE
fix(pi): surface exit status and output tails when the Pi agent install fails silently

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -792,19 +792,20 @@ fn run_command_output(mut cmd: Command) -> Result<Output, String> {
 fn format_install_failure(tool: &str, output: &Output) -> String {
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);
+    // Prefer stderr, fall back to stdout (bun reports some failures there),
+    // and never let both-empty reduce the message to a bare "stderr: " —
+    // signal deaths (SIGILL/SIGKILL) produce exactly that shape.
     let details = if !stderr.trim().is_empty() {
         truncate_stderr(&stderr)
+    } else if !stdout.trim().is_empty() {
+        format!("(stdout) {}", truncate_stderr(&stdout))
     } else {
-        truncate_stderr(&stdout)
+        "(no output captured)".to_string()
     };
     format!(
-        "{} install failed (exit {}). stderr: {}",
+        "{} install failed ({}). output: {}",
         tool,
-        output
-            .status
-            .code()
-            .map(|c| c.to_string())
-            .unwrap_or_else(|| "signal".to_string()),
+        screenpipe_core::agents::pi::describe_exit_status(&output.status),
         details
     )
 }
@@ -849,6 +850,16 @@ fn verify_pi_package_install(install_dir: &Path) -> Result<(), String> {
 fn run_pi_package_install(install_dir: &Path, bun: &str) -> Result<(), String> {
     let cache_dir = install_dir.join(".bun-cache");
     let _ = std::fs::create_dir_all(&cache_dir);
+
+    // Log the exact command + bun version so a failed install is reproducible
+    // from the log alone; a bun that can't even execute (e.g. SIGILL on an
+    // unsupported CPU) shows up right here as the version probe failing.
+    info!(
+        "Running Pi dependency install: {} install (cwd: {}, bun version: {})",
+        bun,
+        install_dir.display(),
+        screenpipe_core::agents::pi::bun_version_string(bun),
+    );
 
     let mut bun_cmd = Command::new(bun);
     bun_cmd
@@ -2941,6 +2952,40 @@ mod tests {
         let dist = pi_dir.join("dist");
         std::fs::create_dir_all(&dist).expect("create dist");
         std::fs::write(dist.join("cli.js"), "console.log('pi')").expect("write cli");
+    }
+
+    /// Regression guard for the empty "Pi background install failed: " log
+    /// (Linux AppImage report, 2026-06-12): a bun that exits non-zero without
+    /// writing to either stream must still produce an actionable message with
+    /// the exit status in it.
+    #[cfg(unix)]
+    #[test]
+    fn format_install_failure_never_empty_details() {
+        use std::os::unix::process::ExitStatusExt;
+        use std::process::{ExitStatus, Output};
+
+        let silent = Output {
+            status: ExitStatus::from_raw(0x0100), // exit code 1
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        };
+        let msg = super::format_install_failure("bun", &silent);
+        assert_eq!(
+            msg,
+            "bun install failed (exit code 1). output: (no output captured)"
+        );
+
+        let sigkill = Output {
+            status: ExitStatus::from_raw(9), // killed by signal 9
+            stdout: b"partial progress".to_vec(),
+            stderr: Vec::new(),
+        };
+        let msg = super::format_install_failure("bun", &sigkill);
+        assert!(
+            msg.contains("killed by signal 9") && msg.contains("(stdout) partial progress"),
+            "signal + stdout fallback must both surface: {}",
+            msg
+        );
     }
 
     #[test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1756,14 +1756,23 @@ impl AgentExecutor for PiExecutor {
 
         std::fs::create_dir_all(&install_dir)?;
 
-        info!("installing pi into {} via bun …", install_dir.display());
+        // Log the exact command + bun version up front so a failed install is
+        // reproducible from the log alone (and a bun that can't even run —
+        // e.g. SIGILL on an unsupported CPU — is exposed before the install).
+        let args = ["add", PI_PACKAGE, PI_AI_PACKAGE, "@anthropic-ai/sdk"];
+        info!(
+            "installing pi into {} via bun at {} (version: {}); command: bun {}",
+            install_dir.display(),
+            bun,
+            bun_version_string(&bun),
+            args.join(" "),
+        );
 
         // Seed package.json with overrides to fix lru-cache resolution on Windows
         seed_pi_package_json(&install_dir);
 
         let mut cmd = std::process::Command::new(&bun);
-        cmd.current_dir(&install_dir)
-            .args(["add", PI_PACKAGE, PI_AI_PACKAGE, "@anthropic-ai/sdk"]);
+        cmd.current_dir(&install_dir).args(args);
 
         #[cfg(windows)]
         {
@@ -1772,14 +1781,19 @@ impl AgentExecutor for PiExecutor {
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
 
-        let output = cmd.output()?;
+        let output = cmd
+            .output()
+            .map_err(|e| anyhow!("pi installation failed: could not run bun at {}: {}", bun, e))?;
         if output.status.success() {
             info!("pi installed successfully into {}", install_dir.display());
             Ok(())
         } else {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            error!("pi installation failed: {}", stderr);
-            Err(anyhow!("pi installation failed: {}", stderr))
+            // Include exit status + both stream tails: bun can exit non-zero
+            // with an EMPTY stderr (signal death, or diagnostics on stdout),
+            // which used to log here as "pi installation failed: " — nothing.
+            let msg = format_subprocess_failure("bun add", &output);
+            error!("pi installation failed: {}", msg);
+            Err(anyhow!("pi installation failed: {}", msg))
         }
     }
 
@@ -2089,6 +2103,87 @@ pub fn find_bun_executable() -> Option<String> {
     ];
 
     paths.into_iter().find(|p| std::path::Path::new(p).exists())
+}
+
+/// Human-readable description of how a subprocess terminated.
+///
+/// Always non-empty: "exit code N", "killed by signal N (NAME)" on unix, or
+/// "terminated without exit code". Signal names matter on Linux/AppImage where
+/// bun can die without writing a single byte to stderr (e.g. SIGILL when the
+/// bundled bun build needs CPU instructions the host lacks, or SIGKILL from
+/// the OOM killer) — exactly the case that used to log as an empty error.
+pub fn describe_exit_status(status: &std::process::ExitStatus) -> String {
+    if let Some(code) = status.code() {
+        return format!("exit code {}", code);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(sig) = status.signal() {
+            let name = match sig {
+                4 => " (SIGILL, illegal instruction; the bun binary may not support this CPU)",
+                6 => " (SIGABRT)",
+                9 => " (SIGKILL, possibly the OOM killer)",
+                11 => " (SIGSEGV)",
+                15 => " (SIGTERM)",
+                _ => "",
+            };
+            return format!("killed by signal {}{}", sig, name);
+        }
+    }
+    "terminated without exit code".to_string()
+}
+
+/// Last `max` bytes of a captured process stream, lossy-decoded and
+/// char-boundary safe, with an "(empty)" placeholder so a silent subprocess
+/// can never reduce an error message to nothing.
+pub fn output_tail(bytes: &[u8], max: usize) -> String {
+    let s = String::from_utf8_lossy(bytes);
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return "(empty)".to_string();
+    }
+    if trimmed.len() <= max {
+        return trimmed.to_string();
+    }
+    let mut start = trimmed.len().saturating_sub(max);
+    while start < trimmed.len() && !trimmed.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("...{}", &trimmed[start..])
+}
+
+/// One-line, always-non-empty summary of a failed subprocess: exit status plus
+/// the tail of BOTH streams (bun reports some install failures on stdout, and
+/// signal deaths leave both streams empty — the status is then the only clue).
+pub fn format_subprocess_failure(what: &str, output: &std::process::Output) -> String {
+    const TAIL: usize = 2048;
+    format!(
+        "{} {}; stderr: {}; stdout: {}",
+        what,
+        describe_exit_status(&output.status),
+        output_tail(&output.stderr, TAIL),
+        output_tail(&output.stdout, TAIL),
+    )
+}
+
+/// Best-effort `bun --version` for install-start logging. Never fails; a
+/// crashing bun (e.g. SIGILL on unsupported CPUs) is reported inline, which
+/// diagnoses the install failure before the install is even attempted.
+pub fn bun_version_string(bun: &str) -> String {
+    let mut cmd = std::process::Command::new(bun);
+    cmd.arg("--version");
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    match cmd.output() {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        Ok(o) => format!("unknown ({})", describe_exit_status(&o.status)),
+        Err(e) => format!("unknown (failed to run: {})", e),
+    }
 }
 
 /// Returns the screenpipe-managed pi install directory (`~/.screenpipe/pi-agent/` or SCREENPIPE_DATA_DIR/pi-agent).
@@ -3267,5 +3362,73 @@ mod tests {
             !lock_path.exists(),
             "stale bun.lock must be cleared so bun re-resolves from the fresh manifest"
         );
+    }
+
+    /// Regression guard for the empty "pi installation failed: " log (Linux
+    /// AppImage report, 2026-06-12): a bun that dies without writing to
+    /// stderr must still produce an actionable error message.
+    #[cfg(unix)]
+    #[test]
+    fn install_failure_message_is_never_empty() {
+        use std::os::unix::process::ExitStatusExt;
+        use std::process::{ExitStatus, Output};
+
+        // Non-zero exit, NOTHING on either stream — the exact shape that used
+        // to format as an empty error.
+        let silent_failure = Output {
+            status: ExitStatus::from_raw(0x0100), // exit code 1
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        };
+        let msg = format_subprocess_failure("bun add", &silent_failure);
+        assert_eq!(
+            msg,
+            "bun add exit code 1; stderr: (empty); stdout: (empty)"
+        );
+
+        // Killed by a signal (raw status = signal number, no exit code).
+        let sigill = Output {
+            status: ExitStatus::from_raw(4),
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        };
+        let msg = format_subprocess_failure("bun add", &sigill);
+        assert!(
+            msg.contains("killed by signal 4") && msg.contains("SIGILL"),
+            "signal deaths must be named: {}",
+            msg
+        );
+
+        // stderr empty but stdout has the diagnostics — both tails included.
+        let stdout_only = Output {
+            status: ExitStatus::from_raw(0x0100),
+            stdout: b"error: tarball download failed".to_vec(),
+            stderr: Vec::new(),
+        };
+        let msg = format_subprocess_failure("bun add", &stdout_only);
+        assert!(
+            msg.contains("stdout: error: tarball download failed"),
+            "stdout diagnostics must survive: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn output_tail_truncates_to_last_bytes() {
+        assert_eq!(output_tail(b"", 100), "(empty)");
+        assert_eq!(output_tail(b"   \n ", 100), "(empty)");
+        assert_eq!(output_tail(b"short error", 100), "short error");
+
+        let long = "x".repeat(3000) + "the real error is at the end";
+        let tail = output_tail(long.as_bytes(), 2048);
+        assert!(tail.starts_with("..."));
+        assert!(tail.ends_with("the real error is at the end"));
+        assert!(tail.len() <= 2048 + 3);
+
+        // Multi-byte chars at the cut point must not panic.
+        let unicode = "é".repeat(2000);
+        let tail = output_tail(unicode.as_bytes(), 101);
+        assert!(tail.starts_with("..."));
+        assert!(tail.ends_with('é'));
     }
 }


### PR DESCRIPTION
## Problem

From a user log bundle (2026-06-12, Ubuntu AppImage, app 2.4.123): the Pi chat agent fails to install and the logged error is EMPTY, so chat silently never works and the log is undiagnosable:

```
INFO screenpipe_app::pi: Found bundled bun at: /tmp/.mount_screenJpGmli/usr/bin/bun
INFO screenpipe_app::pi: Pi not found - installing into /home/agbeli/.screenpipe/pi-agent via bun
WARN screenpipe_app::pi: Pi background install failed (non-fatal):
WARN screenpipe_app::server_core: pi agent install failed: pi installation failed:
```

Browser console then shows `[Pi] Not running, auto-starting before sending message` and the user gets nothing.

This pairs with PR #4077 (Linux AppImage updater re-signing fix), found in the same user log investigation.

## Root cause of the empty message

`PiExecutor::ensure_installed` in `crates/screenpipe-core/src/agents/pi.rs` built its error from stderr alone and discarded everything else:

```rust
let output = cmd.output()?;
...
let stderr = String::from_utf8_lossy(&output.stderr);
Err(anyhow!("pi installation failed: {}", stderr))   // stderr can be EMPTY
```

When bun exits without writing a byte to stderr, the whole error formats to an empty string. That happens in exactly the failure modes you expect on Linux/AppImage hosts:

- bun killed by a signal: SIGILL when the bundled bun build uses CPU instructions the host lacks, SIGKILL from the OOM killer, SIGSEGV. Signal deaths leave both streams empty and `status.code()` is `None`.
- bun printing its diagnostics to stdout instead of stderr (bun does this for some install failures).

The exit status and stdout were never captured into the message, so the only clues were thrown away.

The app-side `format_install_failure` (`apps/screenpipe-app-tauri/src-tauri/src/pi.rs`) was better (it had the exit code) but still printed a bare trailing `stderr: ` when both streams were empty, and printed the literal word `signal` without the signal number.

## What changed

`crates/screenpipe-core/src/agents/pi.rs`:
- New helpers (pub, reused by the app): `describe_exit_status` (exit code, or signal number with name: SIGILL/SIGABRT/SIGKILL/SIGSEGV/SIGTERM), `output_tail` (last 2KB of a stream, char-boundary safe, `(empty)` placeholder), `format_subprocess_failure` (status + stderr tail + stdout tail, never empty), `bun_version_string` (best-effort `bun --version`).
- `ensure_installed` now logs the bun path, bun version, and exact command line at install start (a bun that cannot even execute, e.g. SIGILL, is exposed by the version probe before the install). Spawn errors get context (bun path). Failures report exit status plus both stream tails.

`apps/screenpipe-app-tauri/src-tauri/src/pi.rs`:
- `format_install_failure` uses `describe_exit_status`, falls back to stdout with a `(stdout)` prefix, and prints `(no output captured)` when both streams are empty.
- `run_pi_package_install` logs bun path, cwd, and bun version at install start (covers fresh install, repair, and upgrade paths).

Regression tests in both files: a bun that dies silently (non-zero exit or signal, nothing on either stream) must never again format to an empty error.

## Before / after

```
BEFORE (the actual user log):

  WARN screenpipe_app::server_core: pi agent install failed: pi installation failed:

AFTER (same failure, signal death case):

  INFO installing pi into /home/agbeli/.screenpipe/pi-agent via bun at
       /tmp/.mount_screenJpGmli/usr/bin/bun (version: unknown (killed by signal 4
       (SIGILL, illegal instruction; the bun binary may not support this CPU)));
       command: bun add @earendil-works/pi-coding-agent@0.75.4 @earendil-works/pi-ai@0.75.4 @anthropic-ai/sdk
  WARN pi agent install failed: pi installation failed: bun add killed by signal 4
       (SIGILL, illegal instruction; the bun binary may not support this CPU);
       stderr: (empty); stdout: (empty)

AFTER (diagnostics-on-stdout case):

  WARN pi agent install failed: pi installation failed: bun add exit code 1;
       stderr: (empty); stdout: error: failed to download tarball ...
```

User-visible surface when chat is opened after a failed install (this toast path already existed via `pi_start` -> `take_pi_install_error`; it only ever rendered nothing because the message itself was empty):

```
 +--------------------------------------------------------------+
 | (x) failed to start AI assistant (screenpipe-cloud)          |
 |     Pi not found after install attempt. Install error: bun   |
 |     install failed (killed by signal 9 (SIGKILL, possibly    |
 |     the OOM killer)). output: (no output captured)  Try      |
 |     restarting the app or delete ~/.screenpipe/pi-agent      |
 |     and restart.                                             |
 +--------------------------------------------------------------+
```

## AppImage specifics reviewed (no behavior change)

While in there I checked the plausible AppImage failure causes: both installers already set the subprocess cwd to the install dir (`~/.screenpipe/pi-agent`), not the read-only mount, and the env (HOME etc.) is inherited normally. I did not find a change I was confident enough to ship blind, so this PR is scoped to error surfacing plus the install-start log; with the new logging the next occurrence of this failure will name itself.

Follow-up candidates (not in this PR): consider shipping the bun baseline build for Linux x64 if SIGILL turns out to be the cause, and a proactive toast at install-failure time instead of at first chat attempt.

## Verification

- `cargo check -p screenpipe-core`: clean (2 pre-existing deprecation warnings in `pipes/mod.rs`, untouched by this PR).
- `cargo test -p screenpipe-core --lib install_failure_message_is_never_empty output_tail_truncates_to_last_bytes`: 2 passed.
- `cargo check` in `apps/screenpipe-app-tauri/src-tauri`: finished, exit 0, no warnings in the touched files (fresh worktree needed the usual sidecar symlinks and placeholder `out/index.html` to satisfy build.rs; environment provisioning only).
- `cargo test format_install_failure_never_empty_details` in `apps/screenpipe-app-tauri/src-tauri`: 1 passed, exit 0 (full test-profile build of the app crate).
- No TypeScript touched, so no frontend typecheck was needed.
- Not verified end to end on a Linux AppImage host (no Linux machine here); the change is message construction plus two info logs, no control flow change in the install itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
