### PR TITLE
fix(health): report configured transcription_mode, not activity

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -1073,6 +1073,16 @@ impl AudioManager {
             .collect::<Vec<AudioDevice>>()
     }
 
+    /// Non-blocking read of the *configured* transcription mode. Returns `None`
+    /// if the options lock is momentarily contended, so callers such as
+    /// `/health` never block on it.
+    pub fn configured_transcription_mode(&self) -> Option<TranscriptionMode> {
+        self.options
+            .try_read()
+            .ok()
+            .map(|o| o.transcription_mode.clone())
+    }
+
     pub async fn enabled_devices(&self) -> HashSet<String> {
         self.options.read().await.enabled_devices.clone()
     }

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -16,6 +16,8 @@ use std::sync::{
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
+use screenpipe_audio::audio_manager::builder::TranscriptionMode;
+
 use crate::server::AppState;
 use crate::ui_recorder::{
     tree_walker_snapshot, ui_recorder_status_snapshot, TreeWalkerSnapshot, UiRecorderStatus,
@@ -445,6 +447,30 @@ async fn get_audio_reconciliation_backlog(
     }
 
     result
+}
+
+/// Resolve the `transcription_mode` reported by `/health`.
+///
+/// Reports the *configured* mode (#3989). When the options lock is momentarily
+/// contended, `configured` is `None` and we fall back to the legacy
+/// observed-activity heuristic so `/health` stays non-blocking and still returns
+/// a best-effort value.
+fn transcription_mode_label(
+    configured: Option<TranscriptionMode>,
+    deferred: u64,
+    batch_processed: u64,
+) -> &'static str {
+    match configured {
+        Some(TranscriptionMode::Realtime) => "realtime",
+        Some(TranscriptionMode::Batch) => "batch",
+        None => {
+            if deferred > 0 || batch_processed > 0 {
+                "batch"
+            } else {
+                "realtime"
+            }
+        }
+    }
 }
 
 async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
@@ -1054,14 +1080,15 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
                 } else {
                     Some(device_names)
                 },
-                // Batch/Smart mode
-                transcription_mode: if audio_snap.segments_deferred > 0
-                    || audio_snap.segments_batch_processed > 0
-                {
-                    Some("batch".to_string())
-                } else {
-                    Some("realtime".to_string())
-                },
+                // Reflect the CONFIGURED mode, not observed activity (#3989).
+                transcription_mode: Some(
+                    transcription_mode_label(
+                        state.audio_manager.configured_transcription_mode(),
+                        audio_snap.segments_deferred,
+                        audio_snap.segments_batch_processed,
+                    )
+                    .to_string(),
+                ),
                 transcription_paused: Some(transcription_paused),
                 segments_deferred: if audio_snap.segments_deferred > 0 {
                     Some(audio_snap.segments_deferred)
@@ -1204,6 +1231,31 @@ pub async fn api_vision_status() -> JsonResponse<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn transcription_mode_reports_configuration_not_activity() {
+        // The #3989 bug fix: a batch-configured instance reports "batch"
+        // immediately at idle, before any deferred/batch activity is observed.
+        assert_eq!(
+            transcription_mode_label(Some(TranscriptionMode::Batch), 0, 0),
+            "batch"
+        );
+        // Realtime stays realtime even if batch activity counters are non-zero —
+        // configuration always wins over observed activity when the lock is readable.
+        assert_eq!(
+            transcription_mode_label(Some(TranscriptionMode::Realtime), 5, 3),
+            "realtime"
+        );
+    }
+
+    #[test]
+    fn transcription_mode_falls_back_to_activity_when_contended() {
+        // configured == None (options lock momentarily contended) → legacy
+        // observed-activity heuristic, keeping /health non-blocking.
+        assert_eq!(transcription_mode_label(None, 0, 0), "realtime");
+        assert_eq!(transcription_mode_label(None, 1, 0), "batch");
+        assert_eq!(transcription_mode_label(None, 0, 1), "batch");
+    }
 
     fn dummy_response(status: &str) -> HealthCheckResponse {
         HealthCheckResponse {


### PR DESCRIPTION
## description

Fixes #3989. The `/health` endpoint derives `transcription_mode` from segment **activity counters** rather than the **configured** mode:

```rust
transcription_mode: if audio_snap.segments_deferred > 0
    || audio_snap.segments_batch_processed > 0
{ Some("batch") } else { Some("realtime") }
```

So at startup and during idle — before any deferred/batch segment has been observed — a **batch-configured** instance reports `"realtime"`. The label only flips to `"batch"` once batch activity happens, so it lags and misrepresents the actual configuration.

(Root-cause analysis credit: @seidnerj in #3989.)

### fix

Read the configured mode directly via a new non-blocking accessor on `AudioManager`:

```rust
pub fn configured_transcription_mode(&self) -> Option<TranscriptionMode> {
    self.options.try_read().ok().map(|o| o.transcription_mode.clone())
}
```

`/health` now reports the configured mode immediately. `try_read` keeps the handler non-blocking — if the options lock is momentarily contended it falls back to the legacy activity heuristic (mirrors the existing non-blocking treatment of the meeting-detector lock a few lines down). `segments_deferred` / `segments_batch_processed` remain exposed separately for observed activity.

Single-purpose change: `screenpipe-audio` (the accessor) + `screenpipe-engine` (the `/health` derivation + a unit test).

related issue: #3989

## before

Live on a batch-configured instance (its settings store has `"transcriptionMode": "batch"`), idle, with no batch activity yet:

```
$ curl -s localhost:3030/health | jq '.audio_pipeline | {transcription_mode, segments_deferred, segments_batch_processed}'
{
  "transcription_mode": "realtime",   # ← wrong: configured mode is "batch"
  "segments_deferred": null,          # 0 — no batch activity observed yet
  "segments_batch_processed": null    # 0
}
```

## after

With this change, the same idle batch-configured state reports the configured mode. Proven by a unit test on the extracted pure helper (`transcription_mode_label`):

```
test routes::health::tests::transcription_mode_reports_configuration_not_activity ... ok
test routes::health::tests::transcription_mode_falls_back_to_activity_when_contended ... ok
```

- `transcription_mode_label(Some(Batch), 0, 0) == "batch"`  ← the fix (configured wins at idle)
- `transcription_mode_label(Some(Realtime), 5, 3) == "realtime"`  ← configured wins over activity
- `transcription_mode_label(None, 1, 0) == "batch"`  ← contended-lock fallback preserved

## how to test

1. `cargo test -p screenpipe-engine --lib transcription_mode_` → both tests pass.
2. On a batch-configured instance, `curl -s localhost:3030/health | jq '.audio_pipeline.transcription_mode'` reports `"batch"` immediately at startup/idle (previously `"realtime"` until batch activity occurred).

## desktop app checklist (if applicable)

N/A — confined to `screenpipe-core`/engine and audio crates; no `#[tauri::command]` handlers or frontend-exported types added or changed.
