### PR TITLE
fix(windows-arm64): OPENBLAS_PATH not inherited by cargo, STATUS_DLL_NOT_FOUND

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/.cargo/config.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/.cargo/config.toml
@@ -3,6 +3,13 @@
 
 [env]
 CMAKE_POLICY_VERSION_MINIMUM = "3.5"
+# pre_build.js downloads OpenBLAS to src-tauri/openblas/ and sets OPENBLAS_PATH
+# in its own process, but that env var is NOT inherited by the cargo subprocess
+# that tauri spawns to compile the Rust code. Setting it here ensures
+# antirez-asr-sys/build.rs can find cblas.h on every cargo invocation.
+# `relative = true` resolves the path from the directory that *contains* .cargo/
+# (i.e. src-tauri/), so "openblas" → src-tauri/openblas.
+OPENBLAS_PATH = { value = "openblas", relative = true }
 # whisper.cpp ggml uses std::filesystem::path which requires macOS 10.15+
 # These are picked up by whisper-rs-sys's cmake build before compilation starts
 # CI can still override via explicit env vars (force = false is default)

--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -430,6 +430,41 @@ fn main() {
             .compile("bswap_shim");
     }
 
+    // ARM64 Windows: the OpenBLAS WOA64 package ships with the DLL's PE
+    // internal name set to "openblas.dll", but the file on disk is named
+    // "libopenblas.dll" (to match the MSVC import library). Windows resolves
+    // DLLs by PE internal name at runtime, so the exe crashes with
+    // STATUS_DLL_NOT_FOUND unless "openblas.dll" also exists next to the
+    // binary. The x64 package does not have this mismatch.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
+        && std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("aarch64")
+    {
+        println!("cargo:rerun-if-env-changed=OPENBLAS_PATH");
+        if let Ok(openblas) = std::env::var("OPENBLAS_PATH") {
+            let dll_src = std::path::PathBuf::from(&openblas).join("bin").join("libopenblas.dll");
+            if dll_src.exists() {
+                let out_dir = std::env::var("OUT_DIR").unwrap_or_default();
+                // OUT_DIR = target/{profile}/build/{crate}-{hash}/out — three pops → target/{profile}/
+                let mut target_dir = std::path::PathBuf::from(&out_dir);
+                target_dir.pop();
+                target_dir.pop();
+                target_dir.pop();
+                let dll_dst = target_dir.join("openblas.dll");
+                if !dll_dst.exists() {
+                    match std::fs::copy(&dll_src, &dll_dst) {
+                        Ok(_) => println!(
+                            "cargo:warning=openblas: copied libopenblas.dll → {}",
+                            dll_dst.display()
+                        ),
+                        Err(e) => println!(
+                            "cargo:warning=openblas: could not copy openblas.dll: {e}"
+                        ),
+                    }
+                }
+            }
+        }
+    }
+
     tauri_build::build()
 }
 


### PR DESCRIPTION
## What changed



**src-tauri/.cargo/config.toml**

`pre_build.js` sets `OPENBLAS_PATH` in its own Node.js process. The env var is NOT inherited by the cargo subprocess Tauri spawns, so `antirez-asr-sys` could never find `cblas.h`. Fixed by setting it in `.cargo/config.toml` so every cargo invocation has it regardless of how it is launched. `relative = true` resolves from `src-tauri/`, so `"openblas"` → `src-tauri/openblas`.

**src-tauri/build.rs**

Windows ARM64 only: the WOA64 OpenBLAS package ships the DLL with PE internal name `"openblas.dll"` but the file on disk is `"libopenblas.dll"`. Windows resolves DLLs by PE internal name at runtime — the binary crashes at launch with `STATUS_DLL_NOT_FOUND`. Fixed by copying `libopenblas.dll → openblas.dll` next to the binary at build time. x64 does not have this mismatch.

## Test plan
- [ ] `bun tauri dev` on Windows ARM64 builds without `cblas.h not found`
- [ ] no `STATUS_DLL_NOT_FOUND` at launch on ARM64
- [ ] `bun tauri dev` on Windows x64 unaffected


