### PR TITLE
[pr] docs(contributing): document signing dev builds so macos keeps tcc perms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,30 @@ especially useful if you've done new database migrations and want to avoid break
 
 on macos the /tmp dir keeps being cleaned up by the system fyi
 
+### macos: keeping screen/mic/accessibility permissions across dev rebuilds
+
+macos ties tcc permissions — screen recording, microphone, accessibility — to the app's *code signature*. an unsigned or ad-hoc-signed build gets a fresh signature on every rebuild, so macos sees each rebuild as a new app and re-prompts — or silently drops the permission, which shows up as "capture suddenly returns nothing" after a rebuild.
+
+`apps/screenpipe-app-tauri/scripts/build_macos.sh` already signs the app (with an `Apple Development:` cert). if you don't have an apple developer cert, you can get the same permission-persistence with a **self-signed** code-signing cert:
+
+1. create the cert once — in Keychain Access: Certificate Assistant → Create a Certificate → name it e.g. `screenpipe dev`, Identity Type: **Self-Signed Root**, Certificate Type: **Code Signing** → Create. confirm it's usable:
+
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+
+2. build, then sign with your identity — same flow as `scripts/build_macos.sh`, just your cert:
+
+   ```bash
+   cd apps/screenpipe-app-tauri
+   bun tauri build --no-sign --features metal
+   APP="src-tauri/target/release/bundle/macos/screenpipe - Development.app"
+   xattr -cr "$APP"
+   codesign --force --deep --sign "screenpipe dev" "$APP"
+   ```
+
+3. grant the permissions once. since the signature is stable across rebuilds, macos won't re-prompt and capture won't silently break — as long as you keep signing with the same identity.
+
 ### debugging github action
 
 ssh into the runner:


### PR DESCRIPTION
## description

macos ties tcc permissions — screen recording, microphone, accessibility — to the app's **code signature**. a dev build that's unsigned or ad-hoc-signed gets a fresh signature on every rebuild, so macos treats each rebuild as a new app and re-prompts for permissions — or silently drops them, which shows up as "capture suddenly returns nothing" after a rebuild. this trips up contributors iterating on the desktop app and isn't documented anywhere.

`apps/screenpipe-app-tauri/scripts/build_macos.sh` already solves this for the maintainer by signing with an `Apple Development:` cert. this adds a short subsection to CONTRIBUTING.md → "other hacks" documenting the **self-signed** equivalent for contributors who don't have an apple developer cert:

1. create a self-signed code-signing cert once (Keychain Access → Certificate Assistant).
2. build + sign reusing the **same flow as `build_macos.sh`** (`bun tauri build --no-sign` → `xattr -cr` → `codesign --force --deep --sign`), just with your own identity.
3. grant permissions once; they persist across rebuilds because the signature is stable.

no system-trust-store / `sudo` step is needed — `codesign` accepts a self-signed identity for local signing. it deliberately mirrors the existing script rather than introducing a new approach.

related issue: # (none — fills an undocumented macOS dev-loop gap, adjacent to the existing "running dev + prod" hack)

## before

nothing in CONTRIBUTING.md / README.md / TESTING.md explains why screen/mic/accessibility permissions vanish on every desktop-app rebuild, or how to make them persist. contributors hit silent capture failures and assume a regression.

## after

a new "other hacks" subsection — **"macos: keeping screen/mic/accessibility permissions across dev rebuilds"** — explains the cause (tcc keys off code signature) and gives the self-signed-cert fix, mirroring `scripts/build_macos.sh`.

verified on a real machine: a screenpipe `.app` built via this exact `--no-sign` + manual `codesign` path (with a self-signed "code signing" identity) signs cleanly and **keeps its granted Screen Recording / Microphone / Accessibility permissions across subsequent rebuilds** — no re-prompt, no silent capture loss.

## how to test

1. `security find-identity -v -p codesigning` — confirm your self-signed code-signing cert is listed (create it via Keychain Access → Certificate Assistant if not).
2. build + sign per the new section:
   ```bash
   cd apps/screenpipe-app-tauri
   bun tauri build --no-sign --features metal
   APP="src-tauri/target/release/bundle/macos/screenpipe - Development.app"
   xattr -cr "$APP"
   codesign --force --deep --sign "screenpipe dev" "$APP"
   codesign --verify --strict "$APP" && echo "signed ok"
   ```
3. launch, grant permissions, then rebuild + re-sign with the same identity and relaunch — permissions persist (no re-prompt, capture keeps working).

## desktop app checklist (if applicable)

n/a — documentation only; no `#[tauri::command]` handlers or frontend-exported rust types changed.
