### PR TITLE
fix(connections): sync Claude MCP state with config

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
@@ -9,6 +9,7 @@ import { Check, Loader, Lock } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { commands } from "@/lib/utils/tauri";
 import { useSettings } from "@/lib/hooks/use-settings";
+import { getClaudeConfigPath } from "@/lib/hooks/use-hardcoded-tiles";
 import { localFetch } from "@/lib/api";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { readTextFile, writeFile, mkdir } from "@tauri-apps/plugin-fs";
@@ -136,19 +137,10 @@ async function installCursorMcp(): Promise<void> {
 }
 
 // Claude Desktop
-async function getClaudeMcpConfigPath(): Promise<string> {
-  const home = await homeDir();
-  const os = platform();
-  console.log("[claude-mcp] platform:", os, "home:", home);
-  if (os === "windows") {
-    return join(home, "AppData", "Roaming", "Claude", "claude_desktop_config.json");
-  }
-  return join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json");
-}
-
 async function isClaudeMcpInstalled(): Promise<boolean> {
   try {
-    const configPath = await getClaudeMcpConfigPath();
+    const configPath = await getClaudeConfigPath();
+    if (!configPath) return false;
     console.log("[claude-mcp] checking install at:", configPath);
     const content = await readTextFile(configPath);
     return !!JSON.parse(content)?.mcpServers?.screenpipe;
@@ -159,7 +151,8 @@ async function isClaudeMcpInstalled(): Promise<boolean> {
 }
 
 async function installClaudeMcp(): Promise<void> {
-  const configPath = await getClaudeMcpConfigPath();
+  const configPath = await getClaudeConfigPath();
+  if (!configPath) throw new Error("unsupported platform");
   console.log("[claude-mcp] installing to:", configPath);
   const config = await readMcpConfig(configPath);
   console.log("[claude-mcp] existing config:", JSON.stringify(config));

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -3778,12 +3778,9 @@ export function ConnectionsSection({
     detectInstalledConnectionIds()
       .then(setDetectedConnectionIds)
       .catch(() => setDetectedConnectionIds(new Set()));
-    getInstalledMcpVersion().then(v => {
-      const installed = !!v || localStorage.getItem("screenpipe_claude_connected") === "true";
-      setClaudeInstalled(installed);
-    }).catch(() => {
-      setClaudeInstalled(localStorage.getItem("screenpipe_claude_connected") === "true");
-    });
+    getInstalledMcpVersion()
+      .then(v => setClaudeInstalled(!!v))
+      .catch(() => setClaudeInstalled(false));
     isCursorMcpInstalled().then(setCursorInstalled).catch(() => {});
     isCodexMcpInstalled().then(setCodexInstalled).catch(() => {});
     isGrokMcpInstalled().then(setGrokInstalled).catch(() => {});
@@ -4033,8 +4030,8 @@ export function ConnectionsSection({
     if (!selected) return null;
     switch (selected) {
       case "claude": return <ClaudePanel
-        onConnected={() => { localStorage.setItem("screenpipe_claude_connected", "true"); setClaudeInstalled(true); }}
-        onDisconnected={() => { localStorage.removeItem("screenpipe_claude_connected"); setClaudeInstalled(false); }}
+        onConnected={() => setClaudeInstalled(true)}
+        onDisconnected={() => setClaudeInstalled(false)}
       />;
       case "cursor": return <CursorPanel
         onConnected={() => setCursorInstalled(true)}

--- a/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-hardcoded-tiles.ts
@@ -113,8 +113,8 @@ export function useHardcodedTiles(): HardcodedTile[] {
 
   useEffect(() => {
     getInstalledMcpVersion()
-      .then(v => setClaudeInstalled(!!v || localStorage.getItem("screenpipe_claude_connected") === "true"))
-      .catch(() => setClaudeInstalled(localStorage.getItem("screenpipe_claude_connected") === "true"));
+      .then(v => setClaudeInstalled(!!v))
+      .catch(() => setClaudeInstalled(false));
 
     isCursorMcpInstalled().then(setCursorInstalled).catch(() => {});
     isCodexMcpInstalled().then(setCodexInstalled).catch(() => {});


### PR DESCRIPTION
### Description:


https://github.com/user-attachments/assets/dd87fd44-b4a6-4d54-9829-30421fe5be68



- Reuse the shared Claude config path resolver in onboarding so Windows MSIX Claude Desktop and macOS resolve to the correct config file consistently.
- Remove the stale `screenpipe_claude_connected` localStorage fallback so the UI only shows Claude Desktop as connected when `mcpServers.screenpipe` exists in the actual Claude config.
- Keep the Claude connection CTA behavior unchanged: screenpipe writes/removes the MCP config, while users still need to restart Claude Desktop for Claude to reload MCP servers.

Reference: https://modelcontextprotocol.io/docs/develop/connect-local-servers#server-not-showing-up-in-claude-hammer-icon-missing

Note: the MCP docs clearly state that Claude Desktop must be fully restarted to see MCP server changes after editing `claude_desktop_config.json`.