### PR TITLE
fix(connections): resolve named OAuth instances for M365 and Pi

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -2398,6 +2398,36 @@ fn build_prompt_command(
     Ok(cmd)
 }
 
+async fn open_secret_store_for_connection_context() -> Option<screenpipe_secrets::SecretStore> {
+    let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
+    let db_path = data_dir.join("db.sqlite");
+    let secret_key = match crate::secrets::get_key_if_encryption_enabled() {
+        crate::secrets::KeyResult::Found(k) => Some(k),
+        _ => None,
+    };
+    screenpipe_secrets::SecretStore::open(&db_path.to_string_lossy(), secret_key)
+        .await
+        .ok()
+}
+
+async fn foreground_connections_context(app: &AppHandle) -> String {
+    let api = crate::recording::local_api_context_from_app(app);
+    let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
+    let store = open_secret_store_for_connection_context().await;
+    screenpipe_connect::connections::render_context(&data_dir, api.port, store.as_ref()).await
+}
+
+async fn attach_foreground_connections_context(app: &AppHandle, message: String) -> String {
+    let ctx = foreground_connections_context(app).await;
+    if ctx.trim().is_empty() {
+        return message;
+    }
+    format!(
+        "Current Screenpipe connected integrations context, refreshed for this turn:\n{}\n\nUser request:\n{}",
+        ctx, message
+    )
+}
+
 fn queued_payload_to_steer_command(payload: Value) -> Result<Value, String> {
     let message = payload
         .get("message")
@@ -2421,6 +2451,7 @@ fn queued_payload_to_steer_command(payload: Value) -> Result<Value, String> {
 #[tauri::command]
 #[specta::specta]
 pub async fn pi_prompt(
+    app: AppHandle,
     state: State<'_, PiState>,
     session_id: Option<String>,
     message: String,
@@ -2441,6 +2472,7 @@ pub async fn pi_prompt(
     };
 
     let preview = display_preview.unwrap_or_else(|| message.clone());
+    let message = attach_foreground_connections_context(&app, message).await;
     let cmd = build_prompt_command(message, images)?;
     let (queue_id, rx) = queue
         .send_prompt(
@@ -2461,6 +2493,7 @@ pub async fn pi_prompt(
 #[tauri::command]
 #[specta::specta]
 pub async fn pi_queue_prompt(
+    app: AppHandle,
     state: State<'_, PiState>,
     session_id: Option<String>,
     message: String,
@@ -2481,6 +2514,7 @@ pub async fn pi_queue_prompt(
     };
 
     let preview = display_preview.unwrap_or_else(|| message.clone());
+    let message = attach_foreground_connections_context(&app, message).await;
     let cmd = build_prompt_command(message, images)?;
     let (queue_id, _rx) = queue
         .send_prompt(
@@ -2499,6 +2533,7 @@ pub async fn pi_queue_prompt(
 #[tauri::command]
 #[specta::specta]
 pub async fn pi_steer(
+    app: AppHandle,
     state: State<'_, PiState>,
     session_id: Option<String>,
     message: String,
@@ -2517,6 +2552,7 @@ pub async fn pi_steer(
             .ok_or("Pi command queue not initialized")?
     };
 
+    let message = attach_foreground_connections_context(&app, message).await;
     let mut cmd = json!({
         "type": "steer",
         "message": message,

--- a/crates/screenpipe-connect/src/oauth.rs
+++ b/crates/screenpipe-connect/src/oauth.rs
@@ -267,13 +267,15 @@ pub(crate) async fn load_oauth_json_with_instance(
     }
 
     // Fallback B: callers that don't know about instances (instance=None)
-    // should still find the token when the user has a single named instance.
-    let instances = list_oauth_instances(store, integration_id).await;
-    let named: Vec<String> = instances.into_iter().flatten().collect();
-    match named.len() {
+    // should still find the token when the user has a single usable named
+    // instance. Count recoverable instances, not raw rows: old app versions
+    // and interrupted reconnects can leave stale named rows behind, and those
+    // must not make a single healthy account look ambiguous.
+    let recoverable_named = list_recoverable_named_oauth_instances(store, integration_id).await;
+    match recoverable_named.len() {
         0 => None,
         1 => {
-            let inst = named.into_iter().next().unwrap();
+            let inst = recoverable_named.into_iter().next().unwrap();
             tracing::debug!(
                 "oauth: {} default lookup empty, falling back to single instance {:?}",
                 integration_id,
@@ -288,10 +290,10 @@ pub(crate) async fn load_oauth_json_with_instance(
             // gets None (returning a random instance would be worse — we
             // could leak the wrong account's data).
             tracing::warn!(
-                "oauth: {} default lookup empty and {} instances exist ({}) — caller passed instance=None; pick one explicitly",
+                "oauth: {} default lookup empty and {} recoverable instances exist ({}) — caller passed instance=None; pick one explicitly",
                 integration_id,
-                named.len(),
-                named.join(", "),
+                recoverable_named.len(),
+                recoverable_named.join(", "),
             );
             None
         }
@@ -454,6 +456,26 @@ pub async fn list_connected_oauth_instances(
     connected
 }
 
+async fn list_recoverable_named_oauth_instances(
+    store: Option<&SecretStore>,
+    integration_id: &str,
+) -> Vec<String> {
+    let mut instances = Vec::new();
+    for inst in list_oauth_instances(store, integration_id).await {
+        let Some(name) = inst else {
+            continue;
+        };
+        if load_oauth_json_exact(store, integration_id, Some(&name))
+            .await
+            .as_ref()
+            .is_some_and(oauth_json_is_recoverable)
+        {
+            instances.push(name);
+        }
+    }
+    instances
+}
+
 /// Build a human/AI-readable explanation of why an OAuth lookup failed for
 /// `(integration_id, instance)`. Without this, every miss collapses to the
 /// same "not connected" string — which is wrong (and infuriating) when the
@@ -471,22 +493,28 @@ pub async fn describe_oauth_error(
     display_name: &str,
     instance: Option<&str>,
 ) -> String {
-    let instances: Vec<String> = list_oauth_instances(store, integration_id)
+    let instances: Vec<String> =
+        list_recoverable_named_oauth_instances(store, integration_id).await;
+    let all_instances: Vec<String> = list_oauth_instances(store, integration_id)
         .await
         .into_iter()
         .flatten()
         .collect();
-    match (instance, instances.as_slice()) {
-        (Some(inst), _) => format!(
+    match (instance, instances.as_slice(), all_instances.as_slice()) {
+        (Some(inst), _, _) => format!(
             "{display_name} account '{inst}' is not connected or its token can't be refreshed — reconnect it in Settings > Connections"
         ),
-        (None, []) => format!(
+        (None, [], []) => format!(
             "{display_name} not connected — use 'Connect {display_name}' in Settings > Connections"
         ),
-        (None, [only]) => format!(
+        (None, [], stale) => format!(
+            "{display_name} has saved account row(s) ({}) but none can be refreshed — reconnect it in Settings > Connections",
+            stale.join(", "),
+        ),
+        (None, [only], _) => format!(
             "{display_name} account '{only}' token can't be refreshed — reconnect it in Settings > Connections"
         ),
-        (None, many) => format!(
+        (None, many, _) => format!(
             "multiple {display_name} accounts connected ({}) — specify which one with `instance`. On JSON-body endpoints add `\"instance\": \"<email>\"` to the request body; on proxy/query endpoints add `?instance=<email>` (e.g. instance=\"{}\")",
             many.join(", "),
             many[0],
@@ -1337,6 +1365,38 @@ mod tests {
 
         let got = load_oauth_json(Some(&store), id, None).await;
         assert!(got.is_none(), "expected ambiguous None, got {got:?}");
+    }
+
+    #[tokio::test]
+    async fn load_with_none_ignores_stale_named_instances_when_one_is_recoverable() {
+        // M365 support case: reconnects can leave stale named rows behind.
+        // A default proxy call should not fail as "ambiguous" when only one
+        // named account is actually usable.
+        let store = mem_store().await;
+        let id = "_t_stale_named_rows";
+        let expired = unix_now().saturating_sub(3600);
+        store
+            .set_json(
+                &format!("oauth:{}:old@example.com", id),
+                &json!({"access_token": "old", "expires_at": expired}),
+            )
+            .await
+            .unwrap();
+        store
+            .set_json(
+                &format!("oauth:{}:kevin.sharpen@ami.ca", id),
+                &json!({
+                    "access_token": "fresh",
+                    "refresh_token": "rt",
+                    "expires_at": expired,
+                }),
+            )
+            .await
+            .unwrap();
+
+        let got = load_oauth_json(Some(&store), id, None).await.unwrap();
+        assert_eq!(got["access_token"], "fresh");
+        assert_eq!(got["refresh_token"], "rt");
     }
 
     #[tokio::test]

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -529,6 +529,41 @@ async fn list_instances(
     Path(id): Path<String>,
 ) -> (StatusCode, Json<Value>) {
     let mgr = state.cm.lock().await;
+    let is_oauth = screenpipe_connect::connections::all_integrations()
+        .iter()
+        .find(|i| i.def().id == id)
+        .and_then(|i| i.oauth_config())
+        .is_some();
+
+    if is_oauth {
+        let instances = oauth_store::list_oauth_instances(state.secret_store.as_deref(), &id).await;
+        let mut items = Vec::new();
+        for inst in instances {
+            let token =
+                oauth_store::load_oauth_json(state.secret_store.as_deref(), &id, inst.as_deref())
+                    .await;
+            let display_name = token.as_ref().and_then(|v| {
+                v["email"]
+                    .as_str()
+                    .or_else(|| v["workspace_name"].as_str())
+                    .or_else(|| v["name"].as_str())
+                    .map(str::to_string)
+            });
+            let connected = oauth_store::is_oauth_instance_connected(
+                state.secret_store.as_deref(),
+                &id,
+                inst.as_deref(),
+            )
+            .await;
+            items.push(json!({
+                "instance": inst,
+                "connected": connected,
+                "display_name": display_name,
+            }));
+        }
+        return (StatusCode::OK, Json(json!({ "instances": items })));
+    }
+
     match mgr.get_all_instances(&id).await {
         Ok(instances) => {
             let items: Vec<Value> = instances


### PR DESCRIPTION
### Description:

-after:


https://github.com/user-attachments/assets/cea1bdda-c246-464d-9887-ebaa9df2ac9c



- tests passing:

<img width="1011" height="403" alt="image" src="https://github.com/user-attachments/assets/56694e51-c92d-4dbe-a17f-73da2285817c" />


- logs working M365:


<img width="1204" height="129" alt="image" src="https://github.com/user-attachments/assets/a37af2e7-ae62-40f1-8a2e-c6db58e3ca68" />


  - Fixes Microsoft 365 OAuth lookups when the token is saved under a named account instance but callers request the default instance.
  - Ignores stale/broken named OAuth rows when deciding whether a single usable account can be used as the default.
  - Adds OAuth instance support to the generic /connections/:id/instances endpoint so M365 accounts are visible like other connections.
  - Injects fresh connected-integrations context into foreground Pi prompts so Pi can see newly connected OAuth integrations.
  - Adds a regression test for the stale-row plus one recoverable named OAuth account case.
  - Keeps multi-account behavior conservative: if multiple usable OAuth accounts exist, callers must still specify instance.