### PR TITLE
fix(analytics): count machines, not process starts, for bare-CLI runs

### DIFF
--- a/crates/screenpipe-engine/src/analytics.rs
+++ b/crates/screenpipe-engine/src/analytics.rs
@@ -25,10 +25,9 @@ pub struct Analytics {
 
 impl Analytics {
     fn new() -> Self {
-        // Try env-provided analytics/support IDs first, then fall back to a
-        // random UUID for standalone CLI usage.
-        let distinct_id = TelemetryContext::distinct_id_from_env()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        // Launcher-provided id when present, else the stable per-machine id —
+        // a fresh UUID per process start counted each run as a new user.
+        let distinct_id = TelemetryContext::distinct_id();
 
         debug!("Analytics initialized with distinct_id: {}", distinct_id);
 

--- a/crates/screenpipe-engine/src/resource_monitor.rs
+++ b/crates/screenpipe-engine/src/resource_monitor.rs
@@ -274,9 +274,9 @@ impl ResourceMonitor {
             debug!("Telemetry disabled, will not send performance data to PostHog");
         }
 
-        // Use env-provided analytics/support IDs or generate a random UUID.
-        let distinct_id = TelemetryContext::distinct_id_from_env()
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        // Launcher-provided id when present, else the stable per-machine id —
+        // a fresh UUID per process start counted each run as a new user.
+        let distinct_id = TelemetryContext::distinct_id();
 
         // Collect host info once (OS, CPU, GPU names) — never panics
         let hw_info = HardwareInfo::collect();

--- a/crates/screenpipe-engine/src/telemetry_context.rs
+++ b/crates/screenpipe-engine/src/telemetry_context.rs
@@ -74,6 +74,18 @@ impl TelemetryContext {
         first_env(DISTINCT_ID_ENV_VARS)
     }
 
+    /// Stable telemetry distinct_id.
+    ///
+    /// Prefers a launcher-provided id (the desktop app's analytics id, or an
+    /// enterprise support/telemetry id). For a bare `screenpipe` CLI run — none
+    /// of those set — it falls back to the persistent per-machine id instead of
+    /// a fresh random UUID. Minting a new UUID on every process start made each
+    /// invocation look like a brand-new user, badly inflating PostHog user
+    /// counts for the CLI / Linux / Windows populations.
+    pub fn distinct_id() -> String {
+        Self::distinct_id_from_env().unwrap_or_else(screenpipe_core::sync::get_or_create_machine_id)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.pairs().is_empty()
     }
@@ -224,6 +236,27 @@ mod tests {
                 TelemetryContext::distinct_id_from_env(),
                 Some("spcust_acme_123".to_string())
             );
+        });
+    }
+
+    #[test]
+    fn distinct_id_falls_back_to_stable_machine_id() {
+        with_env(&[], || {
+            // Bare-CLI run (no launcher id): must reuse the persistent
+            // per-machine id, so it's identical across calls — i.e. across
+            // process restarts — instead of a fresh UUID each time (which made
+            // every invocation look like a brand-new user).
+            let first = TelemetryContext::distinct_id();
+            let second = TelemetryContext::distinct_id();
+            assert!(!first.is_empty());
+            assert_eq!(first, second);
+        });
+    }
+
+    #[test]
+    fn distinct_id_prefers_launcher_id_over_machine_id() {
+        with_env(&[("SCREENPIPE_ANALYTICS_ID", "analytics-user")], || {
+            assert_eq!(TelemetryContext::distinct_id(), "analytics-user");
         });
     }
 


### PR DESCRIPTION
## Problem
Telemetry counted **process starts, not machines** for bare-CLI installs. The engine's `distinct_id` fell back to a fresh random UUID on every launch:

```rust
TelemetryContext::distinct_id_from_env()
    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
```

So every `screenpipe` (re)start looked like a brand-new user in PostHog. That's why the CLI-heavy cohorts showed distinct-ID counts ~1.6–2× their distinct-IP counts (Linux, Windows-x86). The desktop app was never affected — it persists its own `analytics_id` and passes it via env.

## Flow (before vs after)

```mermaid
flowchart TD
    S([screenpipe engine start]) --> Q{launcher id in env?<br/>SCREENPIPE_ANALYTICS_ID}
    Q -- "yes · desktop app / enterprise" --> L[use that id<br/>✓ unchanged]
    Q -- "no · bare CLI" --> OLD["<b>before</b><br/>new random UUID<br/>every process start"]
    Q -- "no · bare CLI" --> NEW["<b>after</b><br/>persistent machine_id<br/>~/.screenpipe/machine_id"]
    OLD --> OB[("PostHog: each restart<br/>= a NEW user → inflated")]
    NEW --> NB[("PostHog: one stable<br/>user per machine")]
```

## Fix
Centralize identity in `TelemetryContext::distinct_id()`:
- **app / enterprise** → launcher-provided id (unchanged)
- **bare CLI** → persistent per-machine id (`~/.screenpipe/machine_id`), the same stable UUID the sync layer already uses for `X-Device-Id`

Both telemetry sites (`analytics.rs`, `resource_monitor.rs`) now call it. No new file — reuses the existing `screenpipe_core::sync::get_or_create_machine_id()`.

## Behavior notes
- **Forward-only.** Past events keep their random ids and can't be retro-fixed; distinct **IP** stays the better proxy for historical CLI data.
- **Counts will drop when this ships** — that's the inflation disappearing, not churn. Linux / Windows-x86 compress toward their true (IP-like) values; macOS barely moves (already app-dominated).
- Per-machine id == sync device id, so a machine now has one identity across analytics, sync, and the AI gateway.

## Test
`cargo test -p screenpipe-engine --lib telemetry_context::` → **7 passed**, including 2 new:
- `distinct_id_falls_back_to_stable_machine_id` (stable across calls / process restarts)
- `distinct_id_prefers_launcher_id_over_machine_id` (env still wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
