### PR TITLE
fix: support streaming chat diagnostics

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -819,6 +819,7 @@ const AISection = ({
     // Use tauriFetch for chatgpt.com and Anthropic to bypass CORS
     const fetchFn = (isChatGpt || isAnthropic) ? tauriFetch : fetch;
 
+    let isStreaming = false;
     const chatStart = performance.now();
     try {
       let chatResponse = await fetchFn(chatUrl, {
@@ -847,6 +848,29 @@ const AISection = ({
             signal: abort.signal,
           });
         }
+
+        // Some OpenAI-compatible servers only accept stream_options when
+        // stream=true, so retry the diagnostics request in streaming mode.
+        const updatedErrText = chatResponse.ok ? "" : await chatResponse.clone().text().catch(() => "");
+        const checkText = updatedErrText || errText;
+        if (!chatResponse.ok && (checkText.toLowerCase().includes("stream_options") || checkText.toLowerCase().includes("stream = true"))) {
+          isStreaming = true;
+          const retryBody = {
+            ...buildChatTestBody(
+              settingsPreset?.model || "",
+              "say hi",
+              50,
+              checkText.toLowerCase().includes("max_completion_tokens") ? "max_completion_tokens" : "max_tokens"
+            ),
+            stream: true,
+          };
+          chatResponse = await fetchFn(chatUrl, {
+            method: "POST",
+            headers: chatHeaders,
+            body: JSON.stringify(retryBody),
+            signal: abort.signal,
+          });
+        }
       }
 
       const latencyMs = Math.round(performance.now() - chatStart);
@@ -866,15 +890,32 @@ const AISection = ({
       }
 
       let reply: string;
-      if (isChatGpt) {
+      if (isChatGpt || isStreaming) {
         // Streaming SSE — just confirm we got a 200 response
         reply = "Stream started OK";
       } else if (isAnthropic) {
-        const chatData = await chatResponse.json();
-        reply = chatData.content?.[0]?.text?.slice(0, 100) || "No response";
+        const chatResponseClone = chatResponse.clone();
+        try {
+          const chatData = await chatResponse.json();
+          reply = chatData.content?.[0]?.text?.slice(0, 100) || "No response";
+        } catch {
+          const text = await chatResponseClone.text().catch(() => "");
+          reply = text.slice(0, 100) || "Text response";
+        }
       } else {
-        const chatData = await chatResponse.json();
-        reply = chatData.choices?.[0]?.message?.content?.slice(0, 100) || "No response";
+        const contentType = chatResponse.headers.get("content-type") || "";
+        if (contentType.includes("event-stream")) {
+          reply = "Stream started OK";
+        } else {
+          const chatResponseClone = chatResponse.clone();
+          try {
+            const chatData = await chatResponse.json();
+            reply = chatData.choices?.[0]?.message?.content?.slice(0, 100) || "No response";
+          } catch {
+            const text = await chatResponseClone.text().catch(() => "");
+            reply = text.slice(0, 100) || "Text response";
+          }
+        }
       }
 
       if (abort.signal.aborted) return;


### PR DESCRIPTION
## Summary

Improves custom preset chat diagnostics for OpenAI-compatible endpoints that respond with streaming semantics.

## Changes

- retry the custom preset chat diagnostics request with `stream: true` when an endpoint rejects `stream_options` unless streaming is enabled
- treat successful `text/event-stream` chat responses as a passing diagnostics result instead of trying to parse SSE chunks as JSON
- fall back to plain text if JSON parsing fails for chat diagnostics responses
- keep the change scoped to chat diagnostics only; this PR does not include the private-IP / `.local` CORS handling or capability scope changes from #4333

## Why

Some OpenAI-compatible endpoints behave differently during the diagnostics test:

- some reject `stream_options` unless `stream=true`
- some immediately return SSE from `/chat/completions` even on the generic OpenAI-compatible path

Before this fix, the first case failed without retrying, and the second case failed with errors like `Unexpected identifier "data"` because Screenpipe tried to parse streamed chunks as JSON.

## Testing

- verified the endpoint at `http://192.168.0.51:20128/v1` returns SSE from `/chat/completions`, which matches the reported `Unexpected identifier "data"` failure mode


<img width="953" height="821" alt="image" src="https://github.com/user-attachments/assets/ba86331a-38d5-40bf-93a0-6e00e71872d7" />
