### PR TITLE
chore: clean up apple intelligence removal leftovers

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11096,16 +11096,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "screenpipe-apple-intelligence"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "chrono",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "screenpipe-audio"
 version = "0.4.19"
 dependencies = [
@@ -11342,7 +11332,6 @@ dependencies = [
  "reqwest 0.13.3",
  "rpassword",
  "screenpipe-a11y",
- "screenpipe-apple-intelligence",
  "screenpipe-audio",
  "screenpipe-capture",
  "screenpipe-config",
@@ -11364,7 +11353,6 @@ dependencies = [
  "tempfile",
  "tinfoil",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tower-http 0.5.2",
  "tracing",

--- a/docs/mintlify/docs-mintlify-mig-tmp/architecture.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/architecture.mdx
@@ -106,11 +106,9 @@ graph TD
     CORE[screenpipe-core<br/><i>pipes · config</i>]
     EVENTS[screenpipe-events<br/><i>event system</i>]
     A11Y[screenpipe-accessibility<br/><i>UI events · accessibility tree</i>]
-    AI[screenpipe-apple-intelligence<br/><i>Foundation Models</i>]
     INT[screenpipe-integrations<br/><i>MCP · reminders</i>]
 
     APP --> SERVER
-    APP --> AI
     SERVER --> DB
     SERVER --> VISION
     SERVER --> AUDIO
@@ -178,7 +176,6 @@ REST API on `localhost:3030`:
 | `/frames/{id}/context` | accessibility text + URLs + OCR fallback for a frame |
 | `/health` | system status and metrics |
 | `/raw_sql` | direct database queries |
-| `/ai/chat/completions` | Apple Intelligence (macOS 26+) |
 
 see [API reference](/cli-reference) for the full endpoint list.
 


### PR DESCRIPTION
Follow-up to #4153 — two leftovers caught while double-checking the removal.

### 1. App crate `Cargo.lock` still referenced the deleted crate
The Tauri app crate keeps its **own** `Cargo.lock` (`apps/screenpipe-app-tauri/src-tauri/Cargo.lock`), separate from the workspace lock that #4153 updated. It still had the `screenpipe-apple-intelligence` package entry plus its dep refs in `screenpipe-engine` (`screenpipe-apple-intelligence` + `tokio-stream`).

Non-`--locked` builds tolerate this and self-heal (the Linux E2E build on #4153 proved the app still compiles), so it's **not** a release break — but a committed lockfile shouldn't point at a crate that no longer exists. Removed just those refs; left the pre-existing version drift (`0.4.19`→`0.4.20`) in that lock alone, since the repo regenerates it at release rather than per-commit.

### 2. `architecture.mdx` still documented it
Removed `screenpipe-apple-intelligence` (Foundation Models) from the crate graph + its `APP --> AI` edge, and dropped the `/ai/chat/completions` row from the endpoint table. (The unrelated `AI[Claude · Cursor · etc.]` MCP-clients node is left as-is.)

Everything else from the removal verified clean: no leftover `/ai/*` callers, no orphaned `apple-intelligence` strings/connections/settings/localStorage readers, no `fm-server` sidecar refs, entitlements clean, and `renderConnectionCard` has a safe `default:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)