### PR TITLE
feat(app): in-app "change plan" CTA → web billing upgrade

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -244,6 +244,17 @@ export function AccountSection() {
                 <UserCog className="w-4 h-4 mr-1.5" />
                 manage
               </Button>
+              {/* Opens the web billing page, where an existing plan is
+                  upgraded in place (Basic → Business → Team/Enterprise)
+                  without starting a second subscription. */}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => openUrl("https://screenpipe.com/billing")}
+              >
+                change plan
+                <ExternalLinkIcon className="w-3.5 h-3.5 ml-1.5" />
+              </Button>
               <Button
                 variant="outline"
                 size="sm"

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -733,9 +733,23 @@ fn create_dynamic_menu(
                 .enabled(false)
                 .build(app)?,
         );
-        // Anyone without cloud (Free, Basic, or Lifetime-only) can move up to
-        // Business to add cloud sync, cloud AI, and integrations.
-        if !has_cloud {
+        // Existing subscribers (any paid tier) get a "change plan" item that
+        // opens the web billing page, where the upgrade happens in place on
+        // their current subscription — swapping the price, no second checkout.
+        // Truly-free users (no plan) keep the fresh-checkout "upgrade to
+        // Business" path. Splitting on the paid-plan check avoids sending a
+        // paying Basic user through a NEW checkout (the duplicate-sub trap).
+        let has_paid_plan = matches!(
+            data.subscription_plan
+                .as_deref()
+                .map(str::to_ascii_lowercase)
+                .as_deref(),
+            Some("standard" | "pro" | "team" | "enterprise" | "lifetime")
+        );
+        if has_paid_plan {
+            menu_builder = menu_builder
+                .item(&MenuItemBuilder::with_id("change_plan", "⤴ change plan").build(app)?);
+        } else if !has_cloud {
             menu_builder = menu_builder
                 .item(&MenuItemBuilder::with_id("upgrade", "⚡ Upgrade to Business").build(app)?);
         }
@@ -1240,6 +1254,17 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                 }
                 .show(&app);
                 let _ = app.emit("tray-upgrade", ());
+            });
+        }
+        "change_plan" => {
+            // Open the web billing page, where an existing subscription is
+            // upgraded in place (Basic → Business → Team/Enterprise). /billing
+            // redirects to /account/billing on the website.
+            let app = app_handle.clone();
+            let _ = app_handle.run_on_main_thread(move || {
+                let _ = app
+                    .opener()
+                    .open_url("https://screenpipe.com/billing", None::<&str>);
             });
         }
         "releases" => {


### PR DESCRIPTION
## Why
Companion to the website self-serve upgrade. A paying **Basic** user had no way to reach the upgrade flow from inside the app — and the app's existing "⚡ Upgrade to Business" routed to a *new* checkout (the duplicate-sub trap), because the desktop app only tracks a binary `cloud_subscribed` flag, not the Basic/Business/Enterprise tiers.

## What
The app now **deep-links existing subscribers to the web billing page** (`screenpipe.com/billing`), where the in-place upgrade ([website#281](https://github.com/screenpipe/website/pull/281)) lives.

- **`tray.rs`** — paid-plan users (`subscription_plan ∈ standard/pro/team/enterprise/lifetime`) get a **"⤴ change plan"** item → opens the billing page. Truly-free users keep the fresh-checkout "⚡ Upgrade to Business". Splitting on the paid-plan check is what avoids sending a paying user through a new checkout. New `change_plan` handler mirrors the existing `releases` URL-open handler.
- **`account-section.tsx`** — a "change plan" button next to "manage" → same URL.

## Notes
⚠️ The **Rust tray change is not build-verified locally** (heavy build) — CI builds it. Behavior mirrors existing tray URL-open handlers (`app.opener().open_url(...)`), and the menu-id was kept out of the hidden-UI suppression list (a URL open is safe in that mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)