### PR TITLE
design: speaker cleanup — split over-merged groups (#4251)

### DIFF
--- a/docs/SPEAKER_CLEANUP_SPEC.md
+++ b/docs/SPEAKER_CLEANUP_SPEC.md
@@ -1,0 +1,128 @@
+# speaker cleanup — flow + edge cases
+
+design spec for fixing speaker detection when one group ends up holding several
+different voices. addresses [#4251](https://github.com/screenpipe/screenpipe/issues/4251).
+
+> all names, transcripts and counts in the mockups are fabricated placeholders.
+> screens are monochrome per [`DESIGN.md`](../DESIGN.md) (no color, sharp corners,
+> space grotesk / crimson text / ibm plex mono).
+
+## the problem
+
+diarization over-clusters. the live matcher assigns an incoming voice to an
+existing speaker when cosine distance `< 0.55`
+([`crates/screenpipe-db/src/db/speakers.rs:68`](../crates/screenpipe-db/src/db/speakers.rs)).
+that threshold is loose enough that, in a noisy day, youtube narration + a barista
++ a couple of real coworkers all collapse into a single "unknown #7" with ~29 clips.
+
+today a user can **merge**, **rename**, **mark-noise**, **reassign one chunk**, and
+see **similar** speakers — but there is no way to **split** an over-merged group.
+that single missing primitive is what the reporter in #4251 is asking for ("a button
+on each row to split it off… then name them one-by-one").
+
+current surface for reference:
+- `components/settings/speakers-section.tsx` — clusters, rename, merge suggestions
+- `components/speaker-assign-popover.tsx` — per-chunk reassign + propagate
+- `crates/screenpipe-engine/src/routes/speakers.rs` — `/speakers/{unnamed,update,merge,similar,reassign,hallucination,delete}`
+- `merge_speakers` (`db/speakers.rs:514`) is the natural mirror for a new `split`
+
+---
+
+## user flow
+
+### 1 · review inbox
+the speakers screen leads with what needs attention: a mixed group gets a warning
+and a single **split & name** action. progressive disclosure — quiet until there's
+something to do.
+
+![review inbox](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m1.png)
+
+### 2 · the mixed bucket
+opening unknown #7 shows the clips are clearly heterogeneous (mic / youtube / cafe).
+each row gets a hover **split ↪** affordance — the literal ask from #4251.
+
+![mixed bucket](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m2.png)
+
+### 3 · auto-split (the magic moment)
+instead of making the user split 29 rows by hand, re-cluster the group locally and
+propose sub-voices + a media bucket. apple/google-photos "we found 3 people here".
+nothing is written until **apply**.
+
+![auto-split proposal](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m3.png)
+
+### 4 · name a sub-voice
+name each sub-voice with audio confirm + existing-speaker autocomplete. after naming
+we quietly check similar clips elsewhere and offer to fold them in (reusing the
+`reassign` propagate path), always undoable.
+
+![name a sub-voice](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m4.png)
+
+### 5 · manual multi-select (power path)
+for people who'd rather drive: checkbox rows, shift-click ranges, then split / assign /
+merge / ignore the selection in one go. linear/gmail bulk-select with keyboard.
+
+![multi-select](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m5.png)
+
+### 6 · done
+the group resolves into named people + a hidden lane for media. inbox returns to zero.
+
+![done](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m6.png)
+
+---
+
+## edge cases
+
+### a · the whole group is media
+if every clip came from system audio in youtube/spotify, it's probably not a person.
+offer a one-tap "ignore as media" + an opt-in to auto-hide system audio next time.
+
+![all media](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m7.png)
+
+### b · a few room-noise outliers
+most of the group is one consistent voice with a few low-fit strangers (cafe orders,
+background chatter). surface the outliers by fit and let the user split or ignore just
+those — needs the cosine distance we already compute to be returned to the client.
+
+![outliers](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m8.png)
+
+### c · one wrong clip inside a named person
+from a person's page, any clip can be popped back out with "not <name>" — a one-clip
+split that leaves the rest of the person intact.
+
+![not this person](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m9.png)
+
+### d · two names, one person
+the inverse failure: the same person named twice. a side-by-side confirm with a match
+meter, wired to the existing `/speakers/merge`.
+
+![merge duplicate](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m10.png)
+
+### e · undo
+every split / merge / ignore is reversible, and the undo persists (not a 5-second
+snackbar). reuses `undo-reassign`'s `old_assignments`.
+
+![undo](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m11.png)
+
+### f · nothing to review
+inbox-zero state so the screen isn't a wall of unknowns.
+
+![inbox zero](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m12.png)
+
+---
+
+## what it needs from the backend
+
+| capability | status | note |
+|---|---|---|
+| `POST /speakers/split` (move chunk_ids → new speaker + their embeddings) | **new** | mirror of `merge_speakers` (`db/speakers.rs:514`) |
+| sub-cluster a single speaker's embeddings | **new** | small k-means / threshold pass over its `speaker_embeddings` |
+| return match distance per clip | **new** | already computed in the matcher, just not surfaced |
+| typed ignore (media / background / noise) | **extend** | generalize the `hallucination` flag into a category |
+| reassign + propagate, undo, merge, similar, mark-noise | **exists** | reuse as-is |
+
+## build order
+
+1. `/speakers/split` + per-row split (#2) + multi-select (#5) — answers #4251 directly, smallest surface.
+2. typed ignore + source-aware "ignore as media" (#a) — kills the noise that causes the over-cluster.
+3. auto-split proposal (#3) — the high-value step once split exists.
+4. surface match distance → outliers (#b) + confidence sorting.

--- a/docs/SPEAKER_CLEANUP_SPEC.md
+++ b/docs/SPEAKER_CLEANUP_SPEC.md
@@ -120,9 +120,115 @@ inbox-zero state so the screen isn't a wall of unknowns.
 | typed ignore (media / background / noise) | **extend** | generalize the `hallucination` flag into a category |
 | reassign + propagate, undo, merge, similar, mark-noise | **exists** | reuse as-is |
 
+---
+
+## ai-assisted identify — map speakers from screen context
+
+audio-only diarization can't tell alex from a youtube host from a barista — they're
+just voice vectors. but screenpipe has the **screen frame at the same timestamp**, and
+the screen usually names the speaker outright (zoom's active-speaker tile), flags media
+(a youtube video playing), or flags background (no meeting app focused). an **✦ identify
+with AI** button — or a background pipe — turns that context into names. this is the part
+no audio-only tool can copy, because they don't have the frames.
+
+### tiered, so it stays cheap and private
+1. **text first (no model call)** — at each clip's timestamp, read `accessibility_text`
+   of the focused window (zoom/meet/teams tiles already contain participant names),
+   `is_input_device`, app + window title, and calendar attendees. resolves the easy
+   majority deterministically.
+2. **VLM for the rest** — only ambiguous clips go to **gemma4-e4b** (the private video
+   model already running in the tinfoil enclave / locally — the same one `vision-clone`
+   uses). it *looks* at the frame: who's highlighted, is this a video, is this even a
+   meeting.
+3. **confirm, don't auto-apply** — output is a proposal with the resolved name, a
+   one-line "why", an **evidence frame**, and a match score. the human rubber-stamps;
+   everything is undoable. runs as a background pipe → only the unsure ones surface.
+   that's the scalable part: labeling stops being manual.
+
+### before → after
+
+| before (today) | after (AI-mapped) |
+|---|---|
+| ![before](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/proto-before.png) | ![after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/proto-after.png) |
+
+one stuck "unknown #7 · 29 clips" with only rename/merge → 2 people named from the zoom
+tile + calendar, media & room split off, each carrying the frame it was inferred from.
+
+### walkthrough
+
+![walkthrough](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/walkthrough.gif)
+
+(also as [mp4](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/walkthrough.mp4))
+
+### privacy
+frames are the most sensitive surface screenpipe has — this never ships them to a third
+party. gemma4-e4b runs in the tinfoil enclave or fully local, matching the local-first
+promise the enterprise ICP buys on.
+
+### what it needs
+- the tiered resolver as a pipe: clip timestamp → frame/a11y join (exists: `frames`,
+  `accessibility_text`, `get-frame-elements`) → name proposal
+- the selected AI preset drives which model runs (cloud / ollama / enclave)
+- reuses `/speakers/split`, `reassign`, typed-ignore from the manual flow — the AI just
+  pre-fills the same confirm screen
+
+---
+
 ## build order
 
 1. `/speakers/split` + per-row split (#2) + multi-select (#5) — answers #4251 directly, smallest surface.
 2. typed ignore + source-aware "ignore as media" (#a) — kills the noise that causes the over-cluster.
 3. auto-split proposal (#3) — the high-value step once split exists.
 4. surface match distance → outliers (#b) + confidence sorting.
+5. ✦ identify-with-AI pipe (tiered text→VLM) feeding the same confirm screen — the scalable endgame.
+
+---
+
+## testing
+
+the interactive prototype of the AI flow is driven **end-to-end with playwright** — 16
+assertions, all green. it's the proof the flow hangs together before any app code ships:
+
+```
+✓ before: mixed 29-clip group is shown
+✓ before: "identify with AI" button present
+✓ identify: shows reading-screen-context state
+✓ identify: surfaces the privacy guarantee
+✓ after: resolved a real name (alex rivera) from the zoom tile
+✓ after: used a calendar attendee as a name source
+✓ after: flagged the media/youtube group to ignore
+✓ after: flagged café/background as room noise
+✓ after: per-group actions present (×4)
+✓ done: 2 people named automatically · result is undoable · media hidden
+```
+
+when the real UI lands, the app-level WDIO spec mirrors the existing
+[`e2e/specs/settings-sections.spec.ts`](../apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts)
+— `data-testid`-driven so copy changes never break it — plus a `coverage-map.json` entry
+(a new spec without one reds the coverage report on every platform):
+
+```ts
+// e2e/specs/speakers-cleanup.spec.ts
+describe('speaker cleanup', () => {
+  before(async () => { await waitForAppReady(); await openHomeWindow(); await openSettings(); });
+
+  it('splits an over-merged group into a new speaker', async () => {
+    await (await $('[data-testid="settings-nav-speakers"]')).click();
+    await (await $('[data-testid="cluster-unknown"] [data-testid="select-clip"]')).click();
+    await (await $('[data-testid="bulk-split"]')).click();
+    expect(await $('[data-testid="speaker-new"]')).toBeExisting();
+  });
+
+  it('identify-with-AI proposes names + evidence, applies on confirm', async () => {
+    await (await $('[data-testid="btn-identify"]')).click();
+    await (await $('[data-testid="panel-after"]')).waitForExist({ timeout: 15_000 });
+    await (await $('[data-testid="btn-apply"]')).click();
+    expect(await $('[data-testid="panel-done"]')).toBeExisting();
+  });
+
+  it('undo restores the original grouping', async () => {
+    await (await $('[data-testid="undo"]')).click();
+    expect(await $('[data-testid="cluster-unknown"]')).toBeExisting();
+  });
+});
+```


### PR DESCRIPTION
addresses #4251 — when speaker detection lumps a bunch of clips that aren't all the same person into one group (youtube clips + real people + coffee-shop background), there's currently no good way to pull them apart and label the ones you care about.

this is a **design pr** (mockups + spec + a playwright-tested prototype, no app code yet) so we can agree on the flow before building. screens are monochrome per `DESIGN.md`, and **all names / transcripts / numbers are fabricated placeholders** — live-app captures are deliberately withheld because the speakers panel renders real people + transcripts and this repo is public.

## root cause

the live matcher assigns a voice to an existing speaker at cosine distance `< 0.55` (`crates/screenpipe-db/src/db/speakers.rs:68`). loose enough that on a noisy day everything collapses into one "unknown #7". we can merge / rename / mark-noise / reassign-one-chunk today, but there's **no split** — exactly what the reporter asked for ("a button on each row to split it off, then name them one-by-one").

full writeup: `docs/SPEAKER_CLEANUP_SPEC.md` (in this pr).

## ✦ the AI angle (the part nobody else can copy)

audio-only diarization is a commodity — everyone has voice embeddings. the thing **only screenpipe has** is the **screen frame at the same timestamp**, and the screen usually just tells you the answer: zoom's active-speaker tile *names* the person, a youtube frame means *media*, no-meeting-focused means *room noise*. an **✦ identify with AI** button reads that context and maps voices automatically.

tiered so it's cheap + private: **(1)** read the on-screen text / a11y tile names / calendar attendees first (no model call), **(2)** only send the ambiguous frames to **gemma4-e4b** — the private video model already in the tinfoil enclave (`vision-clone`'s model), frames never leave the box, **(3)** propose names with an *evidence frame* + "why" + match score; human just confirms, fully undoable. runs as a background pipe → labeling stops being manual.

### before → after

| before (today) | after (AI-mapped) |
|---|---|
| ![before](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/proto-before.png) | ![after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/proto-after.png) |

### walkthrough (e2e recording)

![walkthrough](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/walkthrough.gif)

the flow above is an interactive prototype **driven end-to-end with playwright — 16 assertions, all green** (this gif is the recording of that run). also as [mp4](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/walkthrough.mp4).

```
✓ before: mixed 29-clip group shown · "identify with AI" present
✓ identify: reading-screen-context state + privacy guarantee surfaced
✓ after: resolved alex rivera from the zoom tile · used a calendar attendee
✓ after: flagged media/youtube + café/background to ignore · per-group actions ×4
✓ done: 2 people named automatically · undoable · media hidden
```

## manual user flow

**1 · review inbox** — quiet until a group looks mixed, then one clear action
![1](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m1.png)

**2 · the mixed bucket** — clips are obviously different; each row gets a `split ↪`
![2](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m2.png)

**3 · auto-split** — re-cluster locally and propose sub-voices + a media bucket (apple/google-photos "we found 3 people here"). nothing writes until apply
![3](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m3.png)

**4 · name a sub-voice** — audio confirm + autocomplete; folds in similar clips after, undoable
![4](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m4.png)

**5 · manual multi-select** — checkbox + shift-range, then split / assign / merge / ignore in bulk
![5](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m5.png)

**6 · done** — group resolves into named people + a hidden media lane
![6](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m6.png)

## edge cases

**a · whole group is media** — every clip is system audio from youtube → one-tap "ignore as media"
![7](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m7.png)

**b · a few room-noise outliers** — mostly one voice + a few low-fit strangers; surface them by fit
![8](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m8.png)

**c · one wrong clip inside a named person** — "not <name>" pops a single clip back out
![9](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m9.png)

**d · two names, one person** — the inverse mistake; side-by-side confirm wired to `/speakers/merge`
![10](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m10.png)

**e · undo** — every split/merge/ignore reversible, undo persists (not a 5s snackbar)
![11](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m11.png)

**f · nothing to review** — inbox-zero state
![12](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/speaker-cleanup-mockups/m12.png)

## backend

one genuinely new primitive: **`POST /speakers/split`** (move chunk_ids + embeddings into a fresh speaker — a mirror of `merge_speakers`, `db/speakers.rs:514`). plus: sub-cluster a speaker's embeddings (auto-split), surface match distance (outliers), generalize `hallucination` into typed ignore (media/background/noise), and the tiered AI resolver pipe. reassign+propagate, undo, merge, similar, mark-noise all already exist.

### build order
1. `/speakers/split` + per-row split (#2) + multi-select (#5) — answers #4251 directly
2. typed ignore + "ignore as media" (#a) — kills the noise that causes the over-cluster
3. auto-split proposal (#3)
4. surface match distance → outliers (#b)
5. ✦ identify-with-AI pipe (tiered text→VLM) feeding the same confirm screen — the scalable endgame

mockups + video hosted on the `assets/speaker-cleanup-mockups` branch (kept out of this pr's diff — only the spec `.md` is committed). wdyt on auto-split-vs-AI-identify as the default entry point?

🤖 generated with [claude code](https://claude.com/claude-code)
