### PR TITLE
style(chat): float the input (sharp + soft shadow), drop the divider bar

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -88,11 +88,11 @@ No color. Sharp corners. Clean typography. Escher-inspired mathematical abstract
 
 - Width: 1px solid
 - Style: Sharp, binary (on/off)
-- No gradients, no shadows
+- No gradients
 
 ### Shadows
 
-**None.** Flat design throughout. Use borders for separation.
+**Flat by default — use 1px borders for separation.** Subtle shadows are allowed to lift floating / elevated surfaces (chat input, overlays, popovers, dialogs) off the background. Keep them soft and low-opacity (e.g. `shadow-lg shadow-black/5`); never round corners to sell the lift — corners stay sharp.
 
 ---
 
@@ -131,7 +131,7 @@ No color. Sharp corners. Clean typography. Escher-inspired mathematical abstract
 
 ```
 - Border: 1px solid
-- Shadow: None
+- Shadow: Subtle lift allowed (elevated surface)
 - Animation: 150ms fade
 - Title: lowercase
 ```
@@ -180,8 +180,8 @@ When creating new UI components:
 - [ ] Using Space Grotesk for headings
 - [ ] Using Crimson Text for body (or IBM Plex Mono for technical)
 - [ ] 1px solid border
-- [ ] No box shadows
-- [ ] 0px border radius (sharp corners)
+- [ ] Flat by default; subtle shadows OK only to lift floating/elevated surfaces
+- [ ] 0px border radius (sharp corners) — always, even on shadowed surfaces
 - [ ] Black, white, or gray only
 - [ ] 150ms transitions
 - [ ] UPPERCASE for buttons, lowercase for titles

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -9763,7 +9763,7 @@ export function StandaloneChat({
 
           <div
             className={cn(
-              "flex flex-col rounded-xl border bg-input ring-offset-background transition-colors focus-within:border-foreground focus-within:ring-foreground/10 focus-within:ring-1",
+              "flex flex-col rounded-lg border bg-input ring-offset-background transition-colors focus-within:border-foreground focus-within:ring-foreground/10 focus-within:ring-1",
               "bg-background/80 border-border/50 shadow-lg shadow-black/5",
               disabledReason && "border-muted-foreground/30"
             )}

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -9375,7 +9375,7 @@ export function StandaloneChat({
       </div> {/* End of main content area with history sidebar */}
 
       {/* Input */}
-      <div ref={inputSectionRef} className="relative border-t border-border/50 bg-gradient-to-t from-muted/20 to-transparent">
+      <div ref={inputSectionRef} className="relative bg-gradient-to-t from-background via-background/80 to-transparent">
         <div className={CHAT_RAIL_CLASS}>
         {/* Prefill, filters, suggestions first; then attached images in gap; then agent bar; then form */}
         {/* Prefill context indicator from search */}
@@ -9763,8 +9763,8 @@ export function StandaloneChat({
 
           <div
             className={cn(
-              "flex flex-col rounded-lg border bg-input ring-offset-background transition-colors focus-within:border-foreground focus-within:ring-foreground/10 focus-within:ring-1",
-              "bg-background/50 border-border/50",
+              "flex flex-col rounded-xl border bg-input ring-offset-background transition-colors focus-within:border-foreground focus-within:ring-foreground/10 focus-within:ring-1",
+              "bg-background/80 border-border/50 shadow-lg shadow-black/5",
               disabledReason && "border-muted-foreground/30"
             )}
           >


### PR DESCRIPTION
## preview

before / after of the input region (rendered from the exact tailwind classes + the app's real design tokens, `--radius: 0`):

![before/after — floating chat input](https://raw.githubusercontent.com/screenpipe/screenpipe/5b1e4fef2964b2abf2256fd6540679c3a764b8e9/pr4261-floating-input.png)

- **before:** hard `border-t` divider above the input
- **after:** no divider (content fades into the input), sharp box floats on a soft shadow

## what

Makes the chat input float instead of sitting under a hard divider bar — corners stay sharp (on-brand), the lift comes from a subtle shadow.

- **removed** the `border-t` rule above the input — the line that separated the chat history from the "Ask about your screen…" box
- content above now fades softly into the input via a `background → transparent` gradient instead of being cut by a line
- gave the input box a soft drop shadow (`shadow-lg shadow-black/5`) + a more opaque fill (`bg-background/50` → `/80`) so it reads as one floating element with the `+` button
- **corners stay sharp** (`rounded-lg`, which is `0` here) — no rounding

## DESIGN.md

DESIGN.md previously banned all shadows ("flat, use borders for separation"). Updated it to **allow subtle shadows on floating/elevated surfaces** (chat input, overlays, popovers, dialogs), while keeping the **sharp-corners-everywhere** rule intact. Checklist + Borders/Shadows/Dialogs sections updated to match.

## scope

`apps/screenpipe-app-tauri/components/standalone-chat.tsx` (className-only, no logic) + `DESIGN.md`. Preview image lives on a standalone `assets/pr-4261` ref, so this PR's diff stays minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)