### PR TITLE
fix(owned-browser): reveal the on-screen chat's own agent navigation

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -74,6 +74,11 @@ const CHROME_WEBSTORE_URL =
 
 interface BrowserSidebarProps {
   conversationId: string | null;
+  /** Session id the on-screen chat's agent process runs under (the value the
+   *  agent's `x-screenpipe-session` header carries). Used alongside
+   *  `conversationId` to reveal the chat's own agent navigations even when the
+   *  `conversationId` state lags the id the agent was spawned with. */
+  agentSessionId?: string | null;
   filePreview?: {
     path: string;
     visible: boolean;
@@ -149,6 +154,7 @@ function clampWidth(want: number, available: number): number {
 
 export function BrowserSidebar({
   conversationId,
+  agentSessionId,
   filePreview,
   onCloseFilePreview,
   onReplaceFilePreviewPath,
@@ -355,7 +361,20 @@ export function BrowserSidebar({
         // chat's file so it sticks on reopen. Restore/reload paths now tag
         // themselves with the foreground conversation id; ownerless events are
         // treated as stale/legacy and ignored.
-        if (isForeignNavigation(owner, conversationId)) return;
+        if (isForeignNavigation(owner, conversationId, agentSessionId)) {
+          // Diagnostic for the "agent navigated but the sidebar never opened"
+          // report: a *tagged* navigation we dropped because its owner matched
+          // neither the on-screen conversation nor its agent's session. Surfaces
+          // the exact id mismatch (or a missing owner header → owner null, which
+          // this skips since that's the expected stale/legacy case).
+          if (owner) {
+            console.debug(
+              "[browser-sidebar] dropped navigation not owned by this chat",
+              { owner, conversationId, agentSessionId, navigationId, url },
+            );
+          }
+          return;
+        }
         if (!navigationId) return;
         setSessionAccessRequest(null);
         setSessionAccessAnswer(null);
@@ -377,7 +396,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [persistState, conversationId]);
+  }, [persistState, conversationId, agentSessionId]);
 
   useEffect(() => {
     const unlistenPromise = listen<SessionAccessEvent>(
@@ -388,7 +407,7 @@ export function BrowserSidebar({
         if (!requestId || !payload?.url || !payload?.host) return;
         // Same ownership gate as the navigate event — a background pipe's
         // cookie-consent prompt must not surface in another chat.
-        if (isForeignNavigation(payload.owner, conversationId)) return;
+        if (isForeignNavigation(payload.owner, conversationId, agentSessionId)) return;
         if (isMismatchedNavigation(payload.navigationId, currentNavigationId)) return;
         const request = {
           requestId,
@@ -416,7 +435,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [persistState, conversationId, currentNavigationId]);
+  }, [persistState, conversationId, currentNavigationId, agentSessionId]);
 
   useEffect(() => {
     const unlistenPromise = listen<V20CookieBlockEvent>(
@@ -424,7 +443,7 @@ export function BrowserSidebar({
       (e) => {
         const payload = e.payload;
         if (!payload?.url || !payload?.host) return;
-        if (isForeignNavigation(payload.owner, conversationId)) return;
+        if (isForeignNavigation(payload.owner, conversationId, agentSessionId)) return;
         if (isMismatchedNavigation(payload.navigationId, currentNavigationId)) return;
         const block = {
           url: payload.url,
@@ -453,7 +472,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [persistState, conversationId, currentNavigationId]);
+  }, [persistState, conversationId, currentNavigationId, agentSessionId]);
 
   useEffect(() => {
     sessionAccessActiveRef.current =
@@ -519,7 +538,7 @@ export function BrowserSidebar({
       // them so the foreign URL/title isn't persisted into this chat (the
       // sticky half of the leak: without this the URL is restored on reopen
       // even though the panel never visibly popped).
-      if (isForeignNavigation(payload.owner, conversationId)) return;
+      if (isForeignNavigation(payload.owner, conversationId, agentSessionId)) return;
       if (isMismatchedNavigation(payload.navigationId, currentNavigationId)) return;
 
       if (typeof payload.url === "string" && payload.url.length > 0) {
@@ -542,7 +561,7 @@ export function BrowserSidebar({
     return () => {
       unlistenPromise.then((fn) => fn()).catch(() => {});
     };
-  }, [currentNavigationId, currentUrl, persistState, conversationId]);
+  }, [currentNavigationId, currentUrl, persistState, conversationId, agentSessionId]);
 
   // ---------------------------------------------------------------------------
   // Per-conversation restore

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -10118,6 +10118,10 @@ export function StandaloneChat({
           positioned over the placeholder div inside this component. */}
       <BrowserSidebar
         conversationId={conversationId}
+        // Session id the agent process runs under (the value tagged as the
+        // navigation `owner` via x-screenpipe-session). Lets the sidebar reveal
+        // this chat's own agent navigations even if `conversationId` state lags.
+        agentSessionId={piSessionIdRef.current}
         filePreview={filePreview}
         onCloseFilePreview={closeFilePreview}
         onReplaceFilePreviewPath={openFilePreview}

--- a/apps/screenpipe-app-tauri/e2e/specs/zz-owned-browser-background-nav.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-owned-browser-background-nav.spec.ts
@@ -113,6 +113,7 @@ const OWN_CHAT = "33333333-cccc-cccc-cccc-cccccccccccc";
 const FOREIGN_OWNER = "pipe:e2e-background-poster";
 const CHATS_DIR = join(homedir(), ".screenpipe", "chats");
 const FOREIGN_URL = "https://example.com/e2e-foreign-pipe";
+const OWN_URL = "https://example.com/e2e-own-chat";
 const BROWSER_CHAT_A = "44444444-dddd-dddd-dddd-dddddddddddd";
 const BROWSER_CHAT_B = "55555555-eeee-eeee-eeee-eeeeeeeeeeee";
 const PLAIN_CHAT = "66666666-ffff-ffff-ffff-ffffffffffff";
@@ -408,6 +409,50 @@ describe("Owned browser — per-chat navigation ownership", function () {
       await browser.pause(t(2_500));
       expect(await invokeOrThrow<boolean>("e2e_owned_browser_visible")).toBe(
         false,
+      );
+    },
+  );
+
+  // Positive counterpart: the reported reveal bug. A navigation tagged with the
+  // ON-SCREEN chat's own owner MUST reveal the browser — the agent navigated but
+  // the sidebar never opened. Drives from the search window because revealing
+  // attaches the native child to `home` (which destroys home's WebDriver handle);
+  // visibility is read via the global `e2e_owned_browser_visible` probe.
+  (canDriveOwnedBrowser ? it : it.skip)(
+    "reveals the on-screen chat's own agent navigation",
+    async () => {
+      await installSessionCapture();
+      await seedChat(OWN_CHAT, "(e2e) owned-browser reveal probe");
+      await browser.pause(t(200));
+      await loadChatIntoHome(OWN_CHAT);
+      await waitForActiveConversation(OWN_CHAT);
+
+      await showWindow({ Search: { query: null } });
+      await waitForWindowHandle("search", t(10_000));
+      await browser.switchToWindow("search");
+      await browser.pause(t(800));
+
+      // Hidden baseline.
+      await invokeOrThrow("owned_browser_hide");
+      expect(await invokeOrThrow<boolean>("e2e_owned_browser_visible")).toBe(
+        false,
+      );
+
+      // Navigate tagged with OWN_CHAT — the agent of the chat on screen. The
+      // ownership gate must let it through and reveal the panel.
+      const { port, key } = await getLocalApiConfig();
+      const status = await postNavigateAs(port, key, OWN_URL, OWN_CHAT);
+      expect(status).toBe(200);
+
+      // Reveal is async (event → setState → ResizeObserver → set_bounds), so poll.
+      await browser.waitUntil(
+        async () =>
+          (await invokeOrThrow<boolean>("e2e_owned_browser_visible")) === true,
+        {
+          timeout: t(10_000),
+          interval: 300,
+          timeoutMsg: "owned browser did not reveal for its own chat's navigation",
+        },
       );
     },
   );

--- a/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/owned-browser-ownership.test.ts
@@ -52,6 +52,42 @@ describe("owned-browser ownership", () => {
     });
   });
 
+  describe("isForeignNavigation — own-agent session match", () => {
+    it("reveals the chat's own agent navigation when conversationId lags/differs", () => {
+      // The agent runs under session S; the React conversationId state hasn't
+      // caught up (or never matched the spawn id). The navigation is owned by S,
+      // which is this chat's running agent → honored. This is the reveal bug:
+      // before, the owner only matched conversationId, so the chat's own agent
+      // page stayed hidden whenever the two diverged.
+      expect(isForeignNavigation("sess-S", "conv-LAGGED", "sess-S")).toBe(false);
+      expect(isForeignNavigation("sess-S", null, "sess-S")).toBe(false);
+    });
+
+    it("reveals on a conversationId match regardless of agentSessionId", () => {
+      expect(isForeignNavigation("conv-C", "conv-C", "sess-OTHER")).toBe(false);
+    });
+
+    it("still drops another chat's agent and background pipes", () => {
+      // owner is neither this chat's conversation nor its agent session.
+      expect(isForeignNavigation("conv-A", "conv-C", "sess-C")).toBe(true);
+      expect(isForeignNavigation("pipe:reddit", "conv-C", "sess-C")).toBe(true);
+    });
+
+    it("never matches a null/empty agentSessionId (no false reveal when unset)", () => {
+      expect(isForeignNavigation("conv-A", "conv-C", null)).toBe(true);
+      expect(isForeignNavigation("conv-A", "conv-C", undefined)).toBe(true);
+      expect(isForeignNavigation("conv-A", "conv-C", "")).toBe(true);
+      // An ownerless event stays dropped even with an agent session present.
+      expect(isForeignNavigation(null, "conv-C", "sess-C")).toBe(true);
+      expect(isForeignNavigation("", "conv-C", "sess-C")).toBe(true);
+    });
+
+    it("is backward compatible when agentSessionId is omitted", () => {
+      expect(isForeignNavigation("conv-C", "conv-C")).toBe(false);
+      expect(isForeignNavigation("conv-A", "conv-C")).toBe(true);
+    });
+  });
+
   describe("parseNavigatePayload", () => {
     it("parses the object payload with an owner", () => {
       expect(

--- a/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
+++ b/apps/screenpipe-app-tauri/lib/owned-browser-ownership.ts
@@ -54,6 +54,15 @@ export function parseNavigatePayload(payload: OwnedBrowserNavigatePayload): {
  *
  * - owner === conversationId → this chat's own browser lifecycle event,
  *   honored.
+ * - owner === agentSessionId → this chat's own running agent. The navigation
+ *   `owner` is the session id the agent process was spawned under (the value
+ *   the bash shim forwards as `x-screenpipe-session`). That is normally equal
+ *   to `conversationId`, but the React `conversationId` state can lag the ref
+ *   the agent was started with, or a spawn can fall back to a non-matching
+ *   session id — in either case the agent's own page would otherwise never
+ *   reveal. Honor it when the owner matches the id the on-screen chat's agent
+ *   actually runs under. Still safe: another chat's agent / a background pipe
+ *   runs under a different session id, so its navigations are still dropped.
  * - owner null/empty → foreign/stale, ignored. All supported restore/reload
  *   paths now send the real `conversationId`; leaving ownerless events
  *   writable lets the singleton browser leak into whichever chat is open.
@@ -64,15 +73,19 @@ export function parseNavigatePayload(payload: OwnedBrowserNavigatePayload): {
 export function isForeignNavigation(
   owner: string | null | undefined,
   conversationId: string | null | undefined,
+  agentSessionId?: string | null | undefined,
 ): boolean {
   // Ownerless events are stale/legacy and must not mutate whichever chat is
   // currently open. Every supported restore/reload path now tags itself with
   // the foreground conversation id.
   if (!owner) return true;
-  // A tagged navigation is honored only by the chat that issued it. When no
-  // chat is bound (conversationId null/empty), `owner !== conversationId` is
-  // true, so the navigation is treated as foreign and dropped.
-  return owner !== conversationId;
+  // The on-screen chat's own navigation — matched by conversation id...
+  if (owner === conversationId) return false;
+  // ...or by the session id the on-screen chat's own agent process runs under
+  // (robust to a lagging `conversationId` state or a non-matching spawn id).
+  if (agentSessionId && owner === agentSessionId) return false;
+  // Anything else belongs to another chat or a background pipe — dropped.
+  return true;
 }
 
 export function isMismatchedNavigation(


### PR DESCRIPTION
## the bug

The in-app agent navigates the owned browser (e.g. "go to reddit") and reads the page, but the **sidebar never opens** — the page loaded on the off-screen background host and clicking didn't reveal it. (Reported from a real session; the agent salvaged the top post from a snapshot but the browser stayed hidden.)

## cause

The owned browser is a singleton whose `owned-browser:navigate` event is broadcast to every window. `<BrowserSidebar>` reveals a navigation only when its `owner` — the agent's `x-screenpipe-session` session id — equals the React `conversationId` **state** (`isForeignNavigation(owner, conversationId)`).

That gate is correct for keeping a background pipe / another chat's page out of the chat on screen. But it's brittle for the chat's **own** agent: if the `conversationId` state lags the id the agent was actually spawned under (or a spawn falls back to a non-matching session id), the chat's own navigation is dropped as "foreign" and never reveals — it then lazily attaches off-screen, exactly the symptom.

## fix

Honor a navigation when its owner matches **either** the on-screen `conversationId` **or** the session id the on-screen chat's own agent process runs under (`agentSessionId`, threaded from `standalone-chat` as `piSessionIdRef.current` — the same value tagged as `owner`).

- **Still isolated:** another chat's agent / a background pipe runs under a different session id, so it's still dropped. Ownerless (stale/legacy) events stay dropped.
- **Self-diagnosing:** added a `console.debug` when a *tagged* navigation is dropped, logging `owner` vs the ids we accept — so if anything still doesn't reveal (e.g. a missing owner header → `owner` null), the exact cause is captured on the next run.
- **Separation of concerns:** the decision stays in the pure `lib/owned-browser-ownership` module (no React/Tauri), unit-tested in isolation.

## test plan

- **vitest** `lib/__tests__/owned-browser-ownership.test.ts` (runs in CI): own-agent match reveals across a lagging/differing `conversationId`; `conversationId` match still works; other chats + background pipes still dropped; a null/empty `agentSessionId` never false-matches; ownerless dropped; backward compatible when omitted. **15/15 locally.**
- **e2e** `zz-owned-browser-background-nav.spec.ts` (this spec **runs in CI on mac/win** — no `!process.env.CI` gate): new positive test **"reveals the on-screen chat's own agent navigation"** — drives `POST /navigate` tagged with the on-screen chat's owner and asserts the browser reveals. Direct counterpart to the existing foreign-owner "stays hidden" test.
- `tsc --noEmit` clean.

> Note: I could not build/run the desktop app locally, so the **end-to-end reveal is validated by the CI e2e run** (mac/win) rather than a local run — please confirm the new e2e passes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)