### PR TITLE
fix: "open note + HD" button now opens the live note

### DIFF
--- a/apps/screenpipe-app-tauri/app/notification-panel/page.tsx
+++ b/apps/screenpipe-app-tauri/app/notification-panel/page.tsx
@@ -168,11 +168,27 @@ export default function NotificationPanelPage() {
             }
             case "api": {
               if (actionObj.url) {
-                await localFetch(actionObj.url, {
+                const res = await localFetch(actionObj.url, {
                   method: actionObj.method || "POST",
                   headers: { "Content-Type": "application/json" },
                   body: actionObj.body ? JSON.stringify(actionObj.body) : undefined,
                 });
+                // "open note + HD": the meeting-start HD action embeds the
+                // live-note deeplink so a single click both starts HD capture
+                // (this api call) and opens the note. Without this the note
+                // never opens — the button only starts HD. Gated on res.ok so
+                // a failed start doesn't navigate. Mirrors the native handler
+                // in components/notification-handler.tsx.
+                const noteUrl = actionObj.deeplinkUrl || actionObj.deeplink_url;
+                if (
+                  res.ok &&
+                  typeof noteUrl === "string" &&
+                  noteUrl.startsWith("screenpipe://")
+                ) {
+                  await commands.showWindowActivated(windowForDeeplink(noteUrl));
+                  await new Promise((r) => setTimeout(r, 150));
+                  await emit("deep-link-received", noteUrl);
+                }
               }
               break;
             }


### PR DESCRIPTION
## what

The meeting-start notification's **"open note + HD"** button starts HD capture but never opens the note. This makes it open the note like it's supposed to.

## why

That action is sent (in `src-tauri/src/meeting_live_notes.rs`) as `type: "api"` (`POST /capture/hd/start`) with the live-note deeplink embedded in `deeplinkUrl` — one click is meant to **both** start HD capture and open the note. The Rust comment even says so:

```rust
// Embed the note deeplink so the click also opens the live note. The JS
// notification handler reads `deeplinkUrl` after the HD start succeeds.
action["deeplinkUrl"] = json!(url);
```

There are two surfaces that render these action buttons:

- **Native macOS notifications** → Rust `native_notif_action_callback_inner` forwards `api` actions to `components/notification-handler.tsx`, which **does** read `deeplinkUrl` and opens the note. ✅
- **In-app webview notification panel** (`app/notification-panel/page.tsx`) → its `"api"` case fired the fetch and **ignored** `deeplinkUrl`. So in the panel the button started HD but the note never opened. ❌

## fix

In the panel's `"api"` case, after the fetch, open the embedded `deeplinkUrl` (gated on `res.ok` so a failed HD start doesn't navigate). This mirrors the existing native handler exactly — same `showWindowActivated` → wait 150ms → `emit("deep-link-received")` sequence used everywhere else for `screenpipe://meeting/...` routing.

The plain **"open note"** button (a `"deeplink"` action) was already routed correctly; only the combined HD button was affected.

## testing

- No unit tests exist for these notification handlers (only heavy Playwright e2e specs), and the logic is tightly coupled to Tauri `emit`/`commands`. The change reuses the exact pattern already proven in the native handler and the panel's own `"deeplink"`/`"meeting_join"` cases.
- Manual: trigger a meeting-start notification → click "open note + HD" → HD capture starts **and** the live note opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)