### PR TITLE
feat(timeline): preview a frame thumbnail when hovering the bottom track

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -19,7 +19,7 @@ import { type TemplatePipe } from "@/lib/hooks/use-pipes";
 import { AppContextPopover } from "./app-context-popover";
 import { TimelineTagToolbar } from "./timeline-tag-toolbar";
 import { extractDomain, FaviconImg } from "./favicon-utils";
-import { localFetch } from "@/lib/api";
+import { localFetch, getApiBaseUrl } from "@/lib/api";
 
 // Global cache: preloads app-icon images so they render instantly on scroll.
 // Maps app name → "loaded" | "error" | Promise (in-flight).
@@ -1789,6 +1789,21 @@ export const TimelineSlider = ({
 														transform: "translate(-50%, -100%) translateY(-8px)",
 													}}
 												>
+													{/* Frame thumbnail preview — fetched lazily from the local API on hover */}
+													{frameId && (
+														<div className="mb-2 w-64 aspect-video rounded-md overflow-hidden bg-muted border border-border/40">
+															{/* eslint-disable-next-line @next/next/no-img-element */}
+															<img
+																src={`${getApiBaseUrl()}/frames/${frameId}`}
+																alt="frame preview"
+																className="w-full h-full object-cover select-none"
+																loading="lazy"
+																draggable={false}
+																data-lm-disable="true"
+																onError={(e) => { e.currentTarget.style.display = "none"; }}
+															/>
+														</div>
+													)}
 													<div className="flex items-center gap-2 mb-1">
 														{(() => {
 															// Use frame's own browser_url, or fall back to group's top domain


### PR DESCRIPTION
## what

hovering the timeline scrubber (the line at the bottom of rewind) already pops a tooltip with app / time / audio / ui-events — but it never shows the actual frame. so you can't tell *what* a moment was without clicking into it.

this adds a lazy-loaded thumbnail of the hovered frame to the top of that same tooltip, so you can skim the bottom line and preview frames without committing a click.

![timeline hover thumbnail](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/timeline-hover-thumbnail/timeline-thumbnail-preview.png)

_illustrative mockup — fabricated placeholder data, not a real capture (repo is public). the real ui reuses the existing popover styling exactly._

## how

- one block added to the existing hover tooltip in `apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx`
- thumbnail `src` = `${getApiBaseUrl()}/frames/:id` — the same local endpoint the main viewer and search results already render
- only renders when the frame has a `frame_id`; `onError` hides the `<img>` so a missing frame never shows a broken-image icon
- `loading="lazy"`, `draggable={false}`, `data-lm-disable="true"` to match the rest of the frame imagery
- no new state and no new fetch path — purely presentation on the tooltip that was already mounting on hover

## test plan

- [ ] open rewind, hover bars along the bottom track → a thumbnail of that frame shows above the cursor
- [ ] the previewed thumbnail matches the frame you land on when you click
- [ ] hover a frame whose image is missing/unreadable → tooltip still renders, no broken image
- [x] `bunx tsc --noEmit` clean (ran locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
