### PR TITLE
fix(chat): clear, retryable copy when the cloud gateway is unreachable

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -32,9 +32,45 @@ describe("provider error copy", () => {
     expect(msg).toContain("ollama pull llama3.2");
   });
 
-  it("does not rewrite cloud provider connection errors", () => {
+  it("maps screenpipe cloud connection errors to a transient-outage message", () => {
+    const msg = buildProviderErrorMessage("Connection error.", {
+      provider: "screenpipe-cloud",
+      model: "auto",
+    });
+
+    expect(msg).toContain("screenpipe cloud");
+    expect(msg?.toLowerCase()).toContain("try again");
+    // does not blame the user's own machine/setup
+    expect(msg?.toLowerCase()).not.toContain("ollama");
+  });
+
+  it("maps the gateway TLS-handshake / send-request signatures the same way", () => {
+    // exact strings observed reaching the app during the 2026-06-18 outage
+    for (const raw of [
+      "tls handshake eof",
+      "error sending request for url (https://api.screenpipe.com/v1/chat/completions)",
+    ]) {
+      expect(
+        buildProviderErrorMessage(raw, { provider: "screenpipe-cloud", model: "auto" })
+      ).toContain("screenpipe cloud");
+    }
+  });
+
+  it("gives a generic connectivity message for other remote providers", () => {
     expect(
-      buildProviderErrorMessage("Connection error.", {
+      buildProviderErrorMessage("Connection error.", { provider: "anthropic", model: "claude-opus-4-8" })
+    ).toContain("anthropic");
+    expect(
+      buildProviderErrorMessage("Connection error.", { provider: "custom", model: "x" })
+    ).toContain("Can't reach the AI provider");
+  });
+
+  it("leaves non-connection cloud errors untouched (quota/auth handled elsewhere)", () => {
+    expect(
+      buildProviderErrorMessage("model_not_allowed", { provider: "screenpipe-cloud", model: "auto" })
+    ).toBeNull();
+    expect(
+      buildProviderErrorMessage('{"resets_at":"2026-06-19T00:00:00Z"}', {
         provider: "screenpipe-cloud",
         model: "auto",
       })

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -77,6 +77,53 @@ describe("provider error copy", () => {
     ).toBeNull();
   });
 
+  // --- no-regression guard: these strings are handled by dedicated branches at
+  // the call sites (5xx server error, already-processing race, model upgrade,
+  // generic). buildProviderErrorMessage MUST keep returning null for them so it
+  // does not shadow those branches now that it returns non-null for non-ollama.
+  it.each([
+    ["500 Internal server error", "screenpipe-cloud"],
+    ["api_error: something blew up", "screenpipe-cloud"],
+    ["504 Gateway Timeout", "screenpipe-cloud"], // 'Timeout' (one word) != 'timed out'
+    ["403 model_not_allowed", "screenpipe-cloud"],
+    ["agent is already processing a request", "screenpipe-cloud"],
+    ["The AI returned an empty response", "openai"],
+    ["", "anthropic"],
+    ["", "native-ollama"],
+  ])("returns null for non-connection error %j (provider %s)", (raw, provider) => {
+    expect(buildProviderErrorMessage(raw, { provider, model: "auto" })).toBeNull();
+  });
+
+  it("names every remote provider in its connectivity copy", () => {
+    for (const provider of ["openai", "openai-chatgpt", "anthropic"]) {
+      expect(
+        buildProviderErrorMessage("fetch failed", { provider, model: "m" })
+      ).toContain(`(${provider})`);
+    }
+    // custom + unknown/undefined fall back to an unnamed, still-clear message
+    expect(buildProviderErrorMessage("fetch failed", { provider: "custom" })).toBe(
+      "Can't reach the AI provider. Check your internet connection and try again."
+    );
+    expect(buildProviderErrorMessage("fetch failed", null)).toBe(
+      "Can't reach the AI provider. Check your internet connection and try again."
+    );
+  });
+
+  it("is case-insensitive on the gateway signatures", () => {
+    expect(
+      buildProviderErrorMessage("TLS HANDSHAKE EOF", { provider: "screenpipe-cloud" })
+    ).toContain("screenpipe cloud");
+  });
+
+  it("does not regress ollama copy now that other providers are handled", () => {
+    expect(
+      buildProviderErrorMessage("Connection error.", { provider: "native-ollama", model: "gemma4:31b" })
+    ).toContain("Cannot connect to Ollama");
+    expect(
+      buildProviderErrorMessage("model not found", { provider: "native-ollama", model: "llama3.2" })
+    ).toContain("ollama pull llama3.2");
+  });
+
   it("keeps the generic no-response copy for non-Ollama providers", () => {
     expect(buildNoResponseMessage({ provider: "screenpipe-cloud" })).toContain(
       "No response from model"

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -42,25 +42,67 @@ function isConnectionLikeError(errorStr: string): boolean {
     normalized.includes("failed to fetch") ||
     normalized.includes("fetch failed") ||
     normalized.includes("econnrefused") ||
-    normalized.includes("connection refused")
+    normalized.includes("connection refused") ||
+    // network/TLS signatures seen reaching the chat from the gateway, e.g. the
+    // 2026-06-18 outage: reqwest "error sending request" / "tls handshake eof".
+    normalized.includes("error sending request") ||
+    normalized.includes("tls handshake") ||
+    normalized.includes("unexpected eof") ||
+    normalized.includes("unexpectedeof") ||
+    normalized.includes("could not connect") ||
+    normalized.includes("unable to connect") ||
+    normalized.includes("connect error") ||
+    normalized.includes("network error") ||
+    normalized.includes("dns error") ||
+    normalized.includes("enotfound") ||
+    normalized.includes("etimedout") ||
+    normalized.includes("timed out")
   );
+}
+
+export function isHostedScreenpipeProvider(provider?: string | null): boolean {
+  // screenpipe's own hosted gateway (default chat preset + the Pi agent both
+  // route through api.screenpipe.com). A connection failure here is on us,
+  // not the user's machine.
+  return provider === "screenpipe-cloud" || provider === "pi";
+}
+
+export function buildCloudConnectionMessage(): string {
+  return "Can't reach screenpipe cloud right now — this is usually a brief outage on our end, not your setup. Wait a few seconds and try again.";
+}
+
+export function buildRemoteConnectionMessage(provider?: string | null): string {
+  const named = provider && provider !== "custom" ? ` (${provider})` : "";
+  return `Can't reach the AI provider${named}. Check your internet connection and try again.`;
 }
 
 export function buildProviderErrorMessage(
   errorStr: string,
   preset?: ProviderLike | null
 ): string | null {
-  if (!isNativeOllamaProvider(preset?.provider)) return null;
-
+  const provider = preset?.provider;
   const model = preset?.model || undefined;
   const normalized = errorStr.toLowerCase();
-  if (normalized.includes("not found")) {
-    return model
-      ? buildOllamaModelMissingMessage(model)
-      : "The selected Ollama model was not found. Check your AI preset in settings.";
+
+  if (isNativeOllamaProvider(provider)) {
+    if (normalized.includes("not found")) {
+      return model
+        ? buildOllamaModelMissingMessage(model)
+        : "The selected Ollama model was not found. Check your AI preset in settings.";
+    }
+    if (isConnectionLikeError(errorStr)) {
+      return buildOllamaConnectionMessage(model);
+    }
+    return null;
   }
+
+  // Hosted/remote providers: a connection-like failure means we never reached
+  // the gateway (TLS dropped, DNS, offline). The raw "Connection error." reads
+  // like the app is broken — surface a clearer, retryable message instead.
   if (isConnectionLikeError(errorStr)) {
-    return buildOllamaConnectionMessage(model);
+    return isHostedScreenpipeProvider(provider)
+      ? buildCloudConnectionMessage()
+      : buildRemoteConnectionMessage(provider);
   }
 
   return null;


### PR DESCRIPTION
## what

When `api.screenpipe.com` is briefly unreachable, the chat showed a bare **`Error: Connection error.`** — which reads like the app itself is broken rather than a transient cloud hiccup.

This maps connection-like failures to clearer, **retryable** copy depending on the provider:

- **screenpipe-cloud / pi** (the default chat preset + Pi agent, both routed through the hosted gateway):
  > Can't reach screenpipe cloud right now — this is usually a brief outage on our end, not your setup. Wait a few seconds and try again.
- **other remote providers** (openai / anthropic / custom): generic *"Can't reach the AI provider… check your internet connection and try again."*
- **native-ollama**: unchanged.

Every existing call site already attaches a **retry button** when `buildProviderErrorMessage` returns non-null, so users get a one-click retry for free.

## why

Two users (Windows + macOS, both on v2.5.50) sent feedback within minutes of each other during a ~15-minute window on 2026-06-18 where the hosted gateway was failing at the **TLS handshake** level. The errors hitting the app were `tls handshake eof` / `error sending request` against `api.screenpipe.com`, affecting chat, the model gateway, and audio transcription simultaneously — i.e. a server-side incident, not the users' machines. The gateway recovered on its own, but the only thing the users saw was an opaque "Connection error."

## changes

- `lib/chat/provider-errors.ts`
  - `buildProviderErrorMessage` now handles **all** providers (previously returned `null` for everything except native-ollama, letting the raw string through).
  - new exported helpers: `isHostedScreenpipeProvider`, `buildCloudConnectionMessage`, `buildRemoteConnectionMessage`.
  - broadened `isConnectionLikeError` to catch the real signatures observed in the logs: `tls handshake`, `error sending request`, `unexpected eof`, dns/timeout, `could not connect`, etc.
- non-connection errors (quota / `model_not_allowed` / auth) still return `null` and are handled by their existing dedicated branches — verified by tests.

## test

`bunx vitest run lib/chat` → **78 passed**, incl. new cases for the cloud transient-outage message, the exact TLS/send-request signatures from the outage, the generic remote-provider path, and a guard that quota/auth errors are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)