### PR TITLE
fix(audio): link ONNX Runtime at build time on Windows x86_64 (ort load-dynamic hangs)

### DIFF
--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -107,10 +107,15 @@ windows = { workspace = true, features = [
     "Win32_UI_Shell_PropertiesSystem",
 ] }
 
+# Bundle ONNX Runtime at build time on Windows x86_64 (same as Linux/macOS-arm64).
+# `load-dynamic` (runtime LoadLibrary of onnxruntime.dll) was tried but HANGS on
+# some hosts: ort rc.12's first call deadlocks inside `libloading::Library::new`
+# at 0% CPU, before `CreateEnv`, so the audio engine never finishes the
+# `building_audio` boot phase and the app looks dead (recording, VAD, diarization
+# all broken). Load-time linking of the *same* onnxruntime.dll initializes in
+# ~30ms. See PR #4171.
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
-# Avoid build-time network downloads (ort-sys download-binaries) for Windows x86_64.
-# When ONNX Runtime is available at runtime, `ort` can load it dynamically.
-ort = { workspace = true, default-features = false, features = ["load-dynamic"] }
+ort = { workspace = true, features = ["download-binaries", "tls-native"] }
 samplerate = { workspace = true }
 libsamplerate-sys = { workspace = true }
 


### PR DESCRIPTION
Follow-up to #4171, which was squash-merged **before** this fix was committed — so `main` currently has only the boot watchdog and still ships the broken `load-dynamic` line. This is the actual root-cause fix.

## Root cause (bisected + reproduced on a real Windows host)
ONNX Runtime itself is fine; the `ort` crate's `load-dynamic` feature is the bug.

| Test (same machine, same 1.22 DLL) | Result |
|---|---|
| Pure-C `CreateEnv` | ✅ 0.03s |
| Pure-C `CreateEnvWithCustomLogger` @ VERBOSE (exactly what ort does) | ✅ 0.06s |
| `ort` crate, **`load-dynamic`**, ORT_DYLIB_PATH pinned | ❌ HANG, 0% CPU |
| `ort` crate, load-dynamic, `tracing` off | ❌ HANG (not the logger) |
| hang is in **`ort::api()` → `libloading::Library::new`** (runtime LoadLibrary), before CreateEnv | ❌ |
| `ort` crate, **`download-binaries`** (load-time linked, like Linux/macOS) | ✅ api 30ms, builder 77ms |

ort's runtime `LoadLibrary` of onnxruntime.dll deadlocks at 0% CPU on this host; load-time linking of the *same* DLL works in ~77ms. This froze the `building_audio` boot phase in v2.5.40 (port 3030 never bound; recording/VAD/diarization dead).

## Fix
`crates/screenpipe-audio/Cargo.toml`: Windows x86_64 ort `load-dynamic` → `download-binaries` + `tls-native`, matching the other bundled targets. Verified `cargo build -p screenpipe-audio` compiles. Restores ONNX actually working (not just the boot watchdog from #4171, which stays as defense-in-depth).

## For maintainer review
- **Bundling:** ORT now links the prebuilt **CPU** runtime (CI already stages onnxruntime*.dll + sets `ORT_STRATEGY=system`/`ORT_LIB_LOCATION`) instead of the shipped **CUDA** `onnxruntime.dll`. ORT only runs tiny pyannote + Silero models here, so CPU is fine; Windows GPU ASR uses audiopipe/DirectML, unaffected. Reconcile the installer's `onnxruntime.dll` staging to ship the CPU runtime (drop the 540 MB CUDA provider dll).
- **Windows ARM64 / Intel-mac** still use `load-dynamic` and likely hit the same hang — left unchanged (couldn't repro on those targets). Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)