### PR TITLE
fix(meeting): host-boundary URL matching to kill substring false positives

### DIFF
--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -2132,7 +2132,7 @@ fn browser_window_matches_meeting(
         return ids
             .browser_url_patterns
             .iter()
-            .any(|p| contains_case_insensitive(doc, p));
+            .any(|p| browser_url_pattern_matches(doc, p));
     }
     if let Some(t) = title {
         let t_lower = t.to_lowercase();
@@ -2158,6 +2158,64 @@ fn contains_case_insensitive(haystack: &str, needle: &str) -> bool {
     }
 
     haystack.to_lowercase().contains(&needle.to_lowercase())
+}
+
+/// Match a `browser_url_patterns` entry against a URL or window-title string at
+/// host-name boundaries.
+///
+/// A bare substring match leaks: `daily.co` is a substring of `thedaily.com`,
+/// so an unrelated news site became a phantom meeting candidate (the latent
+/// vector behind #4246, follow-up here). This matches a dotted host pattern
+/// only as a whole hostname or a subdomain of it, and a path-qualified pattern
+/// (`cal.com/video`, `zoom.us/j`) only when both the host segment and the path
+/// component are bounded:
+///   * `daily.co`      → matches `daily.co`, `app.daily.co/room`; NOT
+///                       `thedaily.com`, `daily.com`, `daily.co.uk`.
+///   * `cal.com/video` → matches `app.cal.com/video/uid`; NOT `cal.com/videos`,
+///                       `cal.com/pricing`.
+///
+/// Non-domain patterns (containing a space, or with no `.`) keep the previous
+/// case-insensitive substring behavior — they are free-text markers
+/// (e.g. "zoom meeting"), not hostnames.
+fn browser_url_pattern_matches(haystack: &str, pattern: &str) -> bool {
+    if pattern.contains(' ') || !pattern.contains('.') {
+        return contains_case_insensitive(haystack, pattern);
+    }
+    contains_at_domain_boundary(haystack, pattern)
+}
+
+/// True when the dotted `pattern` appears in `haystack` bounded so its leading
+/// host label is whole (or a subdomain boundary, i.e. preceded by `.`) and its
+/// trailing character does not extend the matched host/path component. ASCII
+/// case-insensitive; `pattern` is expected lowercase-or-mixed (compared
+/// case-folded).
+fn contains_at_domain_boundary(haystack: &str, pattern: &str) -> bool {
+    let hay = haystack.to_ascii_lowercase();
+    let pat = pattern.to_ascii_lowercase();
+    let (hb, pb) = (hay.as_bytes(), pat.as_bytes());
+    if pb.is_empty() || pb.len() > hb.len() {
+        return false;
+    }
+    // A char that, on the LEFT of the match, would make the host label longer
+    // (so the pattern is a tail of a bigger label, e.g. `daily` in `thedaily`).
+    // `.` is intentionally NOT in this set: it marks a subdomain boundary.
+    let extends_left = |c: u8| c.is_ascii_alphanumeric() || c == b'-';
+    // On the RIGHT, anything that continues the host or path component: alnum,
+    // `-`, or `.` (which would make `daily.co` part of `daily.com`/`daily.co.uk`).
+    let extends_right = |c: u8| c.is_ascii_alphanumeric() || c == b'-' || c == b'.';
+    let mut i = 0;
+    while i + pb.len() <= hb.len() {
+        if &hb[i..i + pb.len()] == pb {
+            let left_ok = i == 0 || !extends_left(hb[i - 1]);
+            let after = i + pb.len();
+            let right_ok = after == hb.len() || !extends_right(hb[after]);
+            if left_ok && right_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 fn ends_with_ascii_case_insensitive(haystack: &str, suffix: &str) -> bool {
@@ -2339,7 +2397,7 @@ fn has_browser_meeting_url(pid: i32, url_patterns: &[&str]) -> bool {
                 let doc_for_match = url_without_query_or_fragment(&doc);
                 if url_patterns
                     .iter()
-                    .any(|p| contains_case_insensitive(doc_for_match, p))
+                    .any(|p| browser_url_pattern_matches(doc_for_match, p))
                 {
                     return true;
                 }
@@ -2352,7 +2410,7 @@ fn has_browser_meeting_url(pid: i32, url_patterns: &[&str]) -> bool {
                 if url_patterns
                     .iter()
                     .filter(|p| p.contains('.'))
-                    .any(|p| contains_case_insensitive(&title, p))
+                    .any(|p| browser_url_pattern_matches(&title, p))
                 {
                     return true;
                 }
@@ -2536,11 +2594,15 @@ pub fn find_running_meeting_apps(
                 continue;
             }
 
+            // url_patterns are matched against the window TITLE on Windows (no
+            // per-tab URL available). Boundary matching still applies — it keeps
+            // a real meeting host in a title matching while closing the
+            // `daily.co` ⊂ `thedaily.com` substring leak.
             let url_match = profile
                 .app_identifiers
                 .browser_url_patterns
                 .iter()
-                .any(|p| contains_case_insensitive(title, p));
+                .any(|p| browser_url_pattern_matches(title, p));
             // See `browser_title_matches_pattern` for the matching rules.
             let title_match = !profile.app_identifiers.browser_title_patterns.is_empty() && {
                 let title_lower = title.to_lowercase();
@@ -4229,13 +4291,105 @@ mod tests {
             .expect("generic fallback profile present")
     }
 
-    /// Mirrors the lowercase substring match used by `has_browser_meeting_url`
-    /// and `db_find_browser_meetings`.
+    /// Exercises the production matcher used by `browser_window_matches_meeting`
+    /// / `has_browser_meeting_url` / `db_find_browser_meetings` so these tests
+    /// validate the real host-boundary logic, not a stand-in.
     fn url_matches_any_pattern(url: &str, patterns: &[&str]) -> bool {
-        let url_lower = url.to_lowercase();
-        patterns
-            .iter()
-            .any(|p| url_lower.contains(&p.to_lowercase()))
+        patterns.iter().any(|p| browser_url_pattern_matches(url, p))
+    }
+
+    #[test]
+    fn test_url_boundary_matcher_host_patterns() {
+        // A bare host pattern matches the host and its subdomains, but never a
+        // longer label that merely ends with the same letters.
+        for hit in [
+            "daily.co",
+            "https://daily.co",
+            "https://daily.co/room/abc",
+            "https://app.daily.co/room",
+            "https://my.team.daily.co/x",
+        ] {
+            assert!(
+                browser_url_pattern_matches(hit, "daily.co"),
+                "{hit:?} should match host pattern daily.co"
+            );
+        }
+        for miss in [
+            "https://www.thedaily.com",
+            "https://thedaily.com/news",
+            "https://dailywire.com",
+            "https://daily.com",   // different TLD
+            "https://daily.co.uk", // different (longer) domain
+            "https://notdaily.co.uk",
+        ] {
+            assert!(
+                !browser_url_pattern_matches(miss, "daily.co"),
+                "{miss:?} must NOT match host pattern daily.co (substring leak)"
+            );
+        }
+    }
+
+    #[test]
+    fn test_url_boundary_matcher_path_qualified() {
+        for hit in [
+            "https://app.cal.com/video/uid",
+            "https://cal.com/video/8f3e",
+            "https://cal.com/video", // exact, no trailing segment
+        ] {
+            assert!(
+                browser_url_pattern_matches(hit, "cal.com/video"),
+                "{hit:?} should match cal.com/video"
+            );
+        }
+        for miss in [
+            "https://cal.com/videos", // /video is not a prefix component
+            "https://cal.com/pricing",
+            "https://app.cal.com/event-types",
+            "https://thecal.com/video", // host label extended on the left
+        ] {
+            assert!(
+                !browser_url_pattern_matches(miss, "cal.com/video"),
+                "{miss:?} must NOT match cal.com/video"
+            );
+        }
+    }
+
+    #[test]
+    fn test_url_boundary_matcher_keeps_freetext_markers() {
+        // Non-host patterns (space / no dot) keep substring behavior so existing
+        // free-text markers aren't silently disabled.
+        assert!(browser_url_pattern_matches(
+            "some Zoom Meeting in progress",
+            "zoom meeting"
+        ));
+    }
+
+    #[test]
+    fn test_generic_profile_rejects_daily_co_lookalike() {
+        // The concrete vector this PR closes: daily.co (a bare host pattern) must
+        // not match thedaily.com / dailywire.com, while real daily.co calls do.
+        let profile = generic_profile();
+        let patterns = profile.app_identifiers.browser_url_patterns;
+        assert!(
+            patterns.contains(&"daily.co"),
+            "fixture: daily.co host pattern present"
+        );
+        for miss in [
+            "https://www.thedaily.com",
+            "https://thedaily.com/podcast",
+            "https://dailywire.com/news",
+        ] {
+            assert!(
+                !url_matches_any_pattern(miss, patterns),
+                "{miss:?} should NOT match a meeting profile (daily.co substring leak)"
+            );
+        }
+        for hit in ["https://daily.co/standup", "https://app.daily.co/room/x"] {
+            assert!(
+                url_matches_any_pattern(hit, patterns),
+                "real Daily call {hit:?} should still match"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Before / after

Meeting host `daily.co` matching the unrelated news site `thedaily.com` **before** → **rejected** after:

![before/after for #4442](https://raw.githubusercontent.com/pleasedodisturb/screenpipe/pr-evidence/pr4442.gif)

_(This is a backend/DB change with no UI; the recording above is a terminal capture of the deterministic before/after. Full details below.)_

---

## What

Follow-up to #4246 (browser meeting detection → URL-first matching). That PR closed the browser-*title* false-positive vector; this closes the latent **substring** leak in URL matching.

`browser_url_patterns` were matched against the page URL with a bare case-insensitive **substring** check. Because a pattern can be a prefix of a longer hostname, that leaks: **`daily.co` matches `https://www.thedaily.com`** (and `dailywire.com`, `daily.com`, …), making an unrelated site a phantom-meeting candidate that an unrelated tab's "Leave"/"End" button could then sustain.

Until now this was held off only by *path-qualifying the patterns themselves* (`cal.com` → `cal.com/video`). Bare-host patterns like `daily.co`, `app.daily.co`, `pop.com`, `8x8.vc`, `meet.jit.si` still leaked.

## Fix

A host-boundary matcher (`browser_url_pattern_matches`) replaces the bare substring check at every site that matches `browser_url_patterns` against a URL/title:

- Dotted host pattern (`daily.co`) → matches only as a whole hostname or a **subdomain** of it (`app.daily.co`), never a longer label (`thedaily.com`, `daily.com`, `daily.co.uk`).
- Path-qualified pattern (`cal.com/video`, `zoom.us/j`) → host-boundary **and** the path component is bounded (`/video/uid` matches, `/videos` and `/pricing` don't).
- Non-host markers (a space, or no `.` — e.g. `"zoom meeting"`) keep the previous substring behavior.

Routed through `browser_window_matches_meeting` (and thus `db_find_browser_meetings`), the `has_browser_meeting_url` AXDocument + title paths, and the Windows title path.

## Tests

- `test_url_boundary_matcher_host_patterns` / `_path_qualified` / `_keeps_freetext_markers` — the matcher directly.
- `test_generic_profile_rejects_daily_co_lookalike` — the concrete vector: `thedaily.com`/`dailywire.com` rejected, real `daily.co`/`app.daily.co` calls still match.
- The existing lookalike-rejection + `test_real_browser_meetings_still_detected` suite now runs through the **production** matcher (the test helper was a naive-substring stand-in; it now calls the real function), so they validate the actual logic. All green.

```
cargo test -p screenpipe-engine meeting_detector
```

## Scope (one concern)

This PR is the URL-precision fix only. The two other latent vectors from the ticket are reviewed and deferred to keep it focused:

- **Generic single-word native app names** (`pop`, `gather`, `around`, `butter`, `tandem`, `chime`): these are **exact** app-name matches (an app must be named *exactly* "Pop"), so the risk is low; the proper fix is bundle-id qualification, which needs a profile-structure change — separate PR.
- **Weak call-signal corroboration**: optional hardening, separate.

Coordinated with the open Webex PR (#4337) — not bundled.

