### PR TITLE
fix(ci): rustfmt worker_integration.rs (unbreaks format on main)

### DIFF
--- a/crates/screenpipe-redact/tests/worker_integration.rs
+++ b/crates/screenpipe-redact/tests/worker_integration.rs
@@ -108,12 +108,10 @@ async fn seed(pool: &sqlx::SqlitePool) {
         .execute(pool)
         .await
         .unwrap();
-    sqlx::query(
-        "INSERT INTO elements (text) VALUES ('AXStaticText[carol@example.com]')",
-    )
-    .execute(pool)
-    .await
-    .unwrap();
+    sqlx::query("INSERT INTO elements (text) VALUES ('AXStaticText[carol@example.com]')")
+        .execute(pool)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
The squash-merge of #4096 landed before its `Clippy & Format` check finished and carried a non-rustfmt-conformant multi-line `sqlx::query` in the new `elements` seed into main. `cargo fmt` collapses it to a single line. Format CI on main (and every open PR's whole-repo fmt check) is red until this lands. Pure formatting, no logic change. Same class as #4078.

🤖 Generated with [Claude Code](https://claude.com/claude-code)