### PR TITLE
docs: document the screenpipe pipe CLI (npx/bunx) + recurring-automation path across pipes/second-brain/ai-memory/openclaw

### DIFF
--- a/docs/mintlify/docs-mintlify-mig-tmp/ai-memory.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/ai-memory.mdx
@@ -36,7 +36,7 @@ see [MCP server setup](/mcp-server) for details.
 
 ### pipes (scheduled agents)
 
-[pipes](/pipes) are AI agents that run on a schedule and act on your screen data automatically — like syncing to Obsidian, tracking time in Toggl, or sending daily summaries.
+[pipes](/pipes) are AI agents that run on a schedule and act on your screen data automatically — like syncing to Obsidian, tracking time in Toggl, or sending daily summaries. spin one up from the CLI — `npx -y screenpipe@latest pipe install <url-or-path> && npx -y screenpipe@latest pipe enable <name>` (`bunx` / `bun x` work too) — or ask any connected agent to build one for you.
 
 ### direct API
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/openclaw.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/openclaw.mdx
@@ -203,6 +203,8 @@ Once configured, message OpenClaw from any chat app:
 
 the prompts above answer questions on demand. to have OpenClaw *proactively* segment your workflows, summarize your processes, and keep a living memory of you — like the [digital clone pipe](/pipe-store), but inside OpenClaw — paste the prompt from [build a second brain](/second-brain) into OpenClaw and let it run on a schedule.
 
+prefer to run it inside the screenpipe app instead of OpenClaw? do the same thing as a [pipe](/pipes) — `npx -y screenpipe@latest pipe install <path> && npx -y screenpipe@latest pipe enable <name>` (`bunx` works too).
+
 ## troubleshooting
 
 **MCP not connecting?**

--- a/docs/mintlify/docs-mintlify-mig-tmp/pipes.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/pipes.mdx
@@ -190,12 +190,31 @@ Query screenpipe at http://localhost:3030/search using the time range from the c
 Write the summary to ./output/<date>.md
 EOF
 
-# then use the desktop app (settings → pipes) to install, enable, and test
-# or use the REST API:
-# curl -X POST http://localhost:3030/pipes/install -H "Content-Type: application/json" -d '{"source": "~/.screenpipe/pipes/my-pipe"}'
-# curl -X POST http://localhost:3030/pipes/my-pipe/enable -H "Content-Type: application/json" -d '{"enabled": true}'
-# curl -X POST http://localhost:3030/pipes/my-pipe/run
+# install + enable + test it from the CLI (no install needed — npx / bunx / bun x all work):
+npx -y screenpipe@latest pipe install ~/.screenpipe/pipes/my-pipe
+npx -y screenpipe@latest pipe enable my-pipe
+npx -y screenpipe@latest pipe run my-pipe        # run once now to test
+#
+# (or use the desktop app: settings → pipes — or the REST API: POST /pipes/install, /pipes/my-pipe/run)
 ```
+
+## manage pipes from the CLI
+
+every pipe action is available from the CLI — no separate install. `npx -y screenpipe@latest`, `bunx screenpipe@latest`, and `bun x screenpipe@latest` are equivalent; use whichever the machine has.
+
+```bash
+npx -y screenpipe@latest pipe list                   # list all pipes
+npx -y screenpipe@latest pipe install <url-or-path>  # install from a GitHub URL or a local folder
+npx -y screenpipe@latest pipe enable <name>          # turn the schedule on
+npx -y screenpipe@latest pipe disable <name>         # turn it off
+npx -y screenpipe@latest pipe run <name>             # run once now (test before the schedule fires)
+npx -y screenpipe@latest pipe logs <name>            # view execution logs
+npx -y screenpipe@latest pipe delete <name>          # remove a pipe
+```
+
+<Tip>run CLI commands from a clean temp directory to avoid `node_modules` conflicts: `cd "$(mktemp -d)" && npx -y screenpipe@latest pipe list`.</Tip>
+
+this is how you turn a one-off into a recurring **cron** automation: write a `pipe.md` with a `schedule` (e.g. `0 9 * * *`), `install` then `enable` it, and screenpipe runs it on that cron. you can also hand these commands to any AI agent — e.g. *"create a screenpipe pipe that summarizes my day at 6pm"* — and let it scaffold, install, and enable the pipe for you.
 
 ## pipe.md format
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/second-brain.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/second-brain.mdx
@@ -104,7 +104,8 @@ link related notes together.
 ## run on a schedule
 
 set this to run automatically about once an hour using whatever scheduling you have
-(claude tasks, codex automations, openclaw/hermes automations, or a system cron job).
+(claude tasks, codex automations, openclaw/hermes automations, a system cron job, or a
+screenpipe pipe — `npx -y screenpipe@latest pipe install <path>` then `... pipe enable <name>`).
 between runs, when i ask you anything, read now.md and the relevant project/person
 files first so you already know what i was doing.
 
@@ -133,6 +134,7 @@ the prompt above tells the agent to schedule itself, but you control the cadence
 - **OpenClaw / Hermes** — their built-in automations / scheduled tasks
 - **Claude Code** — claude tasks
 - **Codex** — codex automations
+- **screenpipe pipe** — run it inside screenpipe itself: save the prompt to `~/.screenpipe/pipes/second-brain/pipe.md` with a `schedule` (e.g. `0 * * * *`), then `npx -y screenpipe@latest pipe install ~/.screenpipe/pipes/second-brain && npx -y screenpipe@latest pipe enable second-brain` (`bunx` / `bun x` work too — see [pipes](/pipes))
 - **anything else** — a plain `cron` / `launchd` / `systemd` timer that re-runs the prompt
 
 hourly is a good default. lighter machines can run every few hours; use `activity-summary` first to keep token usage low.


### PR DESCRIPTION
## what

Make the **screenpipe pipe CLI** (and the "turn this into a recurring automation" path) consistent across the docs. The `npx`/`bunx` pipe CLI wasn't documented at all, and the agent/second-brain pages told you to "run it on a schedule" without showing the in-app pipe option.

**`pipes.mdx`** (main change)
- CLI-first `install` / `enable` / `run` in the "creating a pipe" example.
- New **"manage pipes from the CLI"** section: `npx -y screenpipe@latest` / `bunx` / `bun x` equivalence + the full surface (`pipe list/install/enable/disable/run/logs/delete`) + temp-dir tip + the cron-automation framing.

**Propagated to the agent / second-brain pages** so "make it recurring" is consistent:
- **`second-brain.mdx`** — adds **screenpipe pipe** as a scheduling option (in the prompt's run-on-a-schedule note and the page's schedule list), with the `install`/`enable` commands.
- **`ai-memory.mdx`** — the pipes blurb now shows the CLI one-liner to spin one up.
- **`openclaw.mdx`** — the "build a second brain (automation)" section notes you can run it as a pipe inside the app instead.

## why

Folks and agents reach for `npx`/`bunx`, and the docs only showed `localhost:3030` curls + the desktop app. This also backs the connect-a-tool prompt in the enterprise dashboard, which tells agents to "set up a screenpipe pipe via `npx/bunx screenpipe@latest pipe …`".

Docs-only, four pages. Verified against the real CLI surface (no invented commands; create = write `pipe.md` + `install`). Code fences balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
