### PR TITLE
fix(ci): rustfmt event_driven_capture.rs

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2429,8 +2429,18 @@ mod tests {
             false,
             recent
         ));
-        assert!(!dedup_applies(&CaptureTrigger::KeyPress, false, false, recent));
-        assert!(!dedup_applies(&CaptureTrigger::Clipboard, false, false, recent));
+        assert!(!dedup_applies(
+            &CaptureTrigger::KeyPress,
+            false,
+            false,
+            recent
+        ));
+        assert!(!dedup_applies(
+            &CaptureTrigger::Clipboard,
+            false,
+            false,
+            recent
+        ));
 
         // HD active → dedup is bypassed even for an otherwise-eligible trigger.
         // This is the fix: video/demo replay moves pixels but not AX text, so
@@ -2468,7 +2478,12 @@ mod tests {
 
         // Idle/Manual are always dedup-exempt (timeline floor), HD or not.
         assert!(!dedup_applies(&CaptureTrigger::Idle, false, false, recent));
-        assert!(!dedup_applies(&CaptureTrigger::Manual, false, false, recent));
+        assert!(!dedup_applies(
+            &CaptureTrigger::Manual,
+            false,
+            false,
+            recent
+        ));
 
         // 30s time-floor: once it elapses, write through regardless.
         assert!(!dedup_applies(
@@ -2599,7 +2614,9 @@ mod tests {
 
         // ~6s since the last capture — past the meeting cap, well under 30s.
         let six_s_ago = Instant::now()
-            .checked_sub(Duration::from_millis(MEETING_IDLE_CAPTURE_INTERVAL_MS + 1_000))
+            .checked_sub(Duration::from_millis(
+                MEETING_IDLE_CAPTURE_INTERVAL_MS + 1_000,
+            ))
             .unwrap_or(Instant::now());
 
         // Not in a meeting: 6s < 30s → no idle capture yet.


### PR DESCRIPTION
Pre-existing rustfmt drift in `crates/screenpipe-engine/src/event_driven_capture.rs` reds the whole-repo **Clippy & Format** check on every open PR (it cites this file even on PRs that never touch it). Landed via an admin-merge before the fmt check finished.

Pure `cargo fmt` output — a few test assertions and one `Duration::from_millis(...)` call expanded to rustfmt's preferred multi-line form. **No logic change.**

```
cargo fmt -p screenpipe-engine --check   # clean after this
```

Unblocks the fmt gate for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)