### PR TITLE
fix(tauri): replace browser clipboard API with native Tauri clipboard command

### DIFF
--- a/apps/screenpipe-app-tauri/app/settings/page.tsx
+++ b/apps/screenpipe-app-tauri/app/settings/page.tsx
@@ -111,7 +111,7 @@ function ReferralSection() {
 
   const handleCopy = async () => {
     if (!referralLink) return;
-    await navigator.clipboard.writeText(referralLink);
+    await commands.copyTextToClipboard(referralLink);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/apps/screenpipe-app-tauri/components/markdown/code-block.tsx
+++ b/apps/screenpipe-app-tauri/components/markdown/code-block.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import type { Options } from "react-markdown";
 import { cn } from "@/lib/utils";
+import { commands } from "@/lib/utils/tauri";
 
 /**
  * One markdown surface, one code block.
@@ -168,7 +169,7 @@ export const MarkdownCodeBlock = React.memo(function MarkdownCodeBlock({
   const handleCopy = async () => {
     if (!value || copied) return;
     try {
-      await navigator.clipboard.writeText(value);
+      await commands.copyTextToClipboard(value);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch (error) {

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -839,8 +839,7 @@ export function NoteView({
       // Use Tauri's native clipboard API (arboard) instead of
       // navigator.clipboard.writeText which fails after async operations
       // due to WebKit's user-activation timeout.
-      const res = await commands.copyTextToClipboard(md);
-      if (res.status === "error") throw new Error(res.error);
+      await commands.copyTextToClipboard(md);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 2000);
       toast({ title: "copied to clipboard" });

--- a/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { cn } from "@/lib/utils";
+import { commands } from "@/lib/utils/tauri";
 import { Button } from "@/components/ui/button";
 import { MediaComponent } from "@/components/rewind/media";
 import { SpeakerAssignPopover } from "@/components/speaker-assign-popover";
@@ -640,7 +641,7 @@ export function TranscriptPanel({
       .map((b) => `[${formatClock(b.startMs)}] ${b.speakerName}\n${b.text}`)
       .join("\n\n");
     try {
-      await navigator.clipboard.writeText(text);
+      await commands.copyTextToClipboard(text);
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     } catch {

--- a/apps/screenpipe-app-tauri/components/rewind/current-frame-timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/current-frame-timeline.tsx
@@ -18,6 +18,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useFrameLoading } from "@/components/rewind/hooks/use-frame-loading";
 import { useLiveText } from "@/components/rewind/hooks/use-live-text";
 import { useFrameActions } from "@/components/rewind/hooks/use-frame-actions";
+import { commands } from "@/lib/utils/tauri";
 
 export interface DetectedUrl {
 	normalized: string;
@@ -254,7 +255,7 @@ export const CurrentFrameTimeline: FC<CurrentFrameTimelineProps> = ({
 			if (!text?.trim()) return;
 
 			e.preventDefault();
-			navigator.clipboard.writeText(text).catch(() => {});
+			commands.copyTextToClipboard(text).catch(() => {});
 			toast({ title: "copied text", description: "all frame text copied to clipboard" });
 		};
 
@@ -367,7 +368,7 @@ export const CurrentFrameTimeline: FC<CurrentFrameTimelineProps> = ({
 								onClick={() => {
 									const text = getSelectableLayerText()?.trim();
 									if (text) {
-										navigator.clipboard.writeText(text).catch(() => {});
+										commands.copyTextToClipboard(text).catch(() => {});
 										toast({ title: "copied selection", description: "selected text copied to clipboard" });
 									}
 									setContextMenuOpen(false);

--- a/apps/screenpipe-app-tauri/components/rewind/hooks/use-frame-actions.ts
+++ b/apps/screenpipe-app-tauri/components/rewind/hooks/use-frame-actions.ts
@@ -56,7 +56,7 @@ export function useFrameActions(opts: {
 			});
 			return;
 		}
-		await navigator.clipboard.writeText(text);
+		await commands.copyTextToClipboard(text);
 		toast({ title: "copied text", description: "text copied to clipboard" });
 	}, [debouncedFrame?.frameId, frameContext?.text, textPositions]);
 

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
@@ -205,7 +205,7 @@ export function AppContextPopover({
 			);
 		}
 
-		navigator.clipboard.writeText(lines.join("\n"));
+		commands.copyTextToClipboard(lines.join("\n"));
 		setCopied(true);
 		setTimeout(() => setCopied(false), 1500);
 	};

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/audio-transcript.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/audio-transcript.tsx
@@ -24,6 +24,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Meeting, deduplicateAudioItems } from "@/lib/hooks/use-meetings";
 import { usePipes } from "@/lib/hooks/use-pipes";
 import { localFetch } from "@/lib/api";
+import { commands } from "@/lib/utils/tauri";
 
 // Extended audio item with timestamp for conversation view
 interface AudioItemWithTimestamp extends AudioData {
@@ -452,7 +453,7 @@ export function AudioTranscript({
 			return `[${time}] ${name}: ${item.audio.transcription || "(no transcription)"}`;
 		});
 
-		navigator.clipboard.writeText(lines.join("\n")).then(() => {
+		commands.copyTextToClipboard(lines.join("\n")).then(() => {
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
 		});

--- a/apps/screenpipe-app-tauri/components/settings/agent-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/agent-card.tsx
@@ -179,7 +179,7 @@ function McpSection({ name, mcp }: { name: string; mcp: AgentCardProps["mcp"] })
   const [copied, setCopied] = useState(false);
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(mcp.snippet);
+      await commands.copyTextToClipboard(mcp.snippet);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {}
@@ -266,7 +266,7 @@ function SkillVariantBody({ name, variant }: { name: string; variant: SkillVaria
 
   const copyMd = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(variant.md);
+      await commands.copyTextToClipboard(variant.md);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
       toast({ title: "copied SKILL.md to clipboard" });
@@ -278,7 +278,7 @@ function SkillVariantBody({ name, variant }: { name: string; variant: SkillVaria
   const copyCmd = useCallback(async () => {
     if (!variant.cliInstall) return;
     try {
-      await navigator.clipboard.writeText(variant.cliInstall);
+      await commands.copyTextToClipboard(variant.cliInstall);
       setCmdCopied(true);
       setTimeout(() => setCmdCopied(false), 2000);
       toast({ title: "copied install command" });
@@ -985,7 +985,7 @@ function SecondBrainCallout({ name }: { name: string }) {
 
   const copyPrompt = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(SECOND_BRAIN_PROMPT);
+      await commands.copyTextToClipboard(SECOND_BRAIN_PROMPT);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
       toast({ title: "copied second-brain prompt", description: `paste it into ${name}` });

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -1279,7 +1279,7 @@ export function BrainSection() {
                     variant="ghost"
                     className="h-7 w-7 opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={() => {
-                      navigator.clipboard.writeText(memory.content);
+                      commands.copyTextToClipboard(memory.content);
                       setCopiedId(memory.id);
                       setTimeout(() => setCopiedId(null), 2000);
                     }}

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -1304,7 +1304,7 @@ function ClaudeCodePanel() {
   const cmd = "claude mcp add screenpipe -- npx -y screenpipe-mcp@latest";
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(cmd);
+      await commands.copyTextToClipboard(cmd);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {}
@@ -1717,7 +1717,7 @@ function AnythingLLMPanel() {
   }, null, 2);
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(config);
+      await commands.copyTextToClipboard(config);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {}
@@ -1755,7 +1755,7 @@ function MstyPanel() {
   }, null, 2);
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(config);
+      await commands.copyTextToClipboard(config);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {}
@@ -1801,7 +1801,7 @@ function WarpPanel() {
   }, null, 2);
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(config);
+      await commands.copyTextToClipboard(config);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {}

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -3014,7 +3014,7 @@ export function PipesSection() {
                                   {exec.model && <span className="text-muted-foreground/60 truncate max-w-[100px]">{exec.model}</span>}
                                   {exec.status === "completed" && exec.stdout && cleanPipeStdout(exec.stdout) && (
                                     <div className="ml-auto flex items-center gap-1">
-                                      <button className="text-muted-foreground hover:text-foreground p-0.5" title="copy" onClick={() => navigator.clipboard.writeText(cleanPipeStdout(exec.stdout))}>
+                                      <button className="text-muted-foreground hover:text-foreground p-0.5" title="copy" onClick={() => commands.copyTextToClipboard(cleanPipeStdout(exec.stdout))}>
                                         <Copy className="w-3.5 h-3.5" />
                                       </button>
                                       <button className="text-muted-foreground hover:text-foreground p-0.5" title="open in chat" onClick={async () => {
@@ -3068,7 +3068,7 @@ export function PipesSection() {
                                   <div className="relative group">
                                     <button
                                       className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-muted"
-                                      onClick={() => navigator.clipboard.writeText(cleanPipeStdout(log.stdout))}
+                                      onClick={() => commands.copyTextToClipboard(cleanPipeStdout(log.stdout))}
                                       title="copy"
                                     >
                                       <Copy className="h-3 w-3 text-muted-foreground" />

--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -835,18 +835,15 @@ export function PrivacySection() {
                   onClick={async () => {
                     if (!liveApiKey) return;
                     try {
-                      await navigator.clipboard.writeText(liveApiKey);
-                    } catch {
-                      const el = document.createElement("textarea");
-                      el.value = liveApiKey;
-                      el.style.position = "fixed";
-                      el.style.opacity = "0";
-                      document.body.appendChild(el);
-                      el.select();
-                      document.execCommand("copy");
-                      document.body.removeChild(el);
+                      await commands.copyTextToClipboard(liveApiKey);
+                      toast({ title: "API key copied to clipboard" });
+                    } catch (error) {
+                      toast({
+                        title: "couldn't copy API key",
+                        description: error instanceof Error ? error.message : String(error),
+                        variant: "destructive",
+                      });
                     }
-                    toast({ title: "API key copied to clipboard" });
                   }}
                 >
                   <Copy className="h-3.5 w-3.5" />
@@ -1696,18 +1693,15 @@ function AdminTeamTokenCard() {
             onClick={async () => {
               if (!liveToken) return;
               try {
-                await navigator.clipboard.writeText(liveToken);
-              } catch {
-                const el = document.createElement("textarea");
-                el.value = liveToken;
-                el.style.position = "fixed";
-                el.style.opacity = "0";
-                document.body.appendChild(el);
-                el.select();
-                document.execCommand("copy");
-                document.body.removeChild(el);
+                await commands.copyTextToClipboard(liveToken);
+                toast({ title: "admin token copied to clipboard" });
+              } catch (error) {
+                toast({
+                  title: "couldn't copy admin token",
+                  description: error instanceof Error ? error.message : String(error),
+                  variant: "destructive",
+                });
               }
-              toast({ title: "admin token copied to clipboard" });
             }}
           >
             <Copy className="h-3.5 w-3.5" />

--- a/apps/screenpipe-app-tauri/components/settings/referral-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/referral-card.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Copy, Check, Gift, Send, Loader2 } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
 import { useSettings } from "@/lib/hooks/use-settings";
+import { commands } from "@/lib/utils/tauri";
 
 interface ReferralData {
   code: string;
@@ -62,7 +63,7 @@ export function ReferralCard() {
   const handleCopy = async () => {
     if (!referral) return;
     try {
-      await navigator.clipboard.writeText(referral.link);
+      await commands.copyTextToClipboard(referral.link);
       setCopied(true);
       toast({ title: "referral link copied!" });
       setTimeout(() => setCopied(false), 2000);

--- a/apps/screenpipe-app-tauri/components/settings/sync-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/sync-settings.tsx
@@ -404,7 +404,7 @@ function EncryptionKeyReveal() {
 
   const handleCopy = () => {
     if (password) {
-      navigator.clipboard.writeText(password);
+      commands.copyTextToClipboard(password);
       toast({
         title: "copied to clipboard",
         description: "paste this on your other device to set up sync",

--- a/apps/screenpipe-app-tauri/components/settings/user-browser-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/user-browser-card.tsx
@@ -22,6 +22,7 @@ import { ExternalLink, Loader2 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { localFetch } from "@/lib/api";
 import { toast } from "@/components/ui/use-toast";
+import { commands } from "@/lib/utils/tauri";
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -134,7 +135,7 @@ export function UserBrowserCard() {
                   try {
                     await openUrl(CHROME_WEBSTORE_URL);
                   } catch {
-                    try { await navigator.clipboard.writeText(CHROME_WEBSTORE_URL); } catch { /* clipboard may be denied */ }
+                    try { await commands.copyTextToClipboard(CHROME_WEBSTORE_URL); } catch { /* clipboard may be denied */ }
                     toast({
                       title: "couldn't open your browser",
                       description: `link copied — paste in Chrome: ${CHROME_WEBSTORE_URL}`,

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -8236,7 +8236,7 @@ export function StandaloneChat({
   const copyFullChatAsMarkdown = async () => {
     if (messages.length === 0) return;
     const md = messages.map(formatMessageAsMarkdown).join("\n\n---\n\n");
-    await navigator.clipboard.writeText(md);
+    await commands.copyTextToClipboard(md);
     toast({ title: "copied full chat as markdown" });
   };
 
@@ -9224,7 +9224,7 @@ export function StandaloneChat({
                   <div className="flex items-center gap-0.5 self-end mt-1 opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 transition-all duration-200">
                     <button
                       onClick={async () => {
-                        await navigator.clipboard.writeText(message.content);
+                        await commands.copyTextToClipboard(message.content);
                         setCopiedMessageId(message.id);
                         setTimeout(() => setCopiedMessageId(null), 2000);
                       }}

--- a/apps/screenpipe-app-tauri/lib/hooks/use-copy-to-clipboard.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-copy-to-clipboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { toast } from "@/components/ui/use-toast";
+import { commands } from "@/lib/utils/tauri";
 import * as React from "react";
 
 export interface useCopyToClipboardProps {
@@ -13,7 +14,7 @@ export function useCopyToClipboard({
   const [isCopied, setIsCopied] = React.useState<boolean>(false);
 
   const copyToClipboard = (value: string) => {
-    if (typeof window === "undefined" || !navigator.clipboard?.writeText) {
+    if (typeof window === "undefined") {
       return;
     }
 
@@ -21,7 +22,7 @@ export function useCopyToClipboard({
       return;
     }
 
-    navigator.clipboard.writeText(value).then(() => {
+    commands.copyTextToClipboard(value).then(() => {
       setIsCopied(true);
       toast({
         title: "Copied to clipboard",
@@ -31,6 +32,8 @@ export function useCopyToClipboard({
       setTimeout(() => {
         setIsCopied(false);
       }, timeout);
+    }).catch((error) => {
+      console.error("failed to copy to clipboard:", error);
     });
   };
 


### PR DESCRIPTION
## Description

Replace all usages of `navigator.clipboard.writeText()` with `commands.copyTextToClipboard()` across the Tauri app to ensure clipboard operations work reliably on desktop platforms.

`navigator.clipboard.writeText()` can fail in Tauri/WebKit environments after asynchronous operations due to user-activation restrictions. Using the native Tauri clipboard API provides more consistent cross-platform behavior and prevents clipboard failures in async workflows.
