### PR TITLE
fix(ci): restore rustfmt formatting in pi.rs

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1789,9 +1789,13 @@ impl AgentExecutor for PiExecutor {
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
 
-        let output = cmd
-            .output()
-            .map_err(|e| anyhow!("pi installation failed: could not run bun at {}: {}", bun, e))?;
+        let output = cmd.output().map_err(|e| {
+            anyhow!(
+                "pi installation failed: could not run bun at {}: {}",
+                bun,
+                e
+            )
+        })?;
         if output.status.success() {
             info!("pi installed successfully into {}", install_dir.display());
             Ok(())
@@ -3389,10 +3393,7 @@ mod tests {
             stderr: Vec::new(),
         };
         let msg = format_subprocess_failure("bun add", &silent_failure);
-        assert_eq!(
-            msg,
-            "bun add exit code 1; stderr: (empty); stdout: (empty)"
-        );
+        assert_eq!(msg, "bun add exit code 1; stderr: (empty); stdout: (empty)");
 
         // Killed by a signal (raw status = signal number, no exit code).
         let sigill = Output {


### PR DESCRIPTION
## what

PR #4080 (surface Pi agent install failures) was admin-merged before the **Clippy & Format** job finished, landing rustfmt drift on `main`. Since then the whole-repo `cargo fmt --all -- --check` reds on **every open PR**, citing `pi.rs` even on PRs that never touched it.

This applies `cargo fmt` to the two drifted spots in `crates/screenpipe-core/src/agents/pi.rs`. No logic change, whitespace only.

## ci flow

```
before:  main ──> cargo fmt --all --check ──> ✗ Diff in pi.rs (1789, 3389)
                                               └─> reds Code Quality on every open PR

after:   main ──> cargo fmt --all --check ──> ✓ exit 0  (verified locally)
```

## verification

```
$ cargo fmt --all -- --check
exit=0
```

Diff is exactly 2 hunks (8 insertions, 7 deletions), `pi.rs` only. No UI surface touched.
