### PR TITLE
fix: make standalone search modal take full screen height

### DIFF
--- a/apps/screenpipe-app-tauri/app/search/page.tsx
+++ b/apps/screenpipe-app-tauri/app/search/page.tsx
@@ -60,7 +60,7 @@ export default function SearchPage() {
 	}, []);
 
 	return (
-		<div className="w-screen bg-transparent">
+		<div className="w-screen h-screen bg-transparent">
 			<SearchModal
 				isOpen={true}
 				standalone

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -2132,7 +2132,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
     return (
       <div className={cn(
         "flex flex-col bg-card/95 backdrop-blur-xl",
-        standalone ? "rounded-xl border border-border/50 shadow-2xl overflow-hidden" : "h-full",
+        standalone ? "h-full rounded-xl border border-border/50 shadow-2xl overflow-hidden" : "h-full",
       )}>
         {/* Search Input — Raycast-style large input */}
         <div className={cn(


### PR DESCRIPTION
## Description

Add h-screen to search page container and h-full to standalone search modal to ensure the search interface properly fills the entire window in standalone mode.

### Before


https://github.com/user-attachments/assets/69dabc45-205c-4a84-8be7-9736f1841a9d






### After 


https://github.com/user-attachments/assets/137cb827-bbe1-45a4-a3b4-aecd108632b5

Closes #4011 