### PR TITLE
feat(notifications): split power-mode-change toasts from capture-stall alerts

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/notifications-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/notifications-settings.tsx
@@ -11,6 +11,7 @@ import type { SettingsField } from "./settings-search";
 /** Settings search index for this section. Co-located with the component so adding a field here means updating one file. See `SettingsField` in `./settings-search` for the schema. */
 export const searchIndex: SettingsField[] = [
   { label: "Capture stalls" },
+  { label: "Power mode changes" },
   { label: "App updates" },
   { label: "Pipe suggestions" },
   { label: "Pipe notifications" },
@@ -30,6 +31,7 @@ import { commands } from "@/lib/utils/tauri";
 
 const defaultPrefs = {
   captureStalls: true,
+  powerModeChanges: true,
   appUpdates: true,
   pipeSuggestions: true,
   pipeNotifications: true,
@@ -79,6 +81,21 @@ export function NotificationsSettings() {
                 showRestartNotifications: v,
               } as Partial<Settings>);
             }}
+          />
+        </div>
+
+        {/* Power mode changes */}
+        <div className="flex items-center justify-between py-3 border-b border-border">
+          <div>
+            <p className="text-sm font-medium">Power mode changes</p>
+            <p className="text-xs text-muted-foreground">
+              Toast when battery saver kicks in (Balanced / Saver). Critical alerts when capture is paused for low battery still fire.
+            </p>
+          </div>
+          <Switch
+            data-testid="notification-pref-power-mode-changes"
+            checked={prefs.powerModeChanges ?? true}
+            onCheckedChange={(v) => updatePref("powerModeChanges", v)}
           />
         </div>
 

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -321,6 +321,9 @@ export type Settings = SettingsStore & {
 		audioCaptureStalled?: boolean;
 		/** In-app /notify when audio is captured but no live transcript arrives within 60s. Default true. */
 		liveTranscriptStalled?: boolean;
+		/** Toast on informational power-profile transitions (Balanced / Saver), e.g. when unplugging AC.
+		 *  Critical AudioPaused/FullPause alerts always fire regardless. Default true. */
+		powerModeChanges?: boolean;
 		mutedPipes: string[];
 	};
 	/** Remote devices to monitor pipes on (LAN addresses) */

--- a/apps/screenpipe-app-tauri/src-tauri/src/engine_events/power.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/engine_events/power.rs
@@ -19,6 +19,7 @@
 //! don't spam.
 
 use crate::notifications::client;
+use crate::store::SettingsStore;
 use serde::Deserialize;
 use serde_json::Value;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -47,7 +48,7 @@ pub fn is_power_capture_paused() -> bool {
     POWER_CAPTURE_PAUSED.load(Ordering::Relaxed)
 }
 
-pub(super) fn handle(_app: &AppHandle, _name: &str, data: &Value) {
+pub(super) fn handle(app: &AppHandle, _name: &str, data: &Value) {
     let evt: PowerProfileChanged = match serde_json::from_value(data.clone()) {
         Ok(e) => e,
         Err(e) => {
@@ -60,6 +61,21 @@ pub(super) fn handle(_app: &AppHandle, _name: &str, data: &Value) {
     POWER_CAPTURE_PAUSED.store(evt.to == "FullPause", Ordering::Relaxed);
 
     if !evt.is_downgrade {
+        return;
+    }
+
+    // Informational tiers (Balanced/Saver) are gated behind the
+    // `Power mode changes` notification toggle. AudioPaused/FullPause
+    // bypass the gate — those are capture-stalled-equivalent events
+    // the user explicitly told us they want to keep. Fail-open: if the
+    // settings store hiccups, show the toast (same policy as
+    // display_changes_enabled / pipe_notifications_enabled).
+    let informational = matches!(evt.to.as_str(), "Balanced" | "Saver");
+    if informational && !power_mode_changes_enabled(app) {
+        debug!(
+            "power_profile_changed → notify: skipped (power-mode-change toasts disabled, to={})",
+            evt.to
+        );
         return;
     }
 
@@ -126,4 +142,100 @@ pub(super) fn handle(_app: &AppHandle, _name: &str, data: &Value) {
     };
 
     client::send_typed(title, body, "power", None);
+}
+
+/// Read `notificationPrefs.powerModeChanges` from the settings store.
+/// Default true (matches the frontend default). Missing store / parse
+/// failure also defaults to true — better one extra toast than a
+/// silently swallowed signal. Mirrors `display_changes_enabled`.
+fn power_mode_changes_enabled(app: &AppHandle) -> bool {
+    let settings = match SettingsStore::get(app) {
+        Ok(Some(s)) => s,
+        _ => return true,
+    };
+    power_mode_changes_enabled_from_extra(&settings.extra)
+}
+
+/// Pure helper split out for unit testing — same fail-open semantics
+/// as `power_mode_changes_enabled` but operates directly on the
+/// settings `extra` map so tests don't need a Tauri `AppHandle`.
+fn power_mode_changes_enabled_from_extra(
+    extra: &std::collections::HashMap<String, serde_json::Value>,
+) -> bool {
+    let prefs = match extra.get("notificationPrefs") {
+        Some(p) => p,
+        None => return true,
+    };
+    prefs
+        .get("powerModeChanges")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    fn extra_with(prefs: serde_json::Value) -> HashMap<String, serde_json::Value> {
+        let mut m = HashMap::new();
+        m.insert("notificationPrefs".to_string(), prefs);
+        m
+    }
+
+    #[test]
+    fn gate_defaults_true_when_prefs_missing() {
+        let extra: HashMap<String, serde_json::Value> = HashMap::new();
+        assert!(power_mode_changes_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_defaults_true_when_key_missing() {
+        let extra = extra_with(json!({ "displayChanges": false }));
+        assert!(power_mode_changes_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_defaults_true_when_value_not_bool() {
+        let extra = extra_with(json!({ "powerModeChanges": "yes" }));
+        assert!(power_mode_changes_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_respects_explicit_false() {
+        let extra = extra_with(json!({ "powerModeChanges": false }));
+        assert!(!power_mode_changes_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn gate_respects_explicit_true() {
+        let extra = extra_with(json!({ "powerModeChanges": true }));
+        assert!(power_mode_changes_enabled_from_extra(&extra));
+    }
+
+    #[test]
+    fn other_toggles_do_not_affect_power_gate() {
+        // captureStalls=false should NOT silence power-mode-change toasts —
+        // they are independent surfaces by design.
+        let extra = extra_with(json!({
+            "captureStalls": false,
+            "powerModeChanges": true,
+        }));
+        assert!(power_mode_changes_enabled_from_extra(&extra));
+    }
+
+    // The gate is applied in `handle()` only when the target profile is
+    // `Balanced` or `Saver` — `AudioPaused` and `FullPause` bypass it.
+    // Encode that contract explicitly so a future refactor can't widen
+    // the gate and silently swallow a critical capture-paused alert.
+    #[test]
+    fn gated_profiles_are_only_balanced_and_saver() {
+        let gated = |to: &str| matches!(to, "Balanced" | "Saver");
+        assert!(gated("Balanced"));
+        assert!(gated("Saver"));
+        assert!(!gated("AudioPaused"));
+        assert!(!gated("FullPause"));
+        assert!(!gated("Performance"));
+    }
 }


### PR DESCRIPTION
### Description:

Fixes #3853 

<img width="953" height="650" alt="image" src="https://github.com/user-attachments/assets/ed5daf91-91a9-4902-a376-fafbbe33c038" />


- tests passing: 

<img width="1191" height="242" alt="image" src="https://github.com/user-attachments/assets/681c6984-c80f-45a3-8502-b6aa52567461" />

                                                                                                                                                
                                                                                                                                                                        
 Adds an independent Power mode changes toggle in Settings → Notifications so users can silence the informational "switched to balanced / saver" toast (e.g. on unplug) 
 without disabling capture-stall alerts. Critical AudioPaused / FullPause toasts always fire regardless. Default on — zero behavior change for existing users until     
 they opt out. Closes the in-app feedback from 2.4.308