### PR TITLE
feat(rewind): always show the current time on the timeline playhead line

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -273,11 +273,9 @@ function appNameToBarColor(name: string): string {
 const PlayheadTimeChip = React.memo(function PlayheadTimeChip({
 	containerRef,
 	timestamp,
-	hidden,
 }: {
 	containerRef: React.RefObject<HTMLDivElement | null>;
 	timestamp: string | undefined;
-	hidden: boolean;
 }) {
 	const [rect, setRect] = useState<{ x: number; y: number } | null>(null);
 
@@ -312,7 +310,7 @@ const PlayheadTimeChip = React.memo(function PlayheadTimeChip({
 		};
 	}, [containerRef, timestamp]);
 
-	if (hidden || !rect || !timestamp) return null;
+	if (!rect || !timestamp) return null;
 
 	return createPortal(
 		<div
@@ -1771,10 +1769,11 @@ export const TimelineSlider = ({
 										? timeMarkers.find(m => m.position === visibleFrames.indexOf(frame))
 										: null;
 
-									// Only show the rich thumbnail preview while actively hovering a bar.
-									// The current/playhead position no longer shows a thumbnail when
-									// idle — it shows the always-visible time chip instead (PlayheadTimeChip).
-									const shouldShowTooltip = hoveredTimestamp === frame.timestamp;
+									// Rich thumbnail preview shows only when hovering OTHER bars.
+									// The playhead bar never shows a thumbnail — it always shows the
+									// live time chip above it instead (PlayheadTimeChip), so hovering
+									// the playhead doesn't disturb the always-on current-time label.
+									const shouldShowTooltip = hoveredTimestamp === frame.timestamp && !isCurrent;
 
 									const frameId = frame.devices?.[0]?.frame_id || '';
 									const frameTags = frameId ? (tags[frameId] || []) : [];
@@ -2005,12 +2004,12 @@ export const TimelineSlider = ({
 			)}
 
 			{/* Playhead time chip — always pinned above the current (big) bar so the
-			    current time position is visible at a glance. Isolated component so the
-			    scroll-driven re-measuring doesn't re-render the whole timeline. */}
+			    current time position is visible at a glance, regardless of hover.
+			    Isolated component so the scroll-driven re-measuring doesn't re-render
+			    the whole timeline. */}
 			<PlayheadTimeChip
 				containerRef={containerRef}
 				timestamp={frames[currentIndex]?.timestamp}
-				hidden={hoveredTimestamp === frames[currentIndex]?.timestamp}
 			/>
 		</div>
 	);

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -6,7 +6,7 @@ import { useTimelineSelection } from "@/lib/hooks/use-timeline-selection";
 import { getStore, type ChatConversation } from "@/lib/hooks/use-settings";
 import { isAfter, subDays, addDays, startOfDay, format, formatDistanceToNow } from "date-fns";
 import { motion } from "framer-motion";
-import { ZoomIn, ZoomOut, Mic, Monitor, AppWindow, Globe, Hash, RotateCcw, Phone, PanelBottomClose, PanelBottomOpen } from "lucide-react";
+import { ZoomIn, ZoomOut, Mic, Monitor, AppWindow, Globe, Hash, RotateCcw, Phone, PanelBottomClose, PanelBottomOpen, Clock } from "lucide-react";
 import type { Meeting } from "@/lib/hooks/use-meetings";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -261,6 +261,78 @@ function appNameToColor(name: string, alpha?: number): string {
 function appNameToBarColor(name: string): string {
 	return `hsl(${appNameToHue(name)}, 35%, 65%)`;
 }
+
+/**
+ * Always-visible time label pinned above the current (playhead) bar.
+ *
+ * The current bar moves while the timeline scrolls — including during the smooth
+ * scroll that re-centers it on a new selection — so we re-measure the bar's screen
+ * rect on every scroll/resize (throttled to one rAF). Kept as its own component so
+ * this scroll-driven state churn never re-renders the (large) TimelineSlider.
+ */
+const PlayheadTimeChip = React.memo(function PlayheadTimeChip({
+	containerRef,
+	timestamp,
+	hidden,
+}: {
+	containerRef: React.RefObject<HTMLDivElement | null>;
+	timestamp: string | undefined;
+	hidden: boolean;
+}) {
+	const [rect, setRect] = useState<{ x: number; y: number } | null>(null);
+
+	useEffect(() => {
+		const container = containerRef.current;
+		if (!container || !timestamp) {
+			setRect(null);
+			return;
+		}
+		let raf = 0;
+		const measure = () => {
+			raf = 0;
+			const el = container.querySelector('[data-current="true"]') as HTMLElement | null;
+			if (!el) {
+				setRect(null);
+				return;
+			}
+			const r = el.getBoundingClientRect();
+			setRect({ x: r.left + r.width / 2, y: r.top });
+		};
+		const schedule = () => {
+			if (!raf) raf = requestAnimationFrame(measure);
+		};
+		// Defer the first measure a frame so the bar has laid out / started scrolling.
+		schedule();
+		container.addEventListener("scroll", schedule, { passive: true });
+		window.addEventListener("resize", schedule);
+		return () => {
+			container.removeEventListener("scroll", schedule);
+			window.removeEventListener("resize", schedule);
+			if (raf) cancelAnimationFrame(raf);
+		};
+	}, [containerRef, timestamp]);
+
+	if (hidden || !rect || !timestamp) return null;
+
+	return createPortal(
+		<div
+			className="fixed z-[9998] flex flex-col items-center pointer-events-none"
+			style={{
+				left: `clamp(64px, ${rect.x}px, calc(100vw - 64px))`,
+				top: `${rect.y}px`,
+				transform: "translate(-50%, -100%) translateY(-6px)",
+			}}
+		>
+			<div className="flex items-center gap-1.5 rounded-full bg-primary px-2.5 py-1 text-[11px] font-mono font-semibold tabular-nums leading-none text-primary-foreground shadow-lg ring-1 ring-black/10 whitespace-nowrap">
+				<Clock className="w-3 h-3 opacity-80" />
+				<span>{format(new Date(timestamp), "h:mm:ss a")}</span>
+			</div>
+			{/* downward pointer connecting the chip to the bar */}
+			<div className="-mt-[3px] h-2 w-2 rotate-45 rounded-[1px] bg-primary ring-1 ring-black/10" />
+		</div>,
+		document.body,
+	);
+});
 
 export const TimelineSlider = ({
 	frames = [],
@@ -1699,9 +1771,10 @@ export const TimelineSlider = ({
 										? timeMarkers.find(m => m.position === visibleFrames.indexOf(frame))
 										: null;
 
-									const shouldShowTooltip = hoveredTimestamp
-										? hoveredTimestamp === frame.timestamp
-										: frames[currentIndex]?.timestamp === frame.timestamp;
+									// Only show the rich thumbnail preview while actively hovering a bar.
+									// The current/playhead position no longer shows a thumbnail when
+									// idle — it shows the always-visible time chip instead (PlayheadTimeChip).
+									const shouldShowTooltip = hoveredTimestamp === frame.timestamp;
 
 									const frameId = frame.devices?.[0]?.frame_id || '';
 									const frameTags = frameId ? (tags[frameId] || []) : [];
@@ -1930,6 +2003,15 @@ export const TimelineSlider = ({
 				</div>,
 				document.body
 			)}
+
+			{/* Playhead time chip — always pinned above the current (big) bar so the
+			    current time position is visible at a glance. Isolated component so the
+			    scroll-driven re-measuring doesn't re-render the whole timeline. */}
+			<PlayheadTimeChip
+				containerRef={containerRef}
+				timestamp={frames[currentIndex]?.timestamp}
+				hidden={hoveredTimestamp === frames[currentIndex]?.timestamp}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
the tall **playhead line** in the rewind timeline — the marker that shows **where you are on the timeline** — now always carries a small time chip showing the current position. no hover, no thumbnail: it's pinned to the line and tracks it as you scrub.

![playhead time chip — always on the main line](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/timeline-playhead-chip/timeline-playhead-chip.png?v=2)

_(mockup uses fabricated app names + times to show the states — no real data)_

### behaviour
- **always on the playhead** — the white chip (`🕐 h:mm:ss a`) sits on the top edge of the current/playhead bar (the `[data-current="true"]` frame — the same one the date pill calls "the frame under the playhead"). it shows whenever there's a current frame, regardless of hover.
- **tracks the line live** — it re-measures the bar's screen position on scroll/resize (throttled to one `requestAnimationFrame`), so it stays glued to the playhead while you scrub and during the smooth re-center, and re-reads the timestamp as the position changes.
- **never replaced by hover** — the playhead bar no longer shows a thumbnail. the rich thumbnail preview now only appears when hovering a **different** bar, so it can't compete with or hide the playhead chip.

### implementation
- `apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx`
- new `PlayheadTimeChip` — portals the chip above the playhead using `getBoundingClientRect` (same pattern as the existing tooltip, so it escapes the timeline's overflow clipping). isolated `React.memo` component so the scroll-driven position updates don't re-render the (large, windowed) `TimelineSlider`.
- `shouldShowTooltip = hoveredTimestamp === frame.timestamp && !isCurrent` — thumbnail preview is for non-playhead bars only.
- no new deps; reuses `date-fns` `format` + `lucide-react` `Clock`.

### testing
- `bunx tsc --noEmit` → no new errors in `timeline.tsx` (only pre-existing repo-config tsc warnings remain); esbuild bundle parses clean.
- timeline lives in the Tauri app crate (not built by Rust CI), so this is frontend-only — worth an eyeball in a dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)