### PR TITLE
feat(settings): more inline previews — power mode, transcription, notifications

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/battery-saver-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/battery-saver-section.tsx
@@ -12,6 +12,7 @@ import { Switch } from "@/components/ui/switch";
 import { useToast } from "@/components/ui/use-toast";
 import { commands } from "@/lib/utils/tauri";
 import type { SettingsField } from "./settings-search";
+import { PowerModePreview } from "./setting-previews";
 
 /** Settings search index for this section. Co-located with the component so adding a field here means updating one file. See `SettingsField` in `./settings-search` for the schema. */
 export const searchIndex: SettingsField[] = [
@@ -257,6 +258,8 @@ export function BatterySaverSection() {
           </button>
         ))}
       </div>
+
+      <PowerModePreview mode={user_pref} />
 
       {/* Thermal warning */}
       {state && (state.thermal_state === "serious" || state.thermal_state === "critical") && (

--- a/apps/screenpipe-app-tauri/components/settings/notifications-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/notifications-settings.tsx
@@ -7,6 +7,7 @@ import React from "react";
 import { useSettings, Settings } from "@/lib/hooks/use-settings";
 import { Switch } from "@/components/ui/switch";
 import type { SettingsField } from "./settings-search";
+import { NotificationSamplePreview } from "./setting-previews";
 
 /** Settings search index for this section. Co-located with the component so adding a field here means updating one file. See `SettingsField` in `./settings-search` for the schema. */
 export const searchIndex: SettingsField[] = [
@@ -62,6 +63,8 @@ export function NotificationsSettings() {
           Control which notifications screenpipe sends you.
         </p>
       </div>
+
+      <NotificationSamplePreview />
 
       <div className="space-y-1">
         {/* Capture stalls */}

--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -8,7 +8,7 @@ const DEFAULT_OPENAI_COMPATIBLE_ENDPOINT = "http://127.0.0.1:8080";
 
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useSettingsIndexDriftCheck, type SettingsField } from "./settings-search";
-import { CaptureFrequencyPreview, AudioCaptureModePreview } from "./setting-previews";
+import { CaptureFrequencyPreview, AudioCaptureModePreview, TranscriptionEnginePreview } from "./setting-previews";
 
 /** Settings search index for this section. Co-located with the component so adding a field here means updating one file. See `SettingsField` in `./settings-search` for the schema. */
 export const searchIndex: SettingsField[] = [
@@ -2701,6 +2701,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                 </Select>
               </div>
             </div>
+            <TranscriptionEnginePreview engine={settings.audioTranscriptionEngine} />
             {audioEngineResolution.fallbackReason && (
               <Alert
                 data-testid="audio-engine-fallback-alert"

--- a/apps/screenpipe-app-tauri/components/settings/setting-previews.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/setting-previews.tsx
@@ -145,3 +145,172 @@ export function RetentionModePreview({
     </div>
   );
 }
+
+// ── shared: a 5-segment geometric meter ──────────────────────────────
+// Filled segments = level (0–5). Black-on-grey, sharp — brand house style.
+function SegMeter({ label, level }: { label: string; level: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="w-[5.5rem] shrink-0 text-[10px] text-muted-foreground">
+        {label}
+      </span>
+      <span className="flex flex-1 gap-[3px]">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <span
+            key={i}
+            className={cn(
+              "h-1.5 flex-1 rounded-[1px]",
+              i < level ? "bg-foreground" : "bg-foreground/15",
+            )}
+          />
+        ))}
+      </span>
+    </div>
+  );
+}
+
+// ── Power mode ───────────────────────────────────────────────────────
+// Three meters (cadence / quality / battery) that re-balance per profile,
+// so the tradeoff each mode makes is visible at a glance.
+const POWER_PROFILE: Record<
+  "auto" | "performance" | "battery_saver",
+  { meters: [number, number, number]; caption: string }
+> = {
+  performance: {
+    meters: [5, 5, 1],
+    caption: "full cadence & quality — ignores battery",
+  },
+  auto: {
+    meters: [3, 3, 3],
+    caption: "adapts to whether you're plugged in",
+  },
+  battery_saver: {
+    meters: [1, 2, 5],
+    caption: "slows capture & trims quality to stretch battery",
+  },
+};
+
+export function PowerModePreview({
+  mode,
+}: {
+  mode: "auto" | "performance" | "battery_saver";
+}) {
+  const p = POWER_PROFILE[mode] ?? POWER_PROFILE.auto;
+  return (
+    <div className="mt-3 space-y-1.5 rounded-md border border-border bg-muted/40 px-2.5 py-2">
+      <SegMeter label="capture cadence" level={p.meters[0]} />
+      <SegMeter label="capture quality" level={p.meters[1]} />
+      <SegMeter label="battery life" level={p.meters[2]} />
+      <p className="pt-0.5 text-[10px] text-muted-foreground">{p.caption}</p>
+    </div>
+  );
+}
+
+// ── Transcription engine ─────────────────────────────────────────────
+// Answers "does my audio leave the device?" with a tiny data-flow plus
+// privacy / speed / device-load meters. Engines are classified by id.
+type EngineClass = {
+  where: "device" | "enclave" | "provider";
+  target: string;
+  note: string;
+  privacy: number;
+  speed: number;
+  load: number;
+};
+
+function classifyEngine(engine: string): EngineClass | null {
+  if (engine === "disabled") return null;
+  if (engine === "screenpipe-cloud")
+    return {
+      where: "enclave",
+      target: "verified enclave",
+      note: "attested · zero-retention",
+      privacy: 4,
+      speed: 5,
+      load: 1,
+    };
+  if (engine === "deepgram")
+    return {
+      where: "provider",
+      target: "Deepgram",
+      note: "third party",
+      privacy: 2,
+      speed: 5,
+      load: 1,
+    };
+  if (engine === "openai-compatible")
+    return {
+      where: "provider",
+      target: "your provider",
+      note: "third party",
+      privacy: 2,
+      speed: 4,
+      load: 1,
+    };
+  // whisper-*, qwen3-asr, parakeet — runs locally
+  return {
+    where: "device",
+    target: "your device",
+    note: "never leaves",
+    privacy: 5,
+    speed: 3,
+    load: 4,
+  };
+}
+
+export function TranscriptionEnginePreview({ engine }: { engine: string }) {
+  const c = classifyEngine(engine);
+  if (!c) {
+    return (
+      <div className="mt-2.5 ml-[26px] rounded-md border border-border bg-muted/40 px-2.5 py-2">
+        <p className="text-[11px] text-muted-foreground">
+          audio is captured but not transcribed — no speech text, nothing sent
+          anywhere, lowest load.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-2.5 ml-[26px] space-y-2 rounded-md border border-border bg-muted/40 px-2.5 py-2">
+      <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+        <span className="rounded border border-border bg-background px-1.5 py-0.5 font-mono">
+          audio
+        </span>
+        <span className="text-muted-foreground">→</span>
+        <span className="rounded border border-border bg-background px-1.5 py-0.5 text-foreground">
+          {c.target}
+        </span>
+        <span className="text-muted-foreground">{c.note}</span>
+      </div>
+      <SegMeter label="privacy" level={c.privacy} />
+      <SegMeter label="speed" level={c.speed} />
+      <SegMeter label="device load" level={c.load} />
+    </div>
+  );
+}
+
+// ── Notifications ────────────────────────────────────────────────────
+// A sample of the actual notification, so the toggles aren't abstract.
+export function NotificationSamplePreview() {
+  return (
+    <div className="mb-4 rounded-lg border border-border bg-card px-3 py-2.5">
+      <p className="mb-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+        what these look like
+      </p>
+      <div className="flex items-start gap-2.5 rounded-md border border-border bg-background px-2.5 py-2">
+        <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-[6px] bg-foreground">
+          <span className="h-2.5 w-2.5 rounded-[2px] bg-background" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-foreground">screenpipe</span>
+            <span className="text-[10px] text-muted-foreground">now</span>
+          </div>
+          <p className="truncate text-xs text-muted-foreground">
+            Audio capture recovered — recording is healthy again.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
More of the "show, don't tell" settings previews, with elevated brand-aligned design (black & white, geometric segmented meters, sharp corners, monospace data chips). **Visual only — no behavior change.**

> Stacks on #4412 (shares the `setting-previews.tsx` module) — base is set to that branch so this diff shows only the new work. Will retarget to `main` once #4412 merges.

![power mode, transcription engine, and notification previews](https://raw.githubusercontent.com/screenpipe/screenpipe/claude/assets-redaction-ux/.github/pr-assets/settings-previews-2.png)

> Preview content is fabricated illustration — never real captured data.

## what's new

1. **Power mode** (`battery-saver-section`) → `PowerModePreview` — three segmented meters (capture cadence / quality / battery life) that re-balance per profile, so each mode's tradeoff is obvious instead of a one-line description.
2. **Transcription engine** (`recording-settings`) → `TranscriptionEnginePreview` — answers the question users actually have ("does my audio leave the device?") with a tiny data-flow (`audio → your device` / `verified enclave` / `provider`) plus privacy / speed / device-load meters. Engines are classified by id: on-device (whisper / qwen3-asr / parakeet), enclave (screenpipe-cloud), third-party (deepgram / openai-compatible), or disabled.
3. **Notifications** (`notifications-settings`) → `NotificationSamplePreview` — renders a sample of the real toast at the top, so the toggle list isn't abstract.

## design notes
- House style: grayscale only, geometric 5-segment meters, mono for the data-flow chips — consistent with `DESIGN.md` and the redaction previews.
- Each preview reflects the live setting value (active power mode, selected engine); the notification sample is static.
- **Schedule was intentionally skipped** — it already ships a full weekly-grid visualization, so no preview was needed there.

## next candidates (future batch)
HD recording quality-vs-disk, monitor-layout map, sync/cloud-archive data-flow, AI-preset model routing, encryption-at-rest padlock.

## test
- `bunx tsc --noEmit` — clean for all four edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)