### PR TITLE
fix(auth): hydrate cloud token on cross-window settings broadcast (#3943 regression)

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -711,6 +711,29 @@ async function setSettingsStripped(store: Store, settings: Settings) {
 	await store.set("settings", toPersist);
 }
 
+/**
+ * #3943: the cloud auth token no longer lives in store.bin (it's in the
+ * encrypted secret store). Neither `store.get("settings")` nor the cross-window
+ * `onKeyChange` broadcast carries it, so hydrate it back into the in-memory
+ * settings here. Every reader of `settings.user.token` (the account "logged in"
+ * indicator, the auth auto-refresh effect, the engine Bearer path) then keeps
+ * working unchanged across windows. Without this on the broadcast path, a login
+ * in one window ships a token-stripped user to every window (including the one
+ * that just logged in), so they all render "not logged in". Mutates in place and
+ * returns the same object for convenience.
+ */
+async function hydrateCloudToken(settings: Settings): Promise<Settings> {
+	if (settings.user && !settings.user.token) {
+		try {
+			const token = await commands.getCloudToken();
+			if (token) settings.user.token = token;
+		} catch (e) {
+			console.warn("failed to hydrate cloud token from secret store:", e);
+		}
+	}
+	return settings;
+}
+
 // Store utilities similar to Cap's implementation
 function createSettingsStore() {
 	const get = async (): Promise<Settings> => {
@@ -720,18 +743,8 @@ function createSettingsStore() {
 			return createDefaultSettingsObject();
 		}
 
-		// #3943: the cloud auth token no longer persists in store.bin (it now
-		// lives in the encrypted secret store). Hydrate it back into the
-		// in-memory settings so every existing reader of settings.user.token
-		// keeps working unchanged — only persistence moved.
-		if (settings.user && !settings.user.token) {
-			try {
-				const token = await commands.getCloudToken();
-				if (token) settings.user.token = token;
-			} catch (e) {
-				console.warn("failed to hydrate cloud token from secret store:", e);
-			}
-		}
+		// #3943: re-hydrate the cloud token that no longer persists in store.bin.
+		await hydrateCloudToken(settings);
 
 		// Migration: Ensure existing users have deviceId for free tier tracking
 		let needsUpdate = false;
@@ -977,8 +990,15 @@ function createSettingsStore() {
 
 	const listen = (callback: (settings: Settings) => void) => {
 		return getStore().then((store) => {
-			return store.onKeyChange("settings", (newValue: Settings | null | undefined) => {
-				callback(newValue || createDefaultSettingsObject());
+			// #3943: the broadcast value is token-stripped (see setSettingsStripped),
+			// so hydrate the cloud token before handing settings to React, mirroring
+			// get(). A monotonic seq drops a slow hydration that a newer broadcast
+			// (e.g. a logout fired right after a login) has already superseded.
+			let seq = 0;
+			return store.onKeyChange("settings", async (newValue: Settings | null | undefined) => {
+				const mySeq = ++seq;
+				const next = await hydrateCloudToken(newValue || createDefaultSettingsObject());
+				if (mySeq === seq) callback(next);
 			});
 		});
 	};


### PR DESCRIPTION
## What

Completes #3986's token-hydration so a logged-in user is recognized across windows. This is the **deterministic root cause** of the `zz-logout-resurrect` E2E red on Linux, Windows, **and** macOS on every main commit since #3986.

## Root cause (a real product regression, not just a test issue)

#3986 moved the cloud token out of `store.bin` into the encrypted secret store, and re-hydrated it in `createSettingsStore.get()` so the ~69 readers of `settings.user.token` keep working. But it did **not** hydrate on the `onKeyChange` broadcast path that drives React state across windows.

`store.set("settings", ...)` persists (and therefore broadcasts) the **token-stripped** copy. So after `loadUser` writes the user, the `onKeyChange` listener in every window (including the one that just logged in) receives `user` with `token = undefined`.

The account section gates its UI on the token:

```jsx
{settings.user?.token ? `logged in as ${settings.user.email}` : "not logged in"}
```

So immediately after a successful login the UI shows **"not logged in"**, and the login buttons stay (logout button is also token-gated). In the E2E spec this is why `loadUser` resolves (the `pi-reauth` log fires 56x) yet Phase A times out waiting for the email: the broadcast stripped the token, so the status never updates.

## Fix

Hydrate the cloud token in the `listen()`/broadcast path too, mirroring `get()`, via a shared `hydrateCloudToken` helper. A monotonic `seq` drops a slow hydration that a newer broadcast (e.g. a logout fired right after a login) has already superseded. The token stays encrypted at rest; only the in-memory shape is restored, which is exactly what #3986 intended.

## Why the prior attempt (#4155) did not fix it

#4155 hardened the test's Phase A retry, but the login could never display because the token was missing from the React state regardless of retries. That change is harmless (and still present on main); this PR fixes the actual product bug it was masking.

## Verification

- `bunx tsc --noEmit` passes.
- Cannot run Linux/Windows/macOS E2E locally; verifying via the E2E Tests workflow on this PR (all three platforms run here). Will confirm green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)