### PR TITLE
fix(windows): robust process kill in NSIS installer hooks

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
+++ b/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
@@ -3,7 +3,7 @@
 !include "x64.nsh"
 
 ; ---------------------------------------------------------------------------
-; _SP_KillProcesses — shared helper called by both PREINSTALL and PREUNINSTALL
+; _SP_KillProcesses -- shared helper called by both PREINSTALL and PREUNINSTALL
 ; Kills all screenpipe processes by name and by install-directory path.
 ; Uses Push/Pop to preserve $0 and $1 across the call site.
 ; ---------------------------------------------------------------------------
@@ -12,7 +12,7 @@
   Push $1
 
   ; $PLUGINSDIR is a per-session temp dir auto-cleaned on installer exit.
-  ; InitPluginsDir is idempotent — safe to call even if a plugin already ran.
+  ; InitPluginsDir is idempotent -- safe to call even if a plugin already ran.
   InitPluginsDir
 
   DetailPrint "Stopping screenpipe processes..."
@@ -26,7 +26,7 @@
   ; Stop any remaining process running from this install directory, including
   ; the bundled Bun sidecar. Use CIM ExecutablePath instead of Get-Process.Path:
   ; reading process module paths can throw "Access to the path is denied".
-  ; FileWriteUTF16LE /BOM writes UTF-16LE with BOM + CRLF line endings — the
+  ; FileWriteUTF16LE /BOM writes UTF-16LE with BOM + CRLF line endings -- the
   ; encoding and line-ending format PowerShell 5.1 on Windows expects. Plain
   ; FileWrite outputs ANSI (system codepage) and silently breaks on non-ASCII
   ; paths; LF-only endings can cause misbehavior on Windows PowerShell 5.1.
@@ -41,7 +41,7 @@
     FileClose $1
     DetailPrint "Stopping processes from $INSTDIR..."
     ; Disable WOW64 FS redirection so System32 resolves to the real 64-bit dir.
-    ; Screenpipe targets 64-bit Windows 10/11 only. RemoteSigned is sufficient —
+    ; Screenpipe targets 64-bit Windows 10/11 only. RemoteSigned is sufficient --
     ; the .ps1 is written locally and has no Zone.Identifier ADS.
     ; /TIMEOUT=30000 caps the wait at 30 s so the installer cannot hang forever.
     ${DisableX64FSRedirection}

--- a/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
+++ b/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
@@ -1,13 +1,75 @@
-!macro NSIS_HOOK_PREINSTALL
-  ; Kill screenpipe processes before installation.
+; x64.nsh provides ${DisableX64FSRedirection} / ${EnableX64FSRedirection}.
+; It has its own include guard so repeated inclusion is safe.
+!include "x64.nsh"
+
+; ---------------------------------------------------------------------------
+; _SP_KillProcesses — shared helper called by both PREINSTALL and PREUNINSTALL
+; Kills all screenpipe processes by name and by install-directory path.
+; Uses Push/Pop to preserve $0 and $1 across the call site.
+; ---------------------------------------------------------------------------
+!macro _SP_KillProcesses
+  Push $0
+  Push $1
+
+  ; $PLUGINSDIR is a per-session temp dir auto-cleaned on installer exit.
+  ; InitPluginsDir is idempotent — safe to call even if a plugin already ran.
+  InitPluginsDir
+
+  DetailPrint "Stopping screenpipe processes..."
   nsExec::ExecToLog 'taskkill /F /T /IM screenpipe.exe'
+  Pop $0
+  DetailPrint "taskkill screenpipe.exe: $0"
   nsExec::ExecToLog 'taskkill /F /T /IM screenpipe-app.exe'
+  Pop $0
+  DetailPrint "taskkill screenpipe-app.exe: $0"
+
   ; Stop any remaining process running from this install directory, including
   ; the bundled Bun sidecar. Use CIM ExecutablePath instead of Get-Process.Path:
   ; reading process module paths can throw "Access to the path is denied".
-  nsExec::ExecToLog 'powershell -NoProfile -ExecutionPolicy Bypass -Command "$$root = [System.IO.Path]::GetFullPath(''$INSTDIR'').TrimEnd(''\'') + ''\''; Get-CimInstance Win32_Process | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.StartsWith($$root, [System.StringComparison]::OrdinalIgnoreCase) } | ForEach-Object { $$pidToStop = $$_.ProcessId; Stop-Process -Id $$pidToStop -Force -ErrorAction SilentlyContinue; Wait-Process -Id $$pidToStop -Timeout 5 -ErrorAction SilentlyContinue }"'
-  ; Wait a moment for processes to fully terminate and release file handles.
-  Sleep 1000
+  ; FileWriteUTF16LE /BOM writes UTF-16LE with BOM + CRLF line endings — the
+  ; encoding and line-ending format PowerShell 5.1 on Windows expects. Plain
+  ; FileWrite outputs ANSI (system codepage) and silently breaks on non-ASCII
+  ; paths; LF-only endings can cause misbehavior on Windows PowerShell 5.1.
+  ; ${__LINE__} makes the skip label unique per insertion so this macro can be
+  ; inserted more than once without duplicate-label compile errors.
+  !define _SP_SKIP ps_skip_${__LINE__}
+  ClearErrors
+  FileOpen $1 "$PLUGINSDIR\screenpipe-kill.ps1" w
+  IfErrors ${_SP_SKIP}
+    FileWriteUTF16LE /BOM $1 '$$d = "$INSTDIR"; if (-not $$d.EndsWith([char]92)) { $$d = $$d + [char]92 }$\r$\n'
+    FileWriteUTF16LE $1 'Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.ToLower().StartsWith($$d.ToLower()) } | ForEach-Object { $$p = $$_.ProcessId; Stop-Process -Id $$p -Force -ErrorAction SilentlyContinue; Wait-Process -Id $$p -Timeout 5 -ErrorAction SilentlyContinue }$\r$\n'
+    FileClose $1
+    DetailPrint "Stopping processes from $INSTDIR..."
+    ; Disable WOW64 FS redirection so System32 resolves to the real 64-bit dir.
+    ; Screenpipe targets 64-bit Windows 10/11 only. RemoteSigned is sufficient —
+    ; the .ps1 is written locally and has no Zone.Identifier ADS.
+    ; /TIMEOUT=30000 caps the wait at 30 s so the installer cannot hang forever.
+    ${DisableX64FSRedirection}
+    nsExec::ExecToLog /TIMEOUT=30000 '"$WINDIR\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -inputformat none -ExecutionPolicy RemoteSigned -File "$PLUGINSDIR\screenpipe-kill.ps1"'
+    Pop $0
+    ${EnableX64FSRedirection}
+    ; $0 is 0 on success, a numeric exit code on failure, or "error"/"timeout"
+    ; if nsExec itself could not launch PowerShell. Surface it for installer logs.
+    DetailPrint "PowerShell process-kill exit: $0"
+  ${_SP_SKIP}:
+  !undef _SP_SKIP
+
+  ; Wait for processes to fully terminate and release file handles.
+  ; 3000ms covers slow machines and Bun sidecar file handle teardown.
+  DetailPrint "Waiting for processes to release file handles..."
+  Sleep 3000
+  DetailPrint "Process cleanup complete."
+
+  Pop $1
+  Pop $0
+!macroend
+
+!macro NSIS_HOOK_PREINSTALL
+  !insertmacro _SP_KillProcesses
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  !insertmacro _SP_KillProcesses
 !macroend
 
 !macro NSIS_HOOK_POSTUNINSTALL


### PR DESCRIPTION
## Problem

Windows upgrades were failing intermittently because the installer couldn't overwrite locked files — processes weren't fully dead before extraction started.

Root causes found in [#4111](https://github.com/louis030195/screenpipe/issues/4111):

- Inline `-Command` PowerShell one-liner broke silently on paths with **non-ASCII characters** (ANSI encoding mismatch)
- WOW64 FS redirection on 32-bit NSIS could resolve `System32\powershell.exe` to the wrong binary
- No timeout → installer could hang indefinitely waiting for PowerShell
- 1 s sleep wasn't enough for the Bun sidecar to release all file handles
- No `NSIS_HOOK_PREUNINSTALL` → same file-lock issues hit on uninstall too

## Solution

- Extracted `_SP_KillProcesses` — shared macro used by both `PREINSTALL` **and** `PREUNINSTALL`
- PS1 written to `$PLUGINSDIR` as **UTF-16LE + BOM** so PowerShell 5.1 handles any path encoding correctly
- `${DisableX64FSRedirection}` / `${EnableX64FSRedirection}` wrap the `powershell.exe` call to always hit the real 64-bit binary
- `/TIMEOUT=30000` caps PowerShell at **30 s** — installer can no longer hang
- Sleep bumped **1 s → 3 s** to cover slow machines and Bun teardown
- All exit codes now surfaced in the installer log for easier debugging

## Verified


https://github.com/user-attachments/assets/e018d47e-dd73-469b-9881-21d653585937




Tested locally with a dev-signed NSIS build. Installer log output:

```
Output folder: C:\Users\anshg\AppData\Local\screenpipe - Development
Stopping screenpipe processes...
ERROR: The process "screenpipe.exe" not found.
taskkill screenpipe.exe: 128
SUCCESS: The process with PID 2628 (child process of PID 12348) has been terminated.
SUCCESS: The process with PID 12348 (child process of PID 9136) has been terminated.
SUCCESS: The process with PID 8068 (child process of PID 24236) has been terminated.
SUCCESS: The process with PID 9136 (child process of PID 24236) has been terminated.
SUCCESS: The process with PID 13736 (child process of PID 10108) has been terminated.
SUCCESS: The process with PID 21248 (child process of PID 10108) has been terminated.
SUCCESS: The process with PID 19736 (child process of PID 10108) has been terminated.
SUCCESS: The process with PID 21588 (child process of PID 10108) has been terminated.
SUCCESS: The process with PID 16028 (child process of PID 10108) has been terminated.
SUCCESS: The process with PID 24420 (child process of PID 10500) has been terminated.
SUCCESS: The process with PID 22228 (child process of PID 11924) has been terminated.
SUCCESS: The process with PID 24236 (child process of PID 10500) has been terminated.
SUCCESS: The process with PID 10108 (child process of PID 2704) has been terminated.
SUCCESS: The process with PID 10500 (child process of PID 2704) has been terminated.
SUCCESS: The process with PID 11924 (child process of PID 2704) has been terminated.
SUCCESS: The process with PID 2704 (child process of PID 8072) has been terminated.
taskkill screenpipe-app.exe: 0
Stopping processes from C:\Users\anshg\AppData\Local\screenpipe - Development...
PowerShell process-kill exit: 0
Waiting for processes to release file handles...
Process cleanup complete.
Extract: screenpipe-app.exe... 100%
Create folder: C:\Users\anshg\AppData\Local\screenpipe - Development\assets
Create folder: C:\Users\anshg\AppData\Local\screenpipe - Development
Extract: assets\dmg-background.png
Extract: assets\nsis-header.bmp
Extract: assets\nsis-sidebar.bmp
Extract: assets\screenpipe-logo-tray-beta-black.png
Extract: assets\screenpipe-logo-tray-beta-white.png
Extract: assets\screenpipe-logo-tray-black-failed.png
Extract: assets\screenpipe-logo-tray-black.png
Extract: assets\screenpipe-logo-tray-updates-black.png
Extract: assets\screenpipe-logo-tray-updates-white.png
Extract: assets\screenpipe-logo-tray-white-failed.png
Extract: assets\screenpipe-logo-tray-white.png
Extract: avcodec-62.dll... 100%
Extract: avdevice-62.dll
Extract: avfilter-11.dll... 100%
Extract: avformat-62.dll... 100%
Extract: avutil-60.dll
Extract: ffmpeg.exe
Extract: ffprobe.exe
Extract: swresample-6.dll
Extract: swscale-9.dll
Extract: avcodec-62.def
Extract: avcodec.lib
Extract: avdevice-62.def
Extract: avdevice.lib
Extract: avfilter-11.def
Extract: avfilter.lib
Extract: avformat-62.def
Extract: avformat.lib
Extract: avutil-60.def
Extract: avutil.lib
Extract: libavcodec.dll.a
Extract: libavdevice.dll.a
Extract: libavfilter.dll.a
Extract: libavformat.dll.a
Extract: libavutil.dll.a
Extract: libswresample.dll.a
Extract: libswscale.dll.a
Extract: swresample-6.def
Extract: swresample.lib
Extract: swscale-9.def
Extract: swscale.lib
Extract: onnxruntime.dll... 100%
Extract: onnxruntime.dll... 100%
Extract: libopenblas.dll... 100%
Extract: msvcp140.dll
Extract: msvcp140_1.dll
Extract: msvcp140_2.dll
Extract: vcruntime140.dll
Extract: vcruntime140_1.dll
Extract: bun.exe... 100%
Created uninstaller: C:\Users\anshg\AppData\Local\screenpipe - Development\uninstall.exe
Completed
```

Closes #4111