### PR TITLE
fix(deps): bump audiopipe to fix Windows DirectML build (mut)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 name = "antirez-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=7e75d67a64143b9b990549e30043921107781f31#7e75d67a64143b9b990549e30043921107781f31"
 dependencies = [
  "cc",
 ]
@@ -644,7 +644,7 @@ dependencies = [
 [[package]]
 name = "audiopipe"
 version = "0.2.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=7e75d67a64143b9b990549e30043921107781f31#7e75d67a64143b9b990549e30043921107781f31"
 dependencies = [
  "antirez-asr-sys",
  "half",
@@ -7175,7 +7175,7 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 [[package]]
 name = "qwen3-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=7e75d67a64143b9b990549e30043921107781f31#7e75d67a64143b9b990549e30043921107781f31"
 dependencies = [
  "cc",
  "cmake",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ wiremock = "0.6"
 
 # Audio
 hound = "3.5"
-audiopipe = { git = "https://github.com/screenpipe/audiopipe.git", rev = "49eaf07f14d39c9a4f422022d76058539cebae9d", default-features = false }
+audiopipe = { git = "https://github.com/screenpipe/audiopipe.git", rev = "7e75d67a64143b9b990549e30043921107781f31", default-features = false }
 mlx-rs = "0.25"
 
 # Privacy filter enclave attestation (shared by engine + redact)

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "antirez-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=7e75d67a64143b9b990549e30043921107781f31#7e75d67a64143b9b990549e30043921107781f31"
 dependencies = [
  "cc",
 ]
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "audiopipe"
 version = "0.2.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=7e75d67a64143b9b990549e30043921107781f31#7e75d67a64143b9b990549e30043921107781f31"
 dependencies = [
  "antirez-asr-sys",
  "half",
@@ -9743,7 +9743,7 @@ checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 [[package]]
 name = "qwen3-asr-sys"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/audiopipe.git?rev=49eaf07f14d39c9a4f422022d76058539cebae9d#49eaf07f14d39c9a4f422022d76058539cebae9d"
+source = "git+https://github.com/screenpipe/audiopipe.git?rev=7e75d67a64143b9b990549e30043921107781f31#7e75d67a64143b9b990549e30043921107781f31"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
Follow-up to #4132. The rc.12 DirectML rewrite missed the `mut` that ort's `commit_from_file` (`&mut self`) needs, so all Windows targets still failed (E0596) and v2.5.39's **Release App + Release CLI** Windows jobs broke. Bumps audiopipe `49eaf07 -> 7e75d67` (screenpipe/audiopipe#11), matching the CPU path.

```
release windows build:  before → ✗ audiopipe E0596 (cannot borrow b as mutable)
                        after  → ✓ let mut b; commit_from_file(&mut self) ok
```

Verified by analogy to the adjacent CPU path (compiles under rc.12); confirmed by the next Windows release build. Does **not** address the separate macOS x64 (Intel) ort-sys prebuilt failure.