### PR TITLE
fix(ci): enable Tauri's DMG bundler to render background image and icon layout

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -943,11 +943,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # https://tauri.app/v1/guides/distribution/sign-macos
-          # CI=false so tauri's DMG bundler renders the background image correctly
-          # (CI=true causes hdiutil to skip the background/icon layout stage)
+          # Keep CI=true while allowing Tauri's DMG bundler to render the
+          # background image and icon layout.
           # See: https://github.com/tauri-apps/tauri-action/issues/740
-          CI: false
+          TAURI_BUNDLER_DMG_IGNORE_CI: true
           SCREENPIPE_RELEASE_TARGET: ${{ matrix.target }}
           # Fix std::filesystem availability - requires macOS 10.15+
           # whisper.cpp ggml uses std::filesystem::path which needs 10.15

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -434,7 +434,10 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CI: false
+          # Keep CI=true while allowing Tauri's DMG bundler to render the
+          # background image and icon layout.
+          # See: https://github.com/tauri-apps/tauri-action/issues/740
+          TAURI_BUNDLER_DMG_IGNORE_CI: true
           SCREENPIPE_RELEASE_TARGET: aarch64-apple-darwin
           MACOSX_DEPLOYMENT_TARGET: "14.0"
           CMAKE_OSX_DEPLOYMENT_TARGET: "14.0"


### PR DESCRIPTION
## Summary
- Replace macOS release `CI: false` overrides with `TAURI_BUNDLER_DMG_IGNORE_CI: true`.
- Keep GitHub Actions CI behavior enabled while preserving Tauri DMG background and icon layout rendering.

- Before


<img width="2000" height="972" alt="image" src="https://github.com/user-attachments/assets/91543816-1703-4dd9-981b-c67f32da4acd" />


- After

<img width="681" height="413" alt="image" src="https://github.com/user-attachments/assets/a1f729bc-6eec-429a-a3b1-6fdaac6e8bcf" />


Ref: https://github.com/tauri-apps/tauri-action/pull/949/files
