### PR TITLE
feat(ai-gateway): block frontier models on background/pipe traffic

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -5,6 +5,7 @@ import { Env, RequestBody } from '../types';
 import { createProvider, resolveModelAlias } from '../providers';
 import { addCorsHeaders } from '../utils/cors';
 import { logModelOutcome } from '../services/model-health';
+import { isFrontierModel } from '../services/cost-tracker';
 import { isFlexEligible } from '../utils/latency';
 import { routeTier, routerArm, TIER_HEAD } from './difficulty-router';
 import { captureException } from '@sentry/cloudflare';
@@ -469,6 +470,20 @@ export async function handleChatCompletions(
   // before the hint injection masks the emptiness. No Sentry — client bug.
   if (!Array.isArray(body.messages) || body.messages.length === 0) {
     return errorResponse(body, 400, 'The request must include at least one message.');
+  }
+
+  // Pipes / background are unattended, often high-volume automations where a
+  // frontier model (opus, gpt-5.5, *-pro, fable) is a cost bomb for marginal gain.
+  // Block them on the background lane: downgrade to 'auto' (→ cheap background
+  // chain) by default, or hard-reject via PIPE_FRONTIER_POLICY=reject. The client
+  // also hides frontier models from pipe presets; this is the worker backstop that
+  // catches old pipes / custom integrations / the passthrough that slip through.
+  if (latency === 'background' && body.model !== 'auto' && isFrontierModel(body.model)) {
+    if (String((env as any)?.PIPE_FRONTIER_POLICY ?? 'downgrade').toLowerCase() === 'reject') {
+      return errorResponse(body, 403, `"${body.model}" (a frontier model) isn't available for scheduled pipes / background tasks. Use "auto" or a fast model (glm-5, gemini, sonnet, haiku).`);
+    }
+    const fallback = String((env as any)?.PIPE_FRONTIER_FALLBACK ?? 'auto');
+    body = { ...body, model: fallback };
   }
 
   body = ensureScreenpipeHint(body);

--- a/packages/ai-gateway/src/services/cost-tracker.ts
+++ b/packages/ai-gateway/src/services/cost-tracker.ts
@@ -340,6 +340,16 @@ export function hasPricing(model: string | null | undefined): boolean {
   return findPricing(model) !== null;
 }
 
+// Output $/Mtok at/above which a model is "frontier" — too expensive for an
+// unattended high-volume pipe. Catches opus (25-75), fable-5 (50), gpt-5.5 (30),
+// gpt-*-pro (180); leaves sonnet (15), gpt-5.4 (15), haiku/flash/glm through.
+const FRONTIER_OUTPUT_USD = 20;
+/** Frontier/premium models that shouldn't run on background/pipe traffic. */
+export function isFrontierModel(model: string | null | undefined): boolean {
+  const p = findPricing(model);
+  return !!p && p.output >= FRONTIER_OUTPUT_USD;
+}
+
 /**
  * Cost attribution for routed requests. 'auto' (and explicit models with
  * fallback chains) can serve a DIFFERENT model than requested — the chat

--- a/packages/ai-gateway/src/test/cost-tracker.unit.test.ts
+++ b/packages/ai-gateway/src/test/cost-tracker.unit.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { getModelCost, logCost, isZeroCostModel, inferProvider } from '../services/cost-tracker';
+import { getModelCost, logCost, isZeroCostModel, inferProvider, isFrontierModel } from '../services/cost-tracker';
 
 describe('getModelCost — cache-aware pricing', () => {
 	it('charges full price when no cache info is given (legacy behavior unchanged)', () => {
@@ -126,6 +126,13 @@ describe('getModelCost — cache-aware pricing', () => {
 	it('does not change zero-cost or provider inference behavior', () => {
 		expect(isZeroCostModel('glm-5')).toBe(true);
 		expect(inferProvider('claude-opus-4-8')).toBe('anthropic');
+	});
+
+	it('isFrontierModel flags the premium tier (blocked on pipes), not mid/cheap', () => {
+		for (const m of ['claude-opus-4-8', 'claude-opus-4-6', 'claude-fable-5', 'gpt-5.5', 'gpt-5.5-pro', 'gpt-5.4-pro'])
+			expect(isFrontierModel(m)).toBe(true);
+		for (const m of ['claude-sonnet-4-5', 'gpt-5.4', 'gpt-5.4-mini', 'claude-haiku-4-5', 'glm-5', 'gemini-3.5-flash', 'gpt-5-nano'])
+			expect(isFrontierModel(m)).toBe(false);
 	});
 });
 

--- a/packages/ai-gateway/wrangler.toml
+++ b/packages/ai-gateway/wrangler.toml
@@ -65,6 +65,9 @@ GEMINI_FLEX_INTERACTIVE = "false"
 # - ROUTER_MODE ("off"): interactive auto difficulty router. "off" = always glm-5
 #   (today's behavior). "heuristic" = regex tiering (0 latency). "embedding" =
 #   bge centroid via Workers AI (best accuracy, +1 embed call). See difficulty-router.ts.
+# - PIPE_FRONTIER_POLICY ("downgrade"): background/pipe traffic on a frontier model
+#   (opus/gpt-5.5/*-pro/fable, output>=$20/Mtok) → "downgrade" to PIPE_FRONTIER_FALLBACK
+#   (default "auto"), or "reject" with a 403. Pipes shouldn't run frontier models.
 # - ROUTER_SAMPLE_PCT ("100"): % of devices in the router arm for A/B (deterministic
 #   by device hash). 50 = half ON / half control → measure ON vs control in cost_log
 #   via the router_tier column ('control' = baseline arm). 0 = effectively off.


### PR DESCRIPTION
Pipes (background) shouldn't run frontier models (opus/gpt-5.5/*-pro/fable, output ≥ $20/Mtok) — unattended high-volume automations where it's a cost bomb. Background + frontier → downgrade to 'auto' (cheap background chain), or reject via `PIPE_FRONTIER_POLICY=reject`. **Interactive chat untouched** (opus still allowed for live chat). Price-based `isFrontierModel()` auto-covers new models. Worker backstop for the client guard. 458 tests pass, deployed (`d963e281`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)