### PR TITLE
fix(engine): /raw_sql returns 400 (not 500) on bad SQL + stop rejecting bounded aggregates

### DIFF
--- a/crates/screenpipe-engine/src/routes/content.rs
+++ b/crates/screenpipe-engine/src/routes/content.rs
@@ -566,6 +566,29 @@ const MAX_SQL_LIMIT: u64 = 10_000;
 
 /// Validate a raw SQL query before execution to prevent unbounded result sets.
 /// Returns Ok(()) if the query is safe to execute, or Err with a helpful message.
+/// True if `upper` (an upper-cased SQL string) calls a SQL aggregate function
+/// as a real token — not as a substring of an identifier such as `ACCOUNT(`.
+fn contains_aggregate(upper: &str) -> bool {
+    const AGGREGATES: [&str; 7] = [
+        "COUNT(",
+        "SUM(",
+        "AVG(",
+        "MIN(",
+        "MAX(",
+        "TOTAL(",
+        "GROUP_CONCAT(",
+    ];
+    AGGREGATES.iter().any(|agg| {
+        upper.match_indices(agg).any(|(idx, _)| {
+            if idx == 0 {
+                return true;
+            }
+            let prev = upper.as_bytes()[idx - 1];
+            !prev.is_ascii_alphanumeric() && prev != b'_'
+        })
+    })
+}
+
 fn validate_raw_sql(query: &str) -> Result<(), String> {
     let normalized = query
         .lines()
@@ -588,8 +611,16 @@ fn validate_raw_sql(query: &str) -> Result<(), String> {
         );
     }
 
-    // Check for LIMIT clause
-    if !upper.contains("LIMIT") {
+    // EXPLAIN queries and single-row aggregations (COUNT/MAX/… with no GROUP BY)
+    // are inherently bounded, so don't force a LIMIT on them. The chat agent is
+    // explicitly told to prefer aggregate queries for counts/stats, and
+    // rejecting a bare `SELECT COUNT(*) FROM frames` for a missing LIMIT just
+    // burns a turn making it re-issue the same query with a pointless LIMIT.
+    let is_explain = trimmed.starts_with("EXPLAIN");
+    let bounded_aggregate = !upper.contains(" GROUP BY ") && contains_aggregate(&upper);
+
+    // Check for LIMIT clause on row-returning queries
+    if !upper.contains("LIMIT") && !is_explain && !bounded_aggregate {
         return Err(format!(
             "Query rejected: SELECT without LIMIT. Add 'LIMIT n' (max {}) to your query. \
              Example: SELECT * FROM frames WHERE timestamp > '2024-01-01' LIMIT 100",
@@ -632,6 +663,16 @@ pub(crate) async fn execute_raw_sql(
 
     match state.db.execute_raw_sql(&payload.query).await {
         Ok(result) => Ok(JsonResponse(result)),
+        // A database-level error means SQLite rejected the *query* itself —
+        // unknown table/column, syntax error, etc. That's a caller mistake, not
+        // a server fault, so return 400 with the underlying message. This lets
+        // the chat agent see "I wrote bad SQL" and self-correct, instead of
+        // reading a 500 as an outage and giving up after burning turns. Reserve
+        // 500 for genuine infrastructure failures (pool timeout, IO, …).
+        Err(e @ sqlx::Error::Database(_)) => Err((
+            StatusCode::BAD_REQUEST,
+            JsonResponse(json!({"error": e.to_string()})),
+        )),
         Err(e) => {
             error!("Failed to execute raw SQL query: {}", e);
             Err((
@@ -672,5 +713,63 @@ pub(crate) async fn validate_media_handler(
             StatusCode::EXPECTATION_FAILED,
             Json(json!({"status": e.to_string()})),
         )),
+    }
+}
+
+#[cfg(test)]
+mod raw_sql_validation_tests {
+    use super::{contains_aggregate, validate_raw_sql};
+
+    #[test]
+    fn rejects_row_query_without_limit() {
+        assert!(validate_raw_sql("SELECT * FROM frames").is_err());
+        assert!(validate_raw_sql("SELECT id, name FROM frames WHERE id > 5").is_err());
+    }
+
+    #[test]
+    fn allows_row_query_with_limit() {
+        assert!(validate_raw_sql("SELECT * FROM frames LIMIT 10").is_ok());
+    }
+
+    #[test]
+    fn allows_bounded_aggregate_without_limit() {
+        // The chat prompt tells the agent to prefer COUNT/aggregate queries;
+        // these collapse to a single row, so a LIMIT must not be required.
+        assert!(validate_raw_sql("SELECT COUNT(*) FROM frames").is_ok());
+        assert!(validate_raw_sql("SELECT COUNT(*) AS n FROM frames").is_ok());
+        assert!(validate_raw_sql("SELECT MAX(timestamp), MIN(timestamp) FROM frames").is_ok());
+    }
+
+    #[test]
+    fn still_requires_limit_for_group_by() {
+        // GROUP BY can return many rows — keep requiring a LIMIT there.
+        assert!(
+            validate_raw_sql("SELECT app_name, COUNT(*) FROM frames GROUP BY app_name").is_err()
+        );
+    }
+
+    #[test]
+    fn allows_explain_without_limit() {
+        assert!(validate_raw_sql("EXPLAIN QUERY PLAN SELECT * FROM frames").is_ok());
+    }
+
+    #[test]
+    fn blocks_writes() {
+        assert!(validate_raw_sql("DELETE FROM frames").is_err());
+        assert!(validate_raw_sql("UPDATE frames SET app_name = 'x' LIMIT 1").is_err());
+        assert!(validate_raw_sql("INSERT INTO frames VALUES (1)").is_err());
+    }
+
+    #[test]
+    fn enforces_max_limit() {
+        assert!(validate_raw_sql("SELECT * FROM frames LIMIT 999999").is_err());
+    }
+
+    #[test]
+    fn aggregate_detection_respects_word_boundaries() {
+        // ACCOUNT( must not be mistaken for COUNT(.
+        assert!(!contains_aggregate("SELECT ACCOUNT(X) FROM T"));
+        assert!(contains_aggregate("SELECT COUNT(*) FROM T"));
+        assert!(contains_aggregate("SELECT SUM(DURATION) FROM T"));
     }
 }


### PR DESCRIPTION
## Why

The built-in chat agent uses `/raw_sql` heavily to query screen/audio data. Two behaviors in that endpoint made it flail — issuing many failed queries and reporting "couldn't find it" even when the data was present (surfaced from a power-user support thread + reproduced against a live local server):

1. **Agent's own SQL mistakes returned `500`.** A wrong/renamed table (e.g. the retired `ocr_text`), a bad column, or a syntax error all came back as `500 INTERNAL_SERVER_ERROR`. The agent can't distinguish that from "the server is down," so it gives up instead of fixing its SQL.
2. **Valid aggregations were rejected.** `SELECT COUNT(*) FROM frames` returned `400 "SELECT without LIMIT"` — even though the chat system prompt explicitly tells the model to *prefer* `COUNT`/`GROUP BY` for aggregation. The server punished the agent for following its own instructions.

## What changed (`crates/screenpipe-engine/src/routes/content.rs`)

- `execute_raw_sql`: a `sqlx::Error::Database(_)` (SQLite rejecting the query itself) now returns **`400`** with the underlying message so the caller can self-correct. `500` is reserved for genuine infra failures (pool timeout, IO).
- `validate_raw_sql`: single-row aggregations (`COUNT`/`SUM`/`AVG`/`MIN`/`MAX`/`TOTAL`/`GROUP_CONCAT` with **no** `GROUP BY`) and `EXPLAIN` are exempt from the LIMIT requirement. `GROUP BY` still requires a `LIMIT` (can be unbounded). Aggregate detection respects word boundaries so `ACCOUNT(` is not mistaken for `COUNT(`.

## Reproduced before / after

| Query | Before | After |
|---|---|---|
| `SELECT text FROM ocr_text LIMIT 1` (retired table) | `500` | `400` + `no such table: ocr_text` |
| `SELECT bogus_col FROM frames LIMIT 1` | `500` | `400` + `no such column: bogus_col` |
| `SELECT COUNT(*) FROM frames` | `400` rejected | `200` |
| `SELECT * FROM frames LIMIT 10` | `200` | `200` (unchanged) |
| `DELETE FROM frames` | rejected | rejected (unchanged) |

## Tests

Adds 8 unit tests (`raw_sql_validation_tests`): LIMIT still enforced on row queries, bounded aggregates/EXPLAIN exempt, `GROUP BY` still requires LIMIT, writes blocked, max-LIMIT ceiling, and word-boundary aggregate detection. `cargo test -p screenpipe-engine --lib` → 8/8 pass, clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Companion change — chat system prompt (`apps/screenpipe-app-tauri/lib/chat/system-prompt.ts`)

Pairs with the server fix so the agent uses the clearer signals:
- A **400** from `/raw_sql` now means *the SQL was wrong* — the prompt tells the agent to read the error and retry, not report "no data".
- Notes that a bare aggregate (`SELECT COUNT(*) …`) needs no `LIMIT`.
- Adds the **real schema** (verified against a live DB) so it stops guessing the retired `ocr_text` table: screen text is `frames.full_text`, audio is `audio_transcriptions.transcription`, UI elements are `elements`.