### PR TITLE
fix(deps): bump audiopipe to compile Windows DirectML path on ort rc.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "antirez-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=e22369a2f22ab49d72ad96cf4236aed980e61820#e22369a2f22ab49d72ad96cf4236aed980e61820"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
 dependencies = [
  "cc",
 ]
@@ -644,7 +644,7 @@ dependencies = [
 [[package]]
 name = "audiopipe"
 version = "0.2.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=e22369a2f22ab49d72ad96cf4236aed980e61820#e22369a2f22ab49d72ad96cf4236aed980e61820"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
 dependencies = [
  "antirez-asr-sys",
  "half",
@@ -7175,7 +7175,7 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 [[package]]
 name = "qwen3-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=e22369a2f22ab49d72ad96cf4236aed980e61820#e22369a2f22ab49d72ad96cf4236aed980e61820"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ wiremock = "0.6"
 
 # Audio
 hound = "3.5"
-audiopipe = { git = "https://github.com/screenpipe/audiopipe.git", rev = "e22369a2f22ab49d72ad96cf4236aed980e61820", default-features = false }
+audiopipe = { git = "https://github.com/screenpipe/audiopipe.git", rev = "49eaf07f14d39c9a4f422022d76058539cebae9d", default-features = false }
 mlx-rs = "0.25"
 
 # Privacy filter enclave attestation (shared by engine + redact)

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "antirez-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=e22369a2f22ab49d72ad96cf4236aed980e61820#e22369a2f22ab49d72ad96cf4236aed980e61820"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
 dependencies = [
  "cc",
 ]
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "audiopipe"
 version = "0.2.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=e22369a2f22ab49d72ad96cf4236aed980e61820#e22369a2f22ab49d72ad96cf4236aed980e61820"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
 dependencies = [
  "antirez-asr-sys",
  "half",
@@ -9743,7 +9743,7 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 [[package]]
 name = "qwen3-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=e22369a2f22ab49d72ad96cf4236aed980e61820#e22369a2f22ab49d72ad96cf4236aed980e61820"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## what

The ort `rc.10 -> rc.12` bump (#4089, between v2.5.37 and v2.5.38) broke the **Windows ARM64 release build**. `audiopipe`'s DirectML branch in `parakeet.rs` used an `and_then` chain that no longer type-checks under rc.12 (builder methods now return `Error<SessionBuilder>`):

```
error[E0308]: mismatched types  (audiopipe/src/parakeet.rs:150)
error[E0282]: type annotations needed
error: could not compile `audiopipe` (lib)
```

macOS is unaffected because `parakeet-mlx` never compiles that block, so it passed CI and `v2.5.38` shipped **without a Windows ARM64 build**.

## release build, before vs after

```
                       publish-tauri
            macos-26 (parakeet-mlx) ──> ✓ builds, signs, notarizes   (unchanged)
  before:   windows-11-arm (directml) ─> ✗ audiopipe E0308/E0282  ← no Windows build
  after:    windows-11-arm (directml) ─> ✓ DirectML branch compiles
```

## fix

Bumps `audiopipe` `e22369a2 -> 49eaf07` (screenpipe/audiopipe#10), which rewrites the DirectML branch to the same `map_err(ort_err)?` pattern the CPU path right below it already uses. Updates the root and `src-tauri` lockfiles (the 3 audiopipe crates: `audiopipe`, `antirez-asr-sys`, `qwen3-asr-sys`).

## verification

- The fix is mechanically identical to the adjacent CPU path, which **compiled cleanly under rc.12 on the same Windows build** (only the `and_then` branch errored).
- DirectML is Windows-only, so it cannot be compiled on macOS locally. Final confirmation is the next Windows release build.
- Depends on screenpipe/audiopipe#10 landing on `ort-rc12` (keep `49eaf07` reachable).
