### PR TITLE
[pr] fix(drm): detect native Apple TV app (reports its name as "TV")

### DIFF
--- a/crates/screenpipe-engine/src/drm_detector.rs
+++ b/crates/screenpipe-engine/src/drm_detector.rs
@@ -79,6 +79,9 @@ const DRM_APPS: &[&str] = &[
     "hulu",
     "prime video",
     "apple tv",
+    // macOS native Apple TV app reports its name as just "TV"; matched exactly
+    // (see is_drm_app) so we don't flag unrelated apps that merely contain "tv".
+    "tv",
     "peacock",
     "paramount+",
     "hbo max",
@@ -95,8 +98,10 @@ const DRM_APPS: &[&str] = &[
 pub fn is_drm_app(app_name: &str) -> bool {
     let lower = app_name.to_lowercase();
     for &drm in DRM_APPS {
-        if drm == "max" {
-            if lower == "max" {
+        // "max" and "tv" are short, generic names — match them exactly so we
+        // don't flag unrelated apps (e.g. "3ds Max", "Plex TV").
+        if drm == "max" || drm == "tv" {
+            if lower == drm {
                 return true;
             }
         } else if lower.contains(drm) {
@@ -642,6 +647,9 @@ mod tests {
         assert!(is_drm_app("Crunchyroll"));
         assert!(is_drm_app("Max"));
         assert!(is_drm_app("max"));
+        // macOS native Apple TV app reports its name as just "TV".
+        assert!(is_drm_app("TV"));
+        assert!(is_drm_app("tv"));
     }
 
     #[test]
@@ -653,6 +661,9 @@ mod tests {
         assert!(!is_drm_app("Max Mustermann"));
         assert!(!is_drm_app("3ds Max"));
         assert!(!is_drm_app("Terminal"));
+        // "tv" is matched exactly — apps merely containing "tv" must not be flagged.
+        assert!(!is_drm_app("Plex TV"));
+        assert!(!is_drm_app("DevTools"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/drm_detector.rs
+++ b/crates/screenpipe-engine/src/drm_detector.rs
@@ -664,6 +664,11 @@ mod tests {
         // "tv" is matched exactly — apps merely containing "tv" must not be flagged.
         assert!(!is_drm_app("Plex TV"));
         assert!(!is_drm_app("DevTools"));
+        // App/tab names that merely end in "tv" must not match (review feedback):
+        // is_drm_app is called on the app/owner name, and only the bare native
+        // Apple TV app reports its name as exactly "TV".
+        assert!(!is_drm_app("Tella TV"));
+        assert!(!is_drm_app("screenpipe tv"));
     }
 
     #[test]


### PR DESCRIPTION
## description

the macOS **native Apple TV app** reports its application name as just **`TV`**, but `DRM_APPS` in `crates/screenpipe-engine/src/drm_detector.rs` only contained `"apple tv"` (matched via substring). so the native app was never detected as protected content, and screenpipe kept recording DRM video from it.

fix:
- add `"tv"` to `DRM_APPS`
- match `"tv"` **exactly** (same treatment the list already gives `"max"`) so a short, generic token doesn't false-positive unrelated apps (e.g. `3ds Max`, `Plex TV`, `DevTools`)

`"Apple TV"` continues to match via the existing `"apple tv"` substring entry; the new exact `"tv"` branch only catches the bare native-app name.

related issue: #3988

## before

`is_drm_app("TV")` → `false` (native Apple TV app slips through; protected video recorded).

## after

`is_drm_app("TV")` → `true`; `is_drm_app("Apple TV")` still `true`; `is_drm_app("Plex TV")` / `is_drm_app("3ds Max")` remain `false`.

## how to test

```bash
cargo test -p screenpipe-engine --lib is_drm_app
```
3 tests pass, including the new positive (`"TV"`/`"tv"`) and negative (`"Plex TV"`/`"DevTools"`) assertions.

live (macOS): `open -a TV`, play protected content, confirm capture pauses for that window (no protected frames recorded) while DRM content is focused.

## desktop app checklist (if applicable)

n/a — Rust engine change; no `#[tauri::command]` handlers or frontend-exported types touched.
