### PR TITLE
fix(mcp): label activity-summary time ranges with real offset, not hardcoded UTC

### DIFF
--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -1137,6 +1137,16 @@ function normalizeTimeFields(
   return out;
 }
 
+// Zone label for a timestamp's HH:MM slice. The server serializes timestamps in
+// its LOCAL timezone (e.g. "...T09:03:44+05:30"), so the HH:MM is already local —
+// derive the label from the string's own offset instead of hardcoding "UTC"
+// (which mislabeled local times by the offset, e.g. "09:03 UTC" for 09:03+05:30).
+function zoneSuffix(iso: string): string {
+  const m = iso.match(/([+-]\d{2}:?\d{2})$/);
+  if (!m) return iso.endsWith("Z") ? " UTC" : "";
+  return m[1] === "+00:00" ? " UTC" : ` ${m[1]}`;
+}
+
 // Middle-truncate long strings: keep head + tail, mark the gap with how much
 // was cut. Used to cap OCR/transcription text in search-content responses
 // so a single call doesn't blow past Claude Code's per-tool output limit
@@ -1488,7 +1498,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           }) => {
             const timeSpan =
               a.first_seen && a.last_seen
-                ? `, ${a.first_seen.slice(11, 16)}–${a.last_seen.slice(11, 16)} UTC`
+                ? `, ${a.first_seen.slice(11, 16)}–${a.last_seen.slice(11, 16)}${zoneSuffix(a.first_seen)}`
                 : "";
             return `  ${a.name}: ${a.minutes} min (${a.frame_count} frames${timeSpan})`;
           }


### PR DESCRIPTION
## Problem

`activity-summary` prints per-app time ranges with a hardcoded `UTC` suffix:

```
cmux: 26.2 min (201 frames, 09:03–09:29 UTC)
```

But the server serializes `first_seen`/`last_seen` in its **local** timezone (e.g. `...T09:03:44+05:30`), so the `HH:MM` that `index.ts` slices out is already local time. The formatter then stamps `UTC` on it — so a frame that actually occurred at `09:03+05:30` is labeled `09:03 UTC`, off by the offset (5.5h for IST).

It's easy to miss because the numbers look plausible. It's verifiable here: the DB's latest frame was `05:26 UTC`, yet the body printed `09:03` — `09:03 UTC` would be in the future, so the value can only be local (IST).

Scope: **display only.** Timezone-aware filtering and the summary header (which echoes the request bound) are correct — only the per-app range label was wrong.

## Fix

Derive the zone label from the timestamp's own trailing offset instead of hardcoding `UTC`:

- `+00:00` / `Z` → `UTC`
- any other offset → that offset, e.g. `+05:30`
- naive string (no offset) → no label

```
cmux: 26.2 min (201 frames, 09:03–09:29 +05:30)
```

## Test

```
zoneSuffix("2026-06-22T09:03:44.123+05:30") === " +05:30"   // was wrongly " UTC"
zoneSuffix("2026-06-22T00:01:26.176+00:00") === " UTC"
zoneSuffix("2026-06-22T09:03:44Z")          === " UTC"
zoneSuffix("2026-06-22T09:03:44.123-08:00") === " -08:00"
zoneSuffix("2026-06-22T09:03:44.123")       === ""
```

One file changed (`packages/screenpipe-mcp/src/index.ts`), +11/-1.