### PR TITLE
fix(redact): don't panic the redaction worker on invalid UTF-8 text

### DIFF
--- a/crates/screenpipe-redact/src/worker/tables.rs
+++ b/crates/screenpipe-redact/src/worker/tables.rs
@@ -209,7 +209,13 @@ pub async fn fetch_unredacted(
         .into_iter()
         .map(|r| UnredactedRow {
             id: r.get::<i64, _>("id"),
-            text: r.get::<String, _>("text"),
+            // Some OCR/transcription rows hold invalid UTF-8 (e.g. a truncated
+            // multi-byte sequence). `get::<String>` panics on the column decode
+            // and takes down the whole redaction worker thread; the row is then
+            // re-fetched and re-panics forever. Read the raw bytes and decode
+            // lossily so the row still gets redacted and stamped, with the bad
+            // bytes replaced by U+FFFD.
+            text: String::from_utf8_lossy(&r.get::<Vec<u8>, _>("text")).into_owned(),
         })
         .collect();
     Ok(out)


### PR DESCRIPTION
A captured OCR/transcript row with invalid UTF-8 (a truncated multi-byte sequence) crashes the redaction worker and stalls all PII redaction.

```
before:
  fetch_unredacted -> r.get::<String>("text") -> ColumnDecode / Utf8Error
                   -> PANIC (worker thread dies) -> row never stamped redacted
                   -> re-fetched -> PANIC -> ...  (redaction silently stalls)

after:
  fetch_unredacted -> r.get::<Vec<u8>>("text") -> from_utf8_lossy (bad -> U+FFFD)
                   -> row redacted + stamped -> worker keeps going
```

Found live while debugging an enterprise build: 3 panics, health `degraded`, redaction stuck. One-line decode change, `cargo check -p screenpipe-redact` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)