### PR TITLE
fix(app): open home from taskbar activation

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -10,7 +10,6 @@
 #![recursion_limit = "256"]
 
 use analytics::AnalyticsManager;
-use commands::show_main_window;
 use serde_json::json;
 use std::env;
 use std::str::FromStr;
@@ -920,9 +919,11 @@ async fn main() {
         let app_for_closure = app.clone();
         let args_clone = args.clone();
         let _ = app.run_on_main_thread(move || {
-            // Focus the existing window
+            // A second app launch is usually the Windows taskbar/dock entry point.
+            // Open the Home app window here; `show_main_window` intentionally
+            // opens the timeline overlay for the global shortcut/tray timeline.
             if !crate::enterprise_policy::is_app_ui_hidden() {
-                show_main_window(app_for_closure.clone());
+                let _ = ShowRewindWindow::Home { page: None }.show(&app_for_closure);
             }
 
             // Forward deep-link URL from args

--- a/apps/screenpipe-app-tauri/src-tauri/src/server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server.rs
@@ -104,7 +104,7 @@ async fn handle_focus(
         payload.args, payload.deep_link_url, payload.target
     );
 
-    if payload.target.as_deref() == Some("browser_pairing") {
+    if payload.target.as_deref() == Some("browser_pairing") || payload.deep_link_url.is_none() {
         let _ = (ShowRewindWindow::Home { page: None }).show(&state.app_handle);
     } else {
         show_main_window(state.app_handle.clone());

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -738,6 +738,7 @@ impl ShowRewindWindow {
                             .inner_size(win_w, win_h)
                             .min_inner_size(800.0, 600.0)
                             .decorations(true)
+                            .skip_taskbar(true)
                             .visible(false)
                             .focused(false)
                             .transparent(false)


### PR DESCRIPTION
### Description:

Fixes #3881


https://github.com/user-attachments/assets/b808fd66-ccee-4d5f-b9bb-8f1f11205edc



- Fixes Windows taskbar/pinned shortcut activation opening the Timeline overlay instead of the main Screenpipe app window.
- Updates the single-instance launch path to show the Home window for normal app activation.
- Keeps the Timeline overlay behavior unchanged for the global shortcut and tray timeline actions.
- Adds a clarifying comment so `show_main_window` is not mistaken for the normal app window path.

Reference: https://github.com/screenpipe/screenpipe/issues/3881