### PR TITLE
fix(connections): route local AI preset connection tests securely through Rust backend

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -172,9 +172,17 @@ const tauriBackendFetch = async (
       throw new Error(res.error);
     }
     const resText = res.data;
+    // The Rust backend returns only the body text (no headers). Sniff SSE so
+    // the diagnostics' content-type check can detect a streamed response.
+    const looksLikeSse = /(^|\n)\s*data:/.test(resText);
+    const contentType = looksLikeSse ? "text/event-stream" : "application/json";
     return {
       ok: true,
       status: 200,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? contentType : null,
+      },
       json: async () => JSON.parse(resText),
       text: async () => resText,
       clone: function () {
@@ -185,6 +193,9 @@ const tauriBackendFetch = async (
     return {
       ok: false,
       status: 500,
+      headers: {
+        get: (_name: string) => null,
+      },
       text: async () => String(err?.message || err),
       json: async () => {
         throw new Error(String(err?.message || err));
@@ -733,9 +744,11 @@ const AISection = ({
       }));
     } else {
       // Local custom providers often do not implement browser CORS preflight on /models.
+      // Route local URLs (loopback, private IP, .local) through the Rust backend,
+      // matching the chat + fetchModels paths — tauriFetch can't reach them.
       const modelsFetchFn =
         settingsPreset?.provider === "custom" && isLocalhostUrl(settingsPreset?.url)
-          ? tauriFetch
+          ? tauriBackendFetch
           : fetch;
       try {
         modelsResponse = await modelsFetchFn(modelsUrl, {

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -136,9 +136,63 @@ const isLocalhostUrl = (url?: string): boolean => {
   if (!url) return false;
   try {
     const hostname = new URL(url).hostname.toLowerCase();
-    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
+    // mDNS/Bonjour .local domains resolve to local addresses (RFC 6762)
+    if (hostname.endsWith(".local")) return true;
+    // Private IP ranges: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
+    if (/^10\.\d+\.\d+\.\d+$/.test(hostname)) return true;
+    if (/^172\.(1[6-9]|2[0-9]|3[01])\.\d+\.\d+$/.test(hostname)) return true;
+    if (/^192\.168\.\d+\.\d+$/.test(hostname)) return true;
+    return false;
   } catch {
     return false;
+  }
+};
+
+const tauriBackendFetch = async (
+  url: string,
+  options?: RequestInit
+): Promise<Response> => {
+  try {
+    const headers: Record<string, string> = {};
+    if (options?.headers) {
+      const h = options.headers as Record<string, string>;
+      Object.keys(h).forEach((key) => {
+        headers[key] = h[key];
+      });
+    }
+    const bodyVal = options?.body ? JSON.parse(options.body as string) : null;
+    const res = await commands.testAiEndpoint(
+      url,
+      options?.method || "GET",
+      headers,
+      bodyVal
+    );
+    if (res.status === "error") {
+      throw new Error(res.error);
+    }
+    const resText = res.data;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => JSON.parse(resText),
+      text: async () => resText,
+      clone: function () {
+        return this;
+      },
+    } as unknown as Response;
+  } catch (err: any) {
+    return {
+      ok: false,
+      status: 500,
+      text: async () => String(err?.message || err),
+      json: async () => {
+        throw new Error(String(err?.message || err));
+      },
+      clone: function () {
+        return this;
+      },
+    } as unknown as Response;
   }
 };
 
@@ -816,8 +870,12 @@ const AISection = ({
       chatHeaders["OpenAI-Beta"] = "responses=experimental";
     }
 
-    // Use tauriFetch for chatgpt.com and Anthropic to bypass CORS
-    const fetchFn = (isChatGpt || isAnthropic) ? tauriFetch : fetch;
+    // Use tauriFetch for chatgpt.com and Anthropic to bypass CORS, and tauriBackendFetch for local URLs
+    const fetchFn = (isChatGpt || isAnthropic)
+      ? tauriFetch
+      : isLocalhostUrl(chatUrl)
+      ? tauriBackendFetch
+      : fetch;
 
     const chatStart = performance.now();
     try {
@@ -955,7 +1013,7 @@ const AISection = ({
           break;
         case "custom":
           try {
-            const customFetchFn = isLocalhostUrl(settingsPreset?.url) ? tauriFetch : fetch;
+            const customFetchFn = isLocalhostUrl(settingsPreset?.url) ? tauriBackendFetch : fetch;
             const customResponse = await customFetchFn(
               `${settingsPreset?.url}/models`,
               {

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -5,6 +5,14 @@
 
 
 export const commands = {
+async testAiEndpoint(url: string, method: string, headers: Record<string, string>, body: any | null) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("test_ai_endpoint", { url, method, headers, body }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Frontend-callable gate. The banner awaits this before calling
  * `downloadAndInstall` (Windows: triggers process::exit internally) or

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -3524,3 +3524,93 @@ pub fn set_autostart(app_handle: tauri::AppHandle, enabled: bool) -> Result<(), 
     );
     Ok(())
 }
+
+fn is_safe_ai_url(url_str: &str) -> bool {
+    let parsed = match url::Url::parse(url_str) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    
+    let host = match parsed.host_str() {
+        Some(h) => h.to_lowercase(),
+        None => return false,
+    };
+    
+    // Allow known public AI providers
+    if host == "api.openai.com" 
+        || host == "api.anthropic.com" 
+        || host == "api.screenpipe.com" 
+        || host == "api.screenpi.pe"
+    {
+        return true;
+    }
+    
+    if host == "localhost" || host.ends_with(".local") {
+        return true;
+    }
+    
+    // Check if host is an IP address
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        match ip {
+            std::net::IpAddr::V4(ipv4) => {
+                ipv4.is_loopback() || ipv4.is_private()
+            }
+            std::net::IpAddr::V6(ipv6) => {
+                ipv6.is_loopback() 
+                    || (ipv6.segments()[0] & 0xfe00) == 0xfc00 // ULA
+                    || (ipv6.segments()[0] & 0xffc0) == 0xfe80 // Link-Local
+            }
+        }
+    } else {
+        false
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn test_ai_endpoint(
+    url: String,
+    method: String,
+    headers: std::collections::HashMap<String, String>,
+    body: Option<serde_json::Value>,
+) -> Result<String, String> {
+    if !is_safe_ai_url(&url) {
+        return Err("URL is blocked for security (only loopback, private IP ranges, .local, or official AI providers allowed)".to_string());
+    }
+
+    let client = reqwest::Client::new();
+    let mut req = match method.to_uppercase().as_str() {
+        "POST" => client.post(&url),
+        "GET" => client.get(&url),
+        _ => return Err("unsupported method".to_string()),
+    };
+
+    for (k, v) in headers {
+        if let Ok(hk) = reqwest::header::HeaderName::from_bytes(k.as_bytes()) {
+            if let Ok(hv) = reqwest::header::HeaderValue::from_str(&v) {
+                req = req.header(hk, hv);
+            }
+        }
+    }
+
+    if let Some(b) = body {
+        req = req.json(&b);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("connection failed: {}", e))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("failed to read response: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!("HTTP error {}: {}", status.as_u16(), text));
+    }
+
+    Ok(text)
+}


### PR DESCRIPTION
Fixes #3928. Supersedes #3929 and #4211.

## Problem
Testing custom presets on local private IPs (like `192.168.0.51:20128`) failed with CORS because they used browser `fetch()` instead of `tauriFetch`.
However, because `tauri-plugin-http` uses the WHATWG URLPattern matcher (which cannot express subnet ranges like `192.168.*` or `10.*`), the only way to allow custom ports on local networks was to open up the capability scope to `http://*:*/*` system-wide. This was closed/rejected due to the broad SSRF security vulnerability.

## Solution
Perform loopback and private IP diagnostics connection tests natively in Rust (using `reqwest`) rather than exposing broad wildcard HTTP capabilities in the Tauri webview scope.

1. **Rust Backend Check** — Introduces a secure `test_ai_endpoint` Tauri command in `commands.rs` that uses `reqwest` to fetch loopbacks, private IP ranges, `.local` domains, and known public AI APIs. Public external target ranges are strictly blocked to prevent SSRF from custom webviews.
2. **Frontend Router** — Routes local connection tests and model list queries through `tauriBackendFetch` (which invokes `test_ai_endpoint`) if `isLocalhostUrl` is true.
3. **Restricts capability scopes** — Eliminates the need for any broad `http://*:*/*` or `https://*:*/*` wildcards inside `capabilities/main.json`.

Verified that typecheck passes.
