### PR TITLE
fix(ci): stop enterprise Windows build failing on ort system-link

### DIFF
--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -164,8 +164,13 @@ jobs:
       - name: Set ORT env vars
         shell: bash
         run: |
-          echo "ORT_STRATEGY=system" >> $GITHUB_ENV
-          echo "ORT_LIB_LOCATION=${{ github.workspace }}/ort-system-lib" >> $GITHUB_ENV
+          # Windows x64 must link ONNX Runtime via ort's download-binaries (its
+          # default) — NOT system linking. ort-sys rc.12's system path needs
+          # static libs the Microsoft dynamic zip doesn't ship, so setting
+          # ORT_STRATEGY=system + ORT_LIB_LOCATION makes the build fail with
+          # "ort-sys could not link to the ONNX Runtime build in .../ort-system-lib".
+          # The runtime onnxruntime.dll is still bundled via the download step
+          # above. Mirrors the consumer release-app.yml x64 fix (11566613b).
           echo "OPENBLAS_PATH=${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/openblas" >> $GITHUB_ENV
 
       - name: Use enterprise config


### PR DESCRIPTION
## Problem

`release-enterprise.yml` → `release-enterprise-windows` fails at the build step (run [27651465133](https://github.com/screenpipe/screenpipe/actions/runs/27651465133)):

```
error: ort-sys@2.0.0-rc.12: could not link to the ONNX Runtime build in `.../ort-system-lib`
```

The workflow set `ORT_STRATEGY=system` + `ORT_LIB_LOCATION` pointing at `ort-system-lib`, populated by extracting Microsoft's **dynamic** `onnxruntime-win-x64` zip — which ships the import lib but **not** the static libs `ort-sys` rc.12's system-link path needs. The consumer `release-app.yml` already learned this: its **x64** path links via `download-binaries` (no `ORT_STRATEGY`/`ORT_LIB_LOCATION`) and only uses `system` for ARM64 (fixed in `11566613b`). This enterprise workflow was the known straggler — it built green on 06-15 and the `ort` rc.10→rc.12 bump tipped it red.

## Fix

Drop the two ORT env vars from the enterprise Windows step (keep `OPENBLAS_PATH`). x64 then links via `download-binaries` like the green consumer build. The runtime `onnxruntime.dll` is still bundled via the existing download step, so no runtime change.

Diagnosed during the v2.5.44 release: the **consumer** app build was fully green (incl. Windows x64), only enterprise Windows failed — confirming this is config-specific, not a core break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)