### PR TITLE
feat(privacy): redact form-field values by default + plain-language redaction UX

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -31,6 +31,7 @@ import {
   Keyboard,
   MousePointerClick,
   FolderTree,
+  ChevronRight,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -276,6 +277,59 @@ function EncryptDataCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+// Live, on-device-only illustration of what the current "what to hide"
+// selection masks. Pure example text — never real captured data. Each token
+// maps to a SpanLabel; it renders as the redaction placeholder when its
+// category is selected (secret is always on), otherwise as the raw value.
+// Makes the abstract category checkboxes concrete without a real frame.
+const REDACTION_PREVIEW_PARTS: (
+  | { text: string }
+  | { cat: string; value: string; ph: string }
+)[] = [
+  { text: "hi, i'm " },
+  { cat: "person", value: "Jordan Lee", ph: "[PERSON]" },
+  { text: " — email " },
+  { cat: "email", value: "jordan@example.com", ph: "[EMAIL]" },
+  { text: ", cell " },
+  { cat: "phone", value: "(555) 010-2983", ph: "[PHONE]" },
+  { text: ", ssn " },
+  { cat: "id", value: "412-09-1764", ph: "[ID]" },
+  { text: ", key " },
+  { cat: "secret", value: "AKIA…X7Q", ph: "[SECRET]" },
+  { text: "." },
+];
+
+function RedactionExamplePreview({ labels }: { labels: string[] }) {
+  const isOn = (cat: string) => cat === "secret" || labels.includes(cat);
+  return (
+    <div className="rounded-md border border-border bg-muted/40 px-2.5 py-2">
+      <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+        Preview
+      </p>
+      <p className="text-xs leading-relaxed text-foreground">
+        {REDACTION_PREVIEW_PARTS.map((part, i) =>
+          "text" in part ? (
+            <span key={i} className="text-muted-foreground">
+              {part.text}
+            </span>
+          ) : isOn(part.cat) ? (
+            <span
+              key={i}
+              className="rounded-[3px] bg-foreground px-1 py-0.5 font-mono text-[10px] text-background align-baseline"
+            >
+              {part.ph}
+            </span>
+          ) : (
+            <span key={i} className="font-medium">
+              {part.value}
+            </span>
+          ),
+        )}
+      </p>
+    </div>
   );
 }
 
@@ -555,15 +609,15 @@ export function PrivacySection() {
     desc: string;
     always?: boolean;
   }[] = [
-    { value: "secret", label: "Secrets", desc: "passwords, API keys, tokens", always: true },
-    { value: "id", label: "IDs", desc: "SSNs, credit cards, account & license numbers" },
+    { value: "secret", label: "Passwords & keys", desc: "passwords, API keys, tokens", always: true },
+    { value: "id", label: "ID numbers", desc: "SSNs, credit cards, account & license numbers" },
     { value: "person", label: "Names", desc: "people's names" },
-    { value: "email", label: "Emails", desc: "email addresses" },
+    { value: "email", label: "Email addresses", desc: "email addresses" },
     { value: "phone", label: "Phone numbers", desc: "phone numbers" },
-    { value: "address", label: "Addresses", desc: "postal addresses" },
-    { value: "url", label: "URLs", desc: "links carrying tokens or session IDs" },
+    { value: "address", label: "Mailing addresses", desc: "postal addresses" },
+    { value: "url", label: "Links with tokens", desc: "links carrying tokens or session IDs" },
     { value: "date", label: "Dates", desc: "dates of birth, timestamps" },
-    { value: "sensitive", label: "Sensitive info", desc: "health, financial, identity context" },
+    { value: "sensitive", label: "Health & financial details", desc: "health, financial, identity context" },
   ];
 
   const piiRedactionLabels = useMemo<string[]>(() => {
@@ -613,31 +667,43 @@ export function PrivacySection() {
     "ui_window_title",
     "element_text",
   ];
-  const PII_COLUMN_OPTIONS: { value: string; label: string; desc: string }[] = [
+  // Form-field values default ON: it's the surface where real PII (typed
+  // passwords / field values a11y exposes that OCR never sees) actually
+  // lives. Kept OUT of CORE so the user can still uncheck it — it only
+  // seeds the default. Keep in sync with the Rust defaults
+  // (`RedactColumns::default` / `default_pii_redaction_columns`).
+  const DEFAULT_OPTIONAL_COLUMNS = ["element_properties"];
+  const PII_COLUMN_OPTIONS: {
+    value: string;
+    label: string;
+    desc: string;
+    recommended?: boolean;
+  }[] = [
     {
       value: "element_properties",
-      label: "Form field values (accessibility)",
-      desc: "the value of every captured control — catches password & form-field contents OCR can't see. Heaviest surface; off by default",
+      label: "Form field values",
+      desc: "what you type into forms — catches passwords and field contents that on-screen text misses",
+      recommended: true,
     },
     {
       value: "browser_url",
-      label: "Page URLs",
-      desc: "the browser address bar — often non-PII, and redacting breaks links",
+      label: "Web addresses",
+      desc: "the address bar — usually not private, and hiding them breaks links",
     },
     {
       value: "ui_element_name",
-      label: "Control names",
-      desc: "accessibility name of clicked/focused controls — usually static labels",
+      label: "Button & menu labels",
+      desc: "names like “Submit” or “Search” — rarely private",
     },
     {
       value: "ui_element_description",
-      label: "Control descriptions",
-      desc: "accessibility help text of controls",
+      label: "Help text on controls",
+      desc: "the longer description some buttons and menus expose",
     },
     {
       value: "a11y_url_field",
-      label: "URLs in accessibility data",
-      desc: "the url field inside captured accessibility nodes",
+      label: "Links inside app data",
+      desc: "URLs embedded in an app’s underlying structure",
     },
   ];
 
@@ -645,6 +711,7 @@ export function PrivacySection() {
     return (
       (settings.piiRedactionColumns as string[] | undefined) ?? [
         ...CORE_REDACTION_COLUMNS,
+        ...DEFAULT_OPTIONAL_COLUMNS,
       ]
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1380,8 +1447,10 @@ export function PrivacySection() {
                   verifies the open-source build before sending anything.
                 </p>
 
+                {/* Axis 1 — WHAT to hide (PII categories). The primary knob:
+                    content-type, applies wherever it's found. */}
                 <p className="text-xs font-medium text-foreground pt-2">
-                  Fields to redact
+                  What to hide
                 </p>
                 {PII_FIELD_OPTIONS.map((opt) => {
                   const checked =
@@ -1419,51 +1488,70 @@ export function PrivacySection() {
                     </label>
                   );
                 })}
+                {textRedactionOn && (
+                  <RedactionExamplePreview labels={piiRedactionLabels} />
+                )}
                 <p className="text-[11px] text-muted-foreground pt-0.5">
                   Unselected types stay visible so your timeline remains
                   searchable. Secrets are always removed in both modes.
                 </p>
 
-                {/* Column allow-list is text-only — hide it when text
-                    redaction is off (Images-only Smart mode). */}
+                {/* Axis 2 — WHERE to look (captured surfaces). Advanced and
+                    orthogonal to the categories above; collapsed by default so
+                    most users only deal with "What to hide". Text-only, so
+                    hide it entirely when text redaction is off (Images-only
+                    Smart mode). */}
                 {textRedactionOn && (
-                  <>
-                    <p className="text-xs font-medium text-foreground pt-3 mt-1.5 border-t border-border">
-                      Where to redact (text)
-                    </p>
-                    {PII_COLUMN_OPTIONS.map((opt) => {
-                      const checked = piiRedactionColumns.includes(opt.value);
-                      return (
-                        <label
-                          key={opt.value}
-                          className="flex items-start gap-2 text-xs cursor-pointer"
-                        >
-                          <input
-                            type="checkbox"
-                            className="mt-0.5"
-                            checked={checked}
-                            onChange={(e) =>
-                              handlePiiColumnToggle(opt.value, e.target.checked)
-                            }
-                          />
-                          <span>
-                            <span className="font-medium text-foreground">
-                              {opt.label}
+                  <details className="group pt-3 mt-1.5 border-t border-border">
+                    <summary className="flex cursor-pointer select-none items-center gap-1.5 text-xs font-medium text-foreground list-none [&::-webkit-details-marker]:hidden">
+                      <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
+                      Where we look
+                      <span className="font-normal text-muted-foreground">
+                        — advanced
+                      </span>
+                    </summary>
+                    <div className="mt-2 space-y-1.5">
+                      <p className="text-[11px] text-muted-foreground">
+                        We always scan what you type, your clipboard,
+                        transcripts, window titles, and on-screen text. Turn on
+                        any of these extra places the same info can hide.
+                      </p>
+                      {PII_COLUMN_OPTIONS.map((opt) => {
+                        const checked = piiRedactionColumns.includes(opt.value);
+                        return (
+                          <label
+                            key={opt.value}
+                            className="flex items-start gap-2 text-xs cursor-pointer"
+                          >
+                            <input
+                              type="checkbox"
+                              className="mt-0.5"
+                              checked={checked}
+                              onChange={(e) =>
+                                handlePiiColumnToggle(
+                                  opt.value,
+                                  e.target.checked,
+                                )
+                              }
+                            />
+                            <span>
+                              <span className="font-medium text-foreground">
+                                {opt.label}
+                              </span>
+                              {opt.recommended && (
+                                <span className="text-muted-foreground">
+                                  {" "}(recommended)
+                                </span>
+                              )}
+                              <span className="text-muted-foreground">
+                                {" "}— {opt.desc}
+                              </span>
                             </span>
-                            <span className="text-muted-foreground">
-                              {" "}— {opt.desc}
-                            </span>
-                          </span>
-                        </label>
-                      );
-                    })}
-                    <p className="text-[11px] text-muted-foreground pt-0.5">
-                      Typed text, clipboard, transcripts, window titles, and
-                      on-screen text are always redacted. These extra capture
-                      surfaces are off by default — enable any that matter for
-                      your threat model.
-                    </p>
-                  </>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </details>
                 )}
 
                 <label className="flex items-start gap-2 text-xs cursor-pointer pt-2 mt-1.5 border-t border-border">

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -709,11 +709,14 @@ fn default_pii_redaction_labels() -> Vec<String> {
     vec!["secret".to_string()]
 }
 
-/// Default columns the worker scrubs: every clear capture surface ON, the
-/// debatable / lossy ones OFF (browser_url, ui element name/description, a11y
+/// Default columns the worker scrubs: every clear capture surface ON, plus
+/// `element_properties` (form-field values — the surface where real PII like
+/// typed passwords actually lives, which OCR never sees). The debatable /
+/// lossy ones stay OFF (browser_url, ui element name/description, a11y
 /// url-field). KEEP IN SYNC with `RedactColumns::default()` in
-/// screenpipe-redact (this crate can't depend on it). `full_text` is always
-/// redacted regardless and is intentionally not a key here.
+/// screenpipe-redact (this crate can't depend on it) and the
+/// `--pii-redaction-columns` clap default. `full_text` is always redacted
+/// regardless and is intentionally not a key here.
 fn default_pii_redaction_columns() -> Vec<String> {
     [
         "accessibility_text",
@@ -724,6 +727,7 @@ fn default_pii_redaction_columns() -> Vec<String> {
         "ui_element_value",
         "ui_window_title",
         "element_text",
+        "element_properties",
     ]
     .iter()
     .map(|s| s.to_string())

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -461,13 +461,14 @@ pub struct RecordArgs {
     /// browser_url, audio_transcription, ui_text_content, ui_element_value,
     /// ui_window_title, ui_element_name, ui_element_description, element_text,
     /// element_properties, a11y_url_field. The list is exact (key present →
-    /// on, absent → off); `full_text` is always redacted. Default leaves
-    /// browser_url / ui_element_name / ui_element_description / a11y_url_field
-    /// / element_properties OFF (opt-in).
+    /// on, absent → off); `full_text` is always redacted. Default scrubs the
+    /// clear surfaces plus element_properties (form-field values — the real
+    /// PII surface); leaves browser_url / ui_element_name /
+    /// ui_element_description / a11y_url_field OFF (opt-in).
     #[arg(
         long,
         value_delimiter = ',',
-        default_value = "accessibility_text,accessibility_tree,window_name,audio_transcription,ui_text_content,ui_element_value,ui_window_title,element_text"
+        default_value = "accessibility_text,accessibility_tree,window_name,audio_transcription,ui_text_content,ui_element_value,ui_window_title,element_text,element_properties"
     )]
     pub pii_redaction_columns: Vec<String>,
 

--- a/crates/screenpipe-redact/src/worker/columns.rs
+++ b/crates/screenpipe-redact/src/worker/columns.rs
@@ -80,21 +80,24 @@ pub struct RedactColumns {
 }
 
 impl Default for RedactColumns {
-    /// The default allow-list: the clear, lighter capture surfaces ON, the
-    /// debatable / lossy / heavy ones OFF (opt-in).
+    /// The default allow-list: the clear capture surfaces ON (incl.
+    /// `element_properties` — form-field values), the debatable / lossy ones
+    /// OFF (opt-in).
     ///
     /// OFF by default: `browser_url` (URLs are structured, often non-PII,
-    /// lossy to redact), `ui_element_name` / `ui_element_description`
-    /// (usually build-time control labels), `a11y_url_field` (the `url` key
-    /// inside the a11y JSON), and `element_properties`.
+    /// lossy to redact and redacting breaks links), `ui_element_name` /
+    /// `ui_element_description` (usually build-time control labels), and
+    /// `a11y_url_field` (the `url` key inside the a11y JSON).
     ///
-    /// `element_properties` is off by deliberate choice: it's the per-element
-    /// accessibility value JSON (millions of rows — the heaviest surface).
-    /// The focused-field value is still caught on the lighter surfaces that
-    /// ARE on by default (`accessibility_tree` node `value`, and
-    /// `ui_element_value` on click/focus). Enable `element_properties` for
-    /// full per-element value coverage (incl. password-field values a11y
-    /// exposes that OCR never sees).
+    /// `element_properties` is ON by default: it's the per-element
+    /// accessibility value JSON — the surface where real PII actually lives
+    /// (incl. password-field values a11y exposes that OCR never sees), so it
+    /// carries the most leak risk. It is also the heaviest surface (millions
+    /// of rows), so redacting it costs more worker CPU; users who want a
+    /// lighter scan can uncheck it (the focused-field value is still caught
+    /// via `accessibility_tree` node `value` and `ui_element_value` on
+    /// click/focus). KEEP IN SYNC with `default_pii_redaction_columns()` in
+    /// screenpipe-config and the `--pii-redaction-columns` clap default.
     fn default() -> Self {
         Self {
             accessibility_text: true,
@@ -108,7 +111,7 @@ impl Default for RedactColumns {
             ui_element_name: false,
             ui_element_description: false,
             element_text: true,
-            element_properties: false,
+            element_properties: true,
             a11y_url_field: false,
         }
     }
@@ -224,15 +227,17 @@ mod tests {
     #[test]
     fn default_has_clear_pii_on_debatable_off() {
         let d = RedactColumns::default();
-        // Clear, lighter capture surfaces — on.
+        // Clear capture surfaces — on.
         assert!(d.accessibility_text && d.accessibility_tree && d.window_name);
         assert!(d.audio_transcription && d.ui_text_content && d.ui_element_value);
         assert!(d.ui_window_title && d.element_text);
-        // Debatable / lossy / heavy — off (opt-in).
+        // Form-field values — on by default (the real PII surface, incl.
+        // password-field values OCR never sees).
+        assert!(d.element_properties);
+        // Debatable / lossy — off (opt-in).
         assert!(!d.browser_url);
         assert!(!d.ui_element_name && !d.ui_element_description);
         assert!(!d.a11y_url_field);
-        assert!(!d.element_properties);
     }
 
     #[test]


### PR DESCRIPTION
## screenshots

**Before** (every surface a flat, equally-weighted, jargon-named checkbox) vs **after** (plain-language **"What to hide"** + a collapsible **"Where we look — advanced"**, with a live on-device preview). Form-field values is now on by default and labeled *recommended*.

![redaction settings before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/claude/assets-redaction-ux/.github/pr-assets/redaction-before-after.png)

**Two previews, one per axis.** *What to hide* (categories) is shown via token-masking on an example line (above, in the "after"). *Where we look* (surfaces) is shown via a mock app window — hover a row to outline the matching region; turning a surface on covers it with a redaction bar; typed/transcript/on-screen text shows as always-hidden:

![where we look hover-to-highlight preview](https://raw.githubusercontent.com/screenpipe/screenpipe/claude/assets-redaction-ux/.github/pr-assets/redaction-where-preview.png)

> All preview text is fabricated (no real captured data). "Where we look" is collapsed by default — shown expanded here.

## why

Two things were off in the PII redaction settings:

1. **Defaults gap.** The one surface where real PII actually lives — **form-field values** (`element_properties`: what you type into forms, incl. passwords the accessibility tree exposes that OCR never sees) — was **OFF by default**, while genuinely low-PII surfaces (page URLs, control labels) sat next to it as equally-weighted checkboxes.
2. **Too technical.** "Where to redact (text)" listed `Form field values (accessibility)`, `URLs in accessibility data`, `Control descriptions` — implementation terms for accessibility-tree node fields. A non-technical user has no idea what maps to what, and the whole block is buried 3 levels deep (PII Removal → Smart → Apply to: Text → …).

The panel was really modeling **two orthogonal axes** but never naming them:
- **what to hide** = PII *categories* (`piiRedactionLabels` / `SpanLabel`) — content-type, applies anywhere
- **where to look** = captured *surfaces* (`piiRedactionColumns` / `RedactColumns`) — which streams get scanned

A value is redacted only when **both** line up: `redact iff (category on) AND (surface on)`.

## what changed

### defaults — form-field values now redacted by default
Flipped in **all four in-sync sources** so CLI, config, engine, and app agree:
- `RedactColumns::default()` — `crates/screenpipe-redact/src/worker/columns.rs`
- `default_pii_redaction_columns()` — `crates/screenpipe-config/src/recording.rs`
- `--pii-redaction-columns` clap default — `crates/screenpipe-engine/src/cli/mod.rs`
- UI fallback — `apps/screenpipe-app-tauri/components/settings/privacy-section.tsx`

`element_properties` → ON. The lossy / low-PII surfaces (`browser_url`, `ui_element_name`, `ui_element_description`, `a11y_url_field`) stay OFF. Only affects users with **Smart text redaction** on (already opt-in); explicit user column configs are still honored exactly (`from_keys` is exact). Updated the `default_*` test.

### UX — name the two axes, plain language, live previews
- Split into **"What to hide"** (categories — primary, for everyone) and **"Where we look — advanced"** (surfaces — collapsed behind a `<details>` disclosure).
- Plain-language relabels, jargon out of the labels:
  - `Form field values (accessibility)` → **Form field values** *(recommended)*
  - `URLs in accessibility data` → **Links inside app data**
  - `Control names` → **Button & menu labels**
  - `Control descriptions` → **Help text on controls**
  - `Page URLs` → **Web addresses**
  - `Secrets` → **Passwords & keys**, `IDs` → **ID numbers**, `Sensitive info` → **Health & financial details**
- **What-to-hide preview** (`RedactionExamplePreview`): masks example tokens (`[PERSON]`, `[EMAIL]`, `[ID]`, `[SECRET]`…) as you toggle categories.
- **Where-we-look preview** (`RedactionWherePreview`): a mock app window — hover a surface row to outline the matching region; toggle it on to cover that region with a redaction bar. Both previews are pure illustration, never real data, grayscale per DESIGN.md.

## tradeoff (flagging for review)
`element_properties` is the **heaviest** surface (per-element accessibility value JSON, millions of rows), so redacting it by default costs more background-worker CPU (`VISION.md`: perf is not optional). Mitigations: it runs **only** when Smart text redaction is enabled (opt-in), it's on the **async background** path (not the recording hot path), and anyone who wants a lighter scan can uncheck it. The focused-field value is still caught on lighter surfaces regardless. Happy to gate this differently if the perf cost is a concern.

## follow-up
A broader pass to make the rest of screenpipe's settings less technical / less verbose is started in #4410 (recording + notifications copy).

## test
- `cargo test -p screenpipe-redact` (columns) — green
- `cargo test -p screenpipe-config` — green
- `bunx tsc --noEmit` — clean for `privacy-section.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
