### PR TITLE
 fix(chat): model change inside a preset not working until new chat

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -1269,12 +1269,16 @@ export const AIPresetsSelector = ({
       });
     }
 
-    // Notify parent to restart Pi if the saved preset is the active/default one
+    // Notify parent to restart Pi only when the edited preset is the one in use.
+    // In chat (controlled mode): the selected preset is the one active in chat.
+    // In Settings (non-controlled): fall back to checking the app-wide default.
     if (onPresetSaved) {
       const savedFull = { ...preset } as AIPreset;
-      const isDefault = selectedPresetToEdit?.defaultPreset ||
-        (!selectedPresetToEdit && settings.aiPresets.length === 0);
-      if (isDefault) {
+      const shouldNotify = isControlled
+        ? selectedPreset === preset.id
+        : selectedPresetToEdit?.defaultPreset ||
+          (!selectedPresetToEdit && settings.aiPresets.length === 0);
+      if (shouldNotify) {
         onPresetSaved(savedFull);
       }
     }


### PR DESCRIPTION
This PR fixes two issues with model switching mid-chat:

1. Editing the model inside a preset mid-chat has no effect — Pi keeps using the old model. Users have to start a new
  chat for the change to work. Switching between different presets works fine; only changing the model within the
  same preset is broken.
  
  

https://github.com/user-attachments/assets/2b865792-8c92-4b99-8613-767516d0acf1



2. Editing the default preset would restart Pi even if the user is chatting with a different preset unexpectedly switching their active model.


https://github.com/user-attachments/assets/f974ca61-bc61-499a-a091-6c613649a674



Fix -

Only notify Pi to restart when the preset being edited is the one you're actually using in the chat.

https://github.com/user-attachments/assets/933349c1-ce58-4e46-833f-7f23005b07d5


https://github.com/user-attachments/assets/83c8bcc2-adbc-4911-8ded-8c8bca0158f3

