### PR TITLE
fix(ci): correct ORT linking for Windows release builds (#4176 regressions)

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -480,6 +480,18 @@ jobs:
           7z x $zipFile -o"apps/screenpipe-app-tauri/src-tauri/" -y
           Write-Host "ONNX Runtime extracted to $extractDir"
           Get-ChildItem "$extractDir/lib" | ForEach-Object { Write-Host $_.Name }
+          # ARM64 has no pyke prebuilt and load-dynamic hangs with ort rc.12
+          # (#4173/#4176), so link the MS DLL at build time. ort-sys's `system`
+          # strategy wants the dir that DIRECTLY contains onnxruntime.lib — the
+          # `lib` subdir, not the extract root. Set these ONLY for ARM64; x64
+          # must stay on download-binaries (no ORT_STRATEGY/ORT_LIB_LOCATION).
+          if ($arch -eq 'arm64') {
+            $libDir = (Resolve-Path "$extractDir/lib").Path
+            "ORT_STRATEGY=system"      | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            "ORT_LIB_LOCATION=$libDir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            "$libDir"                  | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+            Write-Host "ARM64: ORT_STRATEGY=system, ORT_LIB_LOCATION=$libDir"
+          }
 
       - name: Install Ninja (ARM64)
         if: matrix.os_type == 'windows' && matrix.target == 'aarch64-pc-windows-msvc'
@@ -863,12 +875,10 @@ jobs:
           GGML_AVX512_BF16: "OFF"
           CMAKE_ARGS: ${{ matrix.target == 'x86_64-pc-windows-msvc' && '-DGGML_NATIVE=OFF -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF -DGGML_AVX512_BF16=OFF -DCMAKE_C_FLAGS=/arch:AVX2 -DCMAKE_CXX_FLAGS=/arch:AVX2' || '-DGGML_NATIVE=OFF' }}
           OPENBLAS_PATH: ${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/openblas
-          # ONNX Runtime link strategy. x86_64 pulls the pyke prebuilt
-          # (download-binaries). ARM64 has no pyke prebuilt and load-dynamic hangs
-          # with ort rc.12 (see #4173), so link the MS onnxruntime-win-arm64 DLL
-          # downloaded by the "Download ONNX Runtime" step above.
-          ORT_STRATEGY: ${{ matrix.target == 'aarch64-pc-windows-msvc' && 'system' || 'download' }}
-          ORT_LIB_LOCATION: ${{ matrix.target == 'aarch64-pc-windows-msvc' && format('{0}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-arm64-1.22.0', github.workspace) || '' }}
+          # ORT link strategy is set per-arch in the "Download ONNX Runtime" step
+          # via $GITHUB_ENV (ARM64 → system + ORT_LIB_LOCATION; x64 → unset, uses
+          # download-binaries). Setting them inline here broke x64 because empty
+          # env values are still "set" and ort-sys chokes on them.
         run: bunx tauri build --verbose ${{ matrix.tauri-args }}
 
       - name: Sign NSIS installer with SSL.com EV (Windows)


### PR DESCRIPTION
Hotfix: #4176 broke the Windows release build for **both** arches (caught by the build I triggered after merge).

- **x86_64**: #4176 set `ORT_STRATEGY=download` + `ORT_LIB_LOCATION=''` inline on the shared build step. Empty env values are still *set*, so ort-sys did "full static linking" and panicked. x64 must have **no** ORT env (it uses `download-binaries`).
- **aarch64**: `ORT_LIB_LOCATION` pointed at the zip's extract root, but ort-sys's `system` strategy needs the dir that *directly* contains `onnxruntime.lib` — the `lib/` subdir. Failed with `could not link to the ONNX Runtime build`.

**Fix**: set `ORT_STRATEGY=system` + `ORT_LIB_LOCATION=<extract>/lib` via `$GITHUB_ENV` in the "Download ONNX Runtime" step, **gated to ARM64 only**, leaving x64 untouched.

Root cause confirmed from ort-sys build.rs (`system` strategy checks `$ORT_LIB_LOCATION/onnxruntime.lib`) and the failing release logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)