### PR TITLE
fix(api): max_content_length=0 should return full text, not destroy it

### DIFF
--- a/crates/screenpipe-engine/src/routes/search.rs
+++ b/crates/screenpipe-engine/src/routes/search.rs
@@ -230,7 +230,15 @@ pub struct SearchResponse {
 /// Safe on UTF-8 char boundaries.
 pub fn truncate_middle(text: &str, max_chars: usize) -> String {
     let char_count = text.chars().count();
-    if char_count <= max_chars {
+    // `max_chars == 0` means "no truncation" (opt out), mirroring the
+    // documented `max_content_length=0` ⇒ full text contract honored by the
+    // MCP server (`truncateMiddle`: `max <= 0` returns the text untouched) and
+    // surfaced to users as "pass max_content_length=0 for full text". Without
+    // this guard a 0 cap returned only the "...(truncated N chars)..." marker —
+    // it destroyed the very text the caller asked to see in full, and because
+    // the MCP forwards the param to this endpoint the damage happened here,
+    // server-side, before the MCP's own opt-out could apply.
+    if max_chars == 0 || char_count <= max_chars {
         return text.to_string();
     }
     let removed = char_count - max_chars;
@@ -1108,6 +1116,16 @@ mod tests {
     fn test_truncate_middle_short_text() {
         assert_eq!(truncate_middle("hello", 10), "hello");
         assert_eq!(truncate_middle("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_middle_zero_means_full_text() {
+        // max_content_length=0 is the documented "opt out / full text" signal.
+        // It must return the text untouched, not a marker-only stub that
+        // destroys the content the caller asked to see in full.
+        let text = "abcdefghijklmnopqrstuvwxyz";
+        assert_eq!(truncate_middle(text, 0), text);
+        assert_eq!(truncate_middle("", 0), "");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`max_content_length=0` is the documented **"opt out / full text"** signal:

- The MCP server's `search-content` tool description says: *"pass max_content_length=0 to opt out, or a custom integer to override."*
- Its own `truncateMiddle` honors that: `if (max <= 0 || text.length <= max) return text;`
- The marker even tells users: *"…pass max_content_length=0 for full text…"*

But the HTTP `/search` handler's `truncate_middle` only opted out on `char_count <= max_chars`:

```rust
let char_count = text.chars().count();
if char_count <= max_chars { return text.to_string(); }
let removed = char_count - max_chars;
let keep_start = max_chars / 2;   // = 0 when max_chars == 0
let keep_end = max_chars - keep_start; // = 0
// → "" + "...(truncated N chars)..." + ""
```

So `max_content_length=0` returned only the `...(truncated N chars)...` marker — it **destroyed the entire text** the caller explicitly asked to see in full. And since the MCP **forwards** `max_content_length` to this endpoint as a query param, the text was already gone server-side before the MCP's client-side opt-out could apply. Net effect: asking for full text via the documented mechanism returns no text.

## Fix

Treat `max_chars == 0` as "no truncation", mirroring the MCP/CLI contract (`max <= 0` ⇒ untouched).

## Test

Added `test_truncate_middle_zero_means_full_text`. Full `truncate_middle` suite passes:

```
test routes::search::tests::test_truncate_middle_zero_means_full_text ... ok
test result: ok. 4 passed; 0 failed
```

Found via a 24/7 chaos-engineering pass, cross-checking the HTTP handler against the documented MCP contract.