### PR TITLE
[pr] docs(contributing): use $TMPDIR for the dev data-dir so macos doesn't sweep it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,14 +212,14 @@ cargo test
 one command i keep using to avoid having to kill my main "production" process is:
 
 ```bash
-./target/release/screenpipe --port 3035 --data-dir /tmp/sp
+./target/release/screenpipe --port 3035 --data-dir "${TMPDIR:-/tmp}/sp"
 ```
 
 it will avoid conflicts with the port and avoid conflicts with the data dir
 
 especially useful if you've done new database migrations and want to avoid breaking your previous months of data :)
 
-on macos the /tmp dir keeps being cleaned up by the system fyi
+on macos, prefer `$TMPDIR` (a per-user temp dir) over `/tmp` — the system periodically sweeps `/tmp` and can wipe your dev data-dir mid-session, while `$TMPDIR` sticks around for the session. the `${TMPDIR:-/tmp}` form above uses it when set and falls back to `/tmp` otherwise.
 
 ### debugging github action
 


### PR DESCRIPTION
## description

the "running dev + prod in the same time" hack documents `--data-dir /tmp/sp`, then ends with the caveat "on macos the /tmp dir keeps being cleaned up by the system fyi" — but leaves it unsolved. the whole point of that hack is to keep a separate dev data-dir around (e.g. after running new migrations) without touching your real "months of data"; if macos sweeps `/tmp` mid-session, the dev data-dir it was protecting can disappear underneath a long-running instance.

this points the example at a per-user temp dir instead and turns the trailing caveat into the actual fix:

- command → `--data-dir "${TMPDIR:-/tmp}/sp"` — uses `$TMPDIR` when set (macos: a per-user temp dir the periodic sweeper leaves alone for the session), falls back to `/tmp` when unset (e.g. linux).
- the note now explains *why* and *what to use*, instead of just flagging the problem.

bonus: on macos `$TMPDIR` is a per-user dir (`drwx------`) whereas `/tmp` is world-traversable shared (`drwxrwxrwt`). since a dev data-dir holds captured screen/audio, this also moves dev captures out of a shared location into a per-user-private one.

scope: only the persistent dev **data-dir** is changed. the transient profiling paths in the same file (`/tmp/sp-cpu.csv`, `/tmp/sp-sample.txt`, `/tmp/sp.etl`) are single-run artifacts and are intentionally left as-is.

related issue: # (none — improves the existing note in CONTRIBUTING.md)

## before

`CONTRIBUTING.md` → "running dev + prod in the same time":

```
./target/release/screenpipe --port 3035 --data-dir /tmp/sp
...
on macos the /tmp dir keeps being cleaned up by the system fyi
```

## after

```
./target/release/screenpipe --port 3035 --data-dir "${TMPDIR:-/tmp}/sp"
...
on macos, prefer $TMPDIR (a per-user temp dir) over /tmp — the system periodically
sweeps /tmp and can wipe your dev data-dir mid-session, while $TMPDIR sticks around
for the session. the ${TMPDIR:-/tmp} form above uses it when set and falls back to
/tmp otherwise.
```

## how to test

docs-only change. to sanity-check the substitution does the right thing:

1. macos: `echo "${TMPDIR:-/tmp}/sp"` → resolves to a per-user dir like `/var/folders/.../T/sp` (not `/tmp`).
2. linux / `$TMPDIR` unset: `env -u TMPDIR sh -c 'echo "${TMPDIR:-/tmp}/sp"'` → falls back to `/tmp/sp`.
3. run the documented command and confirm screenpipe writes to that dir on `:3035`, isolated from your real `~/.screenpipe`.

## desktop app checklist (if applicable)

n/a — documentation only; no `#[tauri::command]` handlers or frontend-exported rust types changed.
