### PR TITLE
fix sidebar & recording buttons not clickable on timeline

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -919,7 +919,7 @@ function HomeContent() {
               // top-0.5 + items-center puts each icon's center at y≈15px,
               // matching the vertical center of the macOS traffic lights
               // (which sit at y≈14).
-              "fixed top-1 z-20 flex items-center gap-1.5",
+              "fixed top-1 z-[46] flex items-center gap-1.5",
               reserveTrafficLights ? "left-[78px]" : "left-2"
             )}
           >
@@ -930,7 +930,9 @@ function HomeContent() {
                   aria-label={sidebarCollapsed ? "expand sidebar" : "collapse sidebar"}
                   className={cn(
                     "p-1 rounded-md transition-colors",
-                    isTranslucent ? "vibrant-nav-item" : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                    sidebarCollapsed && activeSection === "timeline"
+                      ? "backdrop-blur-sm bg-background/80 shadow-sm text-muted-foreground hover:text-foreground hover:bg-background"
+                      : isTranslucent ? "vibrant-nav-item" : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                   )}
                 >
                   {sidebarCollapsed
@@ -979,6 +981,7 @@ function HomeContent() {
               meetingLoading={meetingLoading}
               onToggleMeeting={() => void toggleMeeting()}
               isTranslucent={isTranslucent}
+              floatingOverMedia={sidebarCollapsed && activeSection === "timeline"}
             />
           </div>
 

--- a/apps/screenpipe-app-tauri/components/recording-status.tsx
+++ b/apps/screenpipe-app-tauri/components/recording-status.tsx
@@ -35,6 +35,8 @@ interface RecordingStatusProps {
   meetingLoading: boolean;
   onToggleMeeting: () => void;
   isTranslucent?: boolean;
+  /** buttons float over full-bleed video (timeline, sidebar collapsed) */
+  floatingOverMedia?: boolean;
 }
 
 const KIND_ICONS: Record<
@@ -61,6 +63,7 @@ export function RecordingStatus({
   meetingLoading,
   onToggleMeeting,
   isTranslucent,
+  floatingOverMedia,
 }: RecordingStatusProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -125,7 +128,9 @@ export function RecordingStatus({
               data-testid="recording-status-trigger"
               className={cn(
                 "flex items-center justify-center h-5 w-5 rounded-md transition-colors",
-                isTranslucent ? "hover:bg-white/10" : "hover:bg-muted/60"
+                floatingOverMedia
+                  ? "backdrop-blur-sm bg-background/80 shadow-sm hover:bg-background"
+                  : isTranslucent ? "hover:bg-white/10" : "hover:bg-muted/60"
               )}
             >
               <span


### PR DESCRIPTION
This PR closes the z-index overlap that made the sidebar toggle and recording status dot unresponsive on the timeline page when the sidebar was collapsed.

the chrome strip was at z-20 while timeline controls sat at z-40, so clicks never reached the buttons. also added a subtle frosted background to each button individually so they don't disappear against the video frame.

Only affects the timeline page with sidebar collapsed every other page is unchanged


Before -

https://github.com/user-attachments/assets/a809c80d-a891-4228-b491-fbc7735ee28f


After -

https://github.com/user-attachments/assets/2c2e90a5-5950-4752-b69a-ae42eae0cf51

