### PR TITLE
fix(audio): stop ort load-dynamic hang on Windows ARM64 (link at build time)

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -863,6 +863,12 @@ jobs:
           GGML_AVX512_BF16: "OFF"
           CMAKE_ARGS: ${{ matrix.target == 'x86_64-pc-windows-msvc' && '-DGGML_NATIVE=OFF -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF -DGGML_AVX512_BF16=OFF -DCMAKE_C_FLAGS=/arch:AVX2 -DCMAKE_CXX_FLAGS=/arch:AVX2' || '-DGGML_NATIVE=OFF' }}
           OPENBLAS_PATH: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/openblas
+          # ONNX Runtime link strategy. x86_64 pulls the pyke prebuilt
+          # (download-binaries). ARM64 has no pyke prebuilt and load-dynamic hangs
+          # with ort rc.12 (see #4173), so link the MS onnxruntime-win-arm64 DLL
+          # downloaded by the "Download ONNX Runtime" step above.
+          ORT_STRATEGY: ${{ matrix.target == 'aarch64-pc-windows-msvc' && 'system' || 'download' }}
+          ORT_LIB_LOCATION: ${{ matrix.target == 'aarch64-pc-windows-msvc' && format('{0}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-arm64-1.22.0', github.workspace) || '' }}
         run: bunx tauri build --verbose ${{ matrix.tauri-args }}
 
       - name: Sign NSIS installer with SSL.com EV (Windows)

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -119,9 +119,14 @@ ort = { workspace = true, features = ["download-binaries", "tls-native"] }
 samplerate = { workspace = true }
 libsamplerate-sys = { workspace = true }
 
-# Windows ARM64: use our own ONNX Runtime DLL at runtime (load-dynamic); no compile-time link, no ort.pyke.io cache
+# Windows ARM64: do NOT use `load-dynamic` — its runtime LoadLibrary of
+# onnxruntime.dll hangs with ort rc.12 the same way it did on x86_64 (see #4173).
+# ort links at build time instead; CI sets ORT_STRATEGY=system + ORT_LIB_LOCATION
+# to the bundled MS onnxruntime-win-arm64 (pyke ships no arm64-windows prebuilt,
+# so the `download-binaries` strategy that comes in transitively is overridden by
+# ORT_STRATEGY=system).
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
-ort = { workspace = true, default-features = false, features = ["load-dynamic"] }
+ort = { workspace = true, default-features = false, features = ["api-24", "tracing"] }
 ort-sys = { workspace = true }
 samplerate = { workspace = true }
 libsamplerate-sys = { workspace = true }


### PR DESCRIPTION
Follow-up to #4173 (which fixed Windows **x86_64**). Windows **ARM64** uses the same `load-dynamic` path whose runtime `LoadLibrary` of `onnxruntime.dll` deadlocks with ort rc.12 — so arm64 almost certainly hangs the same way (engine freezes at `building_audio`; recording/VAD/diarization dead).

## Why arm64 needs a different fix than x64
x64 was fixed by falling through to the pyke `download-binaries` prebuilt. **pyke ships no arm64-windows prebuilt**, so that path isn't available. Instead, link at build time against the **Microsoft `onnxruntime-win-arm64` DLL** that `release-app.yml` already downloads and Tauri already bundles — the same load-time-link approach `release-cli.yml` already uses for x64 (`ORT_STRATEGY=system` + `ORT_LIB_LOCATION`).

## Changes
- **`crates/screenpipe-audio/Cargo.toml`**: drop `load-dynamic` from the `aarch64-pc-windows-msvc` ort dep.
- **`release-app.yml`**: set `ORT_STRATEGY=system` + `ORT_LIB_LOCATION` → `onnxruntime-win-arm64-1.22.0` for the ARM64 build; x86_64 stays on `download`.

## Verified locally (without an arm64 build)
`cargo tree --target aarch64-pc-windows-msvc -p ort -f "{f}"` → **no `load-dynamic`** after the change (it was the only source). x86_64 and macOS-Intel feature sets unchanged. `download-binaries` still arrives transitively via ort `default`/audiopipe, but `ORT_STRATEGY=system` overrides the strategy (this is exactly how `release-cli.yml` builds x64 today).

## ⚠️ Needs CI to validate
I can't build/run Windows ARM64 on an x64 machine, so **do not merge until the ARM64 release job is green** — that job exercises the `ORT_STRATEGY=system` link + bundle path. If pyke turns out to ship an arm64-windows prebuilt after all, this could be simplified to plain `download-binaries` like x64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)