### PR TITLE
fix(auth): don't sign out on local-engine 401s (match host, not substring)

### DIFF
--- a/apps/screenpipe-app-tauri/lib/auth-guard.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/auth-guard.test.tsx
@@ -35,7 +35,7 @@ vi.mock("@/components/ui/use-toast", () => ({ toast: mocks.toast }));
 vi.mock("@/components/ui/toast", () => ({ ToastAction: () => null }));
 vi.mock("@/lib/web-url", () => ({ screenpipeWebUrl: () => "https://screenpipe.com/login" }));
 
-import { AuthGuard, shouldReverifyOnFocus } from "./auth-guard";
+import { AuthGuard, isScreenpipeApi, shouldReverifyOnFocus } from "./auth-guard";
 
 const LOGGED_IN = { token: "tok-123", cloud_subscribed: false };
 
@@ -65,6 +65,39 @@ afterEach(() => {
   vi.clearAllMocks();
   mocks.loadUser.mockResolvedValue(undefined);
   mocks.state.user = null;
+});
+
+describe("isScreenpipeApi", () => {
+  it("matches the cloud API host and its subdomains", () => {
+    expect(isScreenpipeApi("https://screenpipe.com/api/user")).toBe(true);
+    expect(isScreenpipeApi("https://screenpi.pe/api/oauth/exchange")).toBe(true);
+    expect(isScreenpipeApi("https://api.screenpipe.com/v1/chat/completions")).toBe(true);
+    expect(isScreenpipeApi("https://clerk.screenpipe.com/")).toBe(true);
+  });
+
+  it("does NOT match the local engine when a screenpipe-domain email rides in the query", () => {
+    // regression: a connected account on the screenpi.pe domain made the local
+    // engine's 401 look like a cloud session expiry and signed the user out.
+    expect(
+      isScreenpipeApi(
+        "http://localhost:3030/connections/google-calendar/events?hours_back=0&instance=member%40screenpi.pe"
+      )
+    ).toBe(false);
+    expect(
+      isScreenpipeApi("http://127.0.0.1:3030/connections/gmail?instance=x@screenpipe.com")
+    ).toBe(false);
+  });
+
+  it("does NOT match a third-party host that merely mentions the domain in path/query", () => {
+    expect(isScreenpipeApi("https://evil.example.com/?ref=screenpi.pe")).toBe(false);
+    // not a subdomain — must not match on a bare suffix
+    expect(isScreenpipeApi("https://notscreenpipe.com/api")).toBe(false);
+    expect(isScreenpipeApi("https://screenpipe.com.evil.com/api")).toBe(false);
+  });
+
+  it("returns false for an unparseable url", () => {
+    expect(isScreenpipeApi("::::")).toBe(false);
+  });
 });
 
 describe("shouldReverifyOnFocus", () => {

--- a/apps/screenpipe-app-tauri/lib/auth-guard.tsx
+++ b/apps/screenpipe-app-tauri/lib/auth-guard.tsx
@@ -65,8 +65,45 @@ function showSignedOutToast() {
   });
 }
 
-function isScreenpipeApi(url: string): boolean {
-  return url.includes("screenpi.pe") || url.includes("screenpipe.com");
+// Only the screenpipe CLOUD API (screenpi.pe / screenpipe.com and their
+// subdomains) carries the login session whose 401/403 means "signed out".
+//
+// Match on the URL *host* — never a substring of the whole URL. The local
+// engine at localhost:3030 routinely carries a screenpipe-domain value in the
+// query string (e.g. `?instance=member@screenpi.pe` for a connected account),
+// and a substring match treats that local URL as the cloud API. The local
+// engine's 401s are connection-level (an OAuth token that failed to refresh —
+// e.g. during a transient DNS/network blip), NOT session expiry, so misreading
+// them signed the user out and paused recording. This bit anyone whose
+// connected-account email is @screenpi.pe / @screenpipe.com.
+export function isScreenpipeApi(url: string): boolean {
+  let host: string;
+  try {
+    const base =
+      typeof window !== "undefined" && window.location?.href
+        ? window.location.href
+        : "http://localhost";
+    host = new URL(url, base).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  // The local engine is never the cloud auth surface.
+  if (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]"
+  ) {
+    return false;
+  }
+
+  return (
+    host === "screenpi.pe" ||
+    host === "screenpipe.com" ||
+    host.endsWith(".screenpi.pe") ||
+    host.endsWith(".screenpipe.com")
+  );
 }
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## what

`isScreenpipeApi` in the global fetch interceptor (`lib/auth-guard.tsx`) substring-matched the **whole URL** for `screenpi.pe` / `screenpipe.com`. Any 401/403 from a matching URL cleared the session. Changed it to match the URL **host** (exact domain or subdomain), and to never treat `localhost` / `127.0.0.1` / `::1` as the cloud auth surface.

## why (real incident)

A connected account whose email is on a screenpipe domain rides in the query string of **local** engine calls:

```
auth-interceptor: 401 from
  http://localhost:3030/connections/google-calendar/events?...&instance=member%40screenpi.pe
```

`url.includes("screenpi.pe")` → `true` because the account email is in the query → the interceptor treated a **local** 401 as a **cloud login** expiry → `clearSession()` → `user: null`.

Chain of failure:
1. transient DNS/network blip → a connection's OAuth token fails to refresh
2. local engine returns `401` for that connection
3. interceptor false-matches the localhost URL → signs the user out
4. `require_app_entitlement` (recording.rs) sees no user → pauses recording
5. relaunch doesn't help — same local 401, same false match, signed out again

It disproportionately hits anyone whose connected-account email is on a `@screenpi.pe` / `@screenpipe.com` domain (e.g. team members), which is why it looked like a phantom "recording won't stay on" bug. The local engine's 401s are **connection-level**, never session expiry.

## the fix

```ts
export function isScreenpipeApi(url: string): boolean {
  let host: string;
  try { host = new URL(url, base).hostname.toLowerCase(); } catch { return false; }
  if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return false;
  return host === "screenpi.pe" || host === "screenpipe.com"
      || host.endsWith(".screenpi.pe") || host.endsWith(".screenpipe.com");
}
```

Genuine cloud-session 401s (from `screenpipe.com/api/*`, `api.screenpipe.com`, etc.) still sign out as before — the `AuthGuard` interval re-verify path is unchanged and already handles network/5xx correctly.

## tests

Added an `isScreenpipeApi` suite to `lib/auth-guard.test.tsx` covering the regression (localhost + screenpipe-domain email in query → `false`), cloud hosts/subdomains → `true`, and third-party/suffix false-positives → `false`.

```
✓ lib/auth-guard.test.tsx  (19 tests)
```

## follow-ups (not in this PR)

- **Entitlement gate hardening**: `app_entitled_or_dev` already tolerates 72h of staleness for a cached active plan, but a cleared session bypasses that. Worth making the gate fail-open on inability-to-validate (vs. explicit expiry).
- **DB wedge after sleep/wake**: separate issue — `code 522 SQLITE_IOERR_SHORT_READ` on the WAL `-shm` after wake; the in-process recovery can't rebuild `-shm` because the static `SECRET_POOLS` cache keeps a handle open. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)