### PR TITLE
fix(brain): include HTML files in fallback artifact discovery

### DIFF
--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -430,7 +430,10 @@ fn select_newest_files(
 /// Returns `true` if the extension is user-facing for fallback artifact
 /// discovery. Pipes producing other types should declare them in `artifacts:`.
 fn is_user_facing_artifact_ext(ext: &str) -> bool {
-    matches!(ext, "md" | "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg")
+    matches!(
+        ext,
+        "md" | "html" | "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -2061,6 +2064,7 @@ impl PipeManager {
                 for (path, _) in select_newest_files(candidates, fallback_cap) {
                     let kind = match path.extension().and_then(|e| e.to_str()) {
                         Some("md") => "markdown",
+                        Some("html") => "html",
                         Some("json") => "json",
                         Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "svg") => "image",
                         _ => "text",
@@ -5652,6 +5656,7 @@ mod tests {
     fn test_is_user_facing_artifact_ext() {
         // positive cases
         assert!(is_user_facing_artifact_ext("md"));
+        assert!(is_user_facing_artifact_ext("html"));
         assert!(is_user_facing_artifact_ext("png"));
         assert!(is_user_facing_artifact_ext("jpg"));
         assert!(is_user_facing_artifact_ext("jpeg"));
@@ -5691,6 +5696,7 @@ mod tests {
         // Create mixed files in output/
         let files = vec![
             "report.md",
+            "report.html",
             "screenshot.png",
             "data.json",
             "runner.ts",
@@ -5716,7 +5722,21 @@ mod tests {
             .collect();
         names.sort();
 
-        assert_eq!(names, vec!["output/report.md", "output/screenshot.png"]);
+        assert_eq!(
+            names,
+            vec![
+                "output/report.html",
+                "output/report.md",
+                "output/screenshot.png"
+            ]
+        );
+
+        let html_decl = pipe_decls
+            .1
+            .iter()
+            .find(|(decl, _)| decl.path == "output/report.html")
+            .expect("html artifact should be discovered");
+        assert_eq!(html_decl.0.kind.as_deref(), Some("html"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/routes/artifacts.rs
+++ b/crates/screenpipe-engine/src/routes/artifacts.rs
@@ -1083,8 +1083,7 @@ mod tests {
             path: "/Users/test/.screenpipe/outputs/pipe/focus-pipe/relatorio-foco-offline.html"
                 .to_string(),
             original_path: Some(
-                "/Users/test/.screenpipe/pipes/focus-pipe/output/relatorio-foco.html"
-                    .to_string(),
+                "/Users/test/.screenpipe/pipes/focus-pipe/output/relatorio-foco.html".to_string(),
             ),
             size_bytes: 1024,
             preview: Some("<html><body>Resumo do dia</body></html>".to_string()),

--- a/crates/screenpipe-engine/src/routes/artifacts.rs
+++ b/crates/screenpipe-engine/src/routes/artifacts.rs
@@ -579,7 +579,7 @@ fn default_per_pipe_limit() -> u32 {
 
 #[derive(OaSchema, Deserialize)]
 pub(crate) struct ListArtifactsQuery {
-    /// Case-insensitive substring match over title, source, and preview.
+    /// Case-insensitive substring match over title, source, preview, and paths.
     pub q: Option<String>,
     /// Exact source match (pipe name or chat source).
     pub source: Option<String>,
@@ -626,6 +626,22 @@ pub(crate) struct ArtifactListResponse {
     pub pagination: PaginationInfo,
     /// Distinct sources over the full (unfiltered) set, for filter pills.
     pub sources: Vec<String>,
+}
+
+fn artifact_matches_query(item: &ArtifactItem, q: &str) -> bool {
+    item.title.to_lowercase().contains(q)
+        || item.source.to_lowercase().contains(q)
+        || item.path.to_lowercase().contains(q)
+        || item
+            .original_path
+            .as_deref()
+            .map(|p| p.to_lowercase().contains(q))
+            .unwrap_or(false)
+        || item
+            .preview
+            .as_deref()
+            .map(|p| p.to_lowercase().contains(q))
+            .unwrap_or(false)
 }
 
 /// GET /artifacts — unified listing of AI-generated artifacts.
@@ -771,14 +787,7 @@ pub(crate) async fn list_artifacts_handler(
         .map(str::to_lowercase)
         .filter(|q| !q.is_empty())
     {
-        items.retain(|i| {
-            i.title.to_lowercase().contains(&q)
-                || i.source.to_lowercase().contains(&q)
-                || i.preview
-                    .as_deref()
-                    .map(|p| p.to_lowercase().contains(&q))
-                    .unwrap_or(false)
-        });
+        items.retain(|i| artifact_matches_query(i, &q));
     }
 
     // Newest first by parsed instant — sources emit different UTC offsets,
@@ -1060,6 +1069,35 @@ mod tests {
                 "/fake/screenpipe/outputs/pipe/my-pipe/report.txt"
             ))
         );
+    }
+
+    #[test]
+    fn artifact_query_matches_path_and_original_path() {
+        let item = ArtifactItem {
+            registered: true,
+            id: Some(1),
+            source: "focus-pipe".to_string(),
+            source_type: "pipe".to_string(),
+            title: "Daily focus report".to_string(),
+            kind: "html".to_string(),
+            path: "/Users/test/.screenpipe/outputs/pipe/focus-pipe/relatorio-foco-offline.html"
+                .to_string(),
+            original_path: Some(
+                "/Users/test/.screenpipe/pipes/focus-pipe/output/relatorio-foco.html"
+                    .to_string(),
+            ),
+            size_bytes: 1024,
+            preview: Some("<html><body>Resumo do dia</body></html>".to_string()),
+            saf_kind: None,
+            artifact_id: None,
+            saf_version: None,
+            modified_at: "2026-06-20T00:00:00Z".to_string(),
+            created_at: Some("2026-06-20T00:00:00Z".to_string()),
+        };
+
+        assert!(artifact_matches_query(&item, "relatorio-foco-offline.html"));
+        assert!(artifact_matches_query(&item, "relatorio-foco.html"));
+        assert!(!artifact_matches_query(&item, "missing-file-name"));
     }
 
     // ── SAF envelope validator ────────────────────────────────────────────


### PR DESCRIPTION
This PR fixes two Brain artifact issues around HTML reports.

First, fallback artifact discovery now treats plain `.html` files as user-facing artifacts, so a pipe writing something like `output/report.html` will show up in Brain even if it was not explicitly declared or registered.

Second, artifact search now matches filenames and paths as well, so searching for a concrete file like `relatorio-foco.html` can find the artifact reliably.

fixes #4403

### Changes

- add `.html` to the fallback artifact extension allowlist
- classify fallback-discovered HTML files with kind `html`
- expand artifact search to match:
  - `title`
  - `source`
  - `preview`
  - `path`
  - `original_path`
- add focused test coverage for:
  - HTML fallback discovery
  - inferred `html` artifact kind
  - filename/path-based artifact search


### Before -

<img width="1199" height="764" alt="image" src="https://github.com/user-attachments/assets/9e9bdc1f-39b1-420e-97b9-788aa47dc9a6" />


### After -

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/9e64a9ae-cfdd-4806-9809-8de60e972c03" />



https://github.com/user-attachments/assets/cc34d2c8-7e31-47ca-b9f3-574b562fc70e


