### PR TITLE
fix(ai-gateway): backfill missing ids on Vertex MaaS tool calls

### DIFF
--- a/packages/ai-gateway/src/providers/vertex-maas.ts
+++ b/packages/ai-gateway/src/providers/vertex-maas.ts
@@ -16,7 +16,7 @@
  */
 
 import { AIProvider } from './base';
-import { Message, RequestBody, ResponseFormat } from '../types';
+import { Message, RequestBody, ResponseFormat, ToolCall } from '../types';
 import { VertexAIProvider } from './vertex';
 
 const MAX_RETRIES = 3;
@@ -221,6 +221,46 @@ export function resolveVertexMaasModel(model: string): { vertexId: string; regio
 	return null;
 }
 
+/**
+ * Backfill ids onto assistant `tool_calls` (and the matching tool result) that
+ * arrive without one. Vertex MaaS rejects the entire request with
+ * `400 INVALID_ARGUMENT "Expected the 'id' of a(n) 'assistant' 'tool_calls'
+ * array element to be populated"` when any assistant tool call has an empty or
+ * absent id — which happens after some clients reconstruct chat history
+ * (SCREENPIPE-AI-PROXY-C).
+ *
+ * We synthesize a stable id for each such call and hand the same id to the next
+ * tool result that is itself missing a `tool_call_id`, pairing them positionally
+ * (OpenAI emits tool results in call order). Running before the orphan filter in
+ * `formatMessages` means the synthesized ids are visible to it, so a repaired
+ * call/result pair survives instead of being dropped or 400ing. Well-formed
+ * messages (every tool call already has an id) pass through untouched.
+ */
+export function backfillToolCallIds(messages: Message[]): Message[] {
+	let counter = 0;
+	const pendingSynthIds: string[] = [];
+	return messages.map((msg) => {
+		if (msg.role === 'assistant' && Array.isArray((msg as any).tool_calls)) {
+			const calls = (msg as any).tool_calls as ToolCall[];
+			// Untouched unless at least one call is missing its id.
+			if (!calls.some((c) => !c?.id)) return msg;
+			const fixed = calls.map((c) => {
+				if (c && !c.id) {
+					const id = `call_auto_${counter++}`;
+					pendingSynthIds.push(id);
+					return { ...c, id };
+				}
+				return c;
+			});
+			return { ...msg, tool_calls: fixed };
+		}
+		if (msg.role === 'tool' && !msg.tool_call_id && pendingSynthIds.length > 0) {
+			return { ...msg, tool_call_id: pendingSynthIds.shift()! };
+		}
+		return msg;
+	});
+}
+
 export class VertexMaasProvider implements AIProvider {
 	supportsTools = true;
 	supportsVision = true;
@@ -330,6 +370,12 @@ export class VertexMaasProvider implements AIProvider {
 	}
 
 	formatMessages(messages: Message[]): any[] {
+		// Repair assistant tool_calls (and their matching tool result) that lack
+		// an id before anything else, so Vertex doesn't 400 with "Expected the
+		// 'id' of a(n) 'assistant' 'tool_calls' array element to be populated".
+		// Runs first so the orphan filter below sees the synthesized ids.
+		messages = backfillToolCallIds(messages);
+
 		// Drop orphan tool messages (tool_call_id with no matching assistant
 		// tool_calls earlier in the array, or a content `tool_result` part on
 		// a user/tool message whose id was never emitted). Vertex MaaS rejects

--- a/packages/ai-gateway/src/test/vertex-maas.unit.test.ts
+++ b/packages/ai-gateway/src/test/vertex-maas.unit.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect } from 'bun:test';
 import {
+	backfillToolCallIds,
 	isVertexMaasModel,
 	parseVertexMaasJsonResponse,
 	promoteReasoningStream,
@@ -260,6 +261,72 @@ describe('VertexMaasProvider.formatMessages', () => {
 			tool_calls: [{ id: 'call_42' }],
 		});
 		expect(result[2]).toMatchObject({ role: 'tool', tool_call_id: 'call_42' });
+	});
+
+	// SCREENPIPE-AI-PROXY-C: a tool-call turn arriving without an id used to be
+	// forwarded verbatim, so Vertex 400'd with "Expected the 'id' of a(n)
+	// 'assistant' 'tool_calls' array element to be populated" and the whole
+	// request failed. formatMessages must hand it a populated id and keep the
+	// matching tool result paired to it.
+	it('populates id-less assistant tool_calls so Vertex does not 400', () => {
+		const result = provider.formatMessages([
+			{ role: 'user', content: 'list files' },
+			{
+				role: 'assistant',
+				content: '',
+				tool_calls: [{ type: 'function', function: { name: 'ls', arguments: '{}' } }],
+			} as any,
+			{ role: 'tool', content: 'a.txt' } as any,
+		]);
+		expect(result).toHaveLength(3);
+		const id = result[1].tool_calls[0].id;
+		expect(id).toBeTruthy();
+		expect(result[2]).toMatchObject({ role: 'tool', tool_call_id: id });
+	});
+});
+
+describe('backfillToolCallIds', () => {
+	it('synthesizes an id for an id-less assistant tool_call and pairs its result', () => {
+		const out = backfillToolCallIds([
+			{ role: 'user', content: 'list files' },
+			{ role: 'assistant', content: '', tool_calls: [{ type: 'function', function: { name: 'ls', arguments: '{}' } }] },
+			{ role: 'tool', content: 'a.txt' },
+		] as any);
+		const id = (out[1] as any).tool_calls[0].id;
+		expect(id).toBeTruthy();
+		expect((out[2] as any).tool_call_id).toBe(id);
+	});
+
+	it('leaves well-formed messages untouched (same object references)', () => {
+		const input = [
+			{ role: 'assistant', content: '', tool_calls: [{ id: 'call_42', type: 'function', function: { name: 'ls', arguments: '{}' } }] },
+			{ role: 'tool', content: 'x', tool_call_id: 'call_42' },
+		] as any;
+		const out = backfillToolCallIds(input);
+		expect(out[0]).toBe(input[0]);
+		expect(out[1]).toBe(input[1]);
+	});
+
+	it('pairs multiple id-less calls to their results in order', () => {
+		const out = backfillToolCallIds([
+			{
+				role: 'assistant',
+				content: '',
+				tool_calls: [
+					{ type: 'function', function: { name: 'a', arguments: '{}' } },
+					{ type: 'function', function: { name: 'b', arguments: '{}' } },
+				],
+			},
+			{ role: 'tool', content: 'result a' },
+			{ role: 'tool', content: 'result b' },
+		] as any);
+		const id0 = (out[0] as any).tool_calls[0].id;
+		const id1 = (out[0] as any).tool_calls[1].id;
+		expect(id0).toBeTruthy();
+		expect(id1).toBeTruthy();
+		expect(id0).not.toBe(id1);
+		expect((out[1] as any).tool_call_id).toBe(id0);
+		expect((out[2] as any).tool_call_id).toBe(id1);
 	});
 });
 


### PR DESCRIPTION
## Problem

`SCREENPIPE-AI-PROXY-C` is the **second-highest Sentry issue by users affected** (164 users, 658 events, firing daily): `UpstreamError: Vertex MaaS streaming failed: 400`, culprit `VertexMaasProvider.createStreamingCompletion`.

The upstream message is:

```
"Expected the 'id' of a(n) 'assistant' 'tool_calls' array element to be populated." (INVALID_ARGUMENT)
```

Vertex MaaS (the OpenAI-compatible endpoint serving GLM/Kimi/Llama/DeepSeek/Qwen) **rejects the entire request** when any assistant `tool_calls` element has an empty or absent `id`. In `formatMessageContent`, the Anthropic content-block path already synthesizes a fallback id (`part.id || \`call_${...}\``), but **top-level OpenAI-style `tool_calls` were forwarded verbatim** — so an id-less call from a client (which happens after some chat-history reconstruction) reached Vertex and 400'd the whole turn. Tool calling is broken on the cloud path for those users.

## Fix

New `backfillToolCallIds`, run at the top of `formatMessages` (before the orphan filter):

- Synthesizes a stable id (`call_auto_N`) for each assistant `tool_calls` element missing one.
- Hands the same id to the next tool result that is itself missing a `tool_call_id`, pairing them positionally (OpenAI emits tool results in call order).
- Runs **before** the existing orphan filter, so the synthesized ids are visible to it and the repaired call/result pair survives instead of being dropped.
- **No-op for well-formed traffic**: if every tool call already has an id, the messages pass through by reference, untouched.

This mirrors the existing fallback already used for the content-block path and complements the orphan-drop logic added for the sibling `SCREENPIPE-AI-PROXY-13` ("No tool calls but found tool output").

## Testing

`bun test` (full ai-gateway suite: **425 pass, 0 fail**), including 4 new tests:
- `formatMessages` populates an id-less assistant tool_call and keeps the matching tool result paired (the regression).
- `backfillToolCallIds`: synthesizes + pairs a single call/result; leaves well-formed messages untouched (same object references); pairs multiple id-less calls to results in order.

Source file is type-clean. Change is additive only (verified the diff touches no pre-existing lines beyond the one import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
