### PR TITLE
fix(lefthook): scope rust-fmt check to staged files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,7 +17,12 @@ pre-commit:
   commands:
     rust-fmt:
       glob: "*.rs"
-      run: cargo fmt --check -- {staged_files}
+      # `cargo fmt -- <files>` ignores the file args and reformats the WHOLE
+      # workspace, so it false-fails on pre-existing drift in files the commit
+      # never touched. Call rustfmt directly to honor "only on STAGED files".
+      # `--` keeps any odd file name (e.g. one starting with '-') from being
+      # parsed as a flag.
+      run: rustfmt --edition 2021 --check -- {staged_files}
 
     rust-clippy:
       # Only run clippy on the crates that have at least one staged .rs file.


### PR DESCRIPTION
## description

The pre-commit `rust-fmt` hook is supposed to check **only staged files** (per this file's own header), but it runs:

```yaml
run: cargo fmt --check -- {staged_files}
```

`cargo fmt` is package-scoped, not file-scoped — it ignores the trailing file args and formats every package by its crate root. So `{staged_files}` does nothing and the hook checks the **entire workspace**. The result: committing a perfectly-formatted change fails the hook because of pre-existing formatting drift in *unrelated* files the commit never touched (e.g. a stale test file in another crate). The neighbouring `rust-clippy` hook already scopes correctly.

This change calls `rustfmt` directly so the check is genuinely limited to the staged files:

```yaml
run: rustfmt --edition 2021 --check -- {staged_files}
```

- The workspace is uniformly edition 2021 (`[workspace.package]`, all crates inherit), so `--edition 2021` is correct.
- The `--` separator keeps an odd file name (e.g. one starting with `-`) from being parsed as a flag.

related issue: n/a

## before

`cargo fmt --check -- <staged files>` — fails on workspace-wide drift unrelated to the commit (false positive).

## after

`rustfmt --edition 2021 --check -- <staged files>` — checks exactly the staged files; passes when the commit's own files are formatted, regardless of drift elsewhere.

## how to test

1. In a workspace with some pre-existing fmt drift in a file you're **not** committing, stage a correctly-formatted `.rs` change.
2. Old hook: `cargo fmt --check -- <that file>` → fails (reports the unrelated file).
3. New hook: `rustfmt --edition 2021 --check -- <that file>` → passes.
4. Stage a **mis**-formatted `.rs` file → new hook still fails (the gate still works).

## desktop app checklist (if applicable)

N/A — pre-commit hook config only; no Rust/TS code or bindings changed.
