### PR TITLE
feat(telemetry): surface lagged audio loss + fix cpu_count, cheaper process refresh

### DIFF
--- a/crates/screenpipe-audio/src/core/run_record_and_transcribe.rs
+++ b/crates/screenpipe-audio/src/core/run_record_and_transcribe.rs
@@ -386,6 +386,10 @@ async fn recv_audio_chunk(
             Ok(Some(chunk))
         }
         Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
+            // The recorder fell behind the capture broadcast and the OS frames
+            // in between are gone — record the count so this silent loss is
+            // visible in /health and analytics instead of only a debug log.
+            metrics.record_chunks_lagged(n);
             debug!(
                 "audio channel lagged by {} messages for {}, continuing",
                 n, device_name

--- a/crates/screenpipe-audio/src/metrics.rs
+++ b/crates/screenpipe-audio/src/metrics.rs
@@ -18,6 +18,10 @@ pub struct AudioPipelineMetrics {
     pub chunks_channel_full: AtomicU64,
     /// Device stream timeouts (no audio data received for >30s)
     pub stream_timeouts: AtomicU64,
+    /// Audio buffers skipped because the recorder consumer fell behind the
+    /// capture broadcast channel. This is otherwise-silent audio loss under
+    /// CPU contention — previously invisible to telemetry.
+    pub chunks_lagged: AtomicU64,
 
     // --- VAD stage ---
     /// Chunks that passed VAD (speech_ratio > threshold)
@@ -83,6 +87,7 @@ impl AudioPipelineMetrics {
             chunks_sent: AtomicU64::new(0),
             chunks_channel_full: AtomicU64::new(0),
             stream_timeouts: AtomicU64::new(0),
+            chunks_lagged: AtomicU64::new(0),
             vad_passed: AtomicU64::new(0),
             vad_rejected: AtomicU64::new(0),
             speech_ratio_sum_x1000: AtomicU64::new(0),
@@ -119,6 +124,14 @@ impl AudioPipelineMetrics {
 
     pub fn record_stream_timeout(&self) {
         self.stream_timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record `n` audio buffers skipped because the recorder consumer fell
+    /// behind the capture broadcast channel (broadcast `Lagged(n)`). This is
+    /// otherwise-silent audio loss — surfaced so the health endpoint and
+    /// analytics can see contention-induced gaps.
+    pub fn record_chunks_lagged(&self, n: u64) {
+        self.chunks_lagged.fetch_add(n, Ordering::Relaxed);
     }
 
     // --- Consumer stage ---
@@ -281,6 +294,7 @@ impl AudioPipelineMetrics {
             chunks_sent,
             chunks_channel_full: self.chunks_channel_full.load(Ordering::Relaxed),
             stream_timeouts: self.stream_timeouts.load(Ordering::Relaxed),
+            chunks_lagged: self.chunks_lagged.load(Ordering::Relaxed),
             // Consumer
             chunks_received: self.chunks_received.load(Ordering::Relaxed),
             process_errors: self.process_errors.load(Ordering::Relaxed),
@@ -342,6 +356,9 @@ pub struct AudioMetricsSnapshot {
     pub chunks_sent: u64,
     pub chunks_channel_full: u64,
     pub stream_timeouts: u64,
+    /// Audio buffers skipped because the recorder lagged the capture channel
+    /// (silent loss under CPU contention).
+    pub chunks_lagged: u64,
 
     // Consumer stage
     pub chunks_received: u64,

--- a/crates/screenpipe-engine/src/resource_monitor.rs
+++ b/crates/screenpipe-engine/src/resource_monitor.rs
@@ -7,7 +7,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use sysinfo::{CpuExt, PidExt, ProcessExt, System, SystemExt};
+use sysinfo::{CpuExt, PidExt, ProcessExt, ProcessRefreshKind, System, SystemExt};
 use tracing::debug;
 use tracing::trace;
 use tracing::{error, info, warn};
@@ -49,7 +49,14 @@ impl HardwareInfo {
             .unwrap_or_default();
 
         let cpu_arch = std::env::consts::ARCH.to_string();
-        let cpu_count = sys.cpus().len();
+        // `available_parallelism()` is the deterministic source for logical
+        // core count. sysinfo's `cpus()` can still be empty right after a
+        // single `refresh_cpu()` — that flake reported cpu_count=0 on ~99% of
+        // hosts, which made per-core CPU normalization impossible downstream.
+        // Fall back to `cpus().len()` only if the std call fails.
+        let cpu_count = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or_else(|_| sys.cpus().len());
         let os_name = sys.name().unwrap_or_default();
         let os_version = sys.os_version().unwrap_or_default();
         let kernel_version = sys.kernel_version().unwrap_or_default();
@@ -509,7 +516,10 @@ impl ResourceMonitor {
             // Only load process + CPU info — skip disks, networks, components.
             let mut sys = System::new();
             sys.refresh_cpu();
-            sys.refresh_processes();
+            // Refresh per-process CPU only (memory/parent are always collected).
+            // Skipping per-process disk-usage and user lookups avoids the extra
+            // per-PID syscalls that make a full refresh costly on Windows.
+            sys.refresh_processes_specifics(ProcessRefreshKind::new().with_cpu());
             sys.refresh_memory();
 
             loop {
@@ -519,7 +529,9 @@ impl ResourceMonitor {
                         // CPU + process list + system memory totals.
                         // Skips disks, networks, components — saves allocations.
                         sys.refresh_cpu();
-                        sys.refresh_processes();
+                        // CPU-only process refresh: skip per-PID disk/user
+                        // syscalls (the expensive part on Windows).
+                        sys.refresh_processes_specifics(ProcessRefreshKind::new().with_cpu());
                         sys.refresh_memory();
 
                         // Tell the system allocator to return freed pages to the OS.

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -295,6 +295,10 @@ pub struct AudioPipelineHealthInfo {
     pub chunks_received: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub process_errors: Option<u64>,
+    /// Audio buffers skipped because the recorder lagged the capture channel
+    /// (silent loss). Omitted when zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunks_lagged: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audio_level_rms: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1089,6 +1093,11 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
                 // Consumer stage diagnostics
                 chunks_received: Some(audio_snap.chunks_received),
                 process_errors: Some(audio_snap.process_errors),
+                chunks_lagged: if audio_snap.chunks_lagged > 0 {
+                    Some(audio_snap.chunks_lagged)
+                } else {
+                    None
+                },
                 audio_level_rms: Some(audio_snap.audio_level_rms),
                 per_device_audio_level_rms: if per_device_levels.is_empty() {
                     None

--- a/crates/screenpipe-engine/src/server.rs
+++ b/crates/screenpipe-engine/src/server.rs
@@ -492,6 +492,7 @@ impl SCServer {
                                 "chunks_received": snap.chunks_received,
                                 "chunks_channel_full": snap.chunks_channel_full,
                                 "stream_timeouts": snap.stream_timeouts,
+                                "chunks_lagged": snap.chunks_lagged,
                                 "process_errors": snap.process_errors,
                                 "vad_passed": snap.vad_passed,
                                 "vad_rejected": snap.vad_rejected,


### PR DESCRIPTION
## Why

A PostHog review of Windows **audio reliability** and **CPU usage** turned up three measurement blind spots. These are observability/correctness fixes — they don't change capture behavior, so they're safe to ship without on-device audio verification (unlike the Windows audio-lifecycle work, which is tracked separately).

Key findings that motivated this:
- **`cpu_count` was reported as `0` on ~99% of hosts** (a flaky single `refresh_cpu()`), which made it impossible to normalize `total_cpu_percent` per core. The raw "p90 ≈ 250%" that looked alarming was just an un-normalized core-sum; once a few 0.4.x machines started reporting `cpu_count`, normalized CPU was ~3% median / ~10% p90 of total machine capacity. We were flying blind on the one field that makes CPU interpretable.
- **Audio loss from broadcast `Lagged(n)` was invisible.** When the recorder consumer falls behind the capture channel, the in-between OS buffers are gone — but it was only a `debug!` log, counted in no metric. On contended Windows machines that's exactly where silent recording gaps hide, and our telemetry only saw `stream_timeouts`/`channel_full`.
- The resource monitor did a **full `refresh_processes()` every 30s forever**, which on Windows opens a handle + extra syscalls per PID for disk/user info we never use.

## Changes

**Audio (`screenpipe-audio`)**
- New `chunks_lagged` counter in `AudioPipelineMetrics`, incremented by `n` in the `Lagged(n)` arm of `recv_audio_chunk`.
- Exposed on `/health` (`AudioPipelineHealthInfo`, omitted when zero) and emitted in the `audio_pipeline_health` PostHog event next to `stream_timeouts`/`chunks_channel_full`.

**Resource monitor (`screenpipe-engine`)**
- `cpu_count` now comes from `std::thread::available_parallelism()` (deterministic, never 0), falling back to `cpus().len()` only if that fails.
- `refresh_processes()` → `refresh_processes_specifics(ProcessRefreshKind::new().with_cpu())` to skip per-PID disk-usage/user lookups. `memory`/`parent`/`cpu` are still collected, so `collect_metrics` is unchanged.

## Risk / testing
- No dependency changes; additive counters + a deterministic core count + a cheaper refresh.
- `cargo check -p screenpipe-audio -p screenpipe-engine` clean; `rustfmt --check` clean on all touched files.
- Relevant unit tests pass (`metrics::tests`, recorder zero-fill/timeout tests).
- Once a build with this ships, `cpu_count` becomes trustworthy fleet-wide and `chunks_lagged` lets us quantify silent audio loss per version — the next reliability investigation depends on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)