### PR TITLE
fix(app): move Input Monitoring from Connections to Privacy settings

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/integration-icon-keys.test.ts
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/integration-icon-keys.test.ts
@@ -12,7 +12,7 @@ import { connectionNameToId } from "../../../lib/utils/connection-chip";
 describe("INTEGRATION_ICON_KEYS", () => {
   it("is non-empty and includes core integrations", () => {
     expect(INTEGRATION_ICON_KEYS.size).toBeGreaterThan(0);
-    for (const id of ["slack", "gmail", "input-monitoring", "obsidian"]) {
+    for (const id of ["slack", "gmail", "obsidian"]) {
       expect(INTEGRATION_ICON_KEYS.has(id)).toBe(true);
     }
   });

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogClose, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Download, ExternalLink, Check, Loader2, Copy, Terminal, Lock, LogIn, LogOut, Send, X, HelpCircle, Search, Calendar as CalendarIcon, Eye, EyeOff, FolderOpen, Plus, Keyboard, AlertCircle, MessageSquare } from "lucide-react";
+import { Download, ExternalLink, Check, Loader2, Copy, Terminal, Lock, LogIn, LogOut, Send, X, HelpCircle, Search, Calendar as CalendarIcon, Eye, EyeOff, FolderOpen, Plus, AlertCircle, MessageSquare } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { commands } from "@/lib/utils/tauri";
 import { useSettings } from "@/lib/hooks/use-settings";
@@ -46,7 +46,6 @@ import { HermesCard } from "./hermes-card";
 import { BrowserUrlCard } from "./browser-url-card";
 import { UserBrowserCard } from "./user-browser-card";
 import { VoiceMemosCard } from "./voice-memos-card";
-import { InputMonitoringPanel } from "./input-monitoring-card";
 import { CustomMcpCard } from "./custom-mcp-card";
 import { SkillsCard } from "./skills-card";
 import posthog from "posthog-js";
@@ -619,7 +618,6 @@ const INTEGRATION_ICONS: Record<string, React.ReactNode> = {
         <path d="M20.32 4.37a19.8 19.8 0 00-4.89-1.52.07.07 0 00-.08.04c-.21.38-.44.87-.6 1.25a18.27 18.27 0 00-5.49 0 12.64 12.64 0 00-.62-1.25.08.08 0 00-.08-.04 19.74 19.74 0 00-4.89 1.52.07.07 0 00-.03.03C1.11 8.39.34 12.27.74 16.1a.08.08 0 00.03.06 19.9 19.9 0 005.99 3.03.08.08 0 00.08-.03c.46-.63.87-1.3 1.22-2a.08.08 0 00-.04-.11 13.1 13.1 0 01-1.87-.9.08.08 0 01-.01-.13c.13-.09.25-.19.37-.29a.08.08 0 01.08-.01c3.93 1.79 8.18 1.79 12.07 0a.08.08 0 01.08.01c.12.1.25.2.37.29a.08.08 0 01 0 .13c-.6.35-1.22.65-1.87.9a.08.08 0 00-.04.1c.36.7.77 1.37 1.22 2a.08.08 0 00.08.03 19.83 19.83 0 006-3.03.08.08 0 00.04-.05c.46-4.54-.78-8.38-3.36-11.77a.06.06 0 00-.03-.03zM8.02 13.72c-1.02 0-1.86-.93-1.86-2.08s.82-2.08 1.86-2.08c1.05 0 1.88.94 1.86 2.08 0 1.15-.82 2.08-1.86 2.08zm6.88 0c-1.02 0-1.86-.93-1.86-2.08s.82-2.08 1.86-2.08c1.05 0 1.88.94 1.86 2.08 0 1.15-.81 2.08-1.86 2.08z"/>
       </svg>
     ),
-    "input-monitoring": <Keyboard className="h-5 w-5 text-muted-foreground" />,
     "apple-calendar": (
       <svg
         viewBox="0 0 24 24"
@@ -3763,7 +3761,6 @@ export function ConnectionsSection({
   const [krispConnected, setKrispConnected] = useState(false);
   const [plaudConnected, setPlaudConnected] = useState(false);
   const [excalidrawConnected, setExcalidrawConnected] = useState(false);
-  const [inputMonitoringGranted, setInputMonitoringGranted] = useState(false);
   const [importedSkillsCount, setImportedSkillsCount] = useState(0);
 
   const loadSkillsCount = useCallback(() => {
@@ -3842,9 +3839,6 @@ export function ConnectionsSection({
         setBrowserUrlDetected(false);
         setBrowserUrlConnected(false);
       });
-      commands.checkInputMonitoringPermissionCmd()
-        .then(r => setInputMonitoringGranted(r === "granted"))
-        .catch(() => setInputMonitoringGranted(false));
       Promise.all([
         commands.checkPermission("calendar"),
         commands.calendarStatus(),
@@ -3917,7 +3911,6 @@ export function ConnectionsSection({
         { id: "browser-url", name: "Browser URL Capture", icon: "browser-url", connected: browserUrlConnected, detected: browserUrlDetected },
         { id: "voice-memos", name: "Voice Memos", icon: "voice-memos", connected: false },
       ] : []),
-      ...(os === "macos" ? [{ id: "input-monitoring", name: "Input Monitoring", icon: "input-monitoring", connected: inputMonitoringGranted }] : []),
       ...(os === "macos" ? [{ id: "apple-calendar", name: "Apple Calendar", icon: "apple-calendar", connected: appleCalendarConnected }] : []),
       { id: "google-calendar", name: "Google Calendar", icon: "google-calendar", connected: false },
       { id: "google-docs", name: "Google Docs", icon: "google-docs", connected: false },
@@ -3983,7 +3976,7 @@ export function ConnectionsSection({
       category: CONNECTION_CATEGORY_BY_ID[tile.id] ?? tile.category ?? "Other",
       description: tile.description ?? CONNECTION_HARDCODED_DESCRIPTIONS[tile.id],
     }));
-  }, [os, claudeInstalled, cursorInstalled, codexInstalled, grokInstalled, chatgptConnected, browserUrlConnected, browserUrlDetected, integrations, appleCalendarConnected, googleCalendarConnected, googleDocsConnected, googleSheetsConnected, gmailConnected, customMcpConnected, customMcpServerCount, krispConnected, plaudConnected, excalidrawConnected, inputMonitoringGranted, importedSkillsCount, detectedConnectionIds]);
+  }, [os, claudeInstalled, cursorInstalled, codexInstalled, grokInstalled, chatgptConnected, browserUrlConnected, browserUrlDetected, integrations, appleCalendarConnected, googleCalendarConnected, googleDocsConnected, googleSheetsConnected, gmailConnected, customMcpConnected, customMcpServerCount, krispConnected, plaudConnected, excalidrawConnected, importedSkillsCount, detectedConnectionIds]);
 
   const isDefaultView = !search.trim() && categoryFilter === ALL_CONNECTION_CATEGORIES;
 
@@ -4060,7 +4053,6 @@ export function ConnectionsSection({
       case "user-browser": return <UserBrowserCard />;
       case "browser-url": return <BrowserUrlCard onStatusChange={setBrowserUrlConnected} />;
       case "voice-memos": return <VoiceMemosCard />;
-      case "input-monitoring": return <InputMonitoringPanel onStatusChange={setInputMonitoringGranted} />;
       case "apple-calendar": return <AppleCalendarCard onStatusChange={setAppleCalendarConnected} />;
       case "google-calendar": return <GoogleCalendarCard
         onConnected={() => setGoogleCalendarConnected(true)}

--- a/apps/screenpipe-app-tauri/components/settings/input-monitoring-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/input-monitoring-card.tsx
@@ -10,15 +10,15 @@ import { commands } from "@/lib/utils/tauri";
 import { requestPermissionWithFlow } from "@/lib/utils/permission-flow";
 
 /**
- * macOS-only Input Monitoring panel, rendered inside the Connections
- * dialog for the `input-monitoring` tile. Without this TCC permission
- * the UI recorder runs in reduced mode — clipboard + app/window events
- * still flow (NSPasteboard + NSWorkspace need only Accessibility), but
- * keystrokes and clicks are dropped.
+ * macOS-only Input Monitoring panel, rendered in the Privacy settings
+ * section next to the keyboard/click capture toggles it gates. Without
+ * this TCC permission the UI recorder runs in reduced mode — clipboard +
+ * app/window events still flow (NSPasteboard + NSWorkspace need only
+ * Accessibility), but keystrokes and clicks are dropped.
  *
- * Status polling lives here (not the section) because the dialog only
- * mounts when open. The parent passes `onStatusChange` so it can update
- * the tile's connected dot without duplicating the poll.
+ * Status polling lives here so the panel reflects the live grant state on
+ * its own. `onStatusChange` is optional — callers that want to mirror the
+ * granted state (e.g. a connected dot) can pass it.
  */
 export function InputMonitoringPanel({
   onStatusChange,

--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -41,11 +41,13 @@ import { Switch } from "@/components/ui/switch";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { MultiSelect } from "@/components/ui/multi-select";
 import { WindowPicker } from "./window-picker";
+import { InputMonitoringPanel } from "./input-monitoring-card";
 import { ApplyRestartBar } from "./apply-restart-bar";
 import { useSettings, Settings } from "@/lib/hooks/use-settings";
 import { ScheduleSettings } from "./schedule-settings";
 import { useIsEnterpriseBuild } from "@/lib/hooks/use-is-enterprise-build";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
+import { platform } from "@tauri-apps/plugin-os";
 import { useToast } from "@/components/ui/use-toast";
 import { useSqlAutocomplete } from "@/lib/hooks/use-sql-autocomplete";
 import { useInstalledApps } from "@/lib/hooks/use-installed-apps";
@@ -476,6 +478,9 @@ function RedactionWherePreview({
 export function PrivacySection() {
   const { settings, updateSettings } = useSettings();
   const isEnterprise = useIsEnterpriseBuild();
+  // Input Monitoring is a macOS-only TCC permission; the grant card only
+  // renders there (alongside the keyboard/click capture toggles it gates).
+  const isMacOS = typeof window !== "undefined" && platform() === "macos";
   const { toast } = useToast();
   // when the admin forces the PII backend (local/cloud) we lock the radios so
   // the employee can't override it (the value itself is applied to settings by
@@ -1389,6 +1394,26 @@ export function PrivacySection() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Input Monitoring permission (macOS) — the OS-level TCC grant that
+          lets the keyboard/click capture toggles above actually record.
+          Lives here, next to those toggles, instead of under Connections. */}
+      {isMacOS && (
+        <Card>
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center space-x-2.5">
+              <Keyboard className="h-4 w-4 text-muted-foreground shrink-0" />
+              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                Input Monitoring permission
+                <HelpTooltip text="macOS permission that lets screenpipe capture keystrokes and mouse clicks. without it, capture runs in reduced mode — clipboard and app/window switches still work, but keyboard and click recording is dropped." />
+              </h3>
+            </div>
+            <div className="mt-2 ml-[26px]">
+              <InputMonitoringPanel />
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Record While Locked */}
       <Card>

--- a/apps/screenpipe-app-tauri/lib/constants/connections.ts
+++ b/apps/screenpipe-app-tauri/lib/constants/connections.ts
@@ -136,7 +136,6 @@ export const CONNECTION_CATEGORY_BY_ID: Record<string, string> = {
   pushover: "Notifications",
 
   // System — OS-level capture sources & features
-  "input-monitoring": "System",
   "browser-url": "System",
   "user-browser": "System",
   "voice-memos": "System",
@@ -162,7 +161,6 @@ export const CONNECTION_HARDCODED_DESCRIPTIONS: Record<string, string> = {
   "chatgpt": "Search your screen history from ChatGPT",
   "browser-url": "Capture visited URLs from your browser in real time",
   "voice-memos": "Sync Apple Voice Memos for AI-powered search",
-  "input-monitoring": "Track keyboard & mouse for productivity insights",
   "apple-calendar": "Search Apple Calendar events with AI",
   "google-calendar": "Search Google Calendar events with AI",
   "google-docs": "Read and search your Google Docs",
@@ -210,7 +208,6 @@ export const DEVICE_CONNECTION_ORDER = [
   "claude-code",
   "chatgpt",
   "browser-url",
-  "input-monitoring",
   "obsidian",
   "notion",
   "linear",

--- a/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
@@ -109,7 +109,6 @@ export function useHardcodedTiles(): HardcodedTile[] {
   const [chatgptConnected, setChatgptConnected] = useState(false);
   const [customMcpConnected, setCustomMcpConnected] = useState(false);
   const [customMcpDetected, setCustomMcpDetected] = useState(false);
-  const [inputMonitoringGranted, setInputMonitoringGranted] = useState(false);
   const [calendarConnected, setCalendarConnected] = useState(false);
 
   useEffect(() => {
@@ -142,12 +141,6 @@ export function useHardcodedTiles(): HardcodedTile[] {
         setCustomMcpDetected(false);
       });
 
-    if (typeof window !== "undefined" && platform() === "macos") {
-      commands.checkInputMonitoringPermissionCmd()
-        .then(r => setInputMonitoringGranted(r === "granted"))
-        .catch(() => setInputMonitoringGranted(false));
-    }
-
     getStore()
       .then(store => store.get<boolean>("calendarUserDisconnected"))
       .then(val => setCalendarConnected(!(val ?? false)))
@@ -167,7 +160,6 @@ export function useHardcodedTiles(): HardcodedTile[] {
       { id: "browser-url", name: "Browser URL Capture", icon: "browser-url", connected: false },
       { id: "voice-memos", name: "Voice Memos", icon: "voice-memos", connected: false },
     ] as HardcodedTile[] : []),
-    ...(os === "macos" ? [{ id: "input-monitoring", name: "Input Monitoring", icon: "input-monitoring", connected: inputMonitoringGranted } as HardcodedTile] : []),
     ...(os === "macos" ? [{ id: "apple-calendar", name: "Apple Calendar", icon: "apple-calendar", connected: calendarConnected } as HardcodedTile] : []),
   ];
 }


### PR DESCRIPTION
## what

Input Monitoring is a macOS TCC permission that gates **keyboard + click capture** — it isn't a "connection" like Claude / Slack / Gmail. It was showing up as a Connections tile (and a chat connection chip), which is the wrong mental model and put it far from the toggles it actually controls.

This moves the card into **Settings → Privacy → Capture rules**, right under the Capture clipboard / keyboard / clicks toggles it gates (macOS-only), and removes it from every connection surface.

## ui

The card now lives next to the keyboard/clipboard/click capture toggles:

![input monitoring in privacy settings](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/input-monitoring-settings/input-monitoring-settings.png)

## changes

- `privacy-section.tsx` — render `InputMonitoringPanel` in the Capture rules group (macOS-gated via `platform()`)
- `connections-section.tsx` — drop the tile, dialog case, status poll, icon entry, and state
- `use-hardcoded-tiles.ts` — drop the chat connection-chip tile + its permission poll
- `lib/constants/connections.ts` — drop category / description / device-order entries
- `input-monitoring-card.tsx` — doc comment now reflects the Privacy home; `onStatusChange` stays optional (panel polls its own grant state)
- `integration-icon-keys.test.ts` — drop `input-monitoring` from the core-icon assertion

No backend or permission-flow changes.

## test plan

- [x] `bunx tsc --noEmit` clean
- [x] `vitest` — `integration-icon-keys` + `connection-chip` pass
- [x] rendered Privacy settings — card appears under Capture clicks (screenshot above); on a non-macOS build it's hidden