### PR TITLE
fix(engine): main won't compile — dedup_applies missing in_meeting arg

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2043,7 +2043,7 @@ async fn do_capture(
                 // Mirror the downstream content-dedup gate: a non-empty walk
                 // whose hash matches the previous frame (and which is dedup
                 // eligible) won't be stored — count it as deduped.
-                let is_dedup = dedup_applies(trigger, hd_active, last_db_write.elapsed())
+                let is_dedup = dedup_applies(trigger, hd_active, in_meeting, last_db_write.elapsed())
                     && previous_content_hash
                         .is_some_and(|prev| prev == snap.content_hash as i64 && prev != 0);
                 let outcome = if is_dedup {


### PR DESCRIPTION
## main is currently red (compile error)

`cargo build` of `screenpipe-engine` fails on `main`:

```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> crates/screenpipe-engine/src/event_driven_capture.rs:2046:32
   | dedup_applies(trigger, hd_active, last_db_write.elapsed())
   |   argument #3 of type `bool` is missing   (in_meeting)
```

`dedup_applies` gained an `in_meeting: bool` param (from #4214 — "capture screen changes during meetings instead of deduping them away"). The real dedup gate at line 2125 was updated to pass it; this **telemetry-mirror** call at line 2046 (which counts a tree-walk as "deduped" to match the downstream gate) was not — a **semantic merge conflict** (the two PRs were each green in isolation, broke once both landed).

## Fix

Pass `in_meeting` at line 2046, mirroring line 2125. One line.

## Why it matters / scope

- Not feature-gated → affects **all** builds. Surfaced in the enterprise re-run ([27654805811](https://github.com/screenpipe/screenpipe/actions/runs/27654805811)); the **next consumer release would also fail**. (The v2.5.44 consumer build predates the breaking merge, which is why it was green.)
- Verified locally with `cargo check -p screenpipe-engine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)