### PR TITLE
style: cargo fmt — unformatted files from #4086 break every PR's fmt gate

### DIFF
--- a/crates/screenpipe-db/tests/outputs_saf_test.rs
+++ b/crates/screenpipe-db/tests/outputs_saf_test.rs
@@ -11,7 +11,10 @@ async fn setup_test_db() -> DatabaseManager {
     let db = DatabaseManager::new("sqlite::memory:", Default::default())
         .await
         .unwrap();
-    sqlx::migrate!("./src/migrations").run(&db.pool).await.unwrap();
+    sqlx::migrate!("./src/migrations")
+        .run(&db.pool)
+        .await
+        .unwrap();
     db
 }
 
@@ -55,7 +58,15 @@ async fn outputs_insert_and_get_roundtrip_saf_columns() {
         Some(3),
     )
     .await;
-    let plain_id = insert(&db, "my-pipe", "/outputs/pipe/my-pipe/notes.md", None, None, None).await;
+    let plain_id = insert(
+        &db,
+        "my-pipe",
+        "/outputs/pipe/my-pipe/notes.md",
+        None,
+        None,
+        None,
+    )
+    .await;
 
     let saf = db.get_output_by_id(saf_id).await.unwrap();
     assert_eq!(saf.kind, "saf");
@@ -134,7 +145,15 @@ async fn outputs_get_by_artifact_id_scoped_by_source() {
 #[tokio::test]
 async fn outputs_update_sets_and_clears_saf_columns() {
     let db = setup_test_db().await;
-    let id = insert(&db, "my-pipe", "/outputs/pipe/my-pipe/a.json", None, None, None).await;
+    let id = insert(
+        &db,
+        "my-pipe",
+        "/outputs/pipe/my-pipe/a.json",
+        None,
+        None,
+        None,
+    )
+    .await;
 
     // upgrade a plain row to SAF
     db.update_output(
@@ -210,9 +229,20 @@ async fn outputs_list_carries_saf_columns() {
         Some(4),
     )
     .await;
-    insert(&db, "my-pipe", "/outputs/pipe/my-pipe/notes.md", None, None, None).await;
+    insert(
+        &db,
+        "my-pipe",
+        "/outputs/pipe/my-pipe/notes.md",
+        None,
+        None,
+        None,
+    )
+    .await;
 
-    let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
+    let rows = db
+        .list_outputs(Some("my-pipe"), None, None, 100, 0)
+        .await
+        .unwrap();
     assert_eq!(rows.len(), 2);
     let saf_row = rows.iter().find(|r| r.kind == "saf").unwrap();
     assert_eq!(saf_row.saf_kind.as_deref(), Some("sop"));

--- a/crates/screenpipe-engine/src/routes/artifacts.rs
+++ b/crates/screenpipe-engine/src/routes/artifacts.rs
@@ -214,10 +214,7 @@ pub(crate) fn validate_saf_envelope(v: &Value) -> Result<SafFields, String> {
         _ => return Err("saf_version must be the number 1".to_string()),
     }
 
-    let artifact_id = obj
-        .get("artifact_id")
-        .and_then(Value::as_str)
-        .unwrap_or("");
+    let artifact_id = obj.get("artifact_id").and_then(Value::as_str).unwrap_or("");
     if artifact_id.is_empty() {
         return Err("artifact_id must be a non-empty string".to_string());
     }
@@ -433,7 +430,11 @@ pub(crate) async fn register_artifact_handler(
         payload.kind.as_str()
     };
     let (saf_kind, saf_artifact_id, saf_artifact_version) = match &saf {
-        Some(f) => (Some(f.kind.as_str()), Some(f.artifact_id.as_str()), Some(f.version)),
+        Some(f) => (
+            Some(f.kind.as_str()),
+            Some(f.artifact_id.as_str()),
+            Some(f.version),
+        ),
         None => (None, None, None),
     };
 
@@ -876,7 +877,11 @@ pub async fn auto_register_pipe_artifacts(
         let saf = detect_saf_for_file(&dest, filename, size_bytes, pipe_name).await;
         let kind: &str = if saf.is_some() { "saf" } else { declared_kind };
         let (saf_kind, saf_artifact_id, saf_artifact_version) = match &saf {
-            Some(f) => (Some(f.kind.as_str()), Some(f.artifact_id.as_str()), Some(f.version)),
+            Some(f) => (
+                Some(f.kind.as_str()),
+                Some(f.artifact_id.as_str()),
+                Some(f.version),
+            ),
             None => (None, None, None),
         };
 
@@ -1184,10 +1189,7 @@ mod tests {
 
     #[test]
     fn saf_outputs_detect_plain_json_without_marker_is_plain() {
-        assert_eq!(
-            detect_saf(r#"{"a": 1}"#, "data.json"),
-            SafDetection::NotSaf
-        );
+        assert_eq!(detect_saf(r#"{"a": 1}"#, "data.json"), SafDetection::NotSaf);
         // non-object JSON in a regular file is plain too
         assert_eq!(detect_saf("[1, 2]", "data.json"), SafDetection::NotSaf);
     }
@@ -1275,7 +1277,10 @@ mod tests {
         )
         .await;
 
-        let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
+        let rows = db
+            .list_outputs(Some("my-pipe"), None, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].kind, "saf");
         assert_eq!(rows[0].saf_kind.as_deref(), Some("sop"));
@@ -1305,14 +1310,20 @@ mod tests {
         // higher version, same file → same row, bumped version
         std::fs::write(&f, envelope_json("process-refund", 2)).unwrap();
         auto_register_pipe_artifacts(&db, items(), "my-pipe", &sp_dir).await;
-        let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
+        let rows = db
+            .list_outputs(Some("my-pipe"), None, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(rows.len(), 1, "re-emit must not duplicate");
         assert_eq!(rows[0].id, first_id);
         assert_eq!(rows[0].saf_version, Some(2));
 
         // same version again → idempotent
         auto_register_pipe_artifacts(&db, items(), "my-pipe", &sp_dir).await;
-        let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
+        let rows = db
+            .list_outputs(Some("my-pipe"), None, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(rows.len(), 1, "same-version re-emit must be idempotent");
         assert_eq!(rows[0].id, first_id);
         assert_eq!(rows[0].saf_version, Some(2));
@@ -1347,8 +1358,15 @@ mod tests {
         )
         .await;
 
-        let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
-        assert_eq!(rows.len(), 1, "artifact_id match must update, not duplicate");
+        let rows = db
+            .list_outputs(Some("my-pipe"), None, None, 100, 0)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "artifact_id match must update, not duplicate"
+        );
         assert_eq!(rows[0].saf_version, Some(2));
         assert!(
             rows[0].output_path.ends_with("process-refund-v2.saf.json"),
@@ -1376,7 +1394,10 @@ mod tests {
         )
         .await;
 
-        let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
+        let rows = db
+            .list_outputs(Some("my-pipe"), None, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(rows.len(), 1, "invalid SAF must still register");
         assert_eq!(rows[0].kind, "text", "kind stays the declared default");
         assert_eq!(rows[0].saf_kind, None);
@@ -1397,7 +1418,10 @@ mod tests {
         auto_register_pipe_artifacts(&db, vec![(decl("out/notes.md"), f)], "my-pipe", &sp_dir)
             .await;
 
-        let rows = db.list_outputs(Some("my-pipe"), None, None, 100, 0).await.unwrap();
+        let rows = db
+            .list_outputs(Some("my-pipe"), None, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].kind, "text");
         assert_eq!(rows[0].saf_kind, None);
@@ -1426,8 +1450,14 @@ mod tests {
         }
 
         // same artifact_id from two pipes → two distinct rows (source scoping)
-        let a = db.list_outputs(Some("pipe-a"), None, None, 100, 0).await.unwrap();
-        let b = db.list_outputs(Some("pipe-b"), None, None, 100, 0).await.unwrap();
+        let a = db
+            .list_outputs(Some("pipe-a"), None, None, 100, 0)
+            .await
+            .unwrap();
+        let b = db
+            .list_outputs(Some("pipe-b"), None, None, 100, 0)
+            .await
+            .unwrap();
         assert_eq!(a.len(), 1);
         assert_eq!(b.len(), 1);
         assert_ne!(a[0].id, b[0].id);


### PR DESCRIPTION
## Why

`669f426` (SAF envelopes, #4086) landed with two files `cargo fmt --check` rejects. Checks are not required on main, so the red did not block the merge. The **Clippy & Format** job runs on the `pull_request` merge commit, so right now **every open PR fails fmt through no fault of its own** (first hit: #4089).

## What

`cargo fmt --all` output only, zero code change:

```
crates/screenpipe-db/tests/outputs_saf_test.rs   | 40 ++++++++++---
crates/screenpipe-engine/src/routes/artifacts.rs | 68 +++++++++++++-------
```

## Flow

```
before:  PR branch ──merge──> main (unformatted #4086 files) ──> fmt gate RED for all PRs
after:   PR branch ──merge──> main (fmt clean)               ──> fmt gate judges the PR itself
```

Verified locally: `cargo fmt --all -- --check` clean on the whole workspace after this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)