### PR TITLE
fix(ci): add ..Default to TranscribeOptions in bench examples (unblock test-ubuntu)

### DIFF
--- a/crates/screenpipe-audio/examples/bench_quality.rs
+++ b/crates/screenpipe-audio/examples/bench_quality.rs
@@ -171,6 +171,7 @@ fn transcribe_chunked(
     let opts = audiopipe::TranscribeOptions {
         language: lang.map(|s| s.to_string()),
         word_timestamps: false,
+        ..Default::default()
     };
 
     if audio.len() <= chunk_samples {
@@ -188,6 +189,7 @@ fn transcribe_chunked(
         let opts = audiopipe::TranscribeOptions {
             language: lang.map(|s| s.to_string()),
             word_timestamps: false,
+            ..Default::default()
         };
         let result = engine.transcribe_with_sample_rate(chunk, sample_rate, opts);
         let text = result

--- a/crates/screenpipe-audio/examples/bench_quality2.rs
+++ b/crates/screenpipe-audio/examples/bench_quality2.rs
@@ -275,6 +275,7 @@ fn transcribe_full(model: &mut audiopipe::Model, audio: &[f32], sr: u32) -> Stri
     let opts = audiopipe::TranscribeOptions {
         language: None,
         word_timestamps: false,
+        ..Default::default()
     };
     model
         .transcribe_with_sample_rate(audio, sr, opts)
@@ -305,6 +306,7 @@ fn transcribe_fixed_chunks(
         let opts = audiopipe::TranscribeOptions {
             language: None,
             word_timestamps: false,
+            ..Default::default()
         };
         let text = model
             .transcribe_with_sample_rate(chunk, sr, opts)
@@ -356,6 +358,7 @@ fn transcribe_vad_segments(
         let opts = audiopipe::TranscribeOptions {
             language: None,
             word_timestamps: false,
+            ..Default::default()
         };
         let text = model
             .transcribe_with_sample_rate(chunk, sr, opts)
@@ -474,6 +477,7 @@ async fn main() -> anyhow::Result<()> {
         let opts = audiopipe::TranscribeOptions {
             language: None,
             word_timestamps: false,
+            ..Default::default()
         };
         match model.transcribe(chunk, opts) {
             Ok(r) => {


### PR DESCRIPTION
main still fails to compile: `cargo test --workspace` → `error[E0063]: missing fields `keyterm_boost` and `keyterms`` in `bench_quality2.rs` (and `bench_quality.rs`), blocking every open PR's Rust CI (test-ubuntu).

#4212 squash-merged the audiopipe bump that made `keyterms`/`keyterm_boost` required on `TranscribeOptions`, but the matching bench-example fix was pushed after the squash cutoff and didn't land.

(The companion `E0061` compile break in `event_driven_capture.rs` that this PR originally also carried was fixed independently in #4238 and is now in main — rebased out.)

## fix
`..Default::default()` on the 6 `TranscribeOptions { .. }` literals in the bench examples. Zero behavior change (Default = `keyterms: vec![]`, `keyterm_boost: 6.0` = no biasing). Verified `cargo build --examples --features parakeet` + a clean local `cargo test --workspace --no-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)