### PR TITLE
feat(pipes): brand-aligned pipe cards with run / edit / remix

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -2081,7 +2081,7 @@ export function PipesSection() {
           </CardContent>
         </Card>
       ) : (
-        <div className="border border-border rounded-md divide-y divide-border">
+        <div className="rounded-lg border border-border divide-y divide-border">
           {filteredPipes.map((pipe) => {
             const recentExecs = pipeExecutions[pipe.config.name] || [];
             const isRunning = pipe.is_running || runningPipe === pipe.config.name;
@@ -2111,7 +2111,7 @@ export function PipesSection() {
             return (
             <div key={pipe.config.name} className={cn("group", !pipe.config.enabled && "opacity-50")}>
               {/* Table row */}
-              <div className="flex items-center gap-3 px-4 py-2.5 hover:bg-accent/50 transition-colors">
+              <div className="flex items-center gap-3 px-4 py-3 hover:bg-accent transition-colors">
                 {/* Status indicator — monochrome, brand-aligned */}
                 <span
                   className={cn(
@@ -2275,6 +2275,30 @@ export function PipesSection() {
                   )}
                 </span>
 
+                {/* Edit with AI — always visible (promoted out of the overflow
+                    menu) so editing your own pipe is a one-click, discoverable
+                    action: the lever that turns installers into creators. */}
+                {!isReceivedTeamPipe(pipe) && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => {
+                      posthog.capture("pipe_edit_started", { source: "row_button" });
+                      navigateHomeAndPrefill({
+                        context: "the user wants to edit their pipe",
+                        prompt: buildOptimizePrompt(pipe.config.name),
+                        displayLabel: buildOptimizeDisplayLabel(pipe.config.name),
+                        autoSend: true,
+                      });
+                    }}
+                    title="edit this pipe with ai — describe what you want to change"
+                  >
+                    <Sparkles className="h-3.5 w-3.5" />
+                    edit
+                  </Button>
+                )}
+
                 {/* Hover-reveal actions */}
                 <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
                   {/* Run / Stop button */}
@@ -2336,21 +2360,7 @@ export function PipesSection() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      {!isReceivedTeamPipe(pipe) && (
-                        <DropdownMenuItem
-                          onClick={() => {
-                            navigateHomeAndPrefill({
-                              context: "the user wants to optimize their pipe",
-                              prompt: buildOptimizePrompt(pipe.config.name),
-                              displayLabel: buildOptimizeDisplayLabel(pipe.config.name),
-                              autoSend: true,
-                            });
-                          }}
-                        >
-                          <Sparkles className="h-3.5 w-3.5 mr-2" />
-                          optimize with ai
-                        </DropdownMenuItem>
-                      )}
+                      {/* "edit with ai" lives on the row as a visible button now */}
 
                       {/* Team sharing — own pipes can be shared, updated,
                           unshared; received team pipes are read-only and can

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -23,6 +23,7 @@ import {
   MoreHorizontal,
   Plus,
   ArrowRight,
+  GitFork,
   Search,
   Share2,
   Link,
@@ -304,6 +305,20 @@ after analyzing, show me the improved pipe.md and explain what you changed and w
 
 function buildOptimizeDisplayLabel(pipeName: string): string {
   return `Optimize pipe: ${pipeName.trim()}`;
+}
+
+// "remix" = make your own version of an existing pipe. We don't mutate the
+// original — the agent reads it and creates a NEW customized pipe. Framing
+// authoring as "customize a working thing" is the lever that turns installers
+// into creators (see Replit remix / Notion duplicate).
+function buildRemixPrompt(pipeName: string): string {
+  return `i want to remix my existing pipe "${pipeName}" into a new one.
+
+## your task
+1. read the original pipe: ~/.screenpipe/pipes/${pipeName}/pipe.md
+2. ask me what i want to change or do differently
+3. create a NEW pipe (a new name + folder) with those changes — do NOT modify or overwrite "${pipeName}"
+4. install and enable the new pipe, then tell me what it does.`;
 }
 
 function parsePipeError(stderr: string): {
@@ -2059,7 +2074,7 @@ export function PipesSection() {
                       <button
                         key={ex.label}
                         onClick={() => startPipeGeneration(ex.prompt, "empty_state_example")}
-                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-full border border-border bg-muted/50 text-xs hover:bg-muted transition-colors"
+                        className="inline-flex items-center gap-1.5 px-2.5 py-1.5 border border-border bg-muted/50 text-xs hover:bg-muted transition-colors"
                       >
                         {ex.label}
                       </button>
@@ -2072,7 +2087,7 @@ export function PipesSection() {
                       detail: { tab: 'discover' }
                     }));
                   }}
-                  className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-border text-sm font-medium hover:bg-muted transition-colors"
+                  className="inline-flex items-center gap-2 px-4 py-2 border border-border text-sm font-medium hover:bg-muted transition-colors"
                 >
                   or browse the pipe store →
                 </button>
@@ -2081,7 +2096,7 @@ export function PipesSection() {
           </CardContent>
         </Card>
       ) : (
-        <div className="rounded-lg border border-border divide-y divide-border">
+        <div className="flex flex-col gap-2">
           {filteredPipes.map((pipe) => {
             const recentExecs = pipeExecutions[pipe.config.name] || [];
             const isRunning = pipe.is_running || runningPipe === pipe.config.name;
@@ -2109,9 +2124,9 @@ export function PipesSection() {
                     : "idle";
 
             return (
-            <div key={pipe.config.name} className={cn("group", !pipe.config.enabled && "opacity-50")}>
-              {/* Table row */}
-              <div className="flex items-center gap-3 px-4 py-3 hover:bg-accent transition-colors">
+            <div key={pipe.config.name} className={cn("group border border-border hover:bg-accent/40 transition-colors", !pipe.config.enabled && "opacity-60")}>
+              {/* Card top line */}
+              <div className="flex items-center gap-3 px-4 pt-3 pb-1">
                 {/* Status indicator — monochrome, brand-aligned */}
                 <span
                   className={cn(
@@ -2148,13 +2163,21 @@ export function PipesSection() {
                   />
                 </button>
 
-                {/* Pipe name — click to expand */}
-                <button
-                  onClick={() => toggleExpand(pipe.config.name)}
-                  className="text-sm font-medium truncate text-left min-w-0 flex-1 hover:underline"
-                >
-                  {pipe.config.name}
-                </button>
+                {/* Pipe name + outcome — click name to expand */}
+                <div className="flex flex-col min-w-0 flex-1 gap-0.5">
+                  <button
+                    onClick={() => toggleExpand(pipe.config.name)}
+                    className="text-sm font-medium truncate text-left hover:underline"
+                  >
+                    {pipe.config.name}
+                  </button>
+                  {typeof pipe.config.description === "string" &&
+                    (pipe.config.description as string).trim() && (
+                      <span className="text-xs text-muted-foreground truncate">
+                        {(pipe.config.description as string).trim()}
+                      </span>
+                    )}
+                </div>
 
                 {/* Team sharing badges */}
                 {sharedByMe.has(pipe.config.name) && (
@@ -2274,10 +2297,12 @@ export function PipesSection() {
                     "—"
                   )}
                 </span>
+              </div>
 
-                {/* Edit with AI — always visible (promoted out of the overflow
-                    menu) so editing your own pipe is a one-click, discoverable
-                    action: the lever that turns installers into creators. */}
+              {/* Action bar — always visible, brand-aligned (sharp, monochrome).
+                  edit + remix are the install->create lever. */}
+              <div className="flex items-center gap-1 px-3 pb-2.5 pt-0.5">
+                {/* edit with ai — opens a chat to tweak this pipe in plain english */}
                 {!isReceivedTeamPipe(pipe) && (
                   <Button
                     variant="ghost"
@@ -2299,8 +2324,30 @@ export function PipesSection() {
                   </Button>
                 )}
 
-                {/* Hover-reveal actions */}
-                <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                {/* remix — create a NEW pipe based on this one and customize it */}
+                {!isReceivedTeamPipe(pipe) && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1.5 px-2 shrink-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => {
+                      posthog.capture("pipe_remix_started", { source: "row_button" });
+                      navigateHomeAndPrefill({
+                        context: "the user wants to remix their pipe into a new one",
+                        prompt: buildRemixPrompt(pipe.config.name),
+                        displayLabel: `Remix pipe: ${pipe.config.name}`,
+                        autoSend: true,
+                      });
+                    }}
+                    title="remix — create a new pipe based on this one and customize it"
+                  >
+                    <GitFork className="h-3.5 w-3.5" />
+                    remix
+                  </Button>
+                )}
+
+                {/* run + overflow */}
+                <div className="flex items-center gap-0.5 shrink-0">
                   {/* Run / Stop button */}
                   {isRunning ? (
                     <Button
@@ -2335,20 +2382,6 @@ export function PipesSection() {
                       {hasMissingConnections
                         ? <AlertCircle className="h-3.5 w-3.5" />
                         : <Play className="h-3.5 w-3.5" />}
-                    </Button>
-                  )}
-
-                  {/* Publish button — not for received team pipes (someone
-                      else's work; fork first) */}
-                  {!isReceivedTeamPipe(pipe) && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7"
-                      onClick={() => setPublishPipeName(pipe.config.name)}
-                      title="publish to store"
-                    >
-                      <Upload className="h-3.5 w-3.5" />
                     </Button>
                   )}
 
@@ -2460,12 +2493,12 @@ export function PipesSection() {
                   </DropdownMenu>
                 </div>
 
-                {/* Toggle — only visible on hover.
+                {/* Enable toggle — always visible, pushed to the far right.
                     Missing connections block ENABLING (can't run), but never
                     block DISABLING — a stuck-on pipe with broken deps must
                     always be turn-off-able. */}
                 <div
-                  className="opacity-0 group-hover:opacity-100 transition-opacity"
+                  className="ml-auto flex items-center"
                   title={
                     hasMissingConnections && !pipe.config.enabled
                       ? "configure required connections before enabling auto-run"


### PR DESCRIPTION
## why

The pipe list was a dense, hard-to-scan set of divider rows, and the actions that turn an installer into a creator (edit / remix your own pipe) were hidden in a hover-only ⋯ menu. Per the activation analysis, "make editing/remixing a working pipe a visible, one-click action" is the lever; and per `DESIGN.md` the surface should be black-and-white, sharp-cornered, mono-metadata.

I looked at how the best products lay out a list of automations/agents (Linear, Raycast, Zapier, Lindy, GitHub Actions, Apple Shortcuts) — the throughline that survives in a strictly monochrome system: **status by shape (not color), schedule/time in mono, a one-line outcome under the name, and clear per-item actions.** This applies that, in screenpipe's brand.

## what

Each pipe is now a **card** (1px border, sharp corners — no rounded), not a divider row:

- **outcome line under the name** (`config.description` when present) so you can see what a pipe *does* at a glance
- **visible action bar**: `run · edit · remix · ⋯ · enable-toggle` (was hover-only)
- **new `remix`**: creates a NEW pipe based on this one via chat — does *not* mutate the original (Replit-remix / Notion-duplicate framing); fires `pipe_remix_started`
- **`edit`**: opens a chat to tweak the pipe in plain english (promoted out of the ⋯ menu); fires `pipe_edit_started`
- **brand alignment**: status stays shape-based (filled / hollow / dim square), all metadata in mono, sharp corners throughout (also fixed the `rounded-*` I'd introduced in the empty state)

Reuses the existing `navigateHomeAndPrefill` flow for edit/remix — no new execution path.

## design (brand-aligned, per DESIGN.md)

> mockup, dark mode — black & white, sharp corners, IBM Plex Mono metadata, Space Grotesk names. not a live screenshot.

![brand-aligned pipe cards](https://raw.githubusercontent.com/louis030195/screenpipe-pr-assets/main/pipe-cards-brand.png)

## test plan

- [x] `bun run typecheck` clean
- Settings → Pipes: each pipe renders as a bordered card with an action bar; the description shows when the pipe.md defines one
- `run`, `edit`, `remix`, the ⋯ menu, and the enable toggle all work; received team pipes (read-only) show no edit/remix (unchanged — they fork)
- `pipe_edit_started` / `pipe_remix_started` fire with `source: "row_button"`
- legible in both light and dark with zero color reliance

## note

I can't run the Tauri app in this environment, so the visual is a faithful mockup of the implemented structure rather than a live capture — worth a quick local look before merge. If you'd rather the actions sit top-right (Linear-style) instead of a bottom bar, it's a small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)