### PR TITLE
fix(search): tag search freeze and missing results on large DBs

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -889,11 +889,13 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
     (async () => {
       setIsSearchingTags(true);
       try {
-        // Query only the tags table (tiny — just distinct names), not vision_tags.
-        // count is never displayed, so we don't need the expensive GROUP BY aggregate
-        // over vision_tags. COLLATE NOCASE handles Unicode correctly (SQLite LOWER()
-        // is ASCII-only). LIMIT 500 keeps even low-count unique tags (e.g. per-session
-        // workflow tags with count=1) so specific long queries still find their target.
+        // Query the tags table directly (distinct names only), not vision_tags.
+        // count was only used for ORDER BY and is never displayed, so we drop the
+        // GROUP BY aggregate over vision_tags — that full-table scan is what froze
+        // the UI on large DBs. LIKE is ASCII case-insensitive by default, so the
+        // lowercased query matches regardless of tag casing (ASCII only). LIMIT 500
+        // keeps low-count unique tags (e.g. per-session workflow tags with count=1)
+        // so specific long queries still find their target.
         const safeTagQuery = tagQuery.replace(/'/g, "''");
         const tagsSQL = tagQuery.length > 0
           ? `SELECT name FROM tags WHERE name LIKE '%${safeTagQuery}%' COLLATE NOCASE ORDER BY name LIMIT 500`

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -889,15 +889,15 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
     (async () => {
       setIsSearchingTags(true);
       try {
-        // Fetch tags from DB — filter at SQL level for performance on large DBs.
-        // Without a filter, GROUP BY on vision_tags scans the full table; LIMIT 200
-        // bounds the transfer. With a filter, LIKE restricts the join to matching
-        // tags only, which is both faster and correct (finds all matches, not just
-        // the top-N by count that would be returned before the LIMIT cuts off).
+        // Query only the tags table (tiny — just distinct names), not vision_tags.
+        // count is never displayed, so we don't need the expensive GROUP BY aggregate
+        // over vision_tags. COLLATE NOCASE handles Unicode correctly (SQLite LOWER()
+        // is ASCII-only). LIMIT 500 keeps even low-count unique tags (e.g. per-session
+        // workflow tags with count=1) so specific long queries still find their target.
         const safeTagQuery = tagQuery.replace(/'/g, "''");
         const tagsSQL = tagQuery.length > 0
-          ? `SELECT t.name, COUNT(vt.vision_id) as count FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id WHERE LOWER(t.name) LIKE '%${safeTagQuery}%' GROUP BY t.id, t.name ORDER BY count DESC LIMIT 100`
-          : `SELECT t.name, COUNT(vt.vision_id) as count FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id GROUP BY t.id, t.name ORDER BY count DESC LIMIT 200`;
+          ? `SELECT name FROM tags WHERE name LIKE '%${safeTagQuery}%' COLLATE NOCASE ORDER BY name LIMIT 500`
+          : `SELECT name FROM tags ORDER BY name LIMIT 500`;
 
         const tagsResp = await localFetch("/raw_sql", {
           method: "POST",
@@ -907,7 +907,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
         });
 
         if (cancelled) return;
-        const allDbTags: { name: string; count: number }[] = tagsResp.ok
+        const allDbTags: { name: string }[] = tagsResp.ok
           ? await tagsResp.json()
           : [];
 

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -889,13 +889,20 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
     (async () => {
       setIsSearchingTags(true);
       try {
-        // Fetch all distinct tags with counts from the tags + vision_tags tables
+        // Fetch tags from DB — filter at SQL level for performance on large DBs.
+        // Without a filter, GROUP BY on vision_tags scans the full table; LIMIT 200
+        // bounds the transfer. With a filter, LIKE restricts the join to matching
+        // tags only, which is both faster and correct (finds all matches, not just
+        // the top-N by count that would be returned before the LIMIT cuts off).
+        const safeTagQuery = tagQuery.replace(/'/g, "''");
+        const tagsSQL = tagQuery.length > 0
+          ? `SELECT t.name, COUNT(vt.vision_id) as count FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id WHERE LOWER(t.name) LIKE '%${safeTagQuery}%' GROUP BY t.id, t.name ORDER BY count DESC LIMIT 100`
+          : `SELECT t.name, COUNT(vt.vision_id) as count FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id GROUP BY t.id, t.name ORDER BY count DESC LIMIT 200`;
+
         const tagsResp = await localFetch("/raw_sql", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            query: "SELECT t.name, COUNT(vt.vision_id) as count FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id GROUP BY t.id, t.name ORDER BY count DESC",
-          }),
+          body: JSON.stringify({ query: tagsSQL }),
           signal: AbortSignal.timeout(5000),
         });
 
@@ -904,18 +911,12 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
           ? await tagsResp.json()
           : [];
 
-        // Set autocomplete pills (filtered if user typed something after #)
+        // SQL already filtered by tagQuery — use results directly
         const tagNames = allDbTags.map(t => t.name);
-        setAllTags(
-          tagQuery.length > 0
-            ? tagNames.filter(t => t.toLowerCase().includes(tagQuery))
-            : tagNames
-        );
+        setAllTags(tagNames);
 
-        // Find tags that match the query
-        const matched = tagQuery.length > 0
-          ? allDbTags.filter(t => t.name.toLowerCase().includes(tagQuery))
-          : allDbTags;
+        // All returned tags already match the query
+        const matched = allDbTags;
 
         if (matched.length > 0 && !cancelled) {
           // Fetch frames tagged with matching tags


### PR DESCRIPTION
closes #4241 

## Problem

Two bugs when using `#` tag search in the search bar, both triggered by large databases:

### Bug 1 — 5-6s freeze when typing `#`

The initial tags query had no `LIMIT`:

```sql
SELECT t.name, COUNT(vt.vision_id) as count
FROM tags t
JOIN vision_tags vt ON t.id = vt.tag_id
GROUP BY t.id, t.name
ORDER BY count DESC
-- no LIMIT — full table scan on vision_tags
```

SQLite must compute **all** group counts before it can apply `ORDER BY`, so on a large DB with millions of `vision_tags` rows this is O(n). It consistently hit the `AbortSignal.timeout(5000)` deadline, making the UI show a spinner for 5-6s.

### Bug 2 — `#workflow` finds nothing (even with tags like `workflow:abcd`)

The timeout from Bug 1 caused `allDbTags` to return empty → JavaScript filter found nothing. But even without the timeout, the old code fetched every tag and filtered in JS — if the matching tag ranked beyond the rows returned before timeout, it was silently dropped.

## Root Cause

```
type # → full table GROUP BY → hits 5s timeout → allDbTags = [] → JS filter = [] → no results
```

## Fix

Push all filtering into SQL instead of doing it in JavaScript.

**When user types just `#`** — add `LIMIT 200` to bound the scan:
```sql
SELECT t.name, COUNT(vt.vision_id) as count
FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id
GROUP BY t.id, t.name ORDER BY count DESC LIMIT 200
```

**When user types `#workflow`** — use `WHERE LIKE` to filter at DB level:
```sql
SELECT t.name, COUNT(vt.vision_id) as count
FROM tags t JOIN vision_tags vt ON t.id = vt.tag_id
WHERE LOWER(t.name) LIKE '%workflow%'
GROUP BY t.id, t.name ORDER BY count DESC LIMIT 100
```

This is both **faster** (only joins tags matching the query, not all tags) and **correct** (finds every tag containing the search string regardless of count ranking — so `workflow:abcd` is found when searching `#workflow`).

Single-quote escaping is applied to `tagQuery` before interpolation to prevent SQL injection.

## Files Changed

- `apps/screenpipe-app-tauri/components/rewind/search-modal.tsx` — tag search `useEffect` (~line 892)

## Test Plan

- [ ] Open search bar, type `#` — tags load quickly (no 5-6s freeze)
- [ ] Type `#workflow` — returns frames tagged with `workflow:abcd` and similar tags
- [ ] Type `#` with empty DB — shows empty state correctly
- [ ] Autocomplete tag pills still appear and clicking them fills the query

🤖 Generated with [Claude Code](https://claude.com/claude-code)