### PR TITLE
example(pipes): add bundled follow-ups pipe

### DIFF
--- a/crates/screenpipe-core/assets/pipes/follow-ups/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/follow-ups/pipe.md
@@ -1,0 +1,49 @@
+---
+schedule: manual
+enabled: true
+template: true
+title: Follow-ups
+description: "Commitments and action items you took on today — so nothing slips"
+icon: "✅"
+featured: false
+---
+
+Scan my screen and audio recordings from today (last 16 hours only) for things
+**I committed to** or **was asked to do**, and list the open follow-ups so I
+don't drop any. This is read-only — do NOT write or patch anything, just report.
+
+Read the screenpipe skill first so you know the search endpoints.
+
+Look across BOTH sources, scoped to today:
+- **Audio** (`content_type=audio`) — meetings and calls: things I said I'd do
+  ("I'll send…", "I'll get back to you", "let me follow up on…", "I can have
+  that by Friday"), and things others asked of me.
+- **Screen/OCR + UI** (`content_type=ocr` / `content_type=ui`) — chats, email,
+  Slack, Messages, issue trackers: action items assigned to me, "@me can you…",
+  "could you…", unanswered questions directed at me, things I replied "yes" /
+  "on it" / "will do" to.
+
+For each follow-up, capture: **what** needs doing, **for whom** (person/channel),
+**by when** if a due date or timeframe was mentioned, and the **source +
+timestamp** so I can jump back to it.
+
+Use this exact format:
+
+## Open Follow-ups
+- [ ] **<what>** — for <whom>{, due <when>} _(via <app> ~<time>)_
+- [ ] ...
+
+## Probably Already Done
+- Items I committed to AND can see evidence I completed later in the day — with the timestamp of the evidence.
+
+## Needs a Decision
+- Things asked of me that I never acknowledged or answered — flag these first; they're the easiest to lose.
+
+Rules:
+- Only list items you can verify from the recordings — quote or reference the
+  moment. Do not invent commitments.
+- Deduplicate: if the same promise shows up in a meeting and a follow-up chat,
+  list it once with both sources.
+- If you find nothing actionable, say so plainly instead of padding the list.
+
+End with: "**Most urgent:** [the one with the nearest deadline or the longest unanswered]".

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -4334,6 +4334,10 @@ impl PipeManager {
                 "meeting-summary",
                 include_str!("../../assets/pipes/meeting-summary/pipe.md"),
             ),
+            (
+                "follow-ups",
+                include_str!("../../assets/pipes/follow-ups/pipe.md"),
+            ),
         ];
 
         let tombstones = read_tombstones(&self.pipes_dir);


### PR DESCRIPTION
## description

Adds a new bundled example pipe: **`follow-ups`** — a manual, **read-only** digest that scans the day's recordings for commitments the user made or was asked to do, and lists the open follow-ups so none slip.

It scans both sources, scoped to today:
- **audio** (`content_type=audio`) — meetings/calls: "I'll send…", "let me follow up…", things others asked of the user;
- **screen/OCR + UI** — chats, email, Slack, trackers: action items assigned to the user, unanswered questions.

Output is grouped into **Open Follow-ups**, **Probably Already Done**, and **Needs a Decision** (things never acknowledged — easiest to lose).

It's distinct from the existing pipes: `meeting-summary` summarizes *one* meeting; `standup-update` reports what you *did*; this one surfaces what you still *owe*, across sources.

**Read-only by design** — it reports and never PATCHes anything, and only lists items verifiable from the recordings (no invented commitments). Bundled like the other built-ins (one `pipe.md` + a registration line in `install_builtin_pipes`).

related issue: #3659 (Pipes → "more end-to-end examples — the more, the better")

## before / after

N/A — additive example pipe; no behavior change to existing code paths.

## how to test

1. Build/run screenpipe; the pipe installs as a template under the pipes dir on startup (`install_builtin_pipes`).
2. Run it from the app/CLI ("Follow-ups"); on a day with meetings/chats it produces the three grouped sections; with no actionable items it says so plainly.
3. `cargo check -p screenpipe-core` passes (the `include_str!` registration).

## desktop app checklist (if applicable)

N/A — adds a bundled pipe template + one registration line; no `#[tauri::command]` handlers or frontend-exported types changed.
