### PR TITLE
fix(overlay-chat): add macOS traffic light padding and compact header

### DIFF
--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -8266,9 +8266,10 @@ export function StandaloneChat({
         className={cn(
           "relative flex items-center gap-3 px-4 py-3.5 border-b border-border/50 bg-gradient-to-r from-background to-muted/30",
           !className && "cursor-grab active:cursor-grabbing",
-          conversationId && messages.length > 0 && "py-0.5",
+          (!className || (conversationId && messages.length > 0)) && "py-0.5",
           sidebarCollapsed && conversationId && messages.length > 0 && "!pl-[58px]",
-          sidebarCollapsed && isMac && !isFullscreen && "!pl-[128px]"
+          sidebarCollapsed && isMac && !isFullscreen && "!pl-[128px]",
+          !className && isMac && !isFullscreen && "!pl-[78px]"
         )}
         onMouseDown={async (e) => {
           if (className) return; // embedded — don't drag


### PR DESCRIPTION
This PR add left padding to overlay chat header on macOS (non-fullscreen) to prevent overlap with macOS traffic light buttons
Always apply compact header padding in overlay chat window, matching the expected design.

Before -

<img width="2911" height="1617" alt="3" src="https://github.com/user-attachments/assets/855a45bc-010e-4431-8a11-03c64fcd96eb" />
<img width="2491" height="1177" alt="4" src="https://github.com/user-attachments/assets/223cf977-813e-4b27-a6ca-202e9c1ae85d" />

After -
<img width="3000" height="2979" alt="5" src="https://github.com/user-attachments/assets/e719badb-0a31-40d4-bba0-ddc0a641cc27" />
<img width="3000" height="2504" alt="6" src="https://github.com/user-attachments/assets/6f18c709-c8a6-49c4-babe-d5f11faca797" />

