### PR TITLE
fix(meeting): end calls on silence, not just captured-audio existence

### DIFF
--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -1729,6 +1729,23 @@ fn is_browser_app(app_name: &str) -> bool {
             .any(|b| contains_case_insensitive(app_name, b))
 }
 
+/// Whether recent output audio should keep an `Ending` meeting alive.
+///
+/// `recent_output_chunk` comes from the DB (`has_recent_output_audio`), which
+/// matches *any* `(output)` audio chunk in the window — but the system-audio tap
+/// writes those continuously even while silent. On its own it therefore pins a
+/// meeting "live" forever once the call ended (controls gone, tap still running),
+/// so the meeting never auto-finalizes (it flaps Active<->Ending). We additionally
+/// require `recent_voice_activity` (RMS-gated, from the capture pipeline) so a
+/// quiet stretch lets the grace timer run out and the meeting end normally, while
+/// a genuinely audible call (tab-switched / minimized / screen-sharing) stays alive.
+fn output_audio_keeps_meeting_alive(
+    recent_output_chunk: bool,
+    recent_voice_activity: bool,
+) -> bool {
+    recent_output_chunk && recent_voice_activity
+}
+
 /// Advance the state machine based on scan results.
 ///
 /// Returns the new state plus an optional action to perform (DB insert/update).
@@ -3054,7 +3071,19 @@ pub async fn run_meeting_detection_loop(
         // native meeting apps (e.g., Zoom). Audio activity is a strong signal
         // that the user is still in the meeting even if UI controls are hidden.
         let has_output_audio = if matches!(state, MeetingState::Ending { .. }) {
-            db.has_recent_output_audio(30).await.unwrap_or(false)
+            // A recent (output) chunk alone isn't enough: the system-audio tap
+            // writes those continuously even during silence, which would keep an
+            // already-ended call "live" forever (controls gone, tap still running)
+            // and the meeting would never auto-finalize. Require RMS-gated voice
+            // activity too, so a quiet call ends on schedule but an audible one
+            // (tab-switched / minimized / screen-sharing) stays alive. No detector
+            // wired (tests / detector disabled) -> default true to preserve prior
+            // behavior.
+            let recent_output_chunk = db.has_recent_output_audio(30).await.unwrap_or(false);
+            let recent_voice_activity = detector.as_ref().map_or(true, |d| {
+                d.audio_active_within(AUDIO_GATE_WINDOW.as_millis() as u64)
+            });
+            output_audio_keeps_meeting_alive(recent_output_chunk, recent_voice_activity)
         } else {
             false
         };
@@ -3534,6 +3563,20 @@ async fn insert_new_meeting(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn output_audio_keepalive_requires_real_voice_not_just_a_chunk() {
+        // The system-audio tap writes a recent (output) chunk continuously, even
+        // during silence — that alone must NOT keep an ended call alive, or a
+        // detected meeting never auto-finalizes (flaps Active<->Ending forever).
+        assert!(!output_audio_keeps_meeting_alive(true, false));
+        // A genuinely audible call (controls hidden: tab-switch / minimize /
+        // screen-share) stays alive.
+        assert!(output_audio_keeps_meeting_alive(true, true));
+        // No recent output chunk at all -> never kept alive by this signal.
+        assert!(!output_audio_keeps_meeting_alive(false, true));
+        assert!(!output_audio_keeps_meeting_alive(false, false));
+    }
 
     // ── audio-gated scan cadence tests ─────────────────────────────────
     // These pin the CPU optimisation: with apps open but no recent audio the


### PR DESCRIPTION
## Problem (BUG-2 from the v2.5.46 chaos test)
A detected meeting that **loses its call-control UI** (call ended, window minimized, or browser tab switched) **never auto-finalizes** while system-audio output capture is running. It flaps `Active ⇄ Ending` every ~5s indefinitely; the meeting note stays **"ongoing"** with no end time and **no auto-summary** — only a manual *stop* ends it.

Repro this session: after ending a Zoom call (and quitting Zoom), the detector logged `Active → Ending (no controls)` ↔ `Ending → Active (output audio still active)` for 3+ minutes until I clicked stop.

## Root cause
The `Ending → Active` keep-alive ([meeting_detector.rs:3056](../blob/main/crates/screenpipe-engine/src/meeting_detector.rs)) uses `db.has_recent_output_audio(30)`, which is true if **any `(output)` chunk exists in the last 30s** ([audio.rs:206](../blob/main/crates/screenpipe-db/src/db/audio.rs)). The system-audio tap writes an `(output)` chunk every ~30s **continuously, even during silence** (`peak_amp=0.0`), so the liveness signal is pinned true forever and the grace timer never elapses.

The keep-alive intent (#3681 — don't end a live call just because a scan blipped) is correct; the defect is that "audio is live" was measured as *chunk existence*, not *audible content*.

## Fix
Gate the output-audio keep-alive on **RMS-gated voice activity** in addition to the chunk check, via a new pure helper `output_audio_keeps_meeting_alive(recent_output_chunk, recent_voice_activity)`. `recent_voice_activity` comes from `detector.audio_active_within(AUDIO_GATE_WINDOW)`, whose backing `on_audio_activity` **only stamps non-silent chunks** ("inactive chunks are ignored — they must not reset recency").

- **Silent** call (post-hangup, leftover capture) → not kept alive → ends after the normal grace (30s native / 300s browser). ✅ fixes the hang.
- **Audible** call with controls hidden (screen-share / minimized / tab switch) → still kept alive. ✅ no regression to the #3681 behavior.

## Scope / no-regression
- `advance_state` and its ~25 unit tests are **untouched** — the change is confined to the loop's `keep_alive` computation + one pure helper.
- No-detector path (tests / detector disabled) **defaults to prior behavior** (`map_or(true, …)`).
- **All 105 `meeting_detector` unit tests pass** locally, plus a new regression test `output_audio_keepalive_requires_real_voice_not_just_a_chunk`.

## Follow-ups (not in this PR)
This is P0 of a broader reinforcement plan. P1: add a mic/camera-in-use OS signal + bidirectional-audio requirement; P2: confidence-scored start/end fusion + shadow-mode rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)