### PR TITLE
fix: Screenpipe Cloud transcription fallback for paid Basic users

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -105,6 +105,7 @@ import {
   useSettings,
   Settings,
 } from "@/lib/hooks/use-settings";
+import { hasAppEntitlement } from "@/lib/app-entitlement";
 import { useToast } from "@/components/ui/use-toast";
 import { useHealthCheck } from "@/lib/hooks/use-health-check";
 import { localFetch } from "@/lib/api";
@@ -229,7 +230,7 @@ const getAudioEngineResolution = (
     };
   }
 
-  if (requested === "screenpipe-cloud" && !settings.user?.cloud_subscribed) {
+  if (requested === "screenpipe-cloud" && !hasAppEntitlement(settings.user as any)) {
     return {
       requested,
       active: fallback,
@@ -1892,10 +1893,13 @@ export function RecordingSettings() {
       settings.audioTranscriptionEngine,
       settings.deepgramApiKey,
       settings.user?.cloud_subscribed,
+      settings.user?.app_entitled,
+      settings.user?.entitlement,
       settings.user?.id,
       settings.user?.token,
     ]
   );
+  const hasCloudTranscriptionAccess = hasAppEntitlement(settings.user as any);
   const languageSupportEngine = audioEngineResolution.active;
   const languageSupportKey =
     getTranscriptionEngineLanguageSupportKey(languageSupportEngine);
@@ -2302,7 +2306,7 @@ export function RecordingSettings() {
     }
 
     // If trying to use cloud but not subscribed
-    if (value === "screenpipe-cloud" && !settings.user?.cloud_subscribed) {
+    if (value === "screenpipe-cloud" && !hasCloudTranscriptionAccess) {
       try {
         const response = await fetch("https://screenpipe.com/api/cloud-sync/checkout", {
           method: "POST",
@@ -2719,8 +2723,8 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                   <SelectContent>
                     <SelectGroup>
                       <SelectLabel className="text-[10px] text-muted-foreground/70 uppercase tracking-wider">cloud</SelectLabel>
-                      <SelectItem value="screenpipe-cloud" disabled={!settings.user?.cloud_subscribed}>
-                        Screenpipe Cloud {!settings.user?.cloud_subscribed && "(pro)"}{hwCapability?.recommendedEngine === "screenpipe-cloud" && " ★"}
+                      <SelectItem value="screenpipe-cloud" disabled={!hasCloudTranscriptionAccess}>
+                        Screenpipe Cloud {!hasCloudTranscriptionAccess && "(pro)"}{hwCapability?.recommendedEngine === "screenpipe-cloud" && " ★"}
                       </SelectItem>
                       <SelectItem value="deepgram">Deepgram</SelectItem>
                     </SelectGroup>

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1510,6 +1510,29 @@ impl SettingsStore {
         entitlement_checked_recently(entitlement) && entitlement_active(entitlement)
     }
 
+    fn cloud_transcription_entitled(&self) -> bool {
+        // Legacy cloud subscribers keep working during the paid-plan rollout.
+        if self.user.cloud_subscribed == Some(true) {
+            return true;
+        }
+
+        let Some(entitlement) = self.user.entitlement.as_ref() else {
+            return false;
+        };
+
+        let has_app_feature =
+            self.user.app_entitled == Some(true) || entitlement_feature(entitlement, "app");
+        if !has_app_feature {
+            return false;
+        }
+
+        if entitlement_is_lifetime(entitlement) || entitlement_has_future_grace(entitlement) {
+            return true;
+        }
+
+        entitlement_checked_recently(entitlement) && entitlement_active(entitlement)
+    }
+
     pub fn audio_engine_resolution(&self) -> AudioEngineResolution {
         let engine = self.recording.audio_transcription_engine.clone();
         let has_cloud_auth = self
@@ -1518,7 +1541,7 @@ impl SettingsStore {
             .as_ref()
             .map_or(false, |token| !token.is_empty())
             || self.user.id.as_ref().map_or(false, |id| !id.is_empty());
-        let is_subscribed = self.user.cloud_subscribed == Some(true);
+        let is_subscribed = self.cloud_transcription_entitled();
         let has_deepgram_key = !self.recording.deepgram_api_key.is_empty()
             && self.recording.deepgram_api_key != "default";
         let fallback = "whisper-large-v3-turbo-quantized".to_string();
@@ -1922,6 +1945,28 @@ mod tests {
             resolution.fallback_reason,
             Some(AudioEngineFallbackReason::NotSubscribed)
         );
+    }
+
+    #[test]
+    fn screenpipe_cloud_stays_active_for_app_entitled_users() {
+        let mut store = SettingsStore::default();
+        store.recording.audio_transcription_engine = "screenpipe-cloud".to_string();
+        store.user.token = Some("token".to_string());
+        store.user.cloud_subscribed = Some(false);
+        store.user.app_entitled = Some(true);
+        store.user.subscription_plan = Some("standard".to_string());
+        store.user.entitlement = Some(json!({
+            "active": true,
+            "plan": "standard",
+            "source": "subscription",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "features": { "app": true, "cloud": false }
+        }));
+
+        let resolution = store.audio_engine_resolution();
+
+        assert_eq!(resolution.active, "screenpipe-cloud");
+        assert_eq!(resolution.fallback_reason, None);
     }
 
     #[test]


### PR DESCRIPTION
### Description:    
Fixes #4345 

- tests passing:

<img width="1115" height="407" alt="image" src="https://github.com/user-attachments/assets/3469a925-3450-45fa-993b-69a2b4136bdd" />

<img width="1122" height="367" alt="image" src="https://github.com/user-attachments/assets/b827b3a1-220a-42c1-8158-ddd2ed24c035" />



- Fixed the user feedback on discord.
- Fixes Screenpipe Cloud transcription fallback for paid Basic users.   
- Uses app entitlement instead of cloud_subscribed for transcription access checks.   
- Keeps Business/cloud-sync gating separate from cloud transcription gating.   
- Adds regression coverage for Basic users with cloud_subscribed: false.