### PR TITLE
fix(audio): idempotent stop_device so a CoreAudio tap can't orphan (#3942 vector)

### DIFF
--- a/crates/screenpipe-audio/src/device/device_manager.rs
+++ b/crates/screenpipe-audio/src/device/device_manager.rs
@@ -8,7 +8,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use tracing::info;
+use tracing::{debug, info};
 
 pub struct DeviceManager {
     streams: Arc<DashMap<AudioDevice, Arc<AudioStream>>>,
@@ -116,12 +116,26 @@ impl DeviceManager {
         Ok(())
     }
 
+    /// Stop a device and tear down its stream. **Idempotent**: a device that is
+    /// already marked not-running STILL drives stream teardown
+    /// (`AudioStream::stop` + removal from the map).
+    ///
+    /// Previously this early-returned `Err` on the already-stopped path, which
+    /// skipped teardown entirely. For the CoreAudio process-tap path that left
+    /// `is_disconnected` unflipped, so the tap-owning blocking thread looped
+    /// forever and the tap was orphaned — wedging `coreaudiod` system-wide
+    /// (#3942). The recovery monitor and `stop_device_recording` both mark a
+    /// device not-running *before* asking it to stop, hitting exactly that path,
+    /// so teardown must not depend on the running flag still being set.
     pub async fn stop_device(&self, device: &AudioDevice) -> Result<()> {
-        if !self.is_running(device) {
-            return Err(anyhow!("Device {} already stopped", device));
+        if self.is_running(device) {
+            info!("Stopping device: {device}");
+        } else {
+            debug!(
+                "stop_device({device}): already marked stopped — running teardown idempotently \
+                 so the stream (and any CoreAudio tap) is released, not orphaned"
+            );
         }
-
-        info!("Stopping device: {device}");
 
         if let Some(is_running) = self.states.get(device) {
             is_running.store(false, Ordering::Relaxed)
@@ -138,5 +152,68 @@ impl DeviceManager {
 
     pub fn is_running_mut(&self, device: &AudioDevice) -> Option<Arc<AtomicBool>> {
         self.states.get(device).map(|s| s.value().clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::device::DeviceType;
+    use crate::core::stream::AudioStream;
+
+    /// #3942 orphan vector: `stop_device` used to early-`Err` when the device
+    /// was already marked not-running, skipping stream teardown. For a CoreAudio
+    /// process-tap stream that left `is_disconnected` unflipped, so the
+    /// tap-owning thread looped forever and the tap was orphaned. Teardown must
+    /// run regardless of the running flag.
+    #[tokio::test]
+    async fn stop_device_drives_teardown_even_when_already_marked_stopped() {
+        let dm = DeviceManager::new(true, false, false).await.unwrap();
+        let device = AudioDevice::new(
+            "ScreenpipeProcessTap (input)".to_string(),
+            DeviceType::Input,
+        );
+
+        let (stream, _tx) = AudioStream::from_sender_for_test(Arc::new(device.clone()), 48_000, 1);
+        let stream = Arc::new(stream);
+
+        // Present but ALREADY marked not-running (the recovery-monitor /
+        // stop_device_recording state that previously bypassed teardown).
+        dm.states
+            .insert(device.clone(), Arc::new(AtomicBool::new(false)));
+        dm.streams.insert(device.clone(), stream.clone());
+
+        let res = dm.stop_device(&device).await;
+
+        assert!(
+            res.is_ok(),
+            "stop_device must be Ok (idempotent), got {res:?}"
+        );
+        assert!(
+            stream.is_disconnected(),
+            "teardown must flip is_disconnected so the tap thread can exit"
+        );
+        assert!(
+            dm.streams.get(&device).is_none(),
+            "the stream must be removed from the manager"
+        );
+    }
+
+    /// Regression guard: the normal running path still tears down and clears the
+    /// running flag.
+    #[tokio::test]
+    async fn stop_device_tears_down_running_device() {
+        let dm = DeviceManager::new(true, false, false).await.unwrap();
+        let device = AudioDevice::new("Test (input)".to_string(), DeviceType::Input);
+        let (stream, _tx) = AudioStream::from_sender_for_test(Arc::new(device.clone()), 48_000, 1);
+        let stream = Arc::new(stream);
+        dm.states
+            .insert(device.clone(), Arc::new(AtomicBool::new(true)));
+        dm.streams.insert(device.clone(), stream.clone());
+
+        assert!(dm.stop_device(&device).await.is_ok());
+        assert!(stream.is_disconnected());
+        assert!(dm.streams.get(&device).is_none());
+        assert!(!dm.is_running(&device), "running flag must be cleared");
     }
 }


### PR DESCRIPTION
## Before / after

Tap teardown: **skipped** on an already-stopped device (orphan) before → **idempotent** after:

![before/after for #4443](https://raw.githubusercontent.com/pleasedodisturb/screenpipe/pr-evidence/pr4443.gif)

_(This is a backend/DB change with no UI; the recording above is a terminal capture of the deterministic before/after. Full details below.)_

---

## What

On macOS, screenpipe's CoreAudio Process Tap (`ScreenpipeProcessTap` aggregate device) can be left **orphaned** when capture stops, which wedges `coreaudiod` system-wide (all Mac audio dies; screenpipe then hangs on startup CoreAudio enumeration and can't relaunch). Issue #3942.

The tap's entire lifetime is bound to a single `Drop` that runs only on a `spawn_blocking` thread after its `is_disconnected` poll-loop exits. That's fragile in three independent ways, any of which orphans the tap:

1. **`abort()` on a `spawn_blocking` task is a no-op for the OS thread** — if the thread is wedged in a CoreAudio call against a degraded daemon, the `Drop` (and the tap) never runs. *(primary mechanism)*
2. **`stop_device` could skip teardown entirely** — it early-returned `Err` when the device was already marked not-running, so `AudioStream::stop` was never called, `is_disconnected` never flipped, and the tap thread looped forever.
3. **No deterministic force-destroy** path independent of that `Drop`.

## This PR — vector #2: make `stop_device` teardown unconditional

`device_manager.rs::stop_device` no longer early-returns on the already-stopped path. It now **always** drives `AudioStream::stop()` + stream removal (idempotent), so `is_disconnected` is flipped whenever a device is stopped — letting the tap-owning thread exit and run its teardown. The recovery monitor and `stop_device_recording` both mark a device not-running *before* stopping it, hitting exactly the path that previously bypassed cleanup.

`AudioStream::stop` already flips `is_disconnected` as its first action and is a no-op-safe on a thread-less stream, so this is a minimal, lifecycle-correct change — not a manager rewrite.

### Tests

`device_manager` unit tests (no mic, no live tap — pure stream double via `from_sender_for_test`):
- `stop_device_drives_teardown_even_when_already_marked_stopped` — the #3942 vector: a device already marked not-running still tears down (`is_disconnected` set, stream removed, `Ok`).
- `stop_device_tears_down_running_device` — regression guard for the normal path.

```
cargo test -p screenpipe-audio stop_device
```

## Deliberately scoped OUT (follow-ups)

To keep this a focused, verifiable change:

- **Vector #1 — cross-thread force-destroy** of the tap/aggregate when the poll-loop thread is wedged. This needs raw CoreAudio ObjectIDs held outside the `spawn_blocking` thread and a standalone `AudioHardwareDestroyProcessTap` / destroy-aggregate path that preserves the existing callback-drain UAF protection — and it must be validated against a genuinely wedged `coreaudiod` on a tap-capable machine. That's an unsafe-FFI/ownership change I'm not landing without that verification (and it may need a cidre addition). Tracked for a dedicated PR + manual UAT.
- **Startup CoreAudio enumeration timeout** (turn the silent pre-logger hang into a logged error) — touches startup/logger ordering near the ggml/Metal shutdown-ordering constraints; separate PR.
- **`[DEVICE_RECOVERY]` retry-forever** on a vanished tap device — lower-priority follow-up.

## Manual UAT (not gating this PR; needs a tap-capable machine)

End-to-end "an orphaned tap no longer wedges coreaudiod": force a stop/abort mid-teardown, then confirm via `system_profiler SPAudioDataType` that no `ScreenpipeProcessTap` survives and audio/relaunch are healthy without `sudo killall coreaudiod`.

