### PR TITLE
docs(readme): drop "free" framing (app is paid)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ screenpipe is a source-available application that continuously captures your scr
 - **Website**: https://screenpi.pe
 - **Documentation**: https://docs.screenpi.pe
 - **Discord**: https://discord.gg/screenpipe
-- **License**: Screenpipe Commercial License (source-available; free for personal use, commercial use requires a license, see [LICENSE.md](LICENSE.md))
+- **License**: Screenpipe Commercial License (source-available; personal, non-commercial use permitted, commercial use requires a license, see [LICENSE.md](LICENSE.md))
 
 ## Who screenpipe is for
 
@@ -240,7 +240,7 @@ Full REST API running on localhost (default port 3030). Endpoints for searching 
 ## Privacy and security
 
 - **100% local by default**: All data stored on your device in a local SQLite database. Nothing sent to external servers.
-- **Source-available**: fully auditable codebase; free for personal use.
+- **Source-available**: fully auditable codebase; personal, non-commercial use permitted.
 - **Local AI support**: Use Ollama or any local model — no data sent to any cloud.
 - **No account required**: Core application works without any sign-up.
 - **You own your data**: Export, delete, or back up at any time.
@@ -260,11 +260,11 @@ Full REST API running on localhost (default port 3030). Endpoints for searching 
 | Plugin system | ✅ Pipes (AI agents) | ❌ | ❌ | ❌ |
 | AI model choice | Any (local or cloud) | Proprietary | Microsoft AI | Proprietary |
 | Team deployment | ✅ Central config, AI permissions | ❌ | ❌ | ❌ |
-| Pricing | Free OSS core · app from $25/mo | Subscription | Bundled with Windows | Subscription |
+| Pricing | Source-available · app from $25/mo | Subscription | Bundled with Windows | Subscription |
 
 ## Pricing
 
-The source is available and free for personal use (see [LICENSE.md](LICENSE.md)). The signed desktop app uses a subscription:
+The source is available for personal, non-commercial use (see [LICENSE.md](LICENSE.md)). The signed desktop app uses a subscription:
 
 - **Standard**: $25/month. Local-first capture, search, and timeline, all on your device.
 - **Pro**: $50/seat/month. Everything in Standard plus cloud sync, cloud AI, and integrations. Teams buy 5+ seats self-serve.
@@ -333,8 +333,8 @@ Make sure to understand the main branch is moving fast and breaking things, if y
 
 ## Frequently asked questions
 
-**Is screenpipe free?**
-The source is available and free for personal, non-commercial use, so you can build and run screenpipe yourself for free (see [LICENSE.md](LICENSE.md)); commercial use of the source requires a license. The signed desktop app uses a subscription starting at $25/month; existing lifetime licenses remain valid.
+**How much does screenpipe cost?**
+The signed desktop app uses a subscription starting at $25/month; existing lifetime licenses remain valid. The source is available for personal, non-commercial use, so you can build and run it yourself (see [LICENSE.md](LICENSE.md)); commercial use of the source requires a license.
 
 **Does screenpipe send my data to the cloud?**
 No. All data is stored locally by default. You can use fully local AI models via Ollama for complete privacy.


### PR DESCRIPTION
## what

removes every "free" reference from `README.md`. screenpipe has **no free product tier** — the signed app is a paid subscription (from \$25/mo) and the source is *source-available* for personal, non-commercial use only.

## why

saying screenpipe is "free" sets wrong expectations and keeps generating confusion in the community (e.g. the recurring "free vs paid" Discord thread). this aligns the README with how we actually describe it: source-available, paid app.

## changes (6 lines)

| where | before | after |
|---|---|---|
| license line | "free for personal use" | "personal, non-commercial use permitted" |
| privacy bullet | "free for personal use" | "personal, non-commercial use permitted" |
| comparison table | "Free OSS core · app from \$25/mo" | "Source-available · app from \$25/mo" |
| pricing intro | "available and free for personal use" | "available for personal, non-commercial use" |
| FAQ heading | "Is screenpipe free?" | "How much does screenpipe cost?" |
| FAQ body | "build and run screenpipe yourself for free" | "build and run it yourself" |

facts (source-available, paid subscription, lifetime grandfathering, MIT→commercial) are unchanged — only the word "free" and the expectation it set are gone.

note: scoped to the README only. competitor "free tier" mentions in blog/docs and code identifiers (`lock-free`, `use-after-free`, "free disk space") are left untouched. say the word and I'll extend the same cleanup to the website (`onboarding/pricing-section.tsx`, license-update blog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)