### PR TITLE
fix(mcp): shorten server.json description for MCP Registry (<=100 chars)

### DIFF
--- a/packages/screenpipe-mcp/server.json
+++ b/packages/screenpipe-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.screenpipe/screenpipe-mcp",
   "title": "screenpipe",
-  "description": "Search your local screen recordings, audio transcriptions, and computer activity captured by screenpipe.",
+  "description": "Search your local screen recordings, audio transcripts, and computer activity from screenpipe.",
   "repository": {
     "url": "https://github.com/screenpipe/screenpipe",
     "source": "github",


### PR DESCRIPTION
the registry rejected the publish with 422 `expected length <= 100` on `description` (was 104). shortens it so the registry publish on the next release succeeds. npm 0.18.12 already published fine.