### PR TITLE
fix(timeline): stop playhead time chip bobbing + white background

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -294,7 +294,13 @@ const PlayheadTimeChip = React.memo(function PlayheadTimeChip({
 				return;
 			}
 			const r = el.getBoundingClientRect();
-			setRect({ x: r.left + r.width / 2, y: r.top });
+			// Pin the chip's vertical position to the timeline container so it stays
+			// put. The current bar constantly animates its height (80%) and scale
+			// (1.15) as frames scroll under the playhead, so following its measured
+			// top edge made the chip bob up and down. Only the horizontal position
+			// tracks the current bar; Y is anchored just above the bars region.
+			const cr = container.getBoundingClientRect();
+			setRect({ x: r.left + r.width / 2, y: cr.top + 72 });
 		};
 		const schedule = () => {
 			if (!raf) raf = requestAnimationFrame(measure);
@@ -321,12 +327,12 @@ const PlayheadTimeChip = React.memo(function PlayheadTimeChip({
 				transform: "translate(-50%, -100%) translateY(-6px)",
 			}}
 		>
-			<div className="flex items-center gap-1.5 rounded-full bg-primary px-2.5 py-1 text-[11px] font-mono font-semibold tabular-nums leading-none text-primary-foreground shadow-lg ring-1 ring-black/10 whitespace-nowrap">
+			<div className="flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1 text-[11px] font-mono font-semibold tabular-nums leading-none text-neutral-900 shadow-lg ring-1 ring-black/10 whitespace-nowrap">
 				<Clock className="w-3 h-3 opacity-80" />
 				<span>{format(new Date(timestamp), "h:mm:ss a")}</span>
 			</div>
 			{/* downward pointer connecting the chip to the bar */}
-			<div className="-mt-[3px] h-2 w-2 rotate-45 rounded-[1px] bg-primary ring-1 ring-black/10" />
+			<div className="-mt-[3px] h-2 w-2 rotate-45 rounded-[1px] bg-white ring-1 ring-black/10" />
 		</div>,
 		document.body,
 	);


### PR DESCRIPTION
## what

the always-on time chip above the timeline playhead ("10:25:32 AM") had two issues:

1. **it bobbed up and down** while the timeline scrolled
2. **dark background** (near-black) instead of white

## why

the chip pinned its vertical position to the *current bar's* measured top edge. that bar is always animating — `height: 80%` + `scale(1.15)` with a `transition: all 0.2s` as each new frame becomes "current" under the playhead — so its measured `top` kept shifting and the chip jittered vertically.

the background came from `bg-primary` / `text-primary-foreground`, which in the app's light mode renders near-black with white text.

## fix

- anchor the chip's **Y** to the timeline container (`cr.top + 72`, a stable point just above the bars). **X** still tracks the playhead, so it follows horizontally but no longer moves vertically.
- swap the chip and its pointer diamond to `bg-white` + `text-neutral-900`. kept `ring-1 ring-black/10` so the white chip reads cleanly against the dark timeline.

## notes

- used explicit `bg-white` (not a theme token) so it stays white in both light/dark mode.
- the `+ 72` offset is tuned to the current layout (60px top padding + 80% bar height) and is commented inline.

scoped to `PlayheadTimeChip` in `components/rewind/timeline/timeline.tsx` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)