### PR TITLE
feat(macos): "hide dock icon" toggle — run menu-bar only

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -377,6 +377,52 @@ export function DisplaySection() {
         )}
 
         {/*
+         * macOS-only: hide the Dock icon (menu-bar-only "agent" app). The Rust
+         * reset_to_regular_and_refresh_tray in src-tauri/src/window/panel.rs
+         * reads `hideDockIcon` from the settings store, so we persist the value
+         * and then call reset_main_window to re-apply the activation policy
+         * immediately (it reads the freshly-saved value). The tray icon stays
+         * visible either way, so the app is always reachable. Default OFF.
+         */}
+        {isMac && (
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                      Hide Dock Icon
+                      <HelpTooltip text="Run screenpipe as a menu-bar-only app with no icon in the Dock. The menu-bar (tray) icon stays — click it to open screenpipe. Useful if you only need the app occasionally and don't want it in the Dock." />
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      Menu bar only — keep screenpipe out of the Dock
+                    </p>
+                  </div>
+                </div>
+                <Switch
+                  checked={settings?.hideDockIcon ?? false}
+                  onCheckedChange={async (checked) => {
+                    await updateSettings({ hideDockIcon: checked });
+                    // Re-apply the activation policy now (reset_main_window
+                    // reads the freshly-saved hideDockIcon from the store).
+                    commands.resetMainWindow().catch(() => {});
+                    toast({
+                      title: checked
+                        ? "dock icon hidden — menu bar only"
+                        : "dock icon visible",
+                      description: checked
+                        ? "open screenpipe from the menu bar icon."
+                        : undefined,
+                    });
+                  }}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/*
          * Windows-only: hide-to-tray toggle. The Rust close handler in
          * src-tauri/src/main.rs reads `minimizeToTrayOnClose` directly from the
          * settings store, so this switch only needs to round-trip the value —

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -388,6 +388,11 @@ export type Settings = SettingsStore & {
 	 * tray (and removes it from the taskbar) instead of minimizing. The Rust
 	 * close handler in src-tauri/src/main.rs reads this directly. Default off. */
 	minimizeToTrayOnClose?: boolean;
+	/** macOS-only: when true, run as a menu-bar-only "agent" app with no Dock
+	 * icon (NSApplication Accessory activation policy). The tray icon stays
+	 * visible. Read by reset_to_regular_and_refresh_tray in
+	 * src-tauri/src/window/panel.rs at startup and on window events. Default off. */
+	hideDockIcon?: boolean;
 }
 
 export function getEffectiveFilters(settings: Settings) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/panel.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/panel.rs
@@ -78,11 +78,35 @@ pub fn main_label_for_mode(mode: &str) -> &'static str {
     }
 }
 
-/// Reset activation policy to Regular so dock icon and tray are visible.
+/// Apply the desired macOS activation policy (and keep the tray reachable).
+///
+/// Default is `Regular` — dock icon and tray both visible. Two cases switch to
+/// `Accessory` (menu-bar-only "agent" app, no dock icon):
+///   1. enterprise hidden-UI policy, or
+///   2. the user opted into `hideDockIcon` in Settings → Display.
+///
+/// The tray icon is unaffected in every case, so the app stays reachable. This
+/// is a single explicit call (on startup, window close, and when the user
+/// toggles the setting) — NOT the per-tick watchdog toggling that was removed
+/// for causing crashes; setting the policy once on a real event is safe.
 #[cfg(target_os = "macos")]
 pub fn reset_to_regular_and_refresh_tray(app: &AppHandle) {
     if crate::enterprise_policy::is_app_ui_hidden() {
         info!("Setting activation policy to Accessory (enterprise hidden UI mode)");
+        let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
+        return;
+    }
+
+    // `hideDockIcon` is a frontend-only setting, so it lands in the store's
+    // untyped `extra` map rather than a typed field.
+    let hide_dock_icon = crate::store::SettingsStore::get(app)
+        .ok()
+        .flatten()
+        .and_then(|s| s.extra.get("hideDockIcon").and_then(|v| v.as_bool()))
+        .unwrap_or(false);
+
+    if hide_dock_icon {
+        info!("Setting activation policy to Accessory (hideDockIcon — menu bar only)");
         let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
         return;
     }


### PR DESCRIPTION
## what

A macOS-only switch in **Settings → Display → "Hide Dock Icon"**. When on, screenpipe runs as a menu-bar-only "agent" app (NSApplication `Accessory` activation policy) with **no Dock icon**. The menu-bar (tray) icon stays visible, so the app is always reachable. Default **OFF** — current behavior is unchanged.

## why

A user said the persistent Dock icon is the main thing they dislike — they only need the GUI occasionally and were "almost tempted to go to the CLI just so I don't have to interact with the GUI." There's no way to hide the Dock icon on macOS today. Windows already has an analogous "minimize to system tray on close" toggle.

## how

- `src-tauri/src/window/panel.rs` — `reset_to_regular_and_refresh_tray` now reads `hideDockIcon` from the settings store and applies `Accessory` when set, else `Regular`. Enterprise hidden-UI policy still takes precedence. `hideDockIcon` is frontend-only, so it lives in the store's untyped `extra` map (no `tauri.ts`/specta surface change; confirmed `sanitize_legacy_fields` leaves unknown keys intact).
- `components/settings/display-section.tsx` — macOS-only toggle. Persists the setting, then calls `reset_main_window` so the policy applies **immediately** (it re-reads the freshly-saved value).
- `lib/hooks/use-settings.tsx` — `hideDockIcon?: boolean` on the `Settings` type.

Applied on real events only (startup, window close, the toggle) — **not** the per-tick "Accessory watchdog" that was removed for crashing. Startup read order verified: the store plugin + `init_store` both run before the startup `reset_to_regular` call in `main.rs`, so the setting is honored from launch.

## ⚠️ regression risk — please read

`TESTING.md` §2 documents a hard-won invariant: **"activation policy never changes — no Accessory mode switches"** (overlay show/hide was once broken by Accessory switches). This feature *deliberately* introduces an Accessory path, so it's in tension with that invariant. Mitigations:
- **Default OFF** → for the vast majority, the policy stays `Regular` exactly as today (the store read just returns false). The historical bug was *unintended/repeated* switches; this is a single switch only when a user opts in.
- The switch is one-shot on genuine events, never on a timer.

Still, this needs the full `TESTING.md` §2 macOS checklist, run **both** ways:
- toggle **ON**: Dock icon disappears, tray icon remains, window opens from tray with working keyboard input, overlay show/hide 5× stays stable (no crash/flicker), survives relaunch (applied at startup).
- toggle **OFF** (default): "dock icon visible on launch", "dock persists after overlay show/hide", "activation policy never changes" all still pass.
- enterprise hidden-UI mode still forces Accessory regardless of the toggle.

## not compiled locally

The Tauri app crate doesn't build outside CI (Swift `livetext` bridge + bundled frontend), so this hasn't been run locally — needs the CI macOS build + the manual passes above before merge. The Rust change is small and uses existing store/activation APIs; the TS mirrors the existing Windows minimize-to-tray toggle and the overlay toggle's `reset_main_window` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)