### PR TITLE
fix(redact): disable a missing target table instead of retrying it forever

### DIFF
--- a/crates/screenpipe-redact/src/worker/mod.rs
+++ b/crates/screenpipe-redact/src/worker/mod.rs
@@ -203,6 +203,20 @@ impl Worker {
         }
         let mut corruption_logged = false;
 
+        // A "no such table/column" error is non-transient and table-specific:
+        // the schema this binary expects doesn't match the DB it opened, so
+        // retrying that target can never succeed. This happens during version
+        // skew — e.g. an older engine sharing a `db.sqlite` that a newer one
+        // already migrated. The `ocr_text` table (retired 2026-06) hit this
+        // exactly: a pre-retirement binary kept its `Ocr` target and spammed
+        // `no such table: ocr_text` every 2s forever. Detect it, disable that
+        // one target for the process lifetime, and keep reconciling the rest.
+        fn is_missing_object<E: std::fmt::Display + ?Sized>(e: &E) -> bool {
+            let msg = e.to_string().to_lowercase();
+            msg.contains("no such table") || msg.contains("no such column")
+        }
+        let mut disabled: Vec<TargetTable> = Vec::new();
+
         loop {
             if self.paused.load(std::sync::atomic::Ordering::SeqCst) {
                 self.set_paused(true).await;
@@ -219,6 +233,11 @@ impl Worker {
 
             let mut any_work = false;
             for table in &self.cfg.tables {
+                // Permanently skip a target whose table/column isn't in this
+                // schema — see `is_missing_object` and the Err arm below.
+                if disabled.contains(table) {
+                    continue;
+                }
                 // Race the table work against shutdown so a long redact batch
                 // doesn't hold us through tokio teardown.
                 let batch_start = std::time::Instant::now();
@@ -262,6 +281,23 @@ impl Worker {
                         {
                             let mut s = self.status.lock().await;
                             s.last_error = Some(e.to_string());
+                        }
+                        if is_missing_object(&e) {
+                            // Non-transient and scoped to this one target: the
+                            // table or a column it reads isn't in this schema
+                            // (binary/DB version skew). Retrying spins a core
+                            // and floods the log, so disable just this target
+                            // for the run and move on — the others reconcile
+                            // normally. Logged once per target via the disable.
+                            warn!(
+                                table = ?table,
+                                error = %e,
+                                "target table/column missing from this schema — disabling its \
+                                 reconciliation for this run (binary predates a migration that \
+                                 retired it?); upgrade screenpipe to clear this"
+                            );
+                            disabled.push(*table);
+                            continue;
                         }
                         if is_db_corruption(&e) {
                             // Non-transient: the DB is corrupt and every table

--- a/crates/screenpipe-redact/tests/worker_integration.rs
+++ b/crates/screenpipe-redact/tests/worker_integration.rs
@@ -766,3 +766,78 @@ async fn frame_fulltext_falls_back_when_no_map() {
     );
     assert!(!a.contains("bob@example.com"), "raw email survived: {a:?}");
 }
+
+/// A target table missing from the schema (binary/DB version skew — the
+/// `ocr_text` retirement is the real-world case) must be disabled, not
+/// retried forever. The worker should log once and keep reconciling the
+/// other targets at full speed.
+///
+/// Repro shape: reconcile a missing target (`Elements` — no `elements`
+/// table here) *before* a present one (`FullText`). The missing target's
+/// error is non-transient; if the worker treated it as transient it would
+/// sleep 2s before reaching `FullText` on every sweep, so `full_text`
+/// wouldn't be redacted within the short window below. With the fix the
+/// missing target is disabled immediately and `full_text` is redacted in
+/// the same sweep.
+#[tokio::test]
+async fn worker_disables_missing_table_and_keeps_reconciling_others() {
+    // Schema WITHOUT an `elements` table — mirrors an engine whose code
+    // still targets a table this DB's schema no longer has.
+    let pool = SqlitePoolOptions::new()
+        .max_connections(2)
+        .connect("sqlite::memory:")
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        CREATE TABLE frames (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            full_text TEXT,
+            full_text_redacted_at INTEGER,
+            accessibility_text TEXT,
+            accessibility_redacted_at INTEGER
+        );
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO frames (id, full_text) VALUES (1, 'email alice@example.com here')")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let redactor = Arc::new(RegexRedactor::new()) as Arc<dyn Redactor>;
+    let cfg = WorkerConfig {
+        batch_size: 16,
+        idle_between_batches: Duration::from_millis(1),
+        poll_interval: Duration::from_millis(20),
+        // Elements first (missing table) then FullText (present).
+        tables: vec![TargetTable::Elements, TargetTable::FullText],
+        ..Default::default()
+    };
+    let worker = Worker::new(pool.clone(), redactor, cfg);
+    let handle = worker.clone().spawn();
+
+    // 400ms ≪ the 2s transient backoff: only reachable if the missing
+    // `elements` target was disabled rather than slept-on every sweep.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    handle.abort();
+
+    let row = sqlx::query("SELECT full_text, full_text_redacted_at FROM frames WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let red: String = row.get(0);
+    let when: Option<i64> = row.get(1);
+    assert!(
+        red.contains("[EMAIL]") && when.is_some(),
+        "full_text must be redacted despite the missing `elements` table — \
+         the missing target should be disabled, not block/spam the rotation (got {red:?})"
+    );
+    // NB: `last_error` is intentionally not asserted here — the successful
+    // `FullText` pass that follows the missing-table error clears it back to
+    // None, so it's racy by design. The timing-bounded redaction above is the
+    // behavioural proof that the missing target was disabled rather than
+    // retried on a 2s backoff ahead of `FullText`.
+}


### PR DESCRIPTION
## What

The PII reconciliation worker now treats a **missing table/column** as a non-transient, target-scoped error: it logs once and disables just that one target for the process lifetime, instead of warn-spamming `reconciliation error; will retry` every 2 seconds forever. The other surfaces keep reconciling at full speed.

This mirrors the worker's existing `is_db_corruption` handling (log once, back off) — but corruption is DB-wide so it backs off the whole sweep, whereas a missing object is scoped to one target, so only that target is dropped.

## Why (the `ocr_text` log flood)

Reported from a live recorder log:

```
WARN screenpipe_redact::worker: reconciliation error; will retry table=Ocr error=... no such table: ocr_text
WARN screenpipe_redact::worker: reconciliation error; will retry table=Ocr error=... no such table: ocr_text
... (every ~2s, forever)
```

Root cause is **binary/DB version skew**, not a bug in current `main`:

- #4106 retired the `ocr_text` table and unified OCR text onto `frames`, via the one-way migration `20260613130000_unify_ocr_text_into_frames.sql`. Current code no longer has an `Ocr` redact target.
- But the published npm CLI `screenpipe@latest` is still **v0.4.21**, which predates #4106 and keeps the old `Ocr` target (and old `ocr_text` write path).
- When the **desktop app** (≥ `app-v2.5.43`, includes #4106) upgrades a shared `~/.screenpipe/db.sqlite`, then a `bunx screenpipe@latest record` (v0.4.21) runs against it, the stale binary's `Ocr` reconciliation pass hits `no such table: ocr_text` on every cycle and floods the log + burns a core retrying.

The real remediation for that specific incident is shipping **v0.4.22** (already in flight; it contains #4106 and has no `Ocr` target). This PR is the **forward-looking hardening** so this *class* of error — a target whose table/column a binary expects but the live schema doesn't have — degrades to a single warning instead of an indefinite 2s retry storm.

## Change

- `worker/mod.rs`: add `is_missing_object` (detects `no such table` / `no such column`); on that error, `warn!` once and drop the target into a per-run `disabled` set; skip disabled targets at the top of each sweep.
- `tests/worker_integration.rs`: regression test — a worker pointed at a missing `elements` table *ahead of* a present `frames.full_text` still redacts `full_text` well inside the 2s backoff window, which is only possible if the missing target is disabled rather than slept-on every sweep.

## Test

```
cargo test -p screenpipe-redact   # 136 + 12 pass
cargo clippy -p screenpipe-redact --tests   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)