### PR TITLE
fix(analytics): stop post-sleep PostHog event burst + surface 400 body

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -63,7 +63,7 @@ impl AnalyticsManager {
             posthog_api_key,
             distinct_id,
             email,
-            interval: Duration::from_secs(interval_hours * 36),
+            interval: Duration::from_secs(interval_hours * 3600),
             enabled: Arc::new(Mutex::new(analytics_enabled)),
             api_host: "https://us.i.posthog.com".to_string(),
             local_api_base_url,
@@ -253,8 +253,10 @@ impl AnalyticsManager {
 
         let response = self.client.post(posthog_url).json(&payload).send().await?;
 
-        if !response.status().is_success() {
-            return Err(format!("PostHog API error: {}", response.status()).into());
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("PostHog API error: {} — {}", status, body).into());
         }
 
         Ok(())
@@ -262,6 +264,9 @@ impl AnalyticsManager {
 
     pub async fn start_periodic_event(&self) {
         let mut interval = interval(self.interval);
+        // Don't let missed ticks (e.g. after the machine resumes from a long
+        // sleep) fire back-to-back in a burst — coalesce them into one.
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
             interval.tick().await;


### PR DESCRIPTION
## Summary
The desktop app spams PostHog `/capture/` with `app_still_running` events (each returning `400 Bad Request`) for ~1000 ticks every time the machine resumes from a long sleep. Observed live in app logs after a ~62h suspend: a steady stream of `failed to send periodic posthog event: PostHog API error: 400 Bad Request` every 1–2s.

Three compounding root causes in `analytics.rs`:

- **Interval math bug:** `Duration::from_secs(interval_hours * 36)` → with `interval_hours = 6` that's **216s**, not the intended **6h** (`* 3600`). Fires ~100× too often. Long-standing (since 2026-03-26), not a recent regression.
- **Tokio interval `MissedTickBehavior::Burst` (default):** on resume, every missed tick replays back-to-back, producing the burst. Switched to `Skip` so missed ticks coalesce into one.
- **400 reason hidden:** the non-2xx branch discarded the response body, so the actual PostHog rejection cause was undiagnosable. Now logged.

## Changes
- `interval_hours * 36` → `interval_hours * 3600`
- `interval.set_missed_tick_behavior(MissedTickBehavior::Skip)` in `start_periodic_event`
- capture and log the response body on non-2xx PostHog responses

## Test plan
- [ ] CI build/check passes (local `cargo check` blocked by an unrelated missing `cblas.h`/OpenBLAS native dep on the dev machine — no Rust changes involved)
- [ ] After merge, the next 400 log line includes PostHog's rejection body, revealing why `/capture/` returns 400
- [ ] Verify only one `app_still_running` event fires per ~6h, and no burst after resume from sleep

🤖 Generated with [Claude Code](https://claude.com/claude-code)