### PR TITLE
fix(ci): rustfmt pipeline.rs (last format drift on main)

### DIFF
--- a/crates/screenpipe-sync/src/pipeline.rs
+++ b/crates/screenpipe-sync/src/pipeline.rs
@@ -350,7 +350,9 @@ mod tests {
 
         let storage = MockServer::start().await;
         Mock::given(method("PUT"))
-            .and(path("/acme-telemetry/customer-a/enterprise-telemetry/lic-1/dev-1/direct/b-1.jsonl"))
+            .and(path(
+                "/acme-telemetry/customer-a/enterprise-telemetry/lic-1/dev-1/direct/b-1.jsonl",
+            ))
             .and(query_param("X-Amz-Algorithm", "AWS4-HMAC-SHA256"))
             .and(query_param("X-Amz-Expires", "900"))
             .and(query_param(


### PR DESCRIPTION
Pre-existing rustfmt drift in `crates/screenpipe-sync/src/pipeline.rs` (a long `.and(path(...))` test assertion rustfmt wraps). It's the only remaining file failing `cargo fmt --all` on main, so every open PR's whole-repo format check is red because of it. Pure formatting, no logic change. Same class as #4078 / #4101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)