### PR TITLE
fix(pipes): stop showing "never run" for pipes that have actually run

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -1156,10 +1156,16 @@ export function PipesSection() {
 
   const fetchPipes = useCallback(async () => {
     try {
-      // First load: skip executions for speed. Executions load lazily per-pipe.
+      // Load pipes WITH recent executions inline so the list shows the real
+      // last-run status. Without this the "last run" column always reads
+      // "never run" for pipes that have actually run (the badge is driven by
+      // recent_executions). The engine batches this into one fast per-pipe
+      // index-seek query with stdout/stderr stripped (~30ms for 100 pipes), so
+      // it's cheap enough for the 10s poll. Full output for the expanded RUNS
+      // tab still loads lazily via /pipes/:name/executions.
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 5_000);
-      const res = await fetch(`${apiBase}/pipes`, { signal: controller.signal }).finally(() => clearTimeout(timeout));
+      const res = await fetch(`${apiBase}/pipes?include_executions=true`, { signal: controller.signal }).finally(() => clearTimeout(timeout));
       const data = await res.json();
       const rawItems: Array<PipeStatus & { recent_executions?: PipeExecution[] }> = data.data || [];
       const fetched: PipeStatus[] = [];


### PR DESCRIPTION
The pipes list (Settings → Pipes) shows **"never run"** in the last-run column for pipes that are enabled, scheduled, and have actually been running fine.

## Root cause

The last-run badge is driven by each pipe’s `recent_executions`. The frontend (`fetchPipes` in `pipes-section.tsx`) populates `pipeExecutions` from `recent_executions`, but that field is only returned by the engine when `/pipes` is called with `?include_executions=true`. The list fetch dropped that param, so `recent_executions` is always empty → `lastExec` is `undefined` → the badge falls through to **"never run"** for every successful pipe. (Failing pipes still show "failed" only because that branch reads `pipe.last_success`, a separate field — which is why the symptom looked inconsistent.)

This regressed in `8416774c` (Apr 1) which removed `?include_executions=true` for performance: at the time the inline query was a slow `ROW_NUMBER()` scan (1.3–4.7s for ~47 pipes, run on the 10s poll).

That reason no longer holds. `7f9fd873d` (May 4) rewrote `get_all_executions` into per-pipe index seeks run concurrently with `stdout`/`stderr` stripped — but the frontend was never re-enabled.

## Fix

Restore `?include_executions=true` on the list fetch. The data plumbing was already there (`fetchPipes` extracts `recent_executions` into `pipeExecutions`); it just was never requested. Full per-run output for the expanded RUNS tab still loads lazily via `/pipes/:name/executions`, so heavy output stays off the list path.

## Verification (local install, 103 pipes)

```
GET /pipes?include_executions=true   →  http=200  time=0.028s   recent_executions populated for all run pipes
GET /pipes                           →  recent_executions present on 0 pipes  (current broken path)
```

The badge now renders the real last-run time instead of "never run".

## Scope

Frontend-only, one effective line (the query param) plus an explanatory comment. No Tauri command surface change, so bindings are unaffected.

Note: there is a separate, benign inconsistency where `pipe_scheduler_state.last_run_at` is occasionally `NULL` for pipes that have run. It self-heals on the next run and does **not** affect this badge (which reads executions) nor scheduling (a `NULL` makes an interval pipe fire sooner, never later). Left out of this PR to keep it focused.