### PR TITLE
fix(redact,audio): restore Intel mac (x86_64) builds on ort rc.12

### DIFF
--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -125,7 +125,17 @@ libsamplerate-sys = { workspace = true }
 cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a" }
 once_cell = { workspace = true }
 objc = { workspace = true }
+
+# Apple Silicon: bundle ONNX Runtime via the pyke prebuilt (arm64 xcframework).
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 ort = { workspace = true, features = ["download-binaries", "tls-native"] }
+
+# Intel mac: ort rc.12 ships no x86_64 prebuilt (pyke + upstream ONNX Runtime
+# are arm64-only since ~1.20). load-dynamic links against headers only and
+# loads the dylib at runtime if present. The ONNX ASR paths (parakeet/qwen3)
+# are not enabled on Intel, so no dylib is required for a working build.
+[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]
+ort = { workspace = true, default-features = false, features = ["load-dynamic", "api-24"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/screenpipe-redact/Cargo.toml
+++ b/crates/screenpipe-redact/Cargo.toml
@@ -66,7 +66,11 @@ default = []
 
 # Enable the ONNX-based image redactor (rfdetr) AND the v45 phase 3
 # text redactor (xlm-roberta-base BIO token classifier). CPU baseline.
-onnx-cpu = ["dep:ort", "dep:ndarray", "dep:tokenizers", "dep:serde_json", "ort/download-binaries", "ort/tls-native", "ort/std"]
+# NOTE: the ONNX Runtime link strategy (download a pyke prebuilt vs.
+# load-dynamic at runtime) is NOT baked in here — it is target-conditional
+# in the per-target `[target.….dependencies.ort]` entries below, because
+# ort rc.12 ships no x86_64-apple-darwin prebuilt (Intel uses load-dynamic).
+onnx-cpu = ["dep:ort", "dep:ndarray", "dep:tokenizers", "dep:serde_json", "ort/tls-native", "ort/std"]
 # Mac: CoreML execution provider (uses Metal + ANE where available).
 onnx-coreml = ["onnx-cpu", "ort/coreml"]
 # Windows: DirectML EP (any DX12-capable GPU, no CUDA toolkit).
@@ -87,7 +91,33 @@ mlx-mac = ["dep:screenpipe-rfdetr-mlx"]
 
 [dependencies.ort]
 workspace = true
+default-features = false
 features = ["ndarray"]
+optional = true
+
+# ONNX Runtime link strategy, per target (additively merged into the base
+# entry above). aarch64-mac / linux / windows pull a pyke prebuilt exactly
+# as before. Intel mac has no rc.12 prebuilt, so it links against headers
+# only (load-dynamic) and loads the bundled libonnxruntime.dylib at runtime.
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies.ort]
+workspace = true
+features = ["download-binaries", "copy-dylibs", "tracing", "api-24"]
+optional = true
+
+[target.'cfg(target_os = "linux")'.dependencies.ort]
+workspace = true
+features = ["download-binaries", "copy-dylibs", "tracing", "api-24"]
+optional = true
+
+[target.'cfg(target_os = "windows")'.dependencies.ort]
+workspace = true
+features = ["download-binaries", "copy-dylibs", "tracing", "api-24"]
+optional = true
+
+[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies.ort]
+workspace = true
+default-features = false
+features = ["load-dynamic", "api-24", "tracing"]
 optional = true
 
 [dependencies.ndarray]


### PR DESCRIPTION
## what

Restores **x86_64-apple-darwin (Intel mac)** release builds, which broke at the ort rc.10 → rc.12 bump (#4089). ort rc.12 / ONNX Runtime 1.24 ships **no Intel-mac prebuilt** (pyke + upstream both dropped Intel at ~ORT 1.20), so the `download-binaries` default failed the build:

```
error: ort-sys: ort does not provide prebuilt binaries for the target `x86_64-apple-darwin` with feature set (no features)
```

Intel was green until 2 days ago — keeping rc.12 (for the ANE PII speedup on Apple Silicon) means Intel must link ONNX Runtime a different way.

## fix (this PR — Cargo only)

Intel mac now links via **`load-dynamic`** (like Windows) and loads a bundled `libonnxruntime.dylib` at runtime. The link strategy is target-conditional:

```
target                    ort link strategy
------------------------  -----------------------------------------
aarch64-apple-darwin      download-binaries (pyke prebuilt)   ← unchanged
linux / windows           download-binaries / load-dynamic    ← unchanged
x86_64-apple-darwin  NEW  load-dynamic + api-24  (no prebuilt needed)
```

- `screenpipe-audio`: split the macOS ort block by arch.
- `screenpipe-redact`: moved `download-binaries` out of the shared `onnx-cpu` feature into per-target entries — **arm64/linux/windows are byte-identical** (verified via `cargo tree`); Intel gets `load-dynamic + api-24`. `api-24` is required so load-dynamic gets the ORT 1.24 OrtApi bindings (without it ort references a `VitisAI` field the bindings lack).
- `audiopipe` needs no change (its ort unifies with the workspace ort).

## verified locally (Intel cross-compiles cleanly from Apple Silicon)

- ✅ full `screenpipe-engine` cross-compiled to `x86_64-apple-darwin` (`metal,redact-onnx-coreml`) — builds clean
- ✅ arm64 ort features unchanged (`download-binaries, copy-dylibs, tracing, api-24, coreml`)
- ✅ x64 ort features correct (`load-dynamic, api-24, coreml`, no `download-binaries`)

## still to land (follow-up, in the release workflows)

The runtime `libonnxruntime.dylib` (x86_64) gets injected into `Contents/MacOS/` + re-signed, mirroring the existing `mlx.metallib` step. Source: the Homebrew onnxruntime bottle (x86_64, 1.26.0 — ort only *warns* on a newer dylib, so it works). **Do not ship an Intel release until that lands** (build compiles, but the app needs the dylib at runtime).
