### PR TITLE
fix(oauth): write tokens to the configured data dir, not always ~/.screenpipe

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1177,6 +1177,22 @@ async fn main() {
             // Resolve data directory from user setting (custom dir or ~/.screenpipe)
             let (data_dir, data_dir_fell_back) = config::resolve_data_dir(&store.data_dir);
             info!("Recording data directory: {}", data_dir.display());
+
+            // Pin SCREENPIPE_DATA_DIR to the *resolved* dir so every consumer of
+            // `default_screenpipe_data_dir()` agrees with the engine on where the
+            // data lives. Without this, a user with a custom/relocated data dir
+            // hit a split: the engine (server_core) reads its SecretStore from
+            // `config.data_dir` (the custom path) while OAuth token writes
+            // (`open_secret_store`, chatgpt_oauth, …) went to the default
+            // `~/.screenpipe`. Tokens landed in one db.sqlite and were read from
+            // another → "no credentials found … cannot authenticate" 401s on
+            // every Microsoft 365 / Google / ChatGPT call, reconnecting forever
+            // never helping. Setting the env var here (before any OAuth callback
+            // can fire) makes `default_screenpipe_data_dir()` self-consistent and
+            // also propagates the correct dir to child processes (the CLI
+            // sidecar inherits this env).
+            std::env::set_var("SCREENPIPE_DATA_DIR", &data_dir);
+
             if data_dir_fell_back {
                 let app_handle_fb = app_handle.clone();
                 tauri::async_runtime::spawn(async move {


### PR DESCRIPTION
## Problem

Users with a **relocated recording data directory** can't use *any* OAuth connection (Microsoft 365, Google, ChatGPT, …). The connect dialog completes —

```
screenpipe_app::oauth: OAuth connected: microsoft365 (instance=Some("user@corp.com"), display=Some("user@corp.com"))
```

— but every subsequent Graph/API call 401s with:

```
screenpipe_engine::connections_api: proxy: no credentials found for connection 'microsoft365' instance None — cannot authenticate
```

…even **seconds after a fresh connect**, with no refresh/decrypt/corruption error logged. Reconnecting forever never helps.

Surfaced from a real user's feedback logs (data dir relocated to `D:\work\Screenpipe\.screenpipe`): repeated "Microsoft OAuth still not working".

## Root cause — split data directory

The token is **written to one `db.sqlite` and read from another**:

| | resolves data dir via | hits |
|---|---|---|
| Engine + its SecretStore (**reads** the token) | `config.data_dir` ← `resolve_data_dir(store.data_dir)` (`server_core.rs`) | the user's **custom** dir |
| OAuth callback (**writes** the token) | `default_screenpipe_data_dir()` (`oauth.rs` `open_secret_store`) | `~/.screenpipe` (**ignores the custom-dir setting**) |

`default_screenpipe_data_dir()` only honors the `SCREENPIPE_DATA_DIR` env var or `~/.screenpipe`; it does not read the in-app data-dir setting. So on a relocated install the token lands in the default db while the engine reads the custom db → "no credentials found". Invisible on default installs (custom == default), which is why it wasn't caught.

The same hardcoded-default mismatch exists in `chatgpt_oauth.rs`, `pi.rs`, `skills.rs`, `updates.rs`, and `viewer.rs`.

## Fix

Pin `SCREENPIPE_DATA_DIR` to the **resolved** data dir immediately after `resolve_data_dir`, before any OAuth callback can fire:

```rust
let (data_dir, data_dir_fell_back) = config::resolve_data_dir(&store.data_dir);
std::env::set_var("SCREENPIPE_DATA_DIR", &data_dir);
```

Now every `default_screenpipe_data_dir()` consumer agrees with the engine on where the data lives (and the correct dir propagates to child processes). One line fixes the whole bug class.

- No-op on default installs (resolved == `~/.screenpipe`).
- Safe with E2E (already sets `SCREENPIPE_DATA_DIR`; we set it to the same resolved path).
- Placed exactly like the adjacent `HF_ENDPOINT` `set_var`, early in setup.

## Testing

- New line type-checks in isolation (`set_var(&str, &PathBuf)`).
- App crate isn't built by Rust CI (Swift bridge) — compiled by `e2e-test.yml` (Windows tauri build) on this PR.
- Manual check to confirm: with a custom data dir set, connect Microsoft 365 and verify a Graph call succeeds (no `no credentials found` warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)