### PR TITLE
fix(browser): hide native webview behind modals

### DIFF
--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -325,11 +325,14 @@ export function BrowserSidebar({
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
-    const hasOpenDialog = () =>
-      document.querySelectorAll("[role='dialog']").length > 0;
+    // Only target full-page modal dialogs (with backdrop overlay), not small
+    // popovers or dropdown menus. Our DialogOverlay and AlertDialogOverlay
+    // components add data-modal-overlay; popovers/dropdowns don't have one.
+    const hasModalOverlay = () =>
+      document.querySelectorAll("[data-modal-overlay]").length > 0;
 
     const sync = () => {
-      const open = hasOpenDialog();
+      const open = hasModalOverlay();
       if (open && !dialogActiveRef.current) {
         dialogActiveRef.current = true;
         commands.ownedBrowserHide().catch(() => {});
@@ -340,7 +343,7 @@ export function BrowserSidebar({
     };
 
     const observer = new MutationObserver(sync);
-    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ["role", "data-state"] });
+    observer.observe(document.body, { childList: true, subtree: true });
     // Check initial state in case a dialog is already open.
     sync();
 

--- a/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/browser-sidebar.tsx
@@ -191,6 +191,8 @@ export function BrowserSidebar({
   const boundsRafRef = useRef<number | null>(null);
   /** True while the cookie-consent card is up — pushBounds must not re-show the native webview. */
   const sessionAccessActiveRef = useRef(false);
+  /** True while any Radix dialog/modal is open — pushBounds must not re-show the native webview. */
+  const dialogActiveRef = useRef(false);
   const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(
     null,
   );
@@ -260,8 +262,9 @@ export function BrowserSidebar({
     const el = placeholderRef.current;
     if (!el) return;
     // Native child webviews sit above HTML — never position/show while the
-    // session-access card is visible (ResizeObserver races with hide()).
-    if (sessionAccessActiveRef.current) {
+    // session-access card or any dialog/modal is visible (the native webview
+    // would cover the HTML overlay otherwise).
+    if (sessionAccessActiveRef.current || dialogActiveRef.current) {
       await commands.ownedBrowserHide().catch(() => {});
       return;
     }
@@ -315,6 +318,34 @@ export function BrowserSidebar({
       commands.ownedBrowserHide().catch(() => {});
     };
   }, []);
+
+  // ---------------------------------------------------------------------------
+  // Dialog/modal detection — hide the native webview when any Radix dialog is
+  // open, otherwise it covers the HTML overlay.
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    const hasOpenDialog = () =>
+      document.querySelectorAll("[role='dialog']").length > 0;
+
+    const sync = () => {
+      const open = hasOpenDialog();
+      if (open && !dialogActiveRef.current) {
+        dialogActiveRef.current = true;
+        commands.ownedBrowserHide().catch(() => {});
+      } else if (!open && dialogActiveRef.current) {
+        dialogActiveRef.current = false;
+        schedulePushBounds();
+      }
+    };
+
+    const observer = new MutationObserver(sync);
+    observer.observe(document.body, { childList: true, subtree: true, attributes: true, attributeFilter: ["role", "data-state"] });
+    // Check initial state in case a dialog is already open.
+    sync();
+
+    return () => observer.disconnect();
+  }, [schedulePushBounds]);
 
   // ---------------------------------------------------------------------------
   // Viewport resize tracking — drives both the JS clamp and re-pushing bounds

--- a/apps/screenpipe-app-tauri/components/ui/alert-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/alert-dialog.tsx
@@ -16,6 +16,7 @@ const AlertDialogOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
+    data-modal-overlay=""
     className={cn(
       "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className

--- a/apps/screenpipe-app-tauri/components/ui/dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/dialog.tsx
@@ -25,6 +25,7 @@ const DialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     ref={ref}
+    data-modal-overlay=""
     className={cn(
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className


### PR DESCRIPTION
This PR fixes Browser sidebar (native Tauri webview) rendering on top of delete chat modal, rename chat modal, AI preset selector modal and on top of all other Radix dialogs, modals.

## Before
- Opening any modal while browser sidebar is active -> browser stays on top, blocking interaction


<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/8e245044-fd85-4f36-b859-24102d6e6814" />
<img width="1198" height="763" alt="image" src="https://github.com/user-attachments/assets/01e79f8d-c473-460b-b338-727a1a2f8a53" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/0442a181-cb89-4526-9b29-d660313b6cfb" />


## After
- Opening any modal while browser sidebar is active -> native webview hides, modal is fully visible and interactive
- Dismissing the modal -> browser sidebar reappears in correct position


https://github.com/user-attachments/assets/aae84873-644c-442f-b404-b701466f0b84

https://github.com/user-attachments/assets/10505326-a71e-43d1-9249-6558517cdd55


