### PR TITLE
fix(chat): steer agent off retired ocr_text + treat /raw_sql 400 as fixable SQL

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -75,7 +75,8 @@ The local screenpipe server (localhost:3030) requires a bearer token, exposed as
 3. limit=5–10 per call. Never >50.
 4. Cap at 10 search/API calls per user request, then summarize what you have.
 5. Multi-day queries: one day at a time.
-6. Prefer /raw_sql with COUNT/GROUP BY for aggregation over fetching raw rows. SELECT queries must include LIMIT (max 10000).
+6. /raw_sql: prefer COUNT/GROUP BY for aggregation over fetching raw rows. Row-returning SELECTs need LIMIT (max 10000); a bare aggregate like \`SELECT COUNT(*) FROM frames\` does not. A 400 means your SQL was wrong (bad table/column/syntax) — read the error and fix it, don't report "no data".
+7. SQL schema (only when raw_sql is actually needed): screen text is \`frames.full_text\` (other cols: app_name, window_name, browser_url, timestamp, text_source) — there is NO \`ocr_text\` table; audio is \`audio_transcriptions.transcription\` (timestamp, speaker_id, start_time); UI elements are \`elements\` (role, text, source).
 
 # Showing media
 


### PR DESCRIPTION
Follow-up to #4352 (the `/raw_sql` 400-vs-500 + bounded-aggregate fix, already merged). That PR merged before this companion prompt change landed, so opening it separately.

## What

Updates the chat system prompt (`apps/screenpipe-app-tauri/lib/chat/system-prompt.ts`) so the agent uses the clearer server signals from #4352:

- A **400** from `/raw_sql` now means *your SQL was wrong* (bad table/column/syntax) — read the error and retry, don't report "no data".
- A bare aggregate like `SELECT COUNT(*) FROM frames` needs **no** `LIMIT`.
- Adds the **real schema** (verified against a live DB) so the agent stops guessing the **retired `ocr_text` table**: screen text is `frames.full_text` (with `app_name`, `window_name`, `browser_url`, `timestamp`, `text_source`); audio is `audio_transcriptions.transcription` (`timestamp`, `speaker_id`, `start_time`); UI elements are `elements` (`role`, `text`, `source`).

## Why

The chat agent leaned on `/raw_sql` and repeatedly guessed the retired `ocr_text` table → failed queries → "couldn't find it" even when the data was present. With #4352 returning a clean 400 on bad SQL, this tells the agent how to act on it and which tables actually exist.

Prompt parse-checked with `bun build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)