### PR TITLE
ci(mcp): auto-publish screenpipe-mcp to the MCP Registry on release

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # OIDC auth for the MCP Registry (io.github.screenpipe namespace)
 
 env:
   GIT_LFS_SKIP_SMUDGE: 1
@@ -58,6 +59,30 @@ jobs:
           else
             npm publish --access public
           fi
+
+      # Publish to the official MCP Registry (registry.modelcontextprotocol.io).
+      # Feeds downstream directories (Glama, mcp.so, PulseMCP). OIDC auth needs no
+      # secrets for the io.github.screenpipe namespace. Runs after npm publish so the
+      # package being referenced already carries the matching mcpName.
+      - name: Sync server.json version from package.json
+        working-directory: packages/screenpipe-mcp
+        run: |
+          VER=$(node -p "require('./package.json').version")
+          jq --arg v "$VER" '.version = $v | .packages |= map(.version = $v)' server.json > server.tmp && mv server.tmp server.json
+          echo "synced server.json version to $VER"
+
+      - name: Install mcp-publisher
+        working-directory: packages/screenpipe-mcp
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        working-directory: packages/screenpipe-mcp
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        working-directory: packages/screenpipe-mcp
+        run: ./mcp-publisher publish
 
       - name: Sync manifest.json version from package.json
         working-directory: packages/screenpipe-mcp


### PR DESCRIPTION
follow-up to #4226 (now merged — `server.json` + `mcpName` are on main). this wires the actual publish into the existing MCP release flow so screenpipe-mcp lands in the official [MCP Registry](https://registry.modelcontextprotocol.io), which Glama, mcp.so, and PulseMCP pull from.

added to `release-mcp.yml`, right after the npm publish:
- `id-token: write` permission (OIDC — no secrets needed for the `io.github.screenpipe` namespace)
- sync `server.json` version from `package.json`
- install `mcp-publisher`, `login github-oidc`, `publish`

**effect:** the next MCP release (tag `mcp-v*` or workflow_dispatch) publishes the npm package *with* `mcpName`, then auto-registers it in the MCP Registry. it takes effect on a version-bumped release (so npm carries the new `mcpName`); re-running an already-published version is a no-op on the npm step.
