### PR TITLE
Bump app to v2.5.43

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "screenpipe-app"
-version = "2.5.42"
+version = "2.5.43"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
App-only version bump to trigger a fresh release build (creates a **draft**, does not publish — `should_publish` is only true for `release-app-publish` commits).

Ships all the ONNX Runtime fixes merged since v2.5.42:
- Windows **x64** + **ARM64**: stop the `ort` rc.12 `load-dynamic` runtime-LoadLibrary hang by linking ONNX Runtime at build time (#4173, #4176, #4179).
- Bundle onnxruntime **1.24.2** (ort rc.12 needs API 24; 1.22.0 panicked at init) (#4186).

**CLI is intentionally NOT bumped/released** (stays 0.4.21). Only `apps/screenpipe-app-tauri/src-tauri/Cargo.toml` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)