### PR TITLE
test(e2e): fix flaky 'Could not click stop button' in pipes spec

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/pipes.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/pipes.spec.ts
@@ -546,9 +546,14 @@ describe('Pipes: discover → install → play', function () {
     await browser.waitUntil(
       async () =>
         (await browser.execute((name: string) => {
-          for (const nameBtn of Array.from(document.querySelectorAll<HTMLButtonElement>('button'))) {
-            if (nameBtn.textContent?.trim() !== name) continue;
-            const row = nameBtn.closest<HTMLElement>('div.group');
+          // Match the name in a <button> OR <span>. The pipe name renders as a
+          // <span> (pipes-section.tsx), so a 'button'-only scan never locates
+          // the row and the stop click times out ("Could not click stop
+          // button") — even though the running-state wait above, which already
+          // uses 'button, span', passed. Keep the two locators in sync.
+          for (const nameEl of Array.from(document.querySelectorAll<HTMLElement>('button, span'))) {
+            if (nameEl.textContent?.trim() !== name) continue;
+            const row = nameEl.closest<HTMLElement>('div.group');
             if (!row) continue;
             const stopBtn = row.querySelector<HTMLButtonElement>('button[title="stop pipe"]');
             if (stopBtn && !stopBtn.disabled) {
@@ -569,9 +574,10 @@ describe('Pipes: discover → install → play', function () {
     await browser.waitUntil(
       async () =>
         (await browser.execute((name: string) => {
-          for (const nameBtn of Array.from(document.querySelectorAll<HTMLButtonElement>('button'))) {
-            if (nameBtn.textContent?.trim() !== name) continue;
-            const row = nameBtn.closest<HTMLElement>('div.group');
+          // Same 'button, span' locator as above — the name is a <span>.
+          for (const nameEl of Array.from(document.querySelectorAll<HTMLElement>('button, span'))) {
+            if (nameEl.textContent?.trim() !== name) continue;
+            const row = nameEl.closest<HTMLElement>('div.group');
             if (!row) continue;
             const hasStop = !!row.querySelector('button[title="stop pipe"]');
             const hasRun = !!row.querySelector('button[title="run pipe"]');


### PR DESCRIPTION
## Problem

The pipes E2E spec intermittently fails across unrelated PRs:

```
[WebKitGTK] Error: Could not click stop button for "digital-clone"
Spec Files: 55 passed, 1 failed
```

## Root cause

The pipe-name element renders as a `<span>`, not a `<button>` (`components/settings/pipes-section.tsx`):

```tsx
<span className="text-sm font-medium truncate" title={pipe.config.name}>
  {pipe.config.name}
```

The run/stop flow has **four** loops that locate a pipe's row by matching this name and walking up to `div.group`. Two were already migrated to query `'button, span'` — the play-button search and the running-state wait — but the **stop-click** loop and the **leave-running-state** loop still scanned `'button'` only:

```js
for (const nameBtn of Array.from(document.querySelectorAll<HTMLButtonElement>('button'))) {
  if (nameBtn.textContent?.trim() !== name) continue;   // never matches a <span> name
  const row = nameBtn.closest('div.group');
  ...
```

So the stop-click loop could never find a span-named row and timed out after 10s — even though the running-state wait immediately above (using `'button, span'`) had just confirmed the row exists. That mismatch is the flake.

## Fix

Complete the migration: the stop-click and leave-running loops now use the same `'button, span'` locator as their two siblings. Pure test-robustness; no production code change.

## Verification

Verified by source inspection — the DOM structure (name is a `<span>`) and the two sibling loops already using this exact selector and compiling. I did **not** run the full `e2e-windows`/WebKitGTK job locally (it needs the app build + Scream audio driver), so I've flagged that honestly rather than claiming a green E2E run.

Found while checking CI on an unrelated chaos-engineering PR whose E2E job kept failing on this test.