### PR TITLE
fix(ui): use download icon for bulk import button

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -81,7 +81,7 @@ import {
   CheckCircle2,
   XCircle,
   Circle,
-  Upload,
+  Download,
   Trash2,
   Search,
   ListTodo,
@@ -1295,7 +1295,7 @@ function TranscriptionDictionary({
               className="h-7 text-xs px-2 gap-1"
               onClick={() => setShowBulk(!showBulk)}
             >
-              <Upload className="h-3 w-3" />
+              <Download className="h-3 w-3" />
               bulk import
             </Button>
             {vocabularyWords.length > 0 && (


### PR DESCRIPTION
## Summary:

Fixes #3999 

<img width="1204" height="462" alt="image" src="https://github.com/user-attachments/assets/3df8680b-6591-4655-86dc-7879df5999a6" />


- Replace `Upload` (↑) icon with `Download` (↓) on the **Bulk Import** button in Settings → Recording → Custom Vocabulary
- `Upload` implies sending data out; `Download` correctly signals bringing data into the app, matching standard import conventions