### PR TITLE
fix(ci): bundle onnxruntime 1.24.2 in release app (ort rc.12 needs API 24)

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -471,7 +471,11 @@ jobs:
           } else {
             $arch = 'x64'
           }
-          $version = '1.22.0'
+          # ort rc.12 requests ONNX Runtime API 24, which needs onnxruntime >= 1.24.
+          # 1.22.0 only provides API 22 → "API version 24 not available" panic at
+          # runtime (ONNX init fails: VAD/diarization/PII broken). Match ci.yml's
+          # 1.24.2. See #4173/#4176.
+          $version = '1.24.2'
           $url = "https://github.com/microsoft/onnxruntime/releases/download/v$version/onnxruntime-win-$arch-$version.zip"
           $zipFile = "onnxruntime-win-$arch-$version.zip"
           $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-$arch-$version"


### PR DESCRIPTION
**Publish-blocker** surfaced by the ARM64 runtime smoke test.

`release-app.yml` bundled onnxruntime **1.22.0**, but `ort` rc.12 requests ONNX Runtime **API 24** (needs onnxruntime **≥ 1.24**). At runtime:
```
The requested API version [24] is not available, only API versions [1, 22]
are supported. Current ORT Version is: 1.22.0  → panic: Failed to initialize ORT API
```
So ONNX init fails on the bundled-DLL path → VAD / diarization / PII redaction broken. On x86_64 the earlier load-dynamic hang masked it; ARM64 (now load-time linked) exposed it.

Fix: bump to **1.24.2**, matching `ci.yml` and `release-cli.yml`. URL / extract dir / ARM64 `ORT_LIB_LOCATION` all derive from `$version`, so one line covers both arches. Confirmed MS ships `onnxruntime-win-{x64,arm64}-1.24.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)