### PR TITLE
fix(timeline): guard frame.devices access against undefined

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/app-context-popover.tsx
@@ -118,7 +118,7 @@ export function AppContextPopover({
 		const transcripts: { text: string; time: Date; speaker?: string }[] = [];
 		const seenChunks = new Set<number>();
 		for (const frame of frames) {
-			for (const device of frame.devices) {
+			for (const device of frame.devices ?? []) {
 				for (const audio of device.audio || []) {
 					if (!audio.transcription?.trim()) continue;
 					if (seenChunks.has(audio.audio_chunk_id)) continue;

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -1747,13 +1747,13 @@ export const TimelineSlider = ({
 
 									const hasAudio = frame?.devices?.some((d) => d.audio?.some((a) => a.transcription?.trim()));
 									const isCurrent = frameIndex === currentIndex;
-									const matchesDevice = selectedDeviceId === "all" || frame.devices.some((d) => d.device_id === selectedDeviceId);
-									const matchesApp = selectedAppName === "all" || frame.devices.some((d) => d.metadata?.app_name === selectedAppName);
-									const matchesDomain = selectedDomain === "all" || frame.devices.some((d) => {
+									const matchesDevice = selectedDeviceId === "all" || (frame.devices?.some((d) => d.device_id === selectedDeviceId) ?? false);
+									const matchesApp = selectedAppName === "all" || (frame.devices?.some((d) => d.metadata?.app_name === selectedAppName) ?? false);
+									const matchesDomain = selectedDomain === "all" || (frame.devices?.some((d) => {
 										const url = d.metadata?.browser_url?.trim();
 										return url ? extractDomain(url) === selectedDomain : false;
-									});
-									const matchesSpeaker = selectedSpeaker === "all" || frame.devices.some((d) => d.audio?.some((a) => a.speaker_name === selectedSpeaker));
+									}) ?? false);
+									const matchesSpeaker = selectedSpeaker === "all" || (frame.devices?.some((d) => d.audio?.some((a) => a.speaker_name === selectedSpeaker)) ?? false);
 									const frameIdForTag = frame.devices?.[0]?.frame_id || '';
 									const frameTagsForFilter = frameIdForTag ? (tags[frameIdForTag] || []) : [];
 									const matchesTag = selectedTag === "all" || frameTagsForFilter.includes(selectedTag);


### PR DESCRIPTION
## what

Make `frame.devices` access null-safe in the timeline so an undefined `devices` can't crash the whole timeline render.

## why

The frame-filter block in `timeline.tsx` (≈L1750-1756) called `frame.devices.some(...)` **directly** for `matchesDevice` / `matchesApp` / `matchesDomain` / `matchesSpeaker`. If `frame.devices` is ever `undefined` at runtime, those throw `TypeError: Cannot read properties of undefined (reading 'some')` — and because this runs inside the frame `.map(...)` render loop, it takes down the entire timeline, not just one row.

These were the *inconsistent* lines. Right next to them, and elsewhere, the codebase already treats `devices` as possibly-absent:
- L1748 `hasAudio`: `frame?.devices?.some(...)`
- L1882 favicon: `frame.devices?.find(...)`
- helpers: `getFrameAppName` / `getFrameAppNames` open with `if (!frame?.devices?.length) return 'Unknown'`

The `StreamTimeSeriesResponse` type declares `devices: DeviceFrameResponse[]` (required, non-optional), which is exactly why `tsc` never flagged the unguarded `.some()` calls. But since the helpers guard it, there is **no runtime invariant** that `devices` is always present — so the right fix is to guard (consistently with the rest of the file), not to document a non-existent invariant.

## changes

- `timeline.tsx` — the four filters use `frame.devices?.some(...) ?? false`. Semantics preserved: when a filter is active (`!== "all"`) and `devices` is missing, the frame doesn't match (same as an empty devices array).
- `app-context-popover.tsx` — `for (const device of frame.devices ?? [])`.

Minimal, matches the existing defensive style. `bunx tsc --noEmit` passes (no new errors). Pre-existing robustness gap, unrelated to any in-flight retention work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)