### PR TITLE
fix(ai-presets): allow deleting extra cloud preset copies

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -1081,7 +1081,6 @@ export const AIPresetsSelector = ({
   const [selectedPresetToEdit, setSelectedPresetToEdit] = useState<
     AIPreset | undefined
   >();
-
   const isControlled = onControlledSelect !== undefined;
   const { isEnterprise, policy: enterprisePolicy } = useEnterprisePolicy();
   const aiPresetPolicy = enterprisePolicy.aiPresetPolicy ?? DEFAULT_ENTERPRISE_AI_PRESET_POLICY;
@@ -1364,13 +1363,14 @@ export const AIPresetsSelector = ({
       return;
     }
 
-    // Prevent deletion of screenpipe-cloud preset for Pro subscribers
+    // Safety net: prevent deletion of the last screenpipe-cloud preset for subscribers
     if (preset.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed) {
-      toast.error("Cannot delete cloud preset", {
-        description: "This preset is included with your Business subscription",
-      });
-      return;
+      const cloudPresets = settings.aiPresets.filter((p) => p.provider === "screenpipe-cloud");
+      if (cloudPresets.length <= 1) {
+        return;
+      }
     }
+
     if (preset.defaultPreset) {
       toast.error("Cannot delete default preset", {
         description: "Please set another preset as default first",
@@ -1387,6 +1387,14 @@ export const AIPresetsSelector = ({
       description: `${preset.id} has been removed`,
     });
   };
+
+  // Hide delete button on the last remaining screenpipe-cloud preset for subscribers
+  const cloudPresetCount = useMemo(
+    () => (settings?.aiPresets || []).filter((p) => p.provider === "screenpipe-cloud").length,
+    [settings?.aiPresets]
+  );
+  const isLastCloudPreset = (preset: AIPreset) =>
+    preset.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed && cloudPresetCount <= 1;
 
   return (
     <>
@@ -1687,7 +1695,7 @@ export const AIPresetsSelector = ({
                                 <Star className="h-3.5 w-3.5" />
                               </Button>
                             )}
-                            {!preset.defaultPreset && canManageEmployeePresets && !isEnterpriseManagedPreset(preset) && (
+                            {!preset.defaultPreset && canManageEmployeePresets && !isEnterpriseManagedPreset(preset) && !isLastCloudPreset(preset) && (
                               <Button
                                 variant="ghost"
                                 size="icon"

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -1873,7 +1873,7 @@ function SortablePresetCard({
   onEdit: () => void;
   onDuplicate: () => void;
   onSetDefault: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onShareToTeam?: () => void;
   isLoading: boolean;
   isTeamAdmin?: boolean;
@@ -1988,7 +1988,7 @@ function SortablePresetCard({
               </Tooltip>
             </TooltipProvider>
           )}
-          {!isDefault && !readOnly && (
+          {!isDefault && !readOnly && onDelete && (
             <Button variant="ghost" size="sm" className="text-[11px] h-6 px-2 text-destructive hover:text-destructive ml-auto" onClick={(e) => { e.stopPropagation(); onDelete(); }} disabled={isLoading}>
               <Trash2 className="w-3 h-3" />
             </Button>
@@ -2124,12 +2124,15 @@ useEffect(() => {
         return;
       }
       if (presetToRemove?.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed) {
-        toast({
-          title: "Cannot delete cloud preset",
-          description: "This preset is included with your Business subscription",
-          variant: "destructive",
-        });
-        return;
+        const cloudPresets = settings.aiPresets.filter((p) => p.provider === "screenpipe-cloud");
+        if (cloudPresets.length <= 1) {
+          toast({
+            title: "Cannot delete cloud preset",
+            description: "This preset is included with your Business subscription",
+            variant: "destructive",
+          });
+          return;
+        }
       }
 
       const checkIfDefault = settings.aiPresets.find(
@@ -2327,33 +2330,38 @@ useEffect(() => {
           strategy={rectSortingStrategy}
         >
           <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-3">
-            {visiblePresets.map((preset) => {
-              const readOnly =
-                isEnterprise &&
-                (!aiPresetPolicy.allow_employee_custom_presets || isEnterpriseManagedPreset(preset));
-              return (
-                <SortablePresetCard
-                  key={preset.id}
-                  preset={preset}
-                  isDefault={preset.defaultPreset}
-                  hasValidation={!!(preset.provider && preset.model && (preset.url || preset.provider === "screenpipe-cloud" || preset.provider === "openai-chatgpt"))}
-                  chatgptTokenExpired={preset.provider === "openai-chatgpt" && chatgptTokenValid === false}
-                  onEdit={() => {
-                    setSelectedPreset(preset);
-                    setIsDuplicating(false);
-                    setCreatePresentDialog(true);
-                  }}
-                  onDuplicate={() => duplicatePreset(preset.id)}
-                  onSetDefault={() => setPresetToSetDefault(preset.id)}
-                  onDelete={() => setPresetToDelete(preset.id)}
-                  onShareToTeam={isTeamAdmin ? () => sharePresetToTeam(preset) : undefined}
-                  isLoading={isLoading}
-                  isTeamAdmin={isTeamAdmin}
-                  readOnly={readOnly}
-                  defaultLocked={isEnterprise && aiPresetPolicy.lock_default_preset}
-                />
-              );
-            })}
+            {(() => {
+              const cloudPresetCount = visiblePresets.filter((p) => p.provider === "screenpipe-cloud").length;
+              return visiblePresets.map((preset) => {
+                const readOnly =
+                  isEnterprise &&
+                  (!aiPresetPolicy.allow_employee_custom_presets || isEnterpriseManagedPreset(preset));
+                const isLastCloudPreset =
+                  preset.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed && cloudPresetCount <= 1;
+                return (
+                  <SortablePresetCard
+                    key={preset.id}
+                    preset={preset}
+                    isDefault={preset.defaultPreset}
+                    hasValidation={!!(preset.provider && preset.model && (preset.url || preset.provider === "screenpipe-cloud" || preset.provider === "openai-chatgpt"))}
+                    chatgptTokenExpired={preset.provider === "openai-chatgpt" && chatgptTokenValid === false}
+                    onEdit={() => {
+                      setSelectedPreset(preset);
+                      setIsDuplicating(false);
+                      setCreatePresentDialog(true);
+                    }}
+                    onDuplicate={() => duplicatePreset(preset.id)}
+                    onSetDefault={() => setPresetToSetDefault(preset.id)}
+                    onDelete={isLastCloudPreset ? undefined : () => setPresetToDelete(preset.id)}
+                    onShareToTeam={isTeamAdmin ? () => sharePresetToTeam(preset) : undefined}
+                    isLoading={isLoading}
+                    isTeamAdmin={isTeamAdmin}
+                    readOnly={readOnly}
+                    defaultLocked={isEnterprise && aiPresetPolicy.lock_default_preset}
+                  />
+                );
+              });
+            })()}
           </div>
         </SortableContext>
       </DndContext>

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -2331,7 +2331,7 @@ useEffect(() => {
         >
           <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-3">
             {(() => {
-              const cloudPresetCount = visiblePresets.filter((p) => p.provider === "screenpipe-cloud").length;
+              const cloudPresetCount = (settings.aiPresets || []).filter((p) => p.provider === "screenpipe-cloud").length;
               return visiblePresets.map((preset) => {
                 const readOnly =
                   isEnterprise &&


### PR DESCRIPTION
## Summary
- Subscribers were previously blocked from deleting any `screenpipe-cloud` preset copy.
- This keeps the last remaining cloud preset protected, but allows deleting extra cloud preset copies.
- The delete button is hidden only when the preset is the final remaining `screenpipe-cloud` preset.

## Changes
- `ai-presets-selector.tsx`: allow deleting cloud presets when more than one exists; keep a safety guard for the last one.
- `ai-presets.tsx`: make `onDelete` optional and hide delete only for the last cloud preset.

## Test Plan
1. Login with a subscribed account.
2. Create or duplicate multiple `screenpipe-cloud` presets.
3. Verify extra cloud preset copies can be deleted.
4. Verify the final remaining cloud preset cannot be deleted / has no delete action.


Before -


https://github.com/user-attachments/assets/bb517b68-9a4b-403f-ba27-4dc9533d2967

After -


https://github.com/user-attachments/assets/1ee3b9f3-1d90-4642-b5ef-0746c0ba96eb



