### PR TITLE
fix(audio): stop fbank panics from crashing the speaker-embedding worker

### DIFF
--- a/crates/screenpipe-audio/src/speaker/embedding.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding.rs
@@ -26,9 +26,18 @@ impl EmbeddingExtractor {
     pub fn compute(&mut self, samples: &[f32]) -> Result<impl Iterator<Item = f32>> {
         // knf-rs exposes ndarray 0.16 types; the workspace is on 0.17 for
         // ort rc.12 — rebuild the array in our ndarray version via raw parts.
-        let features_016 = knf_rs::compute_fbank(samples)
-            .map_err(anyhow::Error::msg)
-            .context("compute_fbank failed")?;
+        //
+        // knf-rs also *panics* (Option::unwrap on None deep in
+        // OnlineGenericBaseFeature::InputFinished) when `samples` is too short
+        // to yield an fbank frame, unwinding the audio worker instead of
+        // returning an error — the highest-volume crash in the field
+        // (SCREENPIPE-CLI-3S). Run it under the same panic guard create_session
+        // uses so the caller skips the segment gracefully (see get_speaker_embedding).
+        let features_016 = super::catch_panic_into_error("compute_fbank", || {
+            knf_rs::compute_fbank(samples)
+                .map_err(anyhow::Error::msg)
+                .context("compute_fbank failed")
+        })?;
         let (rows, cols) = features_016.dim();
         let features: Array2<f32> =
             Array2::from_shape_vec((rows, cols), features_016.into_raw_vec())

--- a/crates/screenpipe-audio/src/speaker/mod.rs
+++ b/crates/screenpipe-audio/src/speaker/mod.rs
@@ -14,7 +14,7 @@ pub fn create_session<P: AsRef<Path>>(path: P) -> Result<ort::session::Session> 
     // `expect("Failed to initialize ORT API")` at lib.rs:188). That panic
     // bubbles up the tokio worker and Sentry — convert it to a normal error
     // so callers fall back gracefully instead of crashing the runtime.
-    catch_panic_into_error(|| {
+    catch_panic_into_error("ort session init", || {
         // ort rc.12: builder ops return `Error<SessionBuilder>` (recovery
         // payload, not Send+Sync) — convert via Display for anyhow.
         let oe = |e: &dyn std::fmt::Display| anyhow!("ort: {e}");
@@ -29,7 +29,13 @@ pub fn create_session<P: AsRef<Path>>(path: P) -> Result<ort::session::Session> 
     })
 }
 
-fn catch_panic_into_error<F, T>(f: F) -> Result<T>
+/// Run `f`, converting any panic it unwinds into an error tagged with
+/// `context`. Both ort (FFI) and knf-rs (fbank) `unwrap()`/`expect()` deep in
+/// native bindings on bad input or environment mismatches; without this guard
+/// those panics unwind the audio/tokio worker and crash the runtime instead of
+/// being handled. The `context` names which guarded call failed so logs and
+/// Sentry stay legible (e.g. "ort session init" vs "compute_fbank").
+fn catch_panic_into_error<F, T>(context: &str, f: F) -> Result<T>
 where
     F: FnOnce() -> Result<T>,
 {
@@ -41,7 +47,7 @@ where
                 .map(|s| (*s).to_string())
                 .or_else(|| payload.downcast_ref::<String>().cloned())
                 .unwrap_or_else(|| "unknown panic".to_string());
-            Err(anyhow!("ort session init panicked: {}", msg))
+            Err(anyhow!("{context} panicked: {msg}"))
         }
     }
 }
@@ -99,13 +105,14 @@ mod tests {
 
     #[test]
     fn catch_panic_into_error_passes_through_ok() {
-        let r: Result<i32> = catch_panic_into_error(|| Ok(7));
+        let r: Result<i32> = catch_panic_into_error("ort session init", || Ok(7));
         assert_eq!(r.unwrap(), 7);
     }
 
     #[test]
     fn catch_panic_into_error_passes_through_err() {
-        let r: Result<()> = catch_panic_into_error(|| Err(anyhow!("normal failure")));
+        let r: Result<()> =
+            catch_panic_into_error("ort session init", || Err(anyhow!("normal failure")));
         let msg = r.unwrap_err().to_string();
         assert!(msg.contains("normal failure"));
         assert!(!msg.contains("panicked"));
@@ -113,7 +120,7 @@ mod tests {
 
     #[test]
     fn catch_panic_into_error_catches_str_panic() {
-        let r: Result<()> = catch_panic_into_error(|| panic!("boom"));
+        let r: Result<()> = catch_panic_into_error("ort session init", || panic!("boom"));
         let msg = r.unwrap_err().to_string();
         assert!(msg.contains("ort session init panicked"));
         assert!(msg.contains("boom"));
@@ -121,7 +128,8 @@ mod tests {
 
     #[test]
     fn catch_panic_into_error_catches_string_panic() {
-        let r: Result<()> = catch_panic_into_error(|| panic!("formatted: {}", 42));
+        let r: Result<()> =
+            catch_panic_into_error("ort session init", || panic!("formatted: {}", 42));
         let msg = r.unwrap_err().to_string();
         assert!(msg.contains("ort session init panicked"));
         assert!(msg.contains("42"));
@@ -131,10 +139,35 @@ mod tests {
     fn catch_panic_into_error_simulates_ort_api_init_panic() {
         // Mirrors the exact panic ort 2.0.0-rc.10 raises at lib.rs:188 when
         // `NonNull::new(api).expect("Failed to initialize ORT API")` triggers.
-        let r: Result<()> = catch_panic_into_error(|| panic!("Failed to initialize ORT API"));
+        let r: Result<()> = catch_panic_into_error("ort session init", || {
+            panic!("Failed to initialize ORT API")
+        });
         let msg = r.unwrap_err().to_string();
         assert!(msg.contains("ort session init panicked"));
         assert!(msg.contains("Failed to initialize ORT API"));
+    }
+
+    #[test]
+    fn catch_panic_into_error_uses_supplied_context() {
+        // The context tag distinguishes which guarded call panicked. embedding.rs
+        // passes "compute_fbank"; make sure that label reaches the error.
+        let r: Result<()> = catch_panic_into_error("compute_fbank", || panic!("boom"));
+        let msg = r.unwrap_err().to_string();
+        assert!(msg.contains("compute_fbank panicked"), "got: {msg}");
+        assert!(msg.contains("boom"));
+    }
+
+    #[test]
+    fn compute_fbank_tiny_input_is_contained_by_guard() {
+        // SCREENPIPE-CLI-3S regression: knf-rs unwraps a None deep in
+        // OnlineGenericBaseFeature::InputFinished for buffers too short to yield
+        // a frame, unwinding the audio worker. Routing compute_fbank through the
+        // guard must contain that. Reaching the end of this test (no unwind) is
+        // the assertion; the result may be Ok or a handled Err depending on knf.
+        let guarded = catch_panic_into_error("compute_fbank", || {
+            knf_rs::compute_fbank(&[0.0f32; 16]).map_err(anyhow::Error::msg)
+        });
+        let _ = guarded;
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`SCREENPIPE-CLI-3S` is the **highest-volume crash** in Sentry: `panic: called Option::unwrap() on a None value`, culprit `knf::OnlineGenericBaseFeature<T>::InputFinished` (1,500+ events, 8 users, still firing on the current release).

The speaker-embedding path calls `knf_rs::compute_fbank(samples)` in [`EmbeddingExtractor::compute`](crates/screenpipe-audio/src/speaker/embedding.rs). knf-rs `unwrap()`s a `None` deep inside its kaldi-native-fbank binding (`InputFinished`) when a speech segment is too short to yield an fbank frame. That is a **panic, not an `Err`**, so it unwinds past the `?` and takes down the audio/tokio worker instead of being handled.

## Fix

There is already a precedent in the same module: `catch_panic_into_error` (`speaker/mod.rs`) wraps ORT session init for exactly this reason ("convert it to a normal error so callers fall back gracefully instead of crashing the runtime"). This change:

1. Generalizes `catch_panic_into_error` to take a `context` label so logs/Sentry can tell which guarded call failed (`"ort session init"` vs `"compute_fbank"`). The ORT call site and its existing tests are updated; their messages are unchanged.
2. Routes `compute_fbank` through that guard.

The caller `get_speaker_embedding` ([`segment.rs`](crates/screenpipe-audio/src/speaker/segment.rs)) already handles `Err` by logging "Failed to compute speaker embedding, skipping segment" and moving on, so a bad segment now degrades to a skipped segment instead of unwinding the worker. Same graceful-fallback behavior as the existing handled path (`SCREENPIPE-CLI-G9`).

## Testing

`cargo test -p screenpipe-audio --lib speaker::` (25 pass, 1 ignored model test), including:
- `compute_fbank_tiny_input_is_contained_by_guard`: feeds a tiny sub-frame buffer to the **real** knf-rs `compute_fbank` through the guard and confirms it does not unwind out.
- `catch_panic_into_error_uses_supplied_context`: the context tag reaches the error message.
- All existing `catch_panic_into_error` / `resolve_output_name` tests still pass.

`rustfmt --edition 2021 --check` clean; no new clippy findings in the changed files.

Note: a global panic hook may still record the caught panic, so the Sentry count might not drop to zero immediately, but the crash (worker unwind) is what this fixes. Independent of [#4156](https://github.com/screenpipe/screenpipe/pull/4156).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
