### PR TITLE
fix: silence recurring startup error spam (oauth refresh + posthog analytics)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -129,7 +129,9 @@ impl AnalyticsManager {
     /// Send a $create_alias event so PostHog merges the email-based identity
     /// (used by the website download endpoint) with this app's analytics UUID.
     pub async fn send_alias(&self, alias: &str) {
-        if !*self.enabled.lock().await || alias.is_empty() {
+        // PostHog rejects events without a non-empty distinct_id (400). Skip
+        // rather than firing a malformed request when analytics_id isn't set.
+        if !*self.enabled.lock().await || alias.is_empty() || self.distinct_id.is_empty() {
             return;
         }
         let url = format!("{}/capture/", self.api_host);
@@ -150,6 +152,14 @@ impl AnalyticsManager {
         properties: Option<serde_json::Value>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if !*self.enabled.lock().await {
+            return Ok(());
+        }
+
+        // PostHog rejects events without a non-empty distinct_id (400 Bad
+        // Request). This happens when analytics_id isn't populated yet at boot
+        // — skip rather than firing a malformed request that just logs an error.
+        if self.distinct_id.is_empty() {
+            warn!("analytics: skipping '{event}' event — distinct_id (analytics_id) is empty");
             return Ok(());
         }
 

--- a/crates/screenpipe-connect/src/oauth_refresh_scheduler.rs
+++ b/crates/screenpipe-connect/src/oauth_refresh_scheduler.rs
@@ -346,7 +346,21 @@ async fn tick(
             }
         };
 
-        let policy = policies.get(integration_id).copied().unwrap_or_default();
+        // Only manage providers we actually know how to refresh. A secret can
+        // land under the `oauth:` prefix for something that isn't an OAuth
+        // integration in our registry (e.g. `chatgpt`) — the proxy rejects
+        // those with "unsupported provider", so attempting a refresh just fails
+        // and spams a `warn` every scan. Skip anything not in the registry.
+        let policy = match policies.get(integration_id) {
+            Some(policy) => *policy,
+            None => {
+                debug!(
+                    integration_id = %integration_id,
+                    "oauth refresh scheduler: no integration registered for stored secret — skipping (not refreshable)"
+                );
+                continue;
+            }
+        };
         if !needs_refresh_now(&value, policy, now) {
             continue;
         }
@@ -581,6 +595,15 @@ mod tests {
         HashMap::new()
     }
 
+    /// Policy table containing the given integration ids with default policy —
+    /// mirrors production, where the table is built from `all_integrations()`
+    /// and so contains an entry for every known provider.
+    fn policies_with(ids: &[&str]) -> HashMap<String, RefreshPolicy> {
+        ids.iter()
+            .map(|id| (id.to_string(), RefreshPolicy::default()))
+            .collect()
+    }
+
     #[tokio::test]
     async fn tick_refreshes_token_whose_access_is_expiring() {
         let store = mem_store().await;
@@ -597,7 +620,14 @@ mod tests {
         let runner: Arc<dyn RefreshRunner> = Arc::new(RecorderRunner::default());
         let metrics = Arc::new(MetricsInner::default());
         let failures = Arc::new(Mutex::new(HashMap::new()));
-        tick(&store, &runner, &metrics, &failures, &empty_policies()).await;
+        tick(
+            &store,
+            &runner,
+            &metrics,
+            &failures,
+            &policies_with(&["google-calendar"]),
+        )
+        .await;
 
         // Down-cast via Arc::clone to peek at the recorder.
         let snap = metrics.snapshot();
@@ -622,9 +652,51 @@ mod tests {
         let runner: Arc<dyn RefreshRunner> = Arc::new(RecorderRunner::default());
         let metrics = Arc::new(MetricsInner::default());
         let failures = Arc::new(Mutex::new(HashMap::new()));
-        tick(&store, &runner, &metrics, &failures, &empty_policies()).await;
+        tick(
+            &store,
+            &runner,
+            &metrics,
+            &failures,
+            &policies_with(&["google-calendar"]),
+        )
+        .await;
 
         assert_eq!(metrics.snapshot().refreshes_attempted, 0);
+    }
+
+    #[tokio::test]
+    async fn tick_skips_secret_for_unregistered_provider() {
+        // A secret stored under the `oauth:` prefix for a provider that isn't an
+        // OAuth integration in our registry (e.g. `chatgpt`). The proxy rejects
+        // the refresh as "unsupported provider", so the scheduler must not even
+        // attempt it — otherwise it logs a warn on every scan. Regression for
+        // the recurring `oauth refresh failed for chatgpt: unsupported provider`.
+        let store = mem_store().await;
+        let now = unix_now();
+        // Access token already expired → it WOULD be refreshed if registered.
+        store
+            .set_json("oauth:chatgpt", &token(true, Some(now - 60), None))
+            .await
+            .unwrap();
+
+        let runner: Arc<dyn RefreshRunner> = Arc::new(RecorderRunner::default());
+        let metrics = Arc::new(MetricsInner::default());
+        let failures = Arc::new(Mutex::new(HashMap::new()));
+        // Registry knows zoom + google-calendar, but NOT chatgpt.
+        tick(
+            &store,
+            &runner,
+            &metrics,
+            &failures,
+            &policies_with(&["zoom", "google-calendar"]),
+        )
+        .await;
+
+        assert_eq!(
+            metrics.snapshot().refreshes_attempted,
+            0,
+            "must not attempt refresh for a provider absent from the registry"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## context

Found while chaos-testing **v2.5.46** for publish-readiness. Two recurring, log-spamming startup/runtime errors that aren't user-facing failures but pollute logs and telemetry. Both are small, defensive guards.

## fixes

### 1. `fix(connect)`: oauth refresh scheduler retries unregistered providers
The scheduler scans every secret under the `oauth:` prefix. A secret can exist for something that **isn't** an OAuth integration in our registry (e.g. `chatgpt`). The code used `policies.get(id).unwrap_or_default()`, so it treated those as refreshable and hit the proxy every scan — which rejects them with `unsupported provider`, logging a `warn` on every tick:

```
WARN oauth refresh failed for chatgpt(instance=None): ... "unsupported provider: chatgpt"
```

Now we skip any stored secret whose provider isn't in the registry (the policy table is built from `all_integrations()`, so a missing entry = genuinely unknown / not refreshable).

### 2. `fix(analytics)`: posthog events sent with an empty `distinct_id`
When `analytics_id` isn't populated yet at boot, `distinct_id` is empty and PostHog rejects the event:

```
ERROR Failed to send initial PostHog event: 400 Bad Request — event submitted without a distinct_id
ERROR failed to send periodic posthog event: 400 Bad Request — event submitted without a distinct_id
```

`send_event` / `send_alias` now skip when `distinct_id` is empty instead of firing a malformed request.

## verification

- **Fix 1**: `cargo test -p screenpipe-connect oauth_refresh` → **15/15 pass**, including a new regression test `tick_skips_secret_for_unregistered_provider` (asserts a stored `oauth:chatgpt` secret is never refreshed). Two existing tick tests were updated to use a realistic policy table instead of relying on the `unwrap_or_default` fallback.
- **Fix 2**: 3-line guard using existing imports/types; verified by inspection. A full local app build on the test box is blocked by an unrelated Windows MAX_PATH failure (`libsamplerate-sys` cmake), so CI is the authoritative build check here.

## not included
Larger findings from the chaos test (health status flapping to `degraded 503` with "check permissions" messaging on idle; meeting-summary note not populating) are tracked separately — they need design decisions / deeper repro, not a quick guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)