### PR TITLE
fix(nsis): exclude uninstall.exe from directory process scan to fix "Unable to uninstall"

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
+++ b/apps/screenpipe-app-tauri/src-tauri/windows/hooks.nsh
@@ -37,7 +37,7 @@
   FileOpen $1 "$PLUGINSDIR\screenpipe-kill.ps1" w
   IfErrors ${_SP_SKIP}
     FileWriteUTF16LE /BOM $1 '$$d = "$INSTDIR"; if (-not $$d.EndsWith([char]92)) { $$d = $$d + [char]92 }$\r$\n'
-    FileWriteUTF16LE $1 'Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.ToLower().StartsWith($$d.ToLower()) } | ForEach-Object { $$p = $$_.ProcessId; Stop-Process -Id $$p -Force -ErrorAction SilentlyContinue; Wait-Process -Id $$p -Timeout 5 -ErrorAction SilentlyContinue }$\r$\n'
+    FileWriteUTF16LE $1 'Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object { $$_.ExecutablePath -and $$_.ExecutablePath.ToLower().StartsWith($$d.ToLower()) -and $$_.Name -ne "uninstall.exe" } | ForEach-Object { $$p = $$_.ProcessId; Stop-Process -Id $$p -Force -ErrorAction SilentlyContinue; Wait-Process -Id $$p -Timeout 5 -ErrorAction SilentlyContinue }$\r$\n'
     FileClose $1
     DetailPrint "Stopping processes from $INSTDIR..."
     ; Disable WOW64 FS redirection so System32 resolves to the real 64-bit dir.


### PR DESCRIPTION
## Problem

Clicking **Uninstall** from the reinstall/upgrade page of the NSIS installer failed immediately with an **"Unable to uninstall!"** dialog, leaving the app installed with no way to remove it through the installer UI.

### Root cause

The `NSIS_HOOK_PREUNINSTALL` hook runs a PowerShell script that kills every process whose `ExecutablePath` starts with `$INSTDIR`. The script was indiscriminately killing `uninstall.exe` itself.

This happens because of how Tauri's reinstall flow launches the uninstaller ([`PageLeaveReinstall` in `installer.nsi`](https://github.com/tauri-apps/tauri/blob/dev/crates/tauri-bundler/src/bundle/windows/nsis/templates/installer.nsi)):

```nsis
StrCpy $R1 "$R1 _?=$4"   ; append install dir
ExecWait '$R1' $0
```

The [`_?=` flag](https://nsis.sourceforge.io/Reference/Exec) instructs the uninstaller to **skip copying itself to `%TEMP%`** and instead run **directly from `$INSTDIR`**. Without this flag the uninstaller copies itself to a temp location first; with it, `uninstall.exe` is a live process inside `$INSTDIR`. The PowerShell scan matched it, killed it mid-run, and `ExecWait` received a non-zero exit code — triggering the "Unable to uninstall!" guard.



## References

- NSIS `_?=` flag / `ExecWait` behaviour: https://nsis.sourceforge.io/Reference/Exec
- NSIS uninstaller self-copy mechanism: https://nsis.sourceforge.io/Reference/WriteUninstaller
- Tauri NSIS bundler reinstall flow: https://github.com/tauri-apps/tauri/blob/dev/crates/tauri-bundler/src/bundle/windows/nsis/templates/installer.nsi