### PR TITLE
feat(settings): group + reorder recording audio settings

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -2641,60 +2641,11 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
         </Card>
         )}
 
-        {/* Your Name + Train Voice — hidden when transcription is disabled */}
-        {!settings.disableAudio && settings.audioTranscriptionEngine !== "disabled" && (
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <User className="h-4 w-4 text-muted-foreground shrink-0" />
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Your name
-                  <HelpTooltip text="Your name in transcripts. Click 'train' and speak for 30 seconds to teach screenpipe your voice — it will recognize you across all devices using voice matching." />
-                </h3>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <div className="relative">
-                  <Input
-                    placeholder="e.g. Louis"
-                    value={settings.userName || ""}
-                    onChange={(e) => handleSettingsChange({ userName: e.target.value }, false)}
-                    onFocus={() => setSpeakerInputFocused(true)}
-                    onBlur={() => setTimeout(() => setSpeakerInputFocused(false), 150)}
-                    className="w-32 h-7 text-xs"
-                  />
-                  {speakerInputFocused && speakerSuggestions.length > 0 && (
-                    <div className="absolute top-full left-0 w-44 mt-0.5 z-50 bg-popover border border-border shadow-md max-h-[120px] overflow-y-auto">
-                      {speakerSuggestions.map((s) => (
-                        <button
-                          key={s.id}
-                          type="button"
-                          className="w-full px-2 py-1 text-left text-xs hover:bg-accent truncate"
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            handleSettingsChange({ userName: s.name }, false);
-                            setSpeakerInputFocused(false);
-                          }}
-                        >
-                          {s.name}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 text-xs"
-                  onClick={handleStartTraining}
-                  disabled={voiceTraining.active || !settings.userName?.trim()}
-                >
-                  train
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        {!settings.disableAudio && (
+          <div className="flex items-center gap-2 px-1 pt-1.5">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">transcription</span>
+            <div className="h-px flex-1 bg-border/60" />
+          </div>
         )}
 
         {/* Transcription Engine */}
@@ -3073,88 +3024,46 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
         </Card>
         )}
 
-        {/* Meeting Live Notes */}
+        {/* Languages */}
         {!settings.disableAudio && (
         <Card className="border-border bg-card">
           <CardContent className="px-3 py-2.5">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2.5">
-                <Headphones className="h-4 w-4 text-muted-foreground shrink-0" />
+                <Languages className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
-                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                    Live meeting notes
-                    <HelpTooltip text="Streams only the active meeting into the live note. This is separate from background 24/7 recording and can use your selected transcription engine, screenpipe cloud, or a direct provider." />
-                  </h3>
-                  <p className="text-xs text-muted-foreground">Meeting-only live captions, separate from background transcription</p>
+                  <h3 className="text-sm font-medium text-foreground">Languages</h3>
+                  <p className="text-xs text-muted-foreground">{languageSupportDescription}</p>
                 </div>
               </div>
-              <Switch
-                id="meetingLiveTranscriptionEnabled"
-                checked={settings.meetingLiveTranscriptionEnabled ?? true}
-                onCheckedChange={(checked) =>
-                  handleSettingsChange({
-                    meetingLiveTranscriptionEnabled: checked,
-                    meetingLiveTranscriptionProvider: checked
-                      ? ((settings.meetingLiveTranscriptionProvider && settings.meetingLiveTranscriptionProvider !== "disabled")
-                        ? settings.meetingLiveTranscriptionProvider
-                        : "selected-engine")
-                      : "disabled",
-                  }, true)
-                }
-              />
-            </div>
-            {(settings.meetingLiveTranscriptionEnabled ?? true) && (
-              <div className="mt-2.5 ml-[26px] flex flex-col gap-2">
-                <div className="flex items-center justify-between gap-3">
-                  <Label className="text-xs text-muted-foreground">Live engine</Label>
-                  <Select
-                    value={settings.meetingLiveTranscriptionProvider ?? "selected-engine"}
-                    onValueChange={(value) =>
-                      handleSettingsChange({
-                        meetingLiveTranscriptionProvider: value as Settings["meetingLiveTranscriptionProvider"],
-                      }, true)
-                    }
-                  >
-                    <SelectTrigger className="h-8 w-[260px] text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="selected-engine">Current transcription engine</SelectItem>
-                      <SelectItem value="screenpipe-cloud">screenpipe cloud live</SelectItem>
-                      <SelectItem value="deepgram-live">Direct Deepgram live</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                {(settings.meetingLiveTranscriptionProvider ?? "selected-engine") === "screenpipe-cloud" &&
-                  !settings.user?.token &&
-                  !settings.user?.id && (
-                  <p className="text-xs text-muted-foreground">
-                    Log in to screenpipe cloud to use the cloud live provider.
-                  </p>
-                )}
-                {(settings.meetingLiveTranscriptionProvider ?? "selected-engine") === "selected-engine" &&
-                  settings.audioTranscriptionEngine === "disabled" && (
-                  <p className="text-xs text-muted-foreground">
-                    Pick an audio transcription engine above, or choose a cloud/direct live provider.
-                  </p>
-                )}
-              </div>
-            )}
-            <div className="mt-2.5 pt-2.5 border-t border-border/50 flex items-center justify-between">
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Append typed text to note
-                  <HelpTooltip text="When the meeting stops, screenpipe appends what you typed (and the files you edited) during the meeting to the meeting note. Turn off to keep notes clean." />
-                </h3>
-                <p className="text-xs text-muted-foreground">Auto-add your typed text + edited files at the end of the note</p>
-              </div>
-              <Switch
-                id="appendTypedTextToMeetingNote"
-                checked={settings.appendTypedTextToMeetingNote ?? true}
-                onCheckedChange={(checked) =>
-                  handleSettingsChange({ appendTypedTextToMeetingNote: checked }, true)
-                }
-              />
+              <Popover open={openLanguages} onOpenChange={setOpenLanguages}>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" size="sm" className="h-7 text-xs">
+                    {languageTriggerLabel}
+                    <ChevronsUpDown className="ml-1 h-3 w-3 opacity-50" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-[250px] p-0">
+                  <Command>
+                    <CommandInput placeholder="Search languages..." />
+                    <CommandList>
+                      <CommandEmpty>No languages found.</CommandEmpty>
+                      <CommandGroup>
+                        <CommandItem value="auto-detect" onSelect={() => handleLanguageChange(null)}>
+                          <Check className={cn("mr-2 h-3 w-3", settings.languages.length === 0 ? "opacity-100" : "opacity-0")} />
+                          <span className="text-xs">Auto-detect</span>
+                        </CommandItem>
+                        {supportedLanguageOptions.map((language) => (
+                          <CommandItem key={language.code} value={language.code} onSelect={() => handleLanguageChange(language.code)}>
+                            <Check className={cn("mr-2 h-3 w-3", settings.languages.includes(language.code) ? "opacity-100" : "opacity-0")} />
+                            <span className="text-xs">{language.name}</span>
+                          </CommandItem>
+                        ))}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
             </div>
           </CardContent>
         </Card>
@@ -3242,6 +3151,163 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
               </div>
             </CardContent>
           </Card>
+        )}
+
+        {!settings.disableAudio && (
+          <div className="flex items-center gap-2 px-1 pt-1.5">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">meetings</span>
+            <div className="h-px flex-1 bg-border/60" />
+          </div>
+        )}
+
+        {/* Meeting Live Notes */}
+        {!settings.disableAudio && (
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Headphones className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Live meeting notes
+                    <HelpTooltip text="Streams only the active meeting into the live note. This is separate from background 24/7 recording and can use your selected transcription engine, screenpipe cloud, or a direct provider." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">Meeting-only live captions, separate from background transcription</p>
+                </div>
+              </div>
+              <Switch
+                id="meetingLiveTranscriptionEnabled"
+                checked={settings.meetingLiveTranscriptionEnabled ?? true}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({
+                    meetingLiveTranscriptionEnabled: checked,
+                    meetingLiveTranscriptionProvider: checked
+                      ? ((settings.meetingLiveTranscriptionProvider && settings.meetingLiveTranscriptionProvider !== "disabled")
+                        ? settings.meetingLiveTranscriptionProvider
+                        : "selected-engine")
+                      : "disabled",
+                  }, true)
+                }
+              />
+            </div>
+            {(settings.meetingLiveTranscriptionEnabled ?? true) && (
+              <div className="mt-2.5 ml-[26px] flex flex-col gap-2">
+                <div className="flex items-center justify-between gap-3">
+                  <Label className="text-xs text-muted-foreground">Live engine</Label>
+                  <Select
+                    value={settings.meetingLiveTranscriptionProvider ?? "selected-engine"}
+                    onValueChange={(value) =>
+                      handleSettingsChange({
+                        meetingLiveTranscriptionProvider: value as Settings["meetingLiveTranscriptionProvider"],
+                      }, true)
+                    }
+                  >
+                    <SelectTrigger className="h-8 w-[260px] text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="selected-engine">Current transcription engine</SelectItem>
+                      <SelectItem value="screenpipe-cloud">screenpipe cloud live</SelectItem>
+                      <SelectItem value="deepgram-live">Direct Deepgram live</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {(settings.meetingLiveTranscriptionProvider ?? "selected-engine") === "screenpipe-cloud" &&
+                  !settings.user?.token &&
+                  !settings.user?.id && (
+                  <p className="text-xs text-muted-foreground">
+                    Log in to screenpipe cloud to use the cloud live provider.
+                  </p>
+                )}
+                {(settings.meetingLiveTranscriptionProvider ?? "selected-engine") === "selected-engine" &&
+                  settings.audioTranscriptionEngine === "disabled" && (
+                  <p className="text-xs text-muted-foreground">
+                    Pick an audio transcription engine above, or choose a cloud/direct live provider.
+                  </p>
+                )}
+              </div>
+            )}
+            <div className="mt-2.5 pt-2.5 border-t border-border/50 flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                  Append typed text to note
+                  <HelpTooltip text="When the meeting stops, screenpipe appends what you typed (and the files you edited) during the meeting to the meeting note. Turn off to keep notes clean." />
+                </h3>
+                <p className="text-xs text-muted-foreground">Auto-add your typed text + edited files at the end of the note</p>
+              </div>
+              <Switch
+                id="appendTypedTextToMeetingNote"
+                checked={settings.appendTypedTextToMeetingNote ?? true}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({ appendTypedTextToMeetingNote: checked }, true)
+                }
+              />
+            </div>
+          </CardContent>
+        </Card>
+        )}
+
+        {/* Automatic meeting detection */}
+        {!settings.disableAudio && (
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Users className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Automatic meeting detection
+                    <HelpTooltip text="Detects meeting apps (Zoom, Teams, Meet, Discord calls, etc.) to start/stop meetings and live notes. Turn off if it triggers spuriously and split meetings manually. CLI equivalent: --disable-meeting-detector." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">Auto-start meetings when a call app is detected</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                {!settings.disableMeetingDetector && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-[11px] gap-1.5"
+                    onClick={() => setMeetingAppsPickerOpen(true)}
+                    title="Choose apps that should never auto-start a meeting"
+                    data-testid="settings-ignore-meeting-apps-button"
+                  >
+                    <UserX className="h-3.5 w-3.5" />
+                    ignore apps
+                    {(settings.ignoredMeetingApps?.length ?? 0) > 0 && (
+                      <span
+                        className="rounded bg-muted px-1.5 py-0.5 text-[10px] tabular-nums"
+                        data-testid="settings-ignore-meeting-apps-count"
+                      >
+                        {settings.ignoredMeetingApps!.length}
+                      </span>
+                    )}
+                  </Button>
+                )}
+                <ManagedSwitch
+                  settingKey="disableMeetingDetector"
+                  id="disableMeetingDetector"
+                  checked={!settings.disableMeetingDetector}
+                  onCheckedChange={(checked) => handleSettingsChange({ disableMeetingDetector: !checked }, true)}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        )}
+
+        <MeetingAppsPicker
+          open={meetingAppsPickerOpen}
+          onOpenChange={setMeetingAppsPickerOpen}
+          selected={settings.ignoredMeetingApps ?? []}
+          onToggle={handleToggleIgnoredMeetingApp}
+        />
+
+        {!settings.disableAudio && (
+          <div className="flex items-center gap-2 px-1 pt-1.5">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">devices & capture</span>
+            <div className="h-px flex-1 bg-border/60" />
+          </div>
         )}
 
         {/* System Default Audio */}
@@ -3344,59 +3410,6 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
           );
         })()}
 
-        {/* Languages */}
-        {!settings.disableAudio && (
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <Languages className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground">Languages</h3>
-                  <p className="text-xs text-muted-foreground">{languageSupportDescription}</p>
-                </div>
-              </div>
-              <Popover open={openLanguages} onOpenChange={setOpenLanguages}>
-                <PopoverTrigger asChild>
-                  <Button variant="outline" size="sm" className="h-7 text-xs">
-                    {languageTriggerLabel}
-                    <ChevronsUpDown className="ml-1 h-3 w-3 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[250px] p-0">
-                  <Command>
-                    <CommandInput placeholder="Search languages..." />
-                    <CommandList>
-                      <CommandEmpty>No languages found.</CommandEmpty>
-                      <CommandGroup>
-                        <CommandItem value="auto-detect" onSelect={() => handleLanguageChange(null)}>
-                          <Check className={cn("mr-2 h-3 w-3", settings.languages.length === 0 ? "opacity-100" : "opacity-0")} />
-                          <span className="text-xs">Auto-detect</span>
-                        </CommandItem>
-                        {supportedLanguageOptions.map((language) => (
-                          <CommandItem key={language.code} value={language.code} onSelect={() => handleLanguageChange(language.code)}>
-                            <Check className={cn("mr-2 h-3 w-3", settings.languages.includes(language.code) ? "opacity-100" : "opacity-0")} />
-                            <span className="text-xs">{language.name}</span>
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                </PopoverContent>
-              </Popover>
-            </div>
-          </CardContent>
-        </Card>
-        )}
-
-        {/* Transcription Dictionary */}
-        {!settings.disableAudio && (
-        <TranscriptionDictionary
-          vocabularyWords={settings.vocabularyWords ?? []}
-          onChange={(words) => handleSettingsChange({ vocabularyWords: words }, true)}
-        />
-        )}
-
         {/* Windows microphone AEC */}
         {!settings.disableAudio && isWindows && (
         <Card className="border-border bg-card">
@@ -3476,62 +3489,6 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
           </CardContent>
         </Card>
         )}
-
-        {/* Automatic meeting detection */}
-        {!settings.disableAudio && (
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <Users className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                    Automatic meeting detection
-                    <HelpTooltip text="Detects meeting apps (Zoom, Teams, Meet, Discord calls, etc.) to start/stop meetings and live notes. Turn off if it triggers spuriously and split meetings manually. CLI equivalent: --disable-meeting-detector." />
-                  </h3>
-                  <p className="text-xs text-muted-foreground">Auto-start meetings when a call app is detected</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                {!settings.disableMeetingDetector && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 text-[11px] gap-1.5"
-                    onClick={() => setMeetingAppsPickerOpen(true)}
-                    title="Choose apps that should never auto-start a meeting"
-                    data-testid="settings-ignore-meeting-apps-button"
-                  >
-                    <UserX className="h-3.5 w-3.5" />
-                    ignore apps
-                    {(settings.ignoredMeetingApps?.length ?? 0) > 0 && (
-                      <span
-                        className="rounded bg-muted px-1.5 py-0.5 text-[10px] tabular-nums"
-                        data-testid="settings-ignore-meeting-apps-count"
-                      >
-                        {settings.ignoredMeetingApps!.length}
-                      </span>
-                    )}
-                  </Button>
-                )}
-                <ManagedSwitch
-                  settingKey="disableMeetingDetector"
-                  id="disableMeetingDetector"
-                  checked={!settings.disableMeetingDetector}
-                  onCheckedChange={(checked) => handleSettingsChange({ disableMeetingDetector: !checked }, true)}
-                />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-        )}
-
-        <MeetingAppsPicker
-          open={meetingAppsPickerOpen}
-          onOpenChange={setMeetingAppsPickerOpen}
-          selected={settings.ignoredMeetingApps ?? []}
-          onToggle={handleToggleIgnoredMeetingApp}
-        />
 
         {/* Per-app exclusion list for the CoreAudio Process Tap. Only
             meaningful when the tap is the active backend. */}
@@ -3613,6 +3570,77 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
             </div>
           </CardContent>
         </Card>
+        )}
+
+        {!settings.disableAudio && (
+          <div className="flex items-center gap-2 px-1 pt-1.5">
+            <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/70">voice & vocabulary</span>
+            <div className="h-px flex-1 bg-border/60" />
+          </div>
+        )}
+
+        {/* Your Name + Train Voice — hidden when transcription is disabled */}
+        {!settings.disableAudio && settings.audioTranscriptionEngine !== "disabled" && (
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <User className="h-4 w-4 text-muted-foreground shrink-0" />
+                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                  Your name
+                  <HelpTooltip text="Your name in transcripts. Click 'train' and speak for 30 seconds to teach screenpipe your voice — it will recognize you across all devices using voice matching." />
+                </h3>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="relative">
+                  <Input
+                    placeholder="e.g. Louis"
+                    value={settings.userName || ""}
+                    onChange={(e) => handleSettingsChange({ userName: e.target.value }, false)}
+                    onFocus={() => setSpeakerInputFocused(true)}
+                    onBlur={() => setTimeout(() => setSpeakerInputFocused(false), 150)}
+                    className="w-32 h-7 text-xs"
+                  />
+                  {speakerInputFocused && speakerSuggestions.length > 0 && (
+                    <div className="absolute top-full left-0 w-44 mt-0.5 z-50 bg-popover border border-border shadow-md max-h-[120px] overflow-y-auto">
+                      {speakerSuggestions.map((s) => (
+                        <button
+                          key={s.id}
+                          type="button"
+                          className="w-full px-2 py-1 text-left text-xs hover:bg-accent truncate"
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            handleSettingsChange({ userName: s.name }, false);
+                            setSpeakerInputFocused(false);
+                          }}
+                        >
+                          {s.name}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={handleStartTraining}
+                  disabled={voiceTraining.active || !settings.userName?.trim()}
+                >
+                  train
+                </Button>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        )}
+
+        {/* Transcription Dictionary */}
+        {!settings.disableAudio && (
+        <TranscriptionDictionary
+          vocabularyWords={settings.vocabularyWords ?? []}
+          onChange={(words) => handleSettingsChange({ vocabularyWords: words }, true)}
+        />
         )}
 
       </div>


### PR DESCRIPTION
## what

Regroups and reorders the **Recording → Audio** settings. It was one flat
list of ~16 identical bordered cards with only a top-level `AUDIO` header, in a
scrambled order — transcription knobs (Languages, Custom Vocabulary) stranded
far from the engine, audio-device settings split across three places, meeting
settings split too. No grouping, no hierarchy → visually monotonous.

Now the cards sit under four labeled sub-section dividers, related settings
together:

| group | settings |
|---|---|
| **transcription** | engine · languages · batch · filter music |
| **meetings** | live notes (+ append typed text) · automatic meeting detection |
| **devices & capture** | auto-select · device grid · echo cancellation · coreaudio · exclude apps |
| **voice & vocabulary** | your name (train) · custom vocabulary |

The two master toggles (Audio Recording, Capture audio) stay at the top,
ungrouped.

## after

![recording settings — grouped + reordered](https://raw.githubusercontent.com/screenpipe/screenpipe/pr-asset-recording-grouping/recording-after.png)

## notes

- **Pure presentational.** Every card's internals are untouched — only their
  order changed and four guarded `<div>` dividers were inserted. No behavior,
  state, or settings-key changes.
- Each divider is guarded by `!settings.disableAudio`, matching the cards it
  groups, so no empty group renders when audio is off.
- `bunx tsc --noEmit` passes clean (0 errors).
- The image above is a faithful render of the **new** structure (real labels,
  Inter, the app's B&W styling). The Tauri app can't be built in the PR
  sandbox, so it's a layout preview rather than a live-app capture — but the
  grouping/order/labels are exactly what the diff produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
