### PR TITLE
feat(settings): always-on survey card in Help section

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
@@ -30,6 +30,17 @@ export function FeedbackSection() {
       </p>
 
       <div className="space-y-2">
+        <div className="px-3 py-2.5 bg-card border border-border">
+          <div className="flex items-center gap-2.5 mb-2.5">
+            <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
+            <div>
+              <h3 className="text-sm font-medium text-foreground">Send logs</h3>
+              <p className="text-xs text-muted-foreground">logs are included automatically</p>
+            </div>
+          </div>
+          <ShareLogsButton />
+        </div>
+
         <button
           type="button"
           onClick={() => open("https://youtu.be/OLUMknhvxWY")}
@@ -83,17 +94,6 @@ export function FeedbackSection() {
             </span>
           </div>
         </button>
-
-        <div className="px-3 py-2.5 bg-card border border-border">
-          <div className="flex items-center gap-2.5 mb-2.5">
-            <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
-            <div>
-              <h3 className="text-sm font-medium text-foreground">Send logs</h3>
-              <p className="text-xs text-muted-foreground">logs are included automatically</p>
-            </div>
-          </div>
-          <ShareLogsButton />
-        </div>
 
         <div className="px-3 py-2.5 bg-card border border-border">
           <div className="flex items-center justify-between">

--- a/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/feedback-section.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { ShareLogsButton } from "@/components/share-logs-button";
-import { MessageSquare, Github, Lightbulb, FileText, Youtube, BookOpen, Play } from "lucide-react";
+import { MessageSquare, Github, Lightbulb, FileText, Youtube, BookOpen, Play, ClipboardList } from "lucide-react";
 import { open } from "@tauri-apps/plugin-shell";
 
 function DiscordIcon(props: React.SVGProps<SVGSVGElement>) {
@@ -62,6 +62,26 @@ export function FeedbackSection() {
           <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors duration-150 shrink-0">
             watch →
           </span>
+        </button>
+
+        <button
+          type="button"
+          data-testid="help-survey-link"
+          onClick={() => open("https://screenpipe.com/survey?utm_source=app&utm_medium=help")}
+          className="group w-full text-left px-3 py-2.5 bg-card border border-border hover:border-foreground transition-colors duration-150"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2.5">
+              <ClipboardList className="h-4 w-4 text-muted-foreground shrink-0" />
+              <div>
+                <h3 className="text-sm font-medium text-foreground">Shape screenpipe</h3>
+                <p className="text-xs text-muted-foreground">90-second survey — tell us what&apos;s working and what&apos;s not</p>
+              </div>
+            </div>
+            <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors duration-150 shrink-0">
+              take survey →
+            </span>
+          </div>
         </button>
 
         <div className="px-3 py-2.5 bg-card border border-border">


### PR DESCRIPTION
## what

Adds a **"Shape screenpipe"** card to the Help section (`components/settings/feedback-section.tsx`) that opens **screenpipe.com/survey** — the always-on entry point for the new versioned PMF + lane discovery survey ([website#328](https://github.com/screenpipe/website/pull/328)).

Placed as the second item (right after the Getting Started video) so it's visible, since gathering this signal is high-priority right now.

## details

- Opens `https://screenpipe.com/survey?utm_source=app&utm_medium=help` — the UTM params flow into `survey_submissions` so app-driven responses are attributable to source (the survey page already reads `utm_source`/`utm_medium`).
- Matches the existing full-card button pattern (same as "Getting started"), `ClipboardList` icon, `data-testid="help-survey-link"` for parity with the discord link.
- Pure UI change — no Tauri commands touched, so no `tauri.ts` bindings regen needed.

## screenshot

before: cards were Getting started → Send logs → Documentation → …
after: Getting started → **Shape screenpipe** → Send logs → Documentation → …

> Note: the survey page itself (website#328) needs its Supabase migration applied before submissions persist; this card just drives traffic to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)