### PR TITLE
test(frontend): exclude timeline-liveness bun:test file from vitest

### DIFF
--- a/apps/screenpipe-app-tauri/vitest.config.ts
+++ b/apps/screenpipe-app-tauri/vitest.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
 			"lib/__tests__/team-pipes.test.ts",
 			"components/__tests__/url-detection-benchmark.test.ts",
 			"lib/hooks/__tests__/timeline-reconnection.test.ts",
+			"lib/hooks/__tests__/timeline-liveness.test.ts",
 			"lib/hooks/__tests__/timeline-store-logic.test.ts",
 			"lib/hooks/__tests__/server-push-old-frames.test.ts",
 			"lib/hooks/__tests__/window-focus-refresh.test.ts",


### PR DESCRIPTION
## Problem

The **Vitest + bun:test + typecheck** gate fails on any PR that touches frontend files:

```
FAIL  lib/hooks/__tests__/timeline-liveness.test.ts
Error: Failed to resolve import "bun:test". Does the file exist?
Test Files  1 failed | 85 passed (86)
```

The repo runs two test runners. `vitest.config.ts` includes `**/__tests__/**/*.test.ts`, and the bun-native test files (which `import { ... } from "bun:test"`, unresolvable by Vitest) are kept out via a **hand-maintained `exclude` list** that must mirror `package.json`'s `test:bun` glob.

`lib/hooks/__tests__/timeline-liveness.test.ts` was added in #4409 and wired into `test:bun`, but **not** added to the Vitest exclude list. It's the only `bun:test` file missing — its nine siblings are all listed. So Vitest tries to load it and fails.

## Fix

Add the one missing exclude entry. Verified that **every** file importing `bun:test` is now present in the exclude list:

```sh
for f in $(grep -rln "from ['\"]bun:test['\"]" lib components app); do
  grep -q "\"$f\"" vitest.config.ts || echo "MISSING: $f"
done
# (no output → all covered)
```

The test still runs — via `bun test` (`test:bun`), where it already lives.

## Note

The Vitest `exclude` list and `package.json`'s `test:bun` arg list are maintained in parallel by hand and drift easily (this is the second such drift). A small meta-test or lint asserting the two stay in sync would prevent recurrence — left as a follow-up to keep this fix minimal.

Found while checking CI on an unrelated frontend PR whose Vitest gate was red on this pre-existing failure.