### PR TITLE
fix(chat): render home-relative (~/) media paths instead of failing to load

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
@@ -153,6 +153,26 @@ describe("normalizeMediaFilePath — edge cases", () => {
       ),
     ).toBe("/Users/ansh/.screenpipe/data/Mic (input)_2026-05-25_21-42-22.mp4");
   });
+
+  it("preserves the leading ~ on a home-relative path", () => {
+    // Regression: the Unix matcher anchored on the first `/`, dropping the `~`
+    // and turning `~/Downloads/clip.mp4` into a non-existent `/Downloads/clip.mp4`.
+    expect(normalizeMediaFilePath("~/Downloads/audio_17_7pm-8pm.mp4")).toBe(
+      "~/Downloads/audio_17_7pm-8pm.mp4",
+    );
+  });
+
+  it("extracts a home-relative path from surrounding chat text", () => {
+    expect(
+      normalizeMediaFilePath("saved to ~/Downloads/clip.mp4 just now"),
+    ).toBe("~/Downloads/clip.mp4");
+  });
+
+  it("strips backticks around a home-relative path", () => {
+    expect(normalizeMediaFilePath("`~/Downloads/clip.mp4`")).toBe(
+      "~/Downloads/clip.mp4",
+    );
+  });
 });
 
 describe("isAudioMediaPath / isMediaFilePath — edge cases", () => {

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.test.ts
@@ -173,6 +173,21 @@ describe("normalizeMediaFilePath — edge cases", () => {
       "~/Downloads/clip.mp4",
     );
   });
+
+  it("preserves a Windows-style home-relative path (backslashes)", () => {
+    // The backend only expands `~\` on Windows; the frontend just keeps the
+    // prefix intact so the right home dir gets joined there.
+    expect(normalizeMediaFilePath(String.raw`~\Downloads\clip.mp4`)).toBe(
+      String.raw`~\Downloads\clip.mp4`,
+    );
+  });
+
+  it("does not treat a mid-path ~ as a home reference", () => {
+    // The `~` here ends a directory name; it must not be mistaken for `~/`.
+    expect(normalizeMediaFilePath("/Users/me~/clip.mp4")).toBe(
+      "/Users/me~/clip.mp4",
+    );
+  });
 });
 
 describe("isAudioMediaPath / isMediaFilePath — edge cases", () => {

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
@@ -28,6 +28,16 @@ export function normalizeMediaFilePath(path: string): string {
   );
   if (windowsMatch) return windowsMatch[0].trim();
 
+  // Home-relative paths (e.g. `~/Downloads/clip.mp4`). The Unix matcher below
+  // anchors on the first `/`, which would silently drop the leading `~` and turn
+  // `~/Downloads/clip.mp4` into `/Downloads/clip.mp4` — a path that never exists.
+  // Match the tilde explicitly first so the home prefix survives; the backend
+  // expands `~` to the real home directory when reading the file.
+  const tildeMatch = cleaned.match(
+    new RegExp(`~/[^\\n\\r\`"<>]+?\\.(${MEDIA_EXTENSION_PATTERN})`, "i"),
+  );
+  if (tildeMatch) return tildeMatch[0].trim();
+
   const unixMatch = cleaned.match(
     new RegExp(`/[^\\n\\r\`"<>]+?\\.(${MEDIA_EXTENSION_PATTERN})`, "i"),
   );

--- a/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/media-file-path.ts
@@ -28,15 +28,18 @@ export function normalizeMediaFilePath(path: string): string {
   );
   if (windowsMatch) return windowsMatch[0].trim();
 
-  // Home-relative paths (e.g. `~/Downloads/clip.mp4`). The Unix matcher below
-  // anchors on the first `/`, which would silently drop the leading `~` and turn
-  // `~/Downloads/clip.mp4` into `/Downloads/clip.mp4` — a path that never exists.
-  // Match the tilde explicitly first so the home prefix survives; the backend
-  // expands `~` to the real home directory when reading the file.
+  // Home-relative paths (e.g. `~/Downloads/clip.mp4`, or `~\Downloads\clip.mp4`
+  // on Windows). The Unix matcher below anchors on the first `/`, which would
+  // silently drop the leading `~` and turn `~/Downloads/clip.mp4` into
+  // `/Downloads/clip.mp4` — a path that never exists. Match the tilde explicitly
+  // first so the home prefix survives; the backend expands `~` to the real home
+  // directory when reading the file. Require the `~` to sit at a path boundary
+  // (start, or after whitespace) so a directory that merely ends in `~`
+  // (e.g. `/Users/me~/clip.mp4`) isn't mistaken for a home reference.
   const tildeMatch = cleaned.match(
-    new RegExp(`~/[^\\n\\r\`"<>]+?\\.(${MEDIA_EXTENSION_PATTERN})`, "i"),
+    new RegExp(`(?:^|\\s)(~[\\\\/][^\\n\\r\`"<>]+?\\.(?:${MEDIA_EXTENSION_PATTERN}))`, "i"),
   );
-  if (tildeMatch) return tildeMatch[0].trim();
+  if (tildeMatch) return tildeMatch[1].trim();
 
   const unixMatch = cleaned.match(
     new RegExp(`/[^\\n\\r\`"<>]+?\\.(${MEDIA_EXTENSION_PATTERN})`, "i"),

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -176,14 +176,15 @@ use tokio::time::{sleep, Duration};
 #[tauri::command]
 #[specta::specta]
 async fn get_media_file(file_path: &str) -> Result<serde_json::Value, String> {
-    use std::path::Path;
-
     const MAX_RETRIES: u32 = 3;
     const INITIAL_DELAY_MS: u64 = 100;
 
     debug!("Reading media file: {}", file_path);
 
-    let path = Path::new(file_path);
+    // Media paths can arrive home-relative (e.g. `~/Downloads/clip.mp4`) when the
+    // agent prints a friendly path in chat. `Path::new` does not expand `~`, so
+    // resolve it the same way the in-app file viewer does before touching disk.
+    let path = viewer::expand_tilde(file_path);
 
     // Retry loop to handle files that may be in the process of being written
     let mut last_error = String::new();
@@ -198,7 +199,7 @@ async fn get_media_file(file_path: &str) -> Result<serde_json::Value, String> {
         }
 
         if !path.exists() {
-            last_error = format!("File does not exist: {}", file_path);
+            last_error = format!("File does not exist: {}", path.display());
             if attempt < MAX_RETRIES {
                 continue;
             }
@@ -206,7 +207,7 @@ async fn get_media_file(file_path: &str) -> Result<serde_json::Value, String> {
         }
 
         // Read file contents
-        match tokio::fs::read(path).await {
+        match tokio::fs::read(&path).await {
             Ok(contents) => {
                 // Check for empty or suspiciously small files (might still be writing)
                 if contents.is_empty() {

--- a/apps/screenpipe-app-tauri/src-tauri/src/viewer.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/viewer.rs
@@ -22,7 +22,7 @@ const MAX_VIEWER_FILE_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Expand a leading `~` / `~/` to the user's home directory. Leaves every
 /// other path untouched (including bare `~user`, which we don't resolve).
-fn expand_tilde(path: &str) -> PathBuf {
+pub(crate) fn expand_tilde(path: &str) -> PathBuf {
     if path == "~" {
         return dirs::home_dir().unwrap_or_else(|| PathBuf::from(path));
     }

--- a/apps/screenpipe-app-tauri/src-tauri/src/viewer.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/viewer.rs
@@ -22,11 +22,18 @@ const MAX_VIEWER_FILE_BYTES: u64 = 10 * 1024 * 1024;
 
 /// Expand a leading `~` / `~/` to the user's home directory. Leaves every
 /// other path untouched (including bare `~user`, which we don't resolve).
+///
+/// `~\…` is also expanded on Windows, where `\` is the native separator. On
+/// Unix `\` is a valid filename character, so `~\foo` there is a real relative
+/// path, not a home reference, and is left alone.
 pub(crate) fn expand_tilde(path: &str) -> PathBuf {
     if path == "~" {
         return dirs::home_dir().unwrap_or_else(|| PathBuf::from(path));
     }
-    if let Some(rest) = path.strip_prefix("~/") {
+    let rest = path.strip_prefix("~/");
+    #[cfg(windows)]
+    let rest = rest.or_else(|| path.strip_prefix("~\\"));
+    if let Some(rest) = rest {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }
@@ -445,10 +452,16 @@ mod tests {
         if let Some(home) = dirs::home_dir() {
             assert_eq!(expand_tilde("~"), home);
             assert_eq!(expand_tilde("~/notes/a.md"), home.join("notes/a.md"));
+            // Windows uses `\` as its native separator for home-relative paths.
+            #[cfg(windows)]
+            assert_eq!(expand_tilde("~\\Downloads\\a.mp4"), home.join("Downloads\\a.mp4"));
         }
         // Non-tilde paths pass through untouched.
         assert_eq!(expand_tilde("/abs/x.md"), PathBuf::from("/abs/x.md"));
         assert_eq!(expand_tilde(".pi/skills/x"), PathBuf::from(".pi/skills/x"));
+        // On Unix `\` is a valid filename char, so `~\foo` is NOT home-relative.
+        #[cfg(not(windows))]
+        assert_eq!(expand_tilde("~\\foo.mp4"), PathBuf::from("~\\foo.mp4"));
     }
 
     #[test]


### PR DESCRIPTION
## problem

when the agent prints a friendly path like `~/Downloads/clip.mp4` in chat, the inline media player renders an error box instead of a playable clip:

> Failed to load media: failed to read media file: File does not exist: /Downloads/clip.mp4

note the path lost its leading `~` — it became `/Downloads/...`, which never exists.

## root cause

home-relative (`~/`) media paths break in two places:

1. **frontend** — [`normalizeMediaFilePath`](apps/screenpipe-app-tauri/lib/utils/media-file-path.ts) extracts the path with a Unix regex that anchors on the *first* `/`. for `~/Downloads/clip.mp4` that match starts *after* the `~`, so the tilde is silently dropped and the path becomes `/Downloads/clip.mp4`.
2. **backend** — [`get_media_file`](apps/screenpipe-app-tauri/src-tauri/src/main.rs) read via `Path::new(file_path)`, which does not expand `~` either.

a backtick code span like `` `~/Downloads/clip.mp4` `` is rendered inline as a media player by [markdown.tsx](apps/screenpipe-app-tauri/components/markdown.tsx)'s `code`/`a`/`img` handlers, so this is the common path users hit.

## fix

- add a tilde-aware branch to `normalizeMediaFilePath` so the home prefix survives the extraction (checked before the Unix matcher). the `~` must sit at a path boundary (start or whitespace) so a directory that merely ends in `~` (e.g. `/Users/me~/clip.mp4`) isn't mistaken for a home reference.
- expand `~` in `get_media_file` by reusing `viewer::expand_tilde` (promoted to `pub(crate)`) — the same helper the in-app file viewer already uses, already unit-tested in `viewer.rs`.
- the existence-error message now prints the resolved path (`path.display()`) for clearer debugging.

absolute (`/Users/...`), Windows (`C:\...`), and `file://` paths are untouched.

## cross-platform

- **macOS / Linux** — `~/…` resolves via `dirs::home_dir()`. ✅
- **Windows** — `~/…` (forward slash) works too: `dirs::home_dir()` returns `C:\Users\<user>` and the Win32 API accepts `/` as a separator. the backslash form `~\…` is also handled — `expand_tilde` strips `~\` under `#[cfg(windows)]`, and the matcher accepts both separators. ✅
- on Unix, `\` is a valid filename character, so `~\foo` is intentionally **left untouched** there (it's a real relative path, not a home reference).

## test

- `bunx vitest run lib/utils/media-file-path.test.ts` → **28 passed** (regression cases: bare `~/` path, `~/` in prose, `~/` in backticks, Windows `~\` form, and a mid-path `~` that must not be treated as home).
- backend `expand_tilde` is covered by `expand_tilde_handles_home` in `viewer.rs`, now including Windows (`~\`) and Unix (`~\` left alone) assertions.

note: the `screenpipe-app` crate doesn't build locally (livetext Swift bridge); the Rust change is small and reuses a proven helper. it compiles in CI's e2e-test workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
