### PR TITLE
fix(db): start WAL checkpoint maintenance in the desktop app (root-cause of recurring corruption)

### DIFF
--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -420,6 +420,16 @@ impl DatabaseManager {
         // (which used to spin a CPU core retrying a malformed DB).
         db_manager.spawn_startup_integrity_check(Arc::from(database_path));
 
+        // Periodic WAL checkpoint so the write-ahead log can't grow unbounded
+        // when passive auto-checkpoint is blocked by long-lived readers. An
+        // oversized WAL (observed at 650MB on a heavy 24/7 install) is the main
+        // driver of the WAL-index / `-shm` desync that corrupts the DB. Started
+        // here in `new()` — next to the integrity check — so EVERY caller gets
+        // it: the desktop app runs the engine in-process and previously never
+        // started it (only the standalone `screenpipe-engine` CLI did), so app
+        // users got no periodic checkpointing at all.
+        db_manager.start_wal_maintenance();
+
         Ok(db_manager)
     }
 

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1796,8 +1796,8 @@ async fn main() -> anyhow::Result<()> {
     // Start calendar-assisted speaker identification
     let _speaker_id_handle = start_speaker_identification(db.clone(), config.user_name.clone());
 
-    // Periodic WAL checkpoint to prevent unbounded WAL growth
-    db.start_wal_maintenance();
+    // WAL checkpoint maintenance now starts inside DatabaseManager::new(), so
+    // every caller (CLI + in-process desktop app) gets it — no explicit call here.
 
     let server_future = server.start();
     pin_mut!(server_future);


### PR DESCRIPTION
## The bug
The desktop app runs the engine **in-process** (`server_core`) and never calls `db.start_wal_maintenance()` — only the standalone `screenpipe-engine` CLI does. So **app users get no periodic WAL checkpointing at all**, just the one-time checkpoint at boot inside `DatabaseManager::new`.

With nothing draining it, the write-ahead log grows unbounded under 24/7 capture. On a heavy install it was observed at **650MB** on a 5GB DB. An oversized WAL is the main driver of the WAL-index / `-shm` desync that intermittently corrupts the DB — the recurring `database disk image is malformed` (code 11) and `code 522` disk-I/O wedges that have been forcing manual `screenpipe db recover` every ~10h-2 days.

Evidence: a heavy install's app log has **zero** `wal checkpoint:` lines (the maintenance task never ran), and `start_wal_maintenance` is referenced only from `crates/screenpipe-engine/src/bin/screenpipe-engine.rs`, never from the app.

## The fix
Move the 5-minute `wal_checkpoint(TRUNCATE)` maintenance into `DatabaseManager::new()`, right next to the existing `spawn_startup_integrity_check` call, so **every** caller (CLI, desktop app, enterprise, tests) gets it automatically and no binary can forget it. Drop the now-redundant explicit call in the CLI bin.

Even when a long reader makes the `TRUNCATE` step return `busy`, the checkpoint still drains frames up to the oldest reader, so the WAL stops growing unbounded — which is the whole point.

## Why this over just auto-restarting
This is the **prevention** fix: keep the WAL small so the desync that wedges/corrupts the DB stops happening in the first place, rather than only self-healing after the fact (see the complementary backstop in #4196).

## Scope / risk
2-line behavior change reusing an existing, already-shipped mechanism (the CLI has run it for months). `screenpipe-db` + `screenpipe-engine` compile; `rustfmt` clean. No new periodic work for the CLI (it already had it); the app gains the checkpointer it should always have had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)