### PR TITLE
Guard Pi restarts while turns are active

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -358,6 +358,78 @@ pub(crate) struct RpcResponse {
 /// Shared between PiManager (sender side) and the stdout reader thread (resolver side).
 type PendingResponses = Arc<std::sync::Mutex<HashMap<String, oneshot::Sender<RpcResponse>>>>;
 
+fn pi_session_has_in_flight_work(
+    queue_state: Option<&Arc<crate::pi_command_queue::PiQueueState>>,
+    pending_responses: &PendingResponses,
+) -> bool {
+    let pending_rpc = pending_responses
+        .lock()
+        .map(|pending| !pending.is_empty())
+        .unwrap_or(true);
+    pending_rpc || queue_state.map(|state| state.is_busy()).unwrap_or(false)
+}
+
+fn event_tool_call_ids(event: &Value) -> Vec<String> {
+    match event.get("type").and_then(|t| t.as_str()) {
+        Some("tool_execution_start") | Some("tool_execution_end") => event
+            .get("toolCallId")
+            .and_then(|id| id.as_str())
+            .map(|id| vec![id.to_string()])
+            .unwrap_or_default(),
+        Some("message_update") => {
+            let Some(update) = event.get("assistantMessageEvent") else {
+                return Vec::new();
+            };
+            if update.get("type").and_then(|t| t.as_str()) != Some("toolcall_end") {
+                return Vec::new();
+            }
+            update
+                .get("toolCall")
+                .and_then(|tool_call| tool_call.get("id"))
+                .and_then(|id| id.as_str())
+                .map(|id| vec![id.to_string()])
+                .unwrap_or_default()
+        }
+        Some("message_end") => {
+            let Some(message) = event.get("message") else {
+                return Vec::new();
+            };
+            match message.get("role").and_then(|role| role.as_str()) {
+                Some("assistant")
+                    if message.get("stopReason").and_then(|reason| reason.as_str())
+                        == Some("toolUse") =>
+                {
+                    message
+                        .get("content")
+                        .and_then(|content| content.as_array())
+                        .map(|content| {
+                            content
+                                .iter()
+                                .filter(|item| {
+                                    item.get("type").and_then(|t| t.as_str()) == Some("toolCall")
+                                })
+                                .filter_map(|item| {
+                                    item.get("id")
+                                        .or_else(|| item.get("toolCallId"))
+                                        .and_then(|id| id.as_str())
+                                        .map(|id| id.to_string())
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                }
+                Some("toolResult") => message
+                    .get("toolCallId")
+                    .and_then(|id| id.as_str())
+                    .map(|id| vec![id.to_string()])
+                    .unwrap_or_default(),
+                _ => Vec::new(),
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
 #[allow(dead_code)]
 pub struct PiManager {
     child: Option<Child>,
@@ -465,6 +537,10 @@ impl PiManager {
 
     pub fn is_running(&mut self) -> bool {
         self.check_alive()
+    }
+
+    fn has_in_flight_work(&self) -> bool {
+        pi_session_has_in_flight_work(self.queue_state.as_ref(), &self.pending_responses)
     }
 }
 
@@ -1514,6 +1590,16 @@ pub async fn pi_start_inner(
     if let Some(m) = pool.sessions.get_mut(&sid) {
         if m.is_running() {
             let old_pid = m.child.as_ref().map(|c| c.id());
+            if m.has_in_flight_work() {
+                warn!(
+                    "Refusing to restart busy pi instance (pid {:?}) for session '{}'",
+                    old_pid, sid
+                );
+                return Err(format!(
+                    "Pi session '{}' is still working; retry the restart after the current turn finishes",
+                    sid
+                ));
+            }
             info!(
                 "Stopping existing pi instance (pid {:?}) for session '{}' to start new one",
                 old_pid, sid
@@ -2005,7 +2091,7 @@ pub async fn pi_start_inner(
                     }
                     Some("agent_end") => {
                         qs.mark_agent_idle();
-                        qs.signal_done();
+                        qs.signal_done_if_idle();
                     }
                     Some("message_start") => {
                         // Native steer may not emit agent_start — it goes
@@ -2018,12 +2104,57 @@ pub async fn pi_start_inner(
                             qs.clear_steer_in_flight();
                         }
                     }
+                    Some("message_end") => {
+                        if let Some(event) = parsed.as_ref() {
+                            let ids = event_tool_call_ids(event);
+                            let role = event
+                                .get("message")
+                                .and_then(|message| message.get("role"))
+                                .and_then(|role| role.as_str());
+                            match role {
+                                Some("assistant") => {
+                                    for id in ids {
+                                        qs.mark_tool_active(id);
+                                    }
+                                }
+                                Some("toolResult") => {
+                                    for id in ids {
+                                        qs.mark_tool_idle(&id);
+                                    }
+                                    qs.signal_done_if_idle();
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    Some("message_update") => {
+                        if let Some(event) = parsed.as_ref() {
+                            for id in event_tool_call_ids(event) {
+                                qs.mark_tool_active(id);
+                            }
+                        }
+                    }
+                    Some("tool_execution_start") => {
+                        if let Some(event) = parsed.as_ref() {
+                            for id in event_tool_call_ids(event) {
+                                qs.mark_tool_active(id);
+                            }
+                        }
+                    }
+                    Some("tool_execution_end") => {
+                        if let Some(event) = parsed.as_ref() {
+                            for id in event_tool_call_ids(event) {
+                                qs.mark_tool_idle(&id);
+                            }
+                        }
+                        qs.signal_done_if_idle();
+                    }
                     Some("response") => {
                         // Only meaningful for new_session/abort — those don't
                         // fire agent_start/agent_end. Suppress while a prompt
-                        // is mid-stream so the queue never advances on an ACK
-                        // while the assistant is still replying.
-                        if !qs.is_agent_active() {
+                        // or tool is mid-turn so the queue never advances on
+                        // an ACK while the assistant is still working.
+                        if !qs.has_active_turn_work() {
                             // Note: this runs on a std::thread (not tokio),
                             // so use std::thread::spawn + std::thread::sleep.
                             let qs = qs.clone();
@@ -3052,6 +3183,112 @@ mod tests {
     use std::process::{Command, Stdio};
     use std::sync::mpsc;
     use std::time::Duration;
+
+    #[test]
+    fn parses_tool_call_ids_from_pi_events() {
+        let assistant_tool_call = json!({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "stopReason": "toolUse",
+                "content": [
+                    {"type": "text", "text": "checking"},
+                    {"type": "toolCall", "id": "tool-1", "name": "bash"}
+                ]
+            }
+        });
+        assert_eq!(
+            super::event_tool_call_ids(&assistant_tool_call),
+            vec!["tool-1".to_string()]
+        );
+
+        let assistant_tool_update = json!({
+            "type": "message_update",
+            "assistantMessageEvent": {
+                "type": "toolcall_end",
+                "toolCall": {
+                    "type": "toolCall",
+                    "id": "tool-1",
+                    "name": "bash",
+                    "arguments": { "command": "ls" }
+                }
+            }
+        });
+        assert_eq!(
+            super::event_tool_call_ids(&assistant_tool_update),
+            vec!["tool-1".to_string()]
+        );
+
+        let assistant_stop_with_historical_tool = json!({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "stopReason": "stop",
+                "content": [
+                    {"type": "toolCall", "id": "tool-2", "name": "bash"}
+                ]
+            }
+        });
+        assert!(
+            super::event_tool_call_ids(&assistant_stop_with_historical_tool).is_empty()
+        );
+
+        let tool_result = json!({
+            "type": "message_end",
+            "message": {
+                "role": "toolResult",
+                "toolCallId": "tool-1",
+                "content": [{"type": "text", "text": "done"}]
+            }
+        });
+        assert_eq!(
+            super::event_tool_call_ids(&tool_result),
+            vec!["tool-1".to_string()]
+        );
+
+        let tool_end = json!({
+            "type": "tool_execution_end",
+            "toolCallId": "tool-1",
+        });
+        assert_eq!(
+            super::event_tool_call_ids(&tool_end),
+            vec!["tool-1".to_string()]
+        );
+    }
+
+    #[test]
+    fn pi_session_busy_tracks_queue_tools_and_pending_rpc() {
+        let pending: super::PendingResponses =
+            std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let queue_state = crate::pi_command_queue::PiQueueState::new();
+
+        assert!(!super::pi_session_has_in_flight_work(
+            Some(&queue_state),
+            &pending
+        ));
+
+        queue_state.mark_agent_active();
+        assert!(super::pi_session_has_in_flight_work(
+            Some(&queue_state),
+            &pending
+        ));
+        queue_state.mark_agent_idle();
+
+        queue_state.mark_tool_active("tool-1");
+        assert!(super::pi_session_has_in_flight_work(
+            Some(&queue_state),
+            &pending
+        ));
+        queue_state.mark_tool_idle("tool-1");
+        assert!(!super::pi_session_has_in_flight_work(
+            Some(&queue_state),
+            &pending
+        ));
+
+        let (tx, _rx) = tokio::sync::oneshot::channel();
+        pending.lock().unwrap().insert("req_1".to_string(), tx);
+        assert!(super::pi_session_has_in_flight_work(None, &pending));
+    }
 
     fn write_package_json(package_dir: &std::path::Path, name: &str, version: &str) {
         std::fs::create_dir_all(package_dir).expect("create package dir");

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi_command_queue.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi_command_queue.rs
@@ -133,6 +133,11 @@ pub struct PiQueueState {
     /// Prevents the drain loop from writing the next queued prompt during
     /// the brief `agent_end` → `agent_start` transition.
     steer_in_flight: AtomicBool,
+    /// Tool calls that have been requested by the assistant but have not yet
+    /// emitted their matching result. Pi can emit `agent_end` at tool-use
+    /// boundaries, so this keeps Rust from treating the turn as complete while
+    /// the shell/read/edit tool is still running.
+    active_tool_calls: std::sync::Mutex<HashSet<String>>,
 }
 
 impl PiQueueState {
@@ -148,6 +153,7 @@ impl PiQueueState {
             queued_payloads: std::sync::Mutex::new(HashMap::new()),
             agent_active: AtomicBool::new(false),
             steer_in_flight: AtomicBool::new(false),
+            active_tool_calls: std::sync::Mutex::new(HashSet::new()),
         })
     }
 
@@ -191,6 +197,41 @@ impl PiQueueState {
         self.steer_in_flight.load(Ordering::SeqCst)
     }
 
+    pub fn mark_tool_active(&self, tool_call_id: impl Into<String>) {
+        if let Ok(mut active) = self.active_tool_calls.lock() {
+            active.insert(tool_call_id.into());
+        }
+        self.done_notify.notify_waiters();
+    }
+
+    pub fn mark_tool_idle(&self, tool_call_id: &str) {
+        if let Ok(mut active) = self.active_tool_calls.lock() {
+            active.remove(tool_call_id);
+        }
+        self.done_notify.notify_waiters();
+    }
+
+    pub fn has_active_tools(&self) -> bool {
+        self.active_tool_calls
+            .lock()
+            .map(|active| !active.is_empty())
+            .unwrap_or(true)
+    }
+
+    pub fn has_active_turn_work(&self) -> bool {
+        self.is_agent_active() || self.is_steer_in_flight() || self.has_active_tools()
+    }
+
+    pub fn is_busy(&self) -> bool {
+        self.has_active_turn_work() || !self.queued.borrow().is_empty()
+    }
+
+    pub fn signal_done_if_idle(&self) {
+        if !self.has_active_turn_work() {
+            self.signal_done();
+        }
+    }
+
     /// Called by the stdout reader when the process terminates (EOF).
     pub fn signal_terminated(&self) {
         let _ = self.alive.send(false);
@@ -204,6 +245,9 @@ impl PiQueueState {
         }
         if let Ok(mut cancelled) = self.cancelled.lock() {
             cancelled.clear();
+        }
+        if let Ok(mut active_tools) = self.active_tool_calls.lock() {
+            active_tools.clear();
         }
         // Clear the agent-active flag so a future restart doesn't start out
         // in a stuck "active" state if the process died mid-stream.
@@ -538,15 +582,16 @@ pub fn spawn_queue(
                     // before pi-mono actually starts streaming.
                     {
                         let mut died_during_wait = false;
-                        while is_prompt
-                            && (state.is_agent_active() || state.is_steer_in_flight())
-                        {
+                        while is_prompt && state.has_active_turn_work() {
                             // When only steer_in_flight holds us (agent finished
                             // but steer's agent_start hasn't arrived yet), use a
                             // short 30s timeout. If agent_start never fires (Pi
                             // rejected the steer silently), force-clear and let
                             // the queue proceed.
-                            if state.is_steer_in_flight() && !state.is_agent_active() {
+                            if state.is_steer_in_flight()
+                                && !state.is_agent_active()
+                                && !state.has_active_tools()
+                            {
                                 tokio::select! {
                                     _ = state.done_notify.notified() => {}
                                     _ = state.terminated_notify.notified() => {
@@ -982,6 +1027,149 @@ mod tests {
         let _ = child.wait();
     }
 
+    /// Pi can emit `agent_end` when an assistant turn asks for a tool, before
+    /// that tool result exists. The queue must still treat the prompt as
+    /// busy, otherwise a follow-up can race the running shell/read/edit tool.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_active_tool_blocks_drain_loop_after_agent_end() {
+        use std::process::{Command as StdCommand, Stdio};
+
+        let mut child = StdCommand::new("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cat as a fake pi stdin");
+        let stdin = Arc::new(Mutex::new(child.stdin.take().expect("child stdin")));
+
+        let state = PiQueueState::new();
+        let (handle, join) = spawn_queue(stdin, state.clone(), 0);
+
+        state.mark_agent_active();
+        state.mark_tool_active("tool-1");
+        state.mark_agent_idle();
+        state.signal_done_if_idle();
+        assert!(
+            state.has_active_turn_work(),
+            "tool work keeps the turn busy after agent_end"
+        );
+
+        let (_id, mut reply_rx) = handle
+            .send_prompt(
+                json!({ "type": "prompt", "text": "queued-after-tool" }),
+                WaitMode::Prompt,
+                "queued-after-tool".to_string(),
+                true,
+            )
+            .await
+            .expect("enqueue follow-up");
+
+        let blocked =
+            tokio::time::timeout(std::time::Duration::from_millis(300), &mut reply_rx).await;
+        assert!(
+            blocked.is_err(),
+            "follow-up must stay queued while a tool is still running"
+        );
+
+        state.mark_tool_idle("tool-1");
+        state.signal_done_if_idle();
+
+        let released = tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx)
+            .await
+            .expect("follow-up must be released once the tool completes")
+            .expect("reply channel stayed open");
+        assert!(
+            released.is_ok(),
+            "follow-up should be written after the tool finishes, got {released:?}"
+        );
+
+        state.signal_terminated();
+        drop(handle);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), join).await;
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// Reproduces the Rust-level shape behind a Pi restart while a chat turn is
+    /// mid-flight: the active prompt has been written, a follow-up is parked
+    /// behind `agent_active`, then the process is terminated. This is what
+    /// `PiManager::stop()` triggers when `pi_start_inner` restarts the same
+    /// session.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mid_turn_process_termination_fails_queued_followup() {
+        use std::process::{Command as StdCommand, Stdio};
+
+        let mut child = StdCommand::new("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cat as a fake pi stdin");
+        let stdin = Arc::new(Mutex::new(child.stdin.take().expect("child stdin")));
+
+        let state = PiQueueState::new();
+        let (handle, join) = spawn_queue(stdin, state.clone(), 0);
+
+        let (_first_id, first_rx) = handle
+            .send_prompt(
+                json!({ "type": "prompt", "text": "active-turn" }),
+                WaitMode::Prompt,
+                "active-turn".to_string(),
+                true,
+            )
+            .await
+            .expect("enqueue first prompt");
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(5), first_rx)
+            .await
+            .expect("first prompt write should be acknowledged")
+            .expect("first reply channel stayed open");
+        assert!(first.is_ok(), "first prompt should be written, got {first:?}");
+        assert!(
+            state.is_agent_active(),
+            "prompt writes mark the active turn before agent_start arrives"
+        );
+
+        let (_queued_id, mut queued_rx) = handle
+            .send_prompt(
+                json!({ "type": "prompt", "text": "queued-follow-up" }),
+                WaitMode::Prompt,
+                "queued-follow-up".to_string(),
+                true,
+            )
+            .await
+            .expect("enqueue follow-up");
+
+        let blocked =
+            tokio::time::timeout(std::time::Duration::from_millis(300), &mut queued_rx).await;
+        assert!(
+            blocked.is_err(),
+            "follow-up must stay queued while the previous turn is active"
+        );
+
+        state.signal_terminated();
+
+        let queued = tokio::time::timeout(std::time::Duration::from_secs(5), queued_rx)
+            .await
+            .expect("queued prompt should be failed by process termination")
+            .expect("queued reply channel stayed open");
+        assert!(
+            matches!(queued, Err(ref err) if err.contains("Pi process")),
+            "process death while waiting on an active turn loses the queued follow-up: {queued:?}"
+        );
+        assert!(
+            !state.is_agent_active(),
+            "termination clears the active-turn flag for the dead process"
+        );
+
+        drop(handle);
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), join).await;
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
     /// Process death must clear the steer guard. Otherwise a steer that dies
     /// before its `agent_start` arrives would leave `steer_in_flight` set, and
     /// every subsequent queued prompt would eat the full 30s fallback timeout.
@@ -997,6 +1185,19 @@ mod tests {
         assert!(
             !state.is_steer_in_flight(),
             "process termination must clear the in-flight steer guard"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_signal_terminated_clears_active_tools() {
+        let state = PiQueueState::new();
+        state.mark_tool_active("tool-1");
+        assert!(state.has_active_tools(), "tool guard should be set");
+
+        state.signal_terminated();
+        assert!(
+            !state.has_active_tools(),
+            "process termination must clear active tool guards"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the Rust-side cause of the Pi agent stopping mid-turn: `pi_start_inner` no longer kills an existing same-session Pi process while that session still has active queue/RPC/tool work.
- Tracks active Pi tool calls in `PiQueueState`, so `agent_end` at a tool-use boundary does not release queued prompts before the tool result arrives.
- Clears active tool guards on process termination and adds Rust unit coverage for the mid-turn termination failure shape.

## Why this is Rust-level, not TS-level
The observed failure is a live Pi process being stopped while a tool call is still running. A frontend finalizer can hide the spinner or synthesize an error, but it cannot preserve the running shell/read/edit tool or the queued follow-up after Rust kills the Pi child process. This patch makes Rust treat tool-use boundaries as in-flight work and refuses unsafe same-session restarts.

## Tests
- `cargo fmt --all`
- `cargo test pi_command_queue::tests:: -- --nocapture`
- `cargo test pi::tests:: -- --nocapture`
- `cargo test --bin screenpipe-app -- --nocapture`
  - Pi-related tests passed inside the full binary run.
  - Full binary currently has unrelated existing failures: `skills::tests::validate_repo_rejects_junk`, `specta_bindings::tests::tauri_bindings_are_current`.
  - `health::tests::wait_for_boot_ready_observes_transition_to_ready` failed once in the full run but passed when rerun directly.
- `cargo test health::tests::wait_for_boot_ready_observes_transition_to_ready -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --exclude screenpipe-rfdetr-mlx --exclude screenpipe-screen --exclude screenpipe-audio --all-targets -- -W clippy::all`
  - Passed with existing warnings in unrelated crates.
