### PR TITLE
[pr] activity-summary lean mode: include_apps/windows/key_texts toggles

### DIFF
--- a/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
+++ b/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
@@ -35,6 +35,8 @@ curl -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" "http://localhost:3030
 
 Required: `start_time`, `end_time`. Optional: `app_name`, `q` (filters memories+snippets, drives `query_status`), `include_recording|memories|snippets|guidance=false` (each defaults true — disable to slim), `max_snippets` (8/12), `max_snippet_chars` (500/1200), `max_memories` (5/20).
 
+For a lean, token-cheap time-tracking sweep across many ranges, also drop the heavy always-on fields: `include_key_texts=false` (the biggest single win — omits the text-heavy `key_texts`), plus `include_apps=false` / `include_windows=false`. Each defaults true and, when false, omits that field entirely; `total_active_minutes` + per-app/window `minutes` + the status triple still come back. e.g. minutes-only: `&include_key_texts=false&include_windows=false`.
+
 `data_status` ∈ `ok|empty_but_recording|no_capture_in_range|not_recording`. Check before claiming "no activity". `query_status` ∈ `not_requested|matched|no_query_matches`. `guidance.next_best_query` is a ready-to-show hint when empty. Escalate to `/search` only for verbatim quotes / frame_ids.
 
 ---

--- a/crates/screenpipe-engine/src/routes/activity_summary.rs
+++ b/crates/screenpipe-engine/src/routes/activity_summary.rs
@@ -54,6 +54,21 @@ pub struct ActivitySummaryQuery {
     #[serde(default)]
     pub q: Option<String>,
 
+    /// Include per-app usage (`apps`). Default: true. Disable for a leaner,
+    /// token-cheaper payload when you only need totals or other fields.
+    #[serde(default = "default_true")]
+    pub include_apps: bool,
+    /// Include per-window/tab activity (`windows`). Default: true. Disable to
+    /// drop the window list from the response.
+    #[serde(default = "default_true")]
+    pub include_windows: bool,
+    /// Include sampled screen text (`key_texts`). Default: true. This is the
+    /// heaviest field; disable it (`include_key_texts=false`) for pure
+    /// time-tracking sweeps to cut response tokens substantially. Snippets are
+    /// unaffected — they still sample screen text internally.
+    #[serde(default = "default_true")]
+    pub include_key_texts: bool,
+
     /// Include recording health (last frame/audio timestamps, counts, recent
     /// capture flag). Default: true. Disable to skip one cheap SQL call.
     #[serde(default = "default_true")]
@@ -201,11 +216,17 @@ pub struct ActivityGuidance {
 #[derive(Serialize, OaSchema)]
 pub struct ActivitySummaryResponse {
     // --- existing fields (stable schema for Receipts panel + AI summary) ---
-    pub apps: Vec<AppUsage>,
-    /// Distinct windows/tabs visited with time spent (grouped by app+window)
-    pub windows: Vec<WindowActivity>,
-    /// Key text content sampled across the time range (not just the latest frame)
-    pub key_texts: Vec<KeyText>,
+    /// Per-app usage. Omitted when `include_apps=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apps: Option<Vec<AppUsage>>,
+    /// Distinct windows/tabs visited with time spent (grouped by app+window).
+    /// Omitted when `include_windows=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub windows: Option<Vec<WindowActivity>>,
+    /// Key text content sampled across the time range (not just the latest
+    /// frame). This is the heaviest field; omitted when `include_key_texts=false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_texts: Option<Vec<KeyText>>,
     /// Distinct absolute file paths the user had open in editors during the
     /// time range (sourced from `frames.document_path`, populated on macOS
     /// via AXDocument). Empty on Windows/Linux until those platforms grow
@@ -251,6 +272,9 @@ pub struct ActivitySummaryResponse {
 ///
 /// Pass `include_recording=false`, `include_memories=false`,
 /// `include_snippets=false`, or `include_guidance=false` to slim the payload.
+/// For a lean, token-cheap time-tracking sweep also pass `include_apps=false`,
+/// `include_windows=false`, and especially `include_key_texts=false` (the
+/// heaviest field) — each omits its field from the response when disabled.
 #[oasgen]
 pub async fn get_activity_summary(
     State(state): State<Arc<AppState>>,
@@ -325,9 +349,9 @@ pub async fn get_activity_summary(
     };
 
     Ok(JsonResponse(ActivitySummaryResponse {
-        apps: summary_core.apps,
-        windows: summary_core.windows,
-        key_texts: summary_core.key_texts,
+        apps: query.include_apps.then_some(summary_core.apps),
+        windows: query.include_windows.then_some(summary_core.windows),
+        key_texts: query.include_key_texts.then_some(summary_core.key_texts),
         edited_files: summary_core.edited_files,
         audio_summary: summary_core.audio_summary,
         total_frames: summary_core.total_frames,
@@ -1296,6 +1320,9 @@ mod tests {
             end_time: Utc::now(),
             app_name: None,
             q: None,
+            include_apps: true,
+            include_windows: true,
+            include_key_texts: true,
             include_recording: true,
             include_memories: true,
             include_snippets: true,
@@ -1442,6 +1469,9 @@ mod db_tests {
             end_time: "2026-06-02T23:59:59Z".parse().unwrap(),
             app_name: app.map(|s| s.to_string()),
             q: None,
+            include_apps: true,
+            include_windows: true,
+            include_key_texts: true,
             include_recording: true,
             include_memories: false,
             include_snippets: false,
@@ -1954,5 +1984,168 @@ mod db_tests {
             core.total_active_minutes
         );
         assert!(near(app_min(&core, "Arc").unwrap(), 0.5));
+    }
+}
+
+#[cfg(test)]
+mod include_flag_tests {
+    //! Unit tests for the lean-mode `include_apps` / `include_windows` /
+    //! `include_key_texts` toggles. These gate the heavy always-on fields the
+    //! same way the existing `include_recording/memories/snippets/guidance`
+    //! flags gate their fields: when false the field is set to `None` and the
+    //! `skip_serializing_if = "Option::is_none"` attribute drops it from the
+    //! serialized JSON entirely. We test the response serialization (not the
+    //! SQL) because that is exactly the new behavior.
+    use super::*;
+
+    fn sample_response(
+        include_apps: bool,
+        include_windows: bool,
+        include_key_texts: bool,
+    ) -> ActivitySummaryResponse {
+        let apps = vec![AppUsage {
+            name: "Arc".to_string(),
+            frame_count: 3,
+            minutes: 1.0,
+            first_seen: "2026-06-02T10:00:00Z".to_string(),
+            last_seen: "2026-06-02T10:01:00Z".to_string(),
+        }];
+        let windows = vec![WindowActivity {
+            app_name: "Arc".to_string(),
+            window_name: "GitHub".to_string(),
+            browser_url: String::new(),
+            minutes: 1.0,
+            frame_count: 3,
+        }];
+        let key_texts = vec![KeyText {
+            text: "some sampled screen text".to_string(),
+            app_name: "Arc".to_string(),
+            window_name: "GitHub".to_string(),
+            timestamp: "2026-06-02T10:00:30Z".to_string(),
+        }];
+        ActivitySummaryResponse {
+            apps: include_apps.then_some(apps),
+            windows: include_windows.then_some(windows),
+            key_texts: include_key_texts.then_some(key_texts),
+            edited_files: vec![],
+            audio_summary: AudioSummary {
+                segment_count: 0,
+                speakers: vec![],
+                top_transcriptions: vec![],
+            },
+            total_frames: 3,
+            total_active_minutes: 1.0,
+            time_range: TimeRange {
+                start: "2026-06-02T10:00:00Z".to_string(),
+                end: "2026-06-02T11:00:00Z".to_string(),
+            },
+            data_status: "ok".to_string(),
+            query_status: "not_requested".to_string(),
+            recording: None,
+            memories: None,
+            snippets: None,
+            guidance: None,
+        }
+    }
+
+    fn to_json(r: &ActivitySummaryResponse) -> Value {
+        serde_json::to_value(r).expect("serialize response")
+    }
+
+    /// Defaults (all three on) preserve the current full output: every heavy
+    /// field is present, and the always-present totals/status stay put.
+    #[test]
+    fn defaults_keep_all_heavy_fields() {
+        let j = to_json(&sample_response(true, true, true));
+        assert!(j.get("apps").is_some(), "apps must be present by default");
+        assert!(
+            j.get("windows").is_some(),
+            "windows must be present by default"
+        );
+        assert!(
+            j.get("key_texts").is_some(),
+            "key_texts must be present by default"
+        );
+        // Stable always-present fields are unaffected.
+        assert_eq!(j["total_frames"], 3);
+        assert_eq!(j["total_active_minutes"], 1.0);
+        assert_eq!(j["data_status"], "ok");
+    }
+
+    /// The headline lean-mode case: `include_key_texts=false` omits the
+    /// heaviest field while leaving everything else intact.
+    #[test]
+    fn key_texts_false_omits_only_key_texts() {
+        let j = to_json(&sample_response(true, true, false));
+        assert!(
+            j.get("key_texts").is_none(),
+            "key_texts must be omitted when include_key_texts=false"
+        );
+        assert!(j.get("apps").is_some(), "apps unaffected");
+        assert!(j.get("windows").is_some(), "windows unaffected");
+        assert_eq!(j["total_active_minutes"], 1.0);
+    }
+
+    #[test]
+    fn apps_false_omits_only_apps() {
+        let j = to_json(&sample_response(false, true, true));
+        assert!(j.get("apps").is_none(), "apps must be omitted");
+        assert!(j.get("windows").is_some(), "windows unaffected");
+        assert!(j.get("key_texts").is_some(), "key_texts unaffected");
+    }
+
+    #[test]
+    fn windows_false_omits_only_windows() {
+        let j = to_json(&sample_response(true, false, true));
+        assert!(j.get("windows").is_none(), "windows must be omitted");
+        assert!(j.get("apps").is_some(), "apps unaffected");
+        assert!(j.get("key_texts").is_some(), "key_texts unaffected");
+    }
+
+    /// Fully lean sweep: all three heavy fields off, totals/status still there.
+    #[test]
+    fn all_three_false_leaves_lean_payload() {
+        let j = to_json(&sample_response(false, false, false));
+        assert!(j.get("apps").is_none());
+        assert!(j.get("windows").is_none());
+        assert!(j.get("key_texts").is_none());
+        // The whole point: the cheap time-tracking signal survives.
+        assert_eq!(j["total_active_minutes"], 1.0);
+        assert_eq!(j["total_frames"], 3);
+        assert_eq!(j["data_status"], "ok");
+    }
+
+    /// Parse a query string through axum's real `Query` extractor — the exact
+    /// path the live handler uses — so we test deserialization, not a hand-built
+    /// struct.
+    fn parse_query(qs: &str) -> ActivitySummaryQuery {
+        let uri: axum::http::Uri = format!("http://x/activity-summary?{qs}")
+            .parse()
+            .expect("uri");
+        axum::extract::Query::<ActivitySummaryQuery>::try_from_uri(&uri)
+            .expect("parse query")
+            .0
+    }
+
+    /// The three new flags default to `true` when absent from the query string,
+    /// preserving back-compat for callers that pass no params.
+    #[test]
+    fn new_flags_default_to_true() {
+        let q = parse_query("start_time=2026-06-02T10:00:00Z&end_time=2026-06-02T11:00:00Z");
+        assert!(q.include_apps);
+        assert!(q.include_windows);
+        assert!(q.include_key_texts);
+    }
+
+    /// Each flag is parsed independently from the query string.
+    #[test]
+    fn flags_parse_independently() {
+        let q = parse_query(
+            "start_time=2026-06-02T10:00:00Z&end_time=2026-06-02T11:00:00Z\
+             &include_key_texts=false",
+        );
+        assert!(q.include_apps, "include_apps stays default-true");
+        assert!(q.include_windows, "include_windows stays default-true");
+        assert!(!q.include_key_texts, "include_key_texts honored as false");
     }
 }


### PR DESCRIPTION
## description

Adds three additive `include_*` toggles to `GET /activity-summary` so a pure time-tracking sweep can drop the heavy always-on fields and run token-cheap. This mirrors the existing `include_recording|memories|snippets|guidance=false` pattern already on this endpoint and the `format=outline` cost-reduction work from #4287.

New query params (all default `true`, so zero behavior change when unset):

- `include_key_texts` — omits the text-heavy `key_texts` field (the biggest single token win)
- `include_apps` — omits the per-app `apps` rollup
- `include_windows` — omits the per-window/tab `windows` rollup

When a flag is `false`, that field is omitted from the response entirely (via `Option<Vec<…>>` + `serde(skip_serializing_if = "Option::is_none")`), exactly like the existing `recording`/`memories`/`snippets`/`guidance` fields. `total_active_minutes`, per-app/window `minutes` (when those fields are kept), and the `data_status`/`query_status`/`guidance` triple are unaffected — so a minutes-only sweep still gets the "where did time go" answer.

Naming note: the issue title floats `include_texts`; I named the flag `include_key_texts` so it matches the response field it gates (`key_texts`) one-to-one, consistent with how every other flag on this endpoint is named after its field.

Scope: this PR delivers the three field toggles + the required unit tests + the `screenpipe-api` SKILL.md update. The issue's *optional* extras (a single `lean=true` shortcut, `include_audio=false`) are explicitly "consider"/"optional" in the acceptance list — deferred to keep this PR one concern. The required `include_key_texts=false` drop is delivered.

related issue: #4294

## before

`GET /activity-summary` always carries `apps`, `windows`, and the text-heavy `key_texts` — no way to omit them. A dozens-of-ranges hour-by-hour sweep pays for `key_texts` on every range even when it only wanted minutes-per-app.

```jsonc
// GET /activity-summary?start_time=...&end_time=...  (no way to slim the heavy fields)
{
  "apps": [{ "name": "Arc", "minutes": 1.0, "frame_count": 3, "first_seen": "…", "last_seen": "…" }],
  "windows": [{ "app_name": "Arc", "window_name": "GitHub", "browser_url": "", "minutes": 1.0, "frame_count": 3 }],
  "key_texts": [ /* many text-heavy entries — always present */ ],
  "edited_files": [],
  "audio_summary": { "segment_count": 0, "speakers": [], "top_transcriptions": [] },
  "total_frames": 3,
  "total_active_minutes": 1.0,
  "time_range": { "start": "…", "end": "…" },
  "data_status": "ok",
  "query_status": "not_requested"
}
```

## after

Lean sweep — `?…&include_key_texts=false&include_windows=false&include_apps=false`:

```jsonc
{
  // apps / windows / key_texts all omitted
  "edited_files": [],
  "audio_summary": { "segment_count": 0, "speakers": [], "top_transcriptions": [] },
  "total_frames": 3,
  "total_active_minutes": 1.0,   // the time-tracking signal survives
  "time_range": { "start": "…", "end": "…" },
  "data_status": "ok",
  "query_status": "not_requested"
}
```

Just dropping the heaviest field — `?…&include_key_texts=false` — keeps apps + windows for an apps/windows/minutes rollup with no text payload.

No frontend change needed: the only TS consumer of these fields already uses optional chaining (`context?.activity?.windows?.some(...)`), and defaults keep every field present anyway.

## how to test

1. Build/run the engine, then a full (default) call — confirm `apps`, `windows`, `key_texts` are all present:
   ```bash
   curl -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" \
     "http://localhost:3030/activity-summary?start_time=1h%20ago&end_time=now" | jq 'keys'
   ```
2. Lean call — confirm the three heavy fields are gone but `total_active_minutes` + status remain:
   ```bash
   curl -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" \
     "http://localhost:3030/activity-summary?start_time=1h%20ago&end_time=now&include_apps=false&include_windows=false&include_key_texts=false" \
     | jq '{has_apps: has("apps"), has_windows: has("windows"), has_key_texts: has("key_texts"), total_active_minutes, data_status}'
   # => has_apps:false, has_windows:false, has_key_texts:false, total_active_minutes: <n>, data_status:"ok"
   ```
3. Drop only the heaviest field — `&include_key_texts=false` alone — and confirm `apps`/`windows` still come back.
4. Unit tests:
   ```bash
   cargo test -p screenpipe-engine --lib routes::activity_summary
   ```

## desktop app checklist (if applicable)

Not applicable. `/activity-summary` is a plain REST route (`#[oasgen]`), not a `#[tauri::command]`, and no Rust type exported to the frontend changed. No `tauri.ts` bindings are affected.
