### PR TITLE
Bump app to v2.5.44

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "screenpipe-app"
-version = "2.5.43"
+version = "2.5.44"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
Ships the merged write-pool **recording-reliability** fixes to desktop users — the top Sentry cluster by user impact (CLI-FZ 168 users, GR/RC/HA), still on the previous build:

- #4196 — auto-restart recording when the SQLite write queue wedges
- #4200 — start WAL checkpoint maintenance in `DatabaseManager::new`
- #4202 — recover orphaned audio chunks dropped under write-pool saturation

App-only patch bump (2.5.43 → 2.5.44), single line in `src-tauri/Cargo.toml`, mirroring #4187. Merging triggers a **draft** `release-app.yml` build (not auto-published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)