### PR TITLE
release(mcp): bump screenpipe-mcp to 0.18.12 (lists it in the MCP Registry)

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -71,16 +71,21 @@ jobs:
           jq --arg v "$VER" '.version = $v | .packages |= map(.version = $v)' server.json > server.tmp && mv server.tmp server.json
           echo "synced server.json version to $VER"
 
+      # continue-on-error: this is a new step — a first-run hiccup (OIDC, asset URL)
+      # must not abort the npm publish / mcpb bundle / GitHub release that surround it.
       - name: Install mcp-publisher
+        continue-on-error: true
         working-directory: packages/screenpipe-mcp
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
 
       - name: Authenticate to MCP Registry (GitHub OIDC)
+        continue-on-error: true
         working-directory: packages/screenpipe-mcp
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
+        continue-on-error: true
         working-directory: packages/screenpipe-mcp
         run: ./mcp-publisher publish
 

--- a/packages/screenpipe-mcp/package.json
+++ b/packages/screenpipe-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screenpipe-mcp",
-  "version": "0.18.11",
+  "version": "0.18.12",
   "mcpName": "io.github.screenpipe/screenpipe-mcp",
   "description": "MCP server for screenpipe - search your screen recordings and audio transcriptions",
   "main": "dist/index.js",

--- a/packages/screenpipe-mcp/server.json
+++ b/packages/screenpipe-mcp/server.json
@@ -8,13 +8,13 @@
     "source": "github",
     "subfolder": "packages/screenpipe-mcp"
   },
-  "version": "0.18.11",
+  "version": "0.18.12",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "screenpipe-mcp",
-      "version": "0.18.11",
+      "version": "0.18.12",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
bumps `screenpipe-mcp` 0.18.11 → 0.18.12 so a release publishes the npm package **with** the `mcpName` field (the version on npm now lacks it), which the MCP Registry requires for ownership validation.

also re-applies the `continue-on-error` guard on the three registry steps (it didn't make it into the #4230 merge) — a first-run hiccup must not abort the npm publish / mcpb bundle / GitHub release.

after merge i'll trigger the *Release MCP* workflow, which publishes 0.18.12 to npm and auto-registers it in the MCP Registry.
