### PR TITLE
fix(ci): add missing TranscribeOptions fields to bench examples

### DIFF
--- a/crates/screenpipe-audio/examples/bench_quality.rs
+++ b/crates/screenpipe-audio/examples/bench_quality.rs
@@ -171,6 +171,7 @@ fn transcribe_chunked(
     let opts = audiopipe::TranscribeOptions {
         language: lang.map(|s| s.to_string()),
         word_timestamps: false,
+        ..Default::default()
     };
 
     if audio.len() <= chunk_samples {
@@ -188,6 +189,7 @@ fn transcribe_chunked(
         let opts = audiopipe::TranscribeOptions {
             language: lang.map(|s| s.to_string()),
             word_timestamps: false,
+            ..Default::default()
         };
         let result = engine.transcribe_with_sample_rate(chunk, sample_rate, opts);
         let text = result

--- a/crates/screenpipe-audio/examples/bench_quality2.rs
+++ b/crates/screenpipe-audio/examples/bench_quality2.rs
@@ -275,6 +275,7 @@ fn transcribe_full(model: &mut audiopipe::Model, audio: &[f32], sr: u32) -> Stri
     let opts = audiopipe::TranscribeOptions {
         language: None,
         word_timestamps: false,
+        ..Default::default()
     };
     model
         .transcribe_with_sample_rate(audio, sr, opts)
@@ -305,6 +306,7 @@ fn transcribe_fixed_chunks(
         let opts = audiopipe::TranscribeOptions {
             language: None,
             word_timestamps: false,
+            ..Default::default()
         };
         let text = model
             .transcribe_with_sample_rate(chunk, sr, opts)
@@ -356,6 +358,7 @@ fn transcribe_vad_segments(
         let opts = audiopipe::TranscribeOptions {
             language: None,
             word_timestamps: false,
+            ..Default::default()
         };
         let text = model
             .transcribe_with_sample_rate(chunk, sr, opts)
@@ -474,6 +477,7 @@ async fn main() -> anyhow::Result<()> {
         let opts = audiopipe::TranscribeOptions {
             language: None,
             word_timestamps: false,
+            ..Default::default()
         };
         match model.transcribe(chunk, opts) {
             Ok(r) => {


### PR DESCRIPTION
#4212 added `keyterm_boost` + `keyterms` to `audiopipe::TranscribeOptions` but left two examples constructing it without them:

- `crates/screenpipe-audio/examples/bench_quality2.rs`
- `crates/screenpipe-audio/examples/bench_quality.rs`

`cargo test --workspace` (CI's `test-ubuntu` / Clippy & Format) enables `audiopipe` via **feature unification**, so the stale examples fail to compile with `E0063: missing fields keyterm_boost and keyterms` — this reds CI on **every open PR**, not just ones touching audio.

Fix: add `..Default::default()` to each `TranscribeOptions` literal, matching the `engine.rs` call sites. No logic change.

Verified: `cargo build -p screenpipe-audio --examples --features parakeet` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)