### PR TITLE
docs: scrub stale "MIT" license claims after MIT→Commercial move

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -3,7 +3,7 @@
 #
 # CI for the enterprise SDK in ee/sdk. The SDK is source-available under the
 # Screenpipe Enterprise License and intentionally kept outside the root Cargo
-# workspace so the MIT core build stays unchanged.
+# workspace so the core build stays unchanged.
 
 name: SDK
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-fathom.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-fathom.mdx
@@ -14,7 +14,7 @@ screenpipe captures your entire screen and audio 24/7, locally. Fathom is a clou
 | **scope** | 24/7 screen + audio | meeting audio only (Zoom, Meet, Teams) |
 | **screen capture** | all monitors, all apps | none |
 | **data storage** | 100% local | cloud (Fathom's servers) |
-| **open source** | yes (MIT), 17k+ stars | no (proprietary) |
+| **open source** | yes, 17k+ stars | no (proprietary) |
 | **works offline** | yes | no |
 | **AI model** | any (Claude, GPT, Ollama, local) | Fathom's built-in AI only |
 | **CRM integration** | via custom pipes | native Salesforce + HubSpot |
@@ -36,7 +36,7 @@ Fathom joins meetings as a visible participant on some platforms. hosts can bloc
 
 ### local-first, open source, extensible
 
-all data stays on your device. MIT-licensed with 17k+ GitHub stars. 45+ app integrations and 16+ pipes in the store. full REST API and MCP server for custom automations.
+all data stays on your device. source-available with 17k+ GitHub stars. 45+ app integrations and 16+ pipes in the store. full REST API and MCP server for custom automations.
 
 ## get started
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-fireflies.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-fireflies.mdx
@@ -14,7 +14,7 @@ screenpipe captures your entire screen and audio 24/7, locally. Fireflies.ai sen
 | **scope** | 24/7 screen + audio | meeting audio only |
 | **screen capture** | all monitors, all apps | none |
 | **data storage** | 100% local | cloud (AWS/GCP, US-based) |
-| **open source** | yes (MIT), 17k+ stars | no (proprietary) |
+| **open source** | yes, 17k+ stars | no (proprietary) |
 | **meeting presence** | invisible (captures on your device) | visible bot ("Fireflies Notetaker") |
 | **AI limits** | unlimited (choose your model) | credit-capped per plan |
 | **works offline** | yes | no |
@@ -36,7 +36,7 @@ Fireflies records scheduled calls. screenpipe captures your entire workday — m
 
 ### local-first, open source, extensible
 
-all data stays on your device. MIT-licensed with 17k+ GitHub stars. 45+ app integrations and 16+ pipes in the store. full REST API and MCP server for custom workflows. Fireflies has 90+ integrations but requires cloud processing for all of them.
+all data stays on your device. source-available with 17k+ GitHub stars. 45+ app integrations and 16+ pipes in the store. full REST API and MCP server for custom workflows. Fireflies has 90+ integrations but requires cloud processing for all of them.
 
 ## get started
 
@@ -55,7 +55,7 @@ all data stays on your device. MIT-licensed with 17k+ GitHub stars. 45+ app inte
 
 ### is screenpipe better than Fireflies.ai for privacy?
 
-yes. screenpipe processes everything on your device — data never touches an external server. the code is MIT-licensed and auditable. Fireflies processes everything in their cloud (AWS/GCP). they hold SOC 2 Type II but the code is closed. for regulated industries (healthcare, finance, legal), screenpipe's local-first approach is often a compliance requirement.
+yes. screenpipe processes everything on your device — data never touches an external server. the code is source-available and auditable. Fireflies processes everything in their cloud (AWS/GCP). they hold SOC 2 Type II but the code is closed. for regulated industries (healthcare, finance, legal), screenpipe's local-first approach is often a compliance requirement.
 
 ### does screenpipe have CRM integrations like Fireflies?
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-granola.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-granola.mdx
@@ -14,7 +14,7 @@ screenpipe captures your entire screen and audio 24/7, locally. Granola is an AI
 | **scope** | 24/7 screen + audio | meetings only |
 | **screen capture** | all monitors, accessibility-first text + OCR fallback | none |
 | **data storage** | 100% local | cloud-based |
-| **open source** | yes (MIT), 17k+ stars | no |
+| **open source** | yes, 17k+ stars | no |
 | **platforms** | macOS, Windows, Linux | macOS, Windows |
 | **works offline** | yes | no |
 | **requires Google Workspace** | no | yes |
@@ -28,7 +28,7 @@ meetings are ~20% of knowledge work. Granola covers that slice. screenpipe captu
 
 ### local-first, no cloud dependency
 
-all data stays on your device. no third-party servers, no cloud processing. your security team can audit every line of the MIT-licensed source code.
+all data stays on your device. no third-party servers, no cloud processing. your security team can audit every line of the source-available source code.
 
 ### no vendor lock-in
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-limitless.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-limitless.mdx
@@ -12,7 +12,7 @@ Limitless.ai offers an AI-powered pendant and app for recording meetings and con
 | feature | screenpipe | limitless |
 |---------|-----------|-----------|
 | **hardware** | uses your existing devices | requires pendant |
-| **open source** | yes (MIT) | no |
+| **open source** | yes | no |
 | **data location** | 100% local | cloud-based |
 | **platforms** | macOS, Windows, Linux | iOS, web |
 | **screen capture** | yes | no |

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-littlebird.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-littlebird.mdx
@@ -16,7 +16,7 @@ Littlebird raised $11M (March 2026) to build an AI assistant that reads your scr
 | feature | screenpipe | littlebird |
 |---------|-----------|------------|
 | **data storage** | 100% local on your device | cloud (encrypted) |
-| **open source** | yes (MIT) — audit every line | no |
+| **open source** | yes — audit every line | no |
 | **screen capture** | accessibility APIs + OCR fallback, all monitors | reads screen text (no OCR images) |
 | **audio transcription** | yes — meetings, calls, conversations | yes |
 | **platforms** | macOS, Windows, Linux | macOS only |
@@ -32,7 +32,7 @@ this is the fundamental difference. Littlebird uploads your screen context to th
 
 ### open source
 
-screenpipe is MIT licensed with 17k+ GitHub stars. you can audit every line of code, self-host, fork, or contribute. Littlebird is closed source — you trust their encryption and their servers.
+screenpipe is source-available with 17k+ GitHub stars. you can audit every line of code, self-host, fork, or contribute. Littlebird is closed source — you trust their encryption and their servers.
 
 ### cross-platform
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-omi.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-omi.mdx
@@ -20,7 +20,7 @@ Omi (formerly Friend, by Based Hardware) is an $89 open source AI wearable penda
 | **screen capture** | yes — all monitors, all apps | no |
 | **audio capture** | system audio + mic on computer | always-on ambient mic on body |
 | **data storage** | 100% local | phone + optional cloud |
-| **open source** | yes (MIT) | yes (MIT) |
+| **open source** | yes (source-available) | yes (MIT) |
 | **platforms** | macOS, Windows, Linux | iOS, Android |
 | **AI provider** | your choice (local Ollama, ChatGPT, Claude) | GPT-4o via your API key |
 | **extensibility** | 16+ pipes, 45+ app connections, REST API, MCP | developer SDK, community apps |
@@ -72,7 +72,7 @@ it depends on what you want to capture. screenpipe captures your computer screen
 
 ### are Omi and screenpipe both open source?
 
-yes. both are MIT licensed. screenpipe has 17k+ GitHub stars; Omi has 15k+. you can audit, fork, or contribute to either.
+yes. screenpipe is source-available and Omi is MIT licensed. screenpipe has 17k+ GitHub stars; Omi has 15k+. you can audit, fork, or contribute to either.
 
 ### can screenpipe capture audio like Omi does?
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-otter.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-otter.mdx
@@ -15,7 +15,7 @@ screenpipe captures your entire screen and audio 24/7, locally, with no caps. Ot
 | **screen capture** | all monitors, all apps | none |
 | **audio limits** | unlimited | 6000 min/mo cap |
 | **data storage** | 100% local | cloud (Otter's servers) |
-| **open source** | yes (MIT), 17k+ stars | no |
+| **open source** | yes, 17k+ stars | no |
 | **meeting presence** | invisible (captures on your device) | visible bot joins your call |
 | **AI model** | any (Claude, GPT, Ollama, local) | Otter's built-in AI only |
 | **price** | $400 lifetime | $19.99/mo per user (Business) |
@@ -36,7 +36,7 @@ when someone shares a spreadsheet and says "look at the Q3 numbers," screenpipe 
 
 ### local-first, open source
 
-all data stays on your device. MIT-licensed with 17k+ GitHub stars. 45+ app integrations and 16+ pipes in the store. full REST API and MCP server for custom workflows.
+all data stays on your device. source-available with 17k+ GitHub stars. 45+ app integrations and 16+ pipes in the store. full REST API and MCP server for custom workflows.
 
 ## get started
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-pieces.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-pieces.mdx
@@ -19,7 +19,7 @@ Pieces for Developers is a code snippet manager and AI copilot that lives inside
 | **screen recording** | all monitors, all apps | none |
 | **audio transcription** | yes — meetings, calls, conversations | none |
 | **browser, Slack, terminal** | yes — captures everything on screen | no — editor plugins only |
-| **open source** | yes (MIT) | partially open source |
+| **open source** | yes | partially open source |
 | **data location** | 100% local | local + optional cloud sync |
 | **platforms** | macOS, Windows, Linux | macOS, Windows, Linux |
 | **AI integrations** | MCP server for Claude, Cursor, ChatGPT + 45+ app connections | MCP server, IDE plugins |

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-recall.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-recall.mdx
@@ -11,7 +11,7 @@ Microsoft Recall is a Windows 11 feature that captures screenshots and makes the
 
 | feature | screenpipe | microsoft recall |
 |---------|-----------|------------------|
-| **open source** | yes (MIT) | no |
+| **open source** | yes | no |
 | **platforms** | macOS, Windows, Linux | Windows 11 only |
 | **data location** | 100% local | local (with cloud concerns) |
 | **NPU required** | no | yes (Copilot+ PCs) |
@@ -93,7 +93,7 @@ in the desktop app settings, you can exclude specific windows (like password man
 
 ### is there a privacy-focused alternative to Windows Recall?
 
-yes. screenpipe is the privacy-focused, open source alternative to Microsoft Recall. unlike Recall, screenpipe is fully open source (MIT licensed), works on macOS, Windows, and Linux, requires no special hardware (no NPU needed), and stores all data 100% locally with no cloud dependency. you can use local AI models (Ollama) for complete privacy and audit every line of code.
+yes. screenpipe is the privacy-focused, open source alternative to Microsoft Recall. unlike Recall, screenpipe is fully open source (source-available), works on macOS, Windows, and Linux, requires no special hardware (no NPU needed), and stores all data 100% locally with no cloud dependency. you can use local AI models (Ollama) for complete privacy and audit every line of code.
 
 ### does screenpipe work on Windows without a Copilot+ PC?
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-rewind.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-rewind.mdx
@@ -11,7 +11,7 @@ screenpipe is the open source alternative to Rewind.ai. after Rewind pivoted to 
 
 | feature | screenpipe | rewind.ai |
 |---------|-----------|-----------|
-| **open source** | yes (MIT) | no |
+| **open source** | yes | no |
 | **data location** | 100% local | local |
 | **platforms** | macOS, Windows, Linux | macOS only |
 | **status** | active | discontinued (pivoted to Limitless) |
@@ -23,7 +23,7 @@ screenpipe is the open source alternative to Rewind.ai. after Rewind pivoted to 
 
 ### open source
 
-screenpipe is MIT licensed. audit the code, contribute, or fork it. your data, your control.
+screenpipe is source-available. audit the code, contribute, or fork it. your data, your control.
 
 ### cross-platform
 

--- a/packages/screenpipe-mcp/README.md
+++ b/packages/screenpipe-mcp/README.md
@@ -221,8 +221,9 @@ captures is retained according to your Screenpipe storage configuration
 and is deletable at any time (`rm -rf ~/.screenpipe` removes everything).
 
 ### Source code
-The Screenpipe MCP server is MIT-licensed and the entire source is
-public at <https://github.com/screenpipe/screenpipe/tree/main/packages/screenpipe-mcp>.
+The Screenpipe MCP server is source-available under the Screenpipe
+Commercial License and the entire source is public at
+<https://github.com/screenpipe/screenpipe/tree/main/packages/screenpipe-mcp>.
 Every line is auditable.
 
 ### Contact

--- a/packages/screenpipe-mcp/manifest.json
+++ b/packages/screenpipe-mcp/manifest.json
@@ -16,7 +16,7 @@
   "homepage": "https://screenpi.pe",
   "documentation": "https://github.com/screenpipe/screenpipe/tree/main/packages/screenpipe-mcp",
   "support": "https://github.com/screenpipe/screenpipe/issues",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE.md",
   "server": {
     "type": "node",
     "entry_point": "dist/index.js",


### PR DESCRIPTION
## what

The core license moved **MIT → Screenpipe Commercial License** (source-available) on 2026-06-10 (`81e412ff5`, `f390fa9d2`). `LICENSE.md` and the root `README.md` were updated then, but a number of docs still claimed MIT. This scrubs the leftover factually-wrong claims.

## changes
- `packages/screenpipe-mcp/manifest.json` — `"license": "MIT"` → `"SEE LICENSE IN LICENSE.md"` (matches its own `package.json`)
- `packages/screenpipe-mcp/README.md` — "MIT-licensed" → "source-available under the Screenpipe Commercial License"
- `docs/mintlify/.../vs-*.mdx` ×10 — comparison pages drop `(MIT)` / "MIT licensed" (rewind, recall, otter, granola, fathom, fireflies, omi, pieces, littlebird, limitless)
- `.github/workflows/sdk.yml` — CI comment no longer calls the core "MIT"

## deliberately untouched
- **"open source" wording** is left as-is — only the factually-wrong "MIT" is removed (per scope decision).
- **Omi's** genuine MIT references in `vs-omi.mdx` are kept (Omi really is MIT; only screenpipe's column changed).
- `LICENSE.md` note that *prior* versions remain MIT is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)