### PR TITLE
test: cover safe_byte_prefix exact-fit and empty input

### DIFF
--- a/crates/screenpipe-core/src/strings.rs
+++ b/crates/screenpipe-core/src/strings.rs
@@ -96,4 +96,13 @@ mod tests {
         // Emoji count as one char each — must not split.
         assert_eq!(truncate_string("a🎉b🎉c", 3), "a🎉b…");
     }
+
+    #[test]
+    fn safe_byte_prefix_exact_fit_and_empty() {
+        // Exact byte length returns the whole string (the `<=` boundary).
+        assert_eq!(safe_byte_prefix("abc", 3), "abc");
+        // Empty input is always returned as-is, even when max_bytes is 0.
+        assert_eq!(safe_byte_prefix("", 0), "");
+        assert_eq!(safe_byte_prefix("", 5), "");
+    }
 }


### PR DESCRIPTION
## description

Adds a unit test for two previously-uncovered edges of `safe_byte_prefix` in `screenpipe-core` (`strings.rs`):

- `max_bytes` exactly equal to the string's byte length (the `<=` boundary — should return the whole string)
- empty input, including `max_bytes == 0` (should return `""`)

Test-only change — no production code touched, behavior unchanged. Rounds out the existing `safe_byte_prefix` coverage (short / multibyte / emoji / zero) with the exact-fit and empty cases.

related issue: n/a

## before / after

n/a — no behavior change (test-only addition; nothing to record).

## how to test

1. `cargo test -p screenpipe-core safe_byte_prefix`
2. Confirm the `safe_byte_prefix_*` tests pass (0 failures).

## desktop app checklist (if applicable)

N/A — confined to the `screenpipe-core` crate; no `#[tauri::command]` handlers or frontend-exported types added or changed.
