### PR TITLE
ci: fix two pipeline-blocking flakes (7-Zip download + vitest exclude)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,15 +111,37 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Install 7zip
+      - name: Ensure 7-Zip is available
         shell: powershell
         run: |
+          # GitHub-hosted windows runners ship 7-Zip pre-installed, so this is
+          # normally a no-op. Only download when it's genuinely missing, and
+          # retry with backoff — the old unconditional Invoke-WebRequest hit
+          # intermittent "Unable to connect to the remote server" from
+          # 7-zip.org and failed the whole Windows job on unrelated PRs.
+          $sevenZipDir = "C:\Program Files\7-Zip"
+          if (Test-Path "$sevenZipDir\7z.exe") {
+            echo "$sevenZipDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            Write-Host "7-Zip already present at $sevenZipDir"
+            exit 0
+          }
           $7zipUrl = "https://7-zip.org/a/7z2301-x64.exe"
           $7zipInstaller = "7z-installer.exe"
-          Invoke-WebRequest -Uri $7zipUrl -OutFile $7zipInstaller
+          $downloaded = $false
+          for ($i = 1; $i -le 5; $i++) {
+            try {
+              Invoke-WebRequest -Uri $7zipUrl -OutFile $7zipInstaller -UseBasicParsing -TimeoutSec 60
+              $downloaded = $true
+              break
+            } catch {
+              Write-Host "7-Zip download attempt $i failed: $($_.Exception.Message)"
+              Start-Sleep -Seconds ([math]::Min(30, [math]::Pow(2, $i)))
+            }
+          }
+          if (-not $downloaded) { throw "failed to download 7-Zip after 5 attempts" }
           Start-Process -FilePath .\$7zipInstaller -Args "/S" -Wait
           Remove-Item $7zipInstaller
-          echo "C:\Program Files\7-Zip" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$sevenZipDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Download ONNX Runtime (CPU)
         shell: pwsh

--- a/.github/workflows/windows-integration-test.yml
+++ b/.github/workflows/windows-integration-test.yml
@@ -87,15 +87,37 @@ jobs:
           Write-Host "Audio service is already running"
         }
 
-    - name: Install 7zip
+    - name: Ensure 7-Zip is available
       shell: powershell
       run: |
+        # GitHub-hosted windows runners ship 7-Zip pre-installed, so this is
+        # normally a no-op. Only download when it's genuinely missing, and
+        # retry with backoff — the old unconditional Invoke-WebRequest hit
+        # intermittent "Unable to connect to the remote server" from
+        # 7-zip.org and failed the whole Windows job on unrelated PRs.
+        $sevenZipDir = "C:\Program Files\7-Zip"
+        if (Test-Path "$sevenZipDir\7z.exe") {
+          echo "$sevenZipDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host "7-Zip already present at $sevenZipDir"
+          exit 0
+        }
         $7zipUrl = "https://7-zip.org/a/7z2301-x64.exe"
         $7zipInstaller = "7z-installer.exe"
-        Invoke-WebRequest -Uri $7zipUrl -OutFile $7zipInstaller
+        $downloaded = $false
+        for ($i = 1; $i -le 5; $i++) {
+          try {
+            Invoke-WebRequest -Uri $7zipUrl -OutFile $7zipInstaller -UseBasicParsing -TimeoutSec 60
+            $downloaded = $true
+            break
+          } catch {
+            Write-Host "7-Zip download attempt $i failed: $($_.Exception.Message)"
+            Start-Sleep -Seconds ([math]::Min(30, [math]::Pow(2, $i)))
+          }
+        }
+        if (-not $downloaded) { throw "failed to download 7-Zip after 5 attempts" }
         Start-Process -FilePath .\$7zipInstaller -Args "/S" -Wait
         Remove-Item $7zipInstaller
-        echo "C:\Program Files\7-Zip" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "$sevenZipDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Download ONNX Runtime (CPU)
       shell: pwsh

--- a/apps/screenpipe-app-tauri/vitest.config.ts
+++ b/apps/screenpipe-app-tauri/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
 			"lib/__tests__/team-pipes.test.ts",
 			"components/__tests__/url-detection-benchmark.test.ts",
 			"lib/hooks/__tests__/timeline-reconnection.test.ts",
+			"lib/hooks/__tests__/timeline-liveness.test.ts",
 			"lib/hooks/__tests__/timeline-store-logic.test.ts",
 			"lib/hooks/__tests__/server-push-old-frames.test.ts",
 			"lib/hooks/__tests__/window-focus-refresh.test.ts",


### PR DESCRIPTION
Two independent CI breakages that were failing checks across unrelated PRs. Consolidated since both are "the pipeline is red for reasons that have nothing to do with the PR under review."

## 1. Flaky 7-Zip install (`ci.yml`, `windows-integration-test.yml`)

The Windows jobs downloaded 7-Zip from `7-zip.org` via a single, un-retried `Invoke-WebRequest`. That endpoint flakes (`Unable to connect to the remote server`), failing the whole Windows job on PRs that touch no Windows code — observed twice in a row including across a manual re-run.

GitHub-hosted `windows-*` runners already ship 7-Zip pre-installed, so the download is redundant on the happy path. **Fix:** skip when `7z.exe` is present (removes the flake entirely there); when a download is genuinely needed, retry up to 5× with capped backoff. Left the release workflows untouched to keep this low-risk to the release pipeline.

## 2. Vitest picks up a bun:test file (`vitest.config.ts`)

`lib/hooks/__tests__/timeline-liveness.test.ts` imports from `bun:test` and runs via `test:bun`, but was missing from vitest's `exclude` list, so vitest tried to load it and failed (`Failed to resolve import "bun:test"`). It was the only bun:test file missing — added in #4409, red on every frontend PR since. **Fix:** add the one missing exclude entry; verified every `bun:test` file is now covered.

(Was #4419 + #4425, consolidated.)