### PR TITLE
test: add unit tests for video quality preset mapping

### DIFF
--- a/crates/screenpipe-core/src/video.rs
+++ b/crates/screenpipe-core/src/video.rs
@@ -191,3 +191,53 @@ pub async fn finish_ffmpeg_process(child: Child, stdin: Option<ChildStdin>) {
         Err(e) => error!("Failed to wait for FFmpeg process: {}", e),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crf_maps_known_and_falls_back() {
+        assert_eq!(video_quality_to_crf("low"), "32");
+        assert_eq!(video_quality_to_crf("high"), "18");
+        assert_eq!(video_quality_to_crf("max"), "14");
+        assert_eq!(video_quality_to_crf("balanced"), "23");
+        assert_eq!(video_quality_to_crf("nonsense"), "23"); // fallback arm
+    }
+
+    #[test]
+    fn preset_maps_known_and_falls_back() {
+        assert_eq!(video_quality_to_preset("high"), "fast");
+        assert_eq!(video_quality_to_preset("max"), "medium");
+        assert_eq!(video_quality_to_preset("low"), "ultrafast");
+        assert_eq!(video_quality_to_preset("balanced"), "ultrafast");
+        assert_eq!(video_quality_to_preset("nonsense"), "ultrafast");
+    }
+
+    #[test]
+    fn jpeg_q_maps_known_and_falls_back() {
+        assert_eq!(video_quality_to_jpeg_q("low"), "18");
+        assert_eq!(video_quality_to_jpeg_q("high"), "4");
+        assert_eq!(video_quality_to_jpeg_q("max"), "2");
+        assert_eq!(video_quality_to_jpeg_q("balanced"), "10");
+        assert_eq!(video_quality_to_jpeg_q("nonsense"), "10");
+    }
+
+    #[test]
+    fn max_snapshot_width_maps_known_and_falls_back() {
+        assert_eq!(video_quality_to_max_snapshot_width("low"), 1280);
+        assert_eq!(video_quality_to_max_snapshot_width("high"), 3840);
+        assert_eq!(video_quality_to_max_snapshot_width("max"), 0); // native
+        assert_eq!(video_quality_to_max_snapshot_width("balanced"), 1920);
+        assert_eq!(video_quality_to_max_snapshot_width("nonsense"), 1920);
+    }
+
+    #[test]
+    fn jpeg_quality_maps_known_and_falls_back() {
+        assert_eq!(video_quality_to_jpeg_quality("low"), 60);
+        assert_eq!(video_quality_to_jpeg_quality("high"), 85);
+        assert_eq!(video_quality_to_jpeg_quality("max"), 92);
+        assert_eq!(video_quality_to_jpeg_quality("balanced"), 80);
+        assert_eq!(video_quality_to_jpeg_quality("nonsense"), 80);
+    }
+}


### PR DESCRIPTION
## description

Adds unit tests for the five `video_quality_to_*` preset-mapping helpers in `screenpipe-core` (`video.rs`):

- `video_quality_to_crf`
- `video_quality_to_preset`
- `video_quality_to_jpeg_q`
- `video_quality_to_max_snapshot_width`
- `video_quality_to_jpeg_quality`

Each helper maps a quality preset string (`low`/`balanced`/`high`/`max`) to an ffmpeg/JPEG encoding parameter, and falls back to the balanced default for any unknown input. They had no test coverage. The new `#[cfg(test)]` module asserts every known preset plus the fallback arm.

Test-only change — no production code is touched and runtime behavior is unchanged. The tests lock the current mappings so future edits to these encoding defaults are intentional rather than accidental.

related issue: n/a

## before

n/a — no behavior change (test-only addition; nothing to record).

## after

n/a — no behavior change (test-only addition; nothing to record).

## how to test

1. `cargo test -p screenpipe-core video::tests`
2. Confirm the five `*_maps_known_and_falls_back` tests pass (0 failures).

## desktop app checklist (if applicable)

N/A — change is confined to the `screenpipe-core` crate. No `#[tauri::command]` handlers or frontend-exported Rust types are added or changed.
