### PR TITLE
fix(notifications): handle native copy and source actions

### DIFF
--- a/apps/screenpipe-app-tauri/app/notification-panel/page.tsx
+++ b/apps/screenpipe-app-tauri/app/notification-panel/page.tsx
@@ -20,15 +20,18 @@ import { localFetch } from "@/lib/api";
 import { Bell, Check, Copy, ExternalLink } from "lucide-react";
 
 interface NotificationAction {
-  label: string;
-  action: string;
+  label?: string;
+  action?: string;
   primary?: boolean;
   // Pipe notification action fields
   id?: string;
-  type?: "pipe" | "api" | "deeplink" | "meeting_join" | "dismiss";
+  type?: "pipe" | "api" | "deeplink" | "link" | "meeting_join" | "copy" | "source" | "dismiss";
   pipe?: string;
   context?: Record<string, unknown>;
   url?: string;
+  value?: string;
+  source_url?: string;
+  sourceUrl?: string;
   deeplink_url?: string;
   deeplinkUrl?: string;
   method?: string;
@@ -127,7 +130,7 @@ export default function NotificationPanelPage() {
   const handleAction = useCallback(
     async (actionOrObj: string | NotificationAction) => {
       // Support both old string-based actions and new typed action objects
-      const actionStr = typeof actionOrObj === "string" ? actionOrObj : actionOrObj.action;
+      const actionStr = typeof actionOrObj === "string" ? actionOrObj : actionOrObj.action || actionOrObj.type;
       const actionObj = typeof actionOrObj === "object" ? actionOrObj : null;
 
       posthog.capture("notification_action", {
@@ -141,6 +144,42 @@ export default function NotificationPanelPage() {
         // New typed action dispatch (pipe notifications)
         if (actionObj?.type) {
           switch (actionObj.type) {
+            case "copy": {
+              const text = actionObj.value || payload?.body || "";
+              if (text) {
+                await commands.copyTextToClipboard(text);
+                if (copyResetRef.current) clearTimeout(copyResetRef.current);
+                setCopied(true);
+                copyResetRef.current = setTimeout(() => setCopied(false), 1400);
+                posthog.capture("notification_copied", {
+                  type: payload?.type,
+                  id: payload?.id,
+                  source: "action",
+                });
+              }
+              return;
+            }
+            case "source": {
+              const sourceUrl =
+                actionObj.url ||
+                actionObj.source_url ||
+                actionObj.sourceUrl ||
+                actionObj.deeplink_url ||
+                actionObj.deeplinkUrl ||
+                payload?.source_url;
+              if (sourceUrl) {
+                if (sourceUrl.startsWith("screenpipe://")) {
+                  await commands.showWindowActivated(windowForDeeplink(sourceUrl));
+                  await new Promise((r) => setTimeout(r, 150));
+                  await emit("deep-link-received", sourceUrl);
+                } else {
+                  const { open } = await import("@tauri-apps/plugin-shell");
+                  await open(sourceUrl);
+                }
+              }
+              await hide(false);
+              return;
+            }
             case "pipe": {
               const pipeName = actionObj.pipe || payload?.pipe_name;
               if (pipeName) {
@@ -192,6 +231,7 @@ export default function NotificationPanelPage() {
               }
               break;
             }
+            case "link":
             case "deeplink": {
               if (actionObj.url) {
                 if (actionObj.url.startsWith("screenpipe://")) {
@@ -336,7 +376,7 @@ export default function NotificationPanelPage() {
 
       await hide(false);
     },
-    [payload?.type, payload?.id, payload?.pipe_name, hide]
+    [payload?.type, payload?.id, payload?.body, payload?.pipe_name, payload?.source_url, hide]
   );
 
   const openSource = useCallback(async () => {
@@ -737,10 +777,18 @@ export default function NotificationPanelPage() {
                 restart failed{restartError ? `: ${restartError}` : ""}
               </span>
             ) : (
-              payload.actions.map((action) => (
+              payload.actions.map((action, index) => {
+                const actionLabel =
+                  action.label ||
+                  (action.type === "copy" ? (copied ? "copied" : "copy") : undefined) ||
+                  (action.type === "source" ? "source" : undefined) ||
+                  action.action ||
+                  action.type ||
+                  "action";
+                return (
                 <button
-                  key={action.id || action.action}
-                  onClick={() => handleAction(action.type ? action : action.action)}
+                  key={action.id || action.action || action.type || index}
+                  onClick={() => handleAction(action.type ? action : action.action || "")}
                   style={{
                     background: action.primary
                       ? "rgba(0, 0, 0, 0.06)"
@@ -763,9 +811,10 @@ export default function NotificationPanelPage() {
                       : "none")
                   }
                 >
-                  {action.label}
+                  {actionLabel}
                 </button>
-              ))
+              );
+              })
             )}
           </div>
         )}

--- a/apps/screenpipe-app-tauri/components/notification-handler.tsx
+++ b/apps/screenpipe-app-tauri/components/notification-handler.tsx
@@ -161,6 +161,34 @@ const NotificationHandler: React.FC = () => {
           return;
         }
 
+        if (action.type === "copy") {
+          const text = typeof action.value === "string" ? action.value : "";
+          if (text) {
+            await commands.copyTextToClipboard(text);
+          }
+          return;
+        }
+
+        if (action.type === "source") {
+          const url =
+            action.url ||
+            action.source_url ||
+            action.sourceUrl ||
+            action.deeplink_url ||
+            action.deeplinkUrl;
+          if (!url) return;
+          if (typeof url === "string" && url.startsWith("screenpipe://")) {
+            await commands.showWindowActivated(windowForDeeplink(url));
+            await new Promise((r) => setTimeout(r, 150));
+            const { emit } = await import("@tauri-apps/api/event");
+            await emit("deep-link-received", url);
+          } else {
+            const { open } = await import("@tauri-apps/plugin-shell");
+            await open(url);
+          }
+          return;
+        }
+
         // Forward pipe/api/deeplink actions
         if (action.type === "pipe" && action.pipe) {
           if (action.open_in_chat) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -108,6 +108,80 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
         return;
     }
 
+    // Copy is a real notification action, not a dismiss. Native Swift also
+    // writes to NSPasteboard for instant feedback; this Rust path keeps the
+    // action functional if a non-Swift native caller emits the same event.
+    if action_type == Some("copy") {
+        let text = parsed
+            .as_ref()
+            .and_then(|v| v.get("value"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let Some(text) = text else {
+            warn!("copy notification action has no value: {}", json);
+            return;
+        };
+        std::thread::spawn(move || {
+            match arboard::Clipboard::new().and_then(|mut clipboard| clipboard.set_text(text)) {
+                Ok(()) => {}
+                Err(e) => error!("failed to copy notification action value: {}", e),
+            }
+        });
+        return;
+    }
+
+    // Source actions open the originating surface. Accept several field names
+    // because producers have used both URL-shaped and source-shaped payloads.
+    if action_type == Some("source") {
+        let url = parsed
+            .as_ref()
+            .and_then(|v| {
+                v.get("url")
+                    .or_else(|| v.get("source_url"))
+                    .or_else(|| v.get("sourceUrl"))
+                    .or_else(|| v.get("deeplink_url"))
+                    .or_else(|| v.get("deeplinkUrl"))
+            })
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let Some(url) = url else {
+            warn!("source notification action has no url: {}", json);
+            return;
+        };
+
+        let is_in_app = url.starts_with("screenpipe://");
+        let app_clone = app.clone();
+        std::thread::spawn(move || {
+            if is_in_app {
+                let target = if is_meeting_deeplink(&url) {
+                    ShowRewindWindow::Home {
+                        page: Some("meetings".to_string()),
+                    }
+                } else {
+                    ShowRewindWindow::Main
+                };
+                let app_for_show = app_clone.clone();
+                let _ = app_clone.run_on_main_thread(move || {
+                    if let Err(e) = target.show(&app_for_show) {
+                        error!("failed to show window for source action: {}", e);
+                    }
+                });
+                if is_meeting_deeplink(&url) {
+                    emit_meeting_note_route_with_retries(&app_clone, &url);
+                } else {
+                    std::thread::sleep(std::time::Duration::from_millis(150));
+                    let _ = app_clone.emit("deep-link-received", url);
+                }
+            } else {
+                use tauri_plugin_opener::OpenerExt;
+                if let Err(e) = app_clone.opener().open_url(&url, None::<&str>) {
+                    error!("failed to open source url '{}' from notification: {}", url, e);
+                }
+            }
+        });
+        return;
+    }
+
     // Compound meeting action: open the actual call URL, then route the app to
     // the live note. This is intentionally separate from generic link/deeplink
     // handling because meeting-start notifications need both side effects.

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -40,6 +40,26 @@ fn log_webview_build_failure(label: &str, url_hint: &str, err: &(impl std::fmt::
 #[cfg(target_os = "macos")]
 static GLOBAL_APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
 
+#[cfg(target_os = "macos")]
+fn notification_copy_value(action: &serde_json::Value) -> Option<String> {
+    action
+        .get("value")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+#[cfg(target_os = "macos")]
+fn notification_source_url(action: &serde_json::Value) -> Option<String> {
+    action
+        .get("url")
+        .or_else(|| action.get("source_url"))
+        .or_else(|| action.get("sourceUrl"))
+        .or_else(|| action.get("deeplink_url"))
+        .or_else(|| action.get("deeplinkUrl"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
 /// Callback invoked from Swift when user clicks a notification action.
 /// Handles "manage" directly in Rust (opens home window to notifications settings).
 /// Other actions are forwarded as Tauri events to JS.
@@ -112,11 +132,7 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
     // writes to NSPasteboard for instant feedback; this Rust path keeps the
     // action functional if a non-Swift native caller emits the same event.
     if action_type == Some("copy") {
-        let text = parsed
-            .as_ref()
-            .and_then(|v| v.get("value"))
-            .and_then(|v| v.as_str())
-            .map(str::to_string);
+        let text = parsed.as_ref().and_then(notification_copy_value);
         let Some(text) = text else {
             warn!("copy notification action has no value: {}", json);
             return;
@@ -133,17 +149,7 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
     // Source actions open the originating surface. Accept several field names
     // because producers have used both URL-shaped and source-shaped payloads.
     if action_type == Some("source") {
-        let url = parsed
-            .as_ref()
-            .and_then(|v| {
-                v.get("url")
-                    .or_else(|| v.get("source_url"))
-                    .or_else(|| v.get("sourceUrl"))
-                    .or_else(|| v.get("deeplink_url"))
-                    .or_else(|| v.get("deeplinkUrl"))
-            })
-            .and_then(|v| v.as_str())
-            .map(str::to_string);
+        let url = parsed.as_ref().and_then(notification_source_url);
         let Some(url) = url else {
             warn!("source notification action has no url: {}", json);
             return;
@@ -367,7 +373,11 @@ fn emit_meeting_note_route_with_retries(app: &tauri::AppHandle, deeplink_url: &s
 
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
-    use super::{fallback_local_api_config, parse_meeting_deeplink};
+    use super::{
+        fallback_local_api_config, notification_copy_value, notification_source_url,
+        parse_meeting_deeplink,
+    };
+    use serde_json::json;
 
     #[test]
     fn parses_meeting_deeplink_path_id() {
@@ -392,6 +402,62 @@ mod tests {
             None
         );
         assert_eq!(parse_meeting_deeplink("screenpipe://settings"), None);
+    }
+
+    #[test]
+    fn notification_copy_action_uses_value_field() {
+        let action = json!({
+            "type": "copy",
+            "label": "copy",
+            "value": "COPY-TEST-BRAVO-67890"
+        });
+
+        assert_eq!(
+            notification_copy_value(&action),
+            Some("COPY-TEST-BRAVO-67890".to_string())
+        );
+    }
+
+    #[test]
+    fn notification_copy_action_without_value_is_ignored() {
+        let action = json!({
+            "type": "copy",
+            "label": "copy"
+        });
+
+        assert_eq!(notification_copy_value(&action), None);
+    }
+
+    #[test]
+    fn notification_source_action_uses_url_field() {
+        let action = json!({
+            "type": "source",
+            "label": "source",
+            "url": "https://screenpi.pe"
+        });
+
+        assert_eq!(
+            notification_source_url(&action),
+            Some("https://screenpi.pe".to_string())
+        );
+    }
+
+    #[test]
+    fn notification_source_action_accepts_source_and_deeplink_aliases() {
+        for (field, expected) in [
+            ("source_url", "screenpipe://chat/source-url"),
+            ("sourceUrl", "screenpipe://chat/sourceUrl"),
+            ("deeplink_url", "screenpipe://meeting/123"),
+            ("deeplinkUrl", "screenpipe://meeting/456"),
+        ] {
+            let action = json!({
+                "type": "source",
+                "label": "source",
+                field: expected
+            });
+
+            assert_eq!(notification_source_url(&action), Some(expected.to_string()));
+        }
     }
 
     // Regression for b7dc02415: `get_local_api_config` returned {key: null}

--- a/apps/screenpipe-app-tauri/src-tauri/swift/notification_panel.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/notification_panel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 // MARK: - Data types bridged from Rust JSON
 
 struct NotificationAction: Codable {
-    let label: String
+    var label: String?
     // `action` was a required legacy field; many current callers send `id` + `type`
     // instead and omit it entirely, which was failing JSON decode and forcing
     // every notification with actions to fall back to the webview panel.
@@ -23,6 +23,11 @@ struct NotificationAction: Codable {
     var pipe: String?
     var context: [String: AnyCodable]?
     var url: String?
+    var value: String?
+    var source_url: String?
+    var sourceUrl: String?
+    var deeplink_url: String?
+    var deeplinkUrl: String?
     var method: String?
     var body: [String: AnyCodable]?
     var toast: String?
@@ -290,9 +295,26 @@ struct NotificationContentView: View {
                 HStack(spacing: 8) {
                     ForEach(Array(payload.actions.enumerated()), id: \.offset) { _, action in
                         BrandButton(
-                            label: action.label,
+                            label: actionLabel(action),
                             isPrimary: action.primary == true,
-                            action: { onAction(action) }
+                            action: {
+                                if action.type == "copy" {
+                                    var copyAction = action
+                                    if copyAction.value == nil {
+                                        copyAction.value = payload.body
+                                    }
+                                    copyActionText(copyAction)
+                                    copied = true
+                                    sendAction(copyAction)
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+                                        copied = false
+                                    }
+                                } else if action.type == "source" {
+                                    onAction(sourceActionWithFallback(action))
+                                } else {
+                                    onAction(action)
+                                }
+                            }
                         )
                     }
                     Spacer()
@@ -312,6 +334,7 @@ struct NotificationContentView: View {
                     help: "copy notification"
                 ) {
                     copyNotificationText()
+                    sendActionPayload(["type": "copy", "value": notificationClipboardText()])
                     copied = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
                         copied = false
@@ -385,11 +408,64 @@ struct NotificationContentView: View {
         }
     }
 
-    private func copyNotificationText() {
-        let text = "\(payload.title)\n\n\(payload.body)".trimmingCharacters(in: .whitespacesAndNewlines)
+    private func sendActionPayload(_ payload: [String: String]) {
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        sendActionJson(json)
+    }
+
+    private func sendAction(_ action: NotificationAction) {
+        if let data = try? JSONEncoder().encode(action),
+           let json = String(data: data, encoding: .utf8) {
+            sendActionJson(json)
+        }
+    }
+
+    private func actionLabel(_ action: NotificationAction) -> String {
+        if let label = action.label, !label.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return label
+        }
+        switch action.type {
+        case "copy":
+            return copied ? "copied" : "copy"
+        case "source":
+            return "source"
+        case "deeplink":
+            return "open"
+        case "dismiss":
+            return "dismiss"
+        default:
+            return action.action ?? action.type ?? "action"
+        }
+    }
+
+    private func copyActionText(_ action: NotificationAction) {
+        let text = (action.value ?? payload.body).trimmingCharacters(in: .whitespacesAndNewlines)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+    }
+
+    private func sourceActionWithFallback(_ action: NotificationAction) -> NotificationAction {
+        var next = action
+        let source = action.url ?? action.source_url ?? action.sourceUrl ?? payload.source_url
+        next.url = source
+        next.source_url = source
+        return next
+    }
+
+    private func copyNotificationText() {
+        let text = notificationClipboardText()
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+
+    private func notificationClipboardText() -> String {
+        "\(payload.title)\n\n\(payload.body)".trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 
@@ -862,9 +938,7 @@ class NotificationPanelController: NSObject {
             onOpenSource: { [weak self] in
                 guard let self = self, let url = payload.source_url else { return }
                 self.hide()
-                let escaped = url.replacingOccurrences(of: "\\", with: "\\\\")
-                    .replacingOccurrences(of: "\"", with: "\\\"")
-                self.sendAction("{\"type\":\"deeplink\",\"url\":\"\(escaped)\"}")
+                self.sendActionPayload(["type": "source", "url": url])
             }
         )
         // Fixed width, height determined by content
@@ -928,6 +1002,15 @@ class NotificationPanelController: NSObject {
         if let cb = gActionCallback {
             json.withCString { cb($0) }
         }
+    }
+
+    private func sendActionPayload(_ payload: [String: String]) {
+        guard JSONSerialization.isValidJSONObject(payload),
+              let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        sendAction(json)
     }
 }
 


### PR DESCRIPTION
### Description: 

- after:

https://github.com/user-attachments/assets/09643e50-776f-4ed2-af83-9b346b028fcf


- logs for copy action:

<img width="1087" height="37" alt="image" src="https://github.com/user-attachments/assets/bda4f514-0e5a-4af5-94ce-f59c6dbf79dc" />


- logs for source action:

<img width="1409" height="38" alt="image" src="https://github.com/user-attachments/assets/6774739a-5d66-4ad1-8fd5-37e530368545" />


Fixes #4438 

  - Treat copy and source notification actions as real interactive actions in the native panel.
  - Preserve action fields like value, source_url, sourceUrl, deeplink_url, and deeplinkUrl.
  - Copy actions[].value for copy actions, falling back to the notification body when needed.
  - Open source URLs/deeplinks for source actions instead of falling through to dismiss.
  - Emit distinct copy and source action events so logs no longer report these clicks as auto_dismiss.
  - Add matching handling in the React/webview fallback notification path.
  - Keep auto_dismiss reserved for timeout-driven dismissal.