### PR TITLE
feat(mcp): publish screenpipe-mcp to the MCP Registry (server.json + mcpName)

### DIFF
--- a/packages/screenpipe-mcp/package.json
+++ b/packages/screenpipe-mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "screenpipe-mcp",
   "version": "0.18.11",
+  "mcpName": "io.github.screenpipe/screenpipe-mcp",
   "description": "MCP server for screenpipe - search your screen recordings and audio transcriptions",
   "main": "dist/index.js",
   "bin": {

--- a/packages/screenpipe-mcp/server.json
+++ b/packages/screenpipe-mcp/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.screenpipe/screenpipe-mcp",
+  "title": "screenpipe",
+  "description": "Search your local screen recordings, audio transcriptions, and computer activity captured by screenpipe.",
+  "repository": {
+    "url": "https://github.com/screenpipe/screenpipe",
+    "source": "github",
+    "subfolder": "packages/screenpipe-mcp"
+  },
+  "version": "0.18.11",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "screenpipe-mcp",
+      "version": "0.18.11",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
adds the metadata needed to publish `screenpipe-mcp` to the official [MCP Registry](https://registry.modelcontextprotocol.io) — the upstream feed that Glama, mcp.so, and PulseMCP pull from, so one publish surfaces screenpipe across the MCP directory ecosystem (it's currently in none of them because there's no registry entry).

**what's here (metadata only, no runtime changes):**
- `packages/screenpipe-mcp/server.json` — registry manifest (npm package, stdio transport)
- `mcpName` in `package.json` — the ownership proof the registry validates against the published npm package

**to finish the listing (one-time, not in this PR):**
1. cut a release so the npm package ships with `mcpName` (`screenpipe-mcp` >= next version)
2. from `packages/screenpipe-mcp`, authenticated as the screenpipe org: `mcp-publisher login github` then `mcp-publisher publish`
