### PR TITLE
chore(audio): gate audiopipe examples behind the parakeet feature (unbreak clippy hook)

### DIFF
--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -173,6 +173,42 @@ parakeet-mlx = ["dep:audiopipe", "audiopipe?/parakeet-mlx", "dep:mlx-rs"]
 name = "screenpipe-audio"
 path = "examples/screenpipe-audio.rs"
 
+# These benchmark/eval examples use the optional `audiopipe` crate (linked only
+# by the `parakeet` / `qwen3-asr` features). Without a `required-features` guard,
+# `cargo {build,clippy} --all-targets` on default features tries to compile them,
+# fails to resolve the unlinked `audiopipe` crate (E0433), and breaks the
+# lefthook clippy hook for ANY change in this crate. Gating each on `parakeet`
+# (which pulls in `audiopipe`) makes --all-targets skip them unless it's enabled.
+[[example]]
+name = "bench_quality"
+path = "examples/bench_quality.rs"
+required-features = ["parakeet"]
+
+[[example]]
+name = "bench_quality2"
+path = "examples/bench_quality2.rs"
+required-features = ["parakeet"]
+
+[[example]]
+name = "bench_parakeet"
+path = "examples/bench_parakeet.rs"
+required-features = ["parakeet"]
+
+[[example]]
+name = "bench_engines"
+path = "examples/bench_engines.rs"
+required-features = ["parakeet"]
+
+[[example]]
+name = "parakeet_bench"
+path = "examples/parakeet_bench.rs"
+required-features = ["parakeet"]
+
+[[example]]
+name = "wer_battle_test"
+path = "examples/wer_battle_test.rs"
+required-features = ["parakeet"]
+
 [[test]]
 name = "audio_pipeline_benchmark"
 path = "tests/audio_pipeline_benchmark/main.rs"


### PR DESCRIPTION
## Before / after

`cargo clippy --all-targets` fails with **E0433** before (breaking the commit hook) → **clean** after gating the examples:

![before/after for #4446](https://raw.githubusercontent.com/pleasedodisturb/screenpipe/pr-evidence/pr4446.gif)

_(No UI to record — terminal capture of the deterministic before/after. Details below.)_

---

## What

Six benchmark/eval examples in `screenpipe-audio` use the optional `audiopipe` crate (linked only by the `parakeet` / `qwen3-asr` features) but had **no `required-features` guard**. So `cargo {build,clippy} --all-targets` on default features tries to compile them and fails:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `audiopipe`
error: could not compile `screenpipe-audio` (example "parakeet_bench") due to 3 previous errors
```

This breaks the **lefthook `rust-clippy` pre-commit hook** — it runs `cargo clippy -p <crate> --all-targets`, so *any* change to a `.rs` file in `screenpipe-audio` fails the hook and forces `--no-verify`.

## Fix

Add a `[[example]]` block with `required-features = ["parakeet"]` for each of the six (`bench_quality`, `bench_quality2`, `bench_parakeet`, `bench_engines`, `parakeet_bench`, `wer_battle_test`). `--all-targets` then skips them unless `parakeet` is enabled; `cargo run --example <name> --features parakeet` is unchanged.

## Verified

```
$ cargo clippy -p screenpipe-audio --all-targets
    Finished `dev` profile ... target(s)   # clean, no E0433
```

Cargo.toml-only; no source or behavior change.

