### PR TITLE
fix(connections): single prompt value for M365/Teams OAuth (fix AADSTS90023)

### DIFF
--- a/crates/screenpipe-connect/src/connections/microsoft365.rs
+++ b/crates/screenpipe-connect/src/connections/microsoft365.rs
@@ -39,7 +39,10 @@ static OAUTH: OAuthConfig = OAuthConfig {
         // select_account so a second connect shows Microsoft's account picker
         // instead of silently consenting under the already-signed-in account —
         // otherwise "add another account" can never reach a different tenant.
-        ("prompt", "consent select_account"),
+        // NOTE: Microsoft Entra rejects multiple space-separated prompt values
+        // with AADSTS90023 ("Unsupported 'prompt' value"), so we send only
+        // select_account. First-time consent is still prompted automatically.
+        ("prompt", "select_account"),
     ],
     redirect_uri_override: None,
 };

--- a/crates/screenpipe-connect/src/connections/teams.rs
+++ b/crates/screenpipe-connect/src/connections/teams.rs
@@ -28,7 +28,10 @@ static OAUTH: OAuthConfig = OAuthConfig {
         ),
         // select_account so a second connect shows Microsoft's account picker
         // instead of silently consenting under the already-signed-in account.
-        ("prompt", "consent select_account"),
+        // NOTE: Microsoft Entra rejects multiple space-separated prompt values
+        // with AADSTS90023 ("Unsupported 'prompt' value"), so we send only
+        // select_account. First-time consent is still prompted automatically.
+        ("prompt", "select_account"),
     ],
     redirect_uri_override: None,
 };


### PR DESCRIPTION
## what

M365 + Teams OAuth connect has been failing at the Microsoft sign-in page with **AADSTS90023 "Unsupported 'prompt' value"** since 2026-05-25.

Microsoft Entra rejects *multiple* space-separated values in the OAuth `prompt` param (Google allows it, Microsoft does not). Commit `06234064b` ("multi-account … force account picker on google/microsoft") changed the Microsoft `prompt` from `"consent"` → `"consent select_account"`, which Entra rejects before the user can authenticate — so every Microsoft 365 and Teams connection has been broken fleet-wide.

Google connections (gmail/calendar/docs/sheets) accept both values and are unaffected.

## fix

Revert both Microsoft endpoints to a single `select_account` value. It still shows the account picker (keeps the multi-account intent of the original change) and Entra auto-prompts consent on first connect, so nothing is lost.

- `crates/screenpipe-connect/src/connections/microsoft365.rs`
- `crates/screenpipe-connect/src/connections/teams.rs`

## repro

First report: Intercom conv 215474740 (kevinsh@rpen.ca, 2026-06-17) — "unable to add 365 calendar", screenshot shows AADSTS90023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)