### PR TITLE
fix(overlay): pin option to keep timeline overlay open on focus loss (#4293)

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -405,6 +405,8 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 		// Window mode is a small movable window; cursor is often "outside" vs fullscreen
 		// monitor bounds, which incorrectly fired closeWindow and unregistered Escape.
 		if (settings?.overlayMode === "window") return;
+		// Pinned overlay (#4293): don't auto-close when the cursor leaves the monitor.
+		if (settings?.overlayPinned) return;
 		let initialScreenBounds: { x: number; y: number; width: number; height: number } | null = null;
 		let checkInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -459,7 +461,7 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 				clearInterval(checkInterval);
 			}
 		};
-	}, [embedded, settings?.overlayMode]);
+	}, [embedded, settings?.overlayMode, settings?.overlayPinned]);
 
 	// Helper to navigate to a timestamp
 	const navigateToTimestamp = useCallback(async (targetTimestamp: string) => {

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline-controls.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline-controls.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight, ChevronDown, RefreshCw, CalendarIcon, Search, Play, Pause, Loader2, Mic, Volume2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, RefreshCw, CalendarIcon, Search, Play, Pause, Loader2, Mic, Volume2, Pin, PinOff } from "lucide-react";
 import {
 	format,
 	isAfter,
@@ -76,7 +76,7 @@ export function TimelineControls({
 	onToggleDeviceMute,
 }: TimelineControlsProps) {
 	const { isMac } = usePlatform();
-	const { settings } = useSettings();
+	const { settings, updateSettings } = useSettings();
 	const [calendarOpen, setCalendarOpen] = useState(false);
 
 	// Set of "YYYY-MM-DD" local-day strings that have at least one frame.
@@ -297,6 +297,25 @@ export function TimelineControls({
 							</>
 						)}
 					</div>
+				)}
+
+				{/* Pin overlay (#4293): keep the frame visible on focus loss instead
+				    of auto-hiding. Only relevant for the floating overlay, not embedded. */}
+				{!embedded && (
+					<Button
+						variant="ghost"
+						size="icon"
+						onClick={() => updateSettings({ overlayPinned: !settings.overlayPinned })}
+						className={`h-10 w-10 bg-background border border-border transition-colors duration-150 ${
+							settings.overlayPinned
+								? "bg-foreground text-background hover:bg-foreground/90"
+								: "text-foreground hover:bg-foreground hover:text-background"
+						}`}
+						title={settings.overlayPinned ? "Unpin overlay (auto-hide on focus loss)" : "Pin overlay (keep open while you work elsewhere)"}
+						aria-pressed={settings.overlayPinned}
+					>
+						{settings.overlayPinned ? <Pin className="h-4 w-4" /> : <PinOff className="h-4 w-4" />}
+					</Button>
 				)}
 
 				{onSearchClick && (

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -625,6 +625,7 @@ let DEFAULT_SETTINGS: Settings = {
 				historyEnabled: true,
 			},
 			overlayMode: "fullscreen",
+			overlayPinned: false,
 			showOverlayInScreenRecording: false,
 			disableTimeline: false,
 			videoQuality: "balanced",

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -2946,6 +2946,12 @@ overlayMode?: string;
  */
 showOverlayInScreenRecording?: boolean;
 /**
+ * When true, the timeline overlay (fullscreen panel mode) stays open on focus
+ * loss instead of auto-hiding, so a frame can be kept visible while the user
+ * works in another app/window. Default false preserves the auto-hide. See #4293.
+ */
+overlayPinned?: boolean;
+/**
  * When true, the chat window stays above all other windows (default: true).
  */
 chatAlwaysOnTop?: boolean;

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -848,6 +848,11 @@ pub struct SettingsStore {
     /// Disabled by default so the overlay doesn't appear in screenpipe's own recordings.
     #[serde(rename = "showOverlayInScreenRecording", default)]
     pub show_overlay_in_screen_recording: bool,
+    /// When true, the timeline overlay (fullscreen panel mode) stays open on focus
+    /// loss instead of auto-hiding, so a frame can be kept visible while the user
+    /// works in another app/window. Default false preserves the auto-hide. See #4293.
+    #[serde(rename = "overlayPinned", default)]
+    pub overlay_pinned: bool,
 
     // NOTE: `disableTimeline` lives on the flattened `recording`
     // (`RecordingSettings::disable_timeline`) so the engine can read it too. The
@@ -1290,6 +1295,7 @@ Rules:
             #[cfg(not(target_os = "macos"))]
             overlay_mode: "window".to_string(),
             show_overlay_in_screen_recording: false,
+            overlay_pinned: false,
             chat_always_on_top: true,
             show_restart_notifications: false,
             #[cfg(target_os = "macos")]

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -829,6 +829,18 @@ impl ShowRewindWindow {
                         match event {
                             tauri::WindowEvent::Focused(is_focused) => {
                                 if !is_focused {
+                                    // Pinned overlay (#4293): keep the panel visible on
+                                    // focus loss so the user can reference a frame while
+                                    // working in another app. Re-read each blur so toggling
+                                    // the pin while the overlay is open takes effect live.
+                                    let pinned = SettingsStore::get(&app_clone)
+                                        .ok()
+                                        .flatten()
+                                        .map(|s| s.overlay_pinned)
+                                        .unwrap_or(false);
+                                    if pinned {
+                                        return;
+                                    }
                                     // Synchronous alpha=0 — no order_out (which
                                     // causes focus-fight loops when restored).
                                     #[cfg(target_os = "macos")]
@@ -1229,6 +1241,18 @@ impl ShowRewindWindow {
                         #[cfg(not(target_os = "linux"))]
                         tauri::WindowEvent::Focused(is_focused) => {
                             if !is_focused {
+                                // Pinned overlay (#4293): keep the panel visible on focus
+                                // loss so the user can reference a frame while working in
+                                // another app. Re-read each blur so toggling pin while the
+                                // overlay is open takes effect live.
+                                let pinned = SettingsStore::get(&app_clone)
+                                    .ok()
+                                    .flatten()
+                                    .map(|s| s.overlay_pinned)
+                                    .unwrap_or(false);
+                                if pinned {
+                                    return;
+                                }
                                 info!("Main window lost focus, scheduling hide (300ms debounce)");
                                 // Synchronous alpha=0 — panel stays in window list
                                 // but is invisible. No order_out (causes focus loops).


### PR DESCRIPTION
## Summary
Fixes #4293. The timeline/screenshot overlay auto-hides the moment it loses focus, so a user can't keep a captured frame visible while typing what they see into another app or window.

This adds an **opt-in `overlayPinned` setting** (default `false`, so existing auto-hide behavior is unchanged) plus a **Pin toggle** in the overlay controls. When pinned, the overlay stays visible on focus loss.

## Root cause
There are **two** macOS focus-loss hide handlers in `window/show.rs` — one for **window** overlay mode and one for **fullscreen** overlay mode — plus a separate **multi-monitor cursor-leave** handler in `timeline.tsx`. All three need to respect the pin, or the overlay still vanishes (the fullscreen handler is the one that runs by default).

## Changes
- **`store.rs`** — add `overlayPinned` to `SettingsStore` (default `false`).
- **`window/show.rs`** — guard *both* `WindowEvent::Focused(false)` hide handlers (window + fullscreen modes); re-reads the setting on each blur so toggling takes effect live.
- **`timeline.tsx`** — the cursor-leaves-monitor auto-close path also respects pin (covers multi-monitor).
- **`timeline-controls.tsx`** — a `Pin`/`PinOff` toggle button in the overlay control bar.
- **`use-settings.tsx` + `tauri.ts`** — default value + regenerated bindings.


Default-off, so zero behavior change unless a user enables the pin. Note: this branch is based on a slightly older `main` (2.5.45) and may need a rebase.
