### PR TITLE
fix(search): move content filter chips to top of results area

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -1510,6 +1510,32 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
         </div>
       ) : (
         <>
+          {/* Content type filter chips — always at the top */}
+          {!isTagSearch && !isPeopleSearch && (
+            <div className="flex gap-2 mb-3">
+              {([
+                { key: "all" as ContentFilter, label: "All", icon: null },
+                { key: "screen" as ContentFilter, label: "Screen", icon: Monitor },
+                { key: "input" as ContentFilter, label: "Keyboard & Clipboard", icon: Keyboard },
+                { key: "chats" as ContentFilter, label: "Chats", icon: MessageSquare },
+              ] as const).map(({ key, label, icon: Icon }) => (
+                <button
+                  key={key}
+                  onClick={() => { setContentFilter(key); setSelectedIndex(0); setSelectedChatIndex(0); }}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-full border transition-colors",
+                    contentFilter === key
+                      ? "bg-foreground text-background border-foreground"
+                      : "border-border text-muted-foreground hover:border-foreground/40"
+                  )}
+                >
+                  {Icon && <Icon className="w-3 h-3" />}
+                  {label}
+                </button>
+              ))}
+            </div>
+          )}
+
           {/* Empty state */}
           {showEmpty && (
             <div className="py-12 text-center text-sm text-muted-foreground">
@@ -1681,30 +1707,6 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
               </div>
             </div>
           )}
-
-          {/* Content type filter chips — always visible */}
-          <div className="flex gap-2 mb-3">
-            {([
-              { key: "all" as ContentFilter, label: "All", icon: null },
-              { key: "screen" as ContentFilter, label: "Screen", icon: Monitor },
-              { key: "input" as ContentFilter, label: "Keyboard & Clipboard", icon: Keyboard },
-              { key: "chats" as ContentFilter, label: "Chats", icon: MessageSquare },
-            ] as const).map(({ key, label, icon: Icon }) => (
-              <button
-                key={key}
-                onClick={() => { setContentFilter(key); setSelectedIndex(0); setSelectedChatIndex(0); }}
-                className={cn(
-                  "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-full border transition-colors",
-                  contentFilter === key
-                    ? "bg-foreground text-background border-foreground"
-                    : "border-border text-muted-foreground hover:border-foreground/40"
-                )}
-              >
-                {Icon && <Icon className="w-3 h-3" />}
-                {label}
-              </button>
-            ))}
-          </div>
 
           {/* Inline chat section in "All" view — appears instantly (in-memory filter) while screen results load */}
           {contentFilter !== "chats" && debouncedQuery.trim().length >= 1 && filteredChats.length > 0 && !isTagSearch && !isPeopleSearch && (


### PR DESCRIPTION
## Summary

- Filter tabs (All / Screen / Keyboard & Clipboard / Chats) were rendered **after** the empty-state message in the JSX tree
- When a search returned no results, the tabs sank to the bottom of the empty space instead of staying at the top
- Moved the chip row to the very top of the results pane, before the empty state and any result content
- Added a guard to hide the chips during `#tag` and `@person` searches where they don't apply

**Before:** filters appear at the bottom of the empty area when no results found  
**After:** filters always anchor to the top; empty state message sits below them

## Test plan

- [ ] Open the search modal and type a query with no results — filter tabs should appear at the top
- [ ] Verify filter tabs still appear correctly when results are present
- [ ] Verify `#tag` and `@person` searches still hide the content filter tabs
- [ ] Verify switching between All / Screen / Keyboard & Clipboard / Chats still works


## Before
<img width="684" height="588" alt="2026-06-18_03-12-55" src="https://github.com/user-attachments/assets/c267c520-c32c-4ddf-a238-83bd43d80b99" />

## After 

<img width="736" height="625" alt="2026-06-18_03-17-28" src="https://github.com/user-attachments/assets/65647602-ef09-4b60-9118-5c1d24b54bfb" />
