### PR TITLE
fix(db): close secret-store pools in DB-wedge recovery so -shm can rebuild in-process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8566,6 +8566,7 @@ dependencies = [
  "screenpipe-config",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "tempfile",
  "tokio",

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -191,6 +191,16 @@ async fn recover_from_db_wedge(app: tauri::AppHandle, breaker: DbWedgeBreaker) {
             e
         );
     }
+
+    // stop_screenpipe rebuilds the engine's read/write pools on respawn, but the
+    // secret-store pool is a process-lifetime cache (min_connections=1, no idle
+    // reaping) that would otherwise keep a connection — and the poisoned `-shm`
+    // WAL-index — open across the restart. SQLite only rebuilds `-shm` once the
+    // LAST connection to the db closes, so without this the wedge survives an
+    // in-process restart and recording stays down until a full process exit.
+    // Pools recreate lazily on the next secret access after spawn reopens.
+    screenpipe_secrets::close_all_secret_pools().await;
+
     if let Err(e) = spawn_screenpipe(app.state::<RecordingState>(), app.clone(), None).await {
         error!("db wedge auto-recovery: spawn_screenpipe failed: {}", e);
     }

--- a/crates/screenpipe-secrets/Cargo.toml
+++ b/crates/screenpipe-secrets/Cargo.toml
@@ -25,3 +25,4 @@ keyring = { workspace = true, features = ["linux-native-sync-persistent"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
+serial_test = "3"

--- a/crates/screenpipe-secrets/src/lib.rs
+++ b/crates/screenpipe-secrets/src/lib.rs
@@ -16,4 +16,4 @@ mod store;
 
 pub use migration::{fix_secret_file_permissions, migrate_legacy_secrets, MigrationReport};
 pub use state::{is_encryption_requested, mark_encryption_disabled, mark_encryption_enabled};
-pub use store::{shared_secret_pool, SecretStore};
+pub use store::{close_all_secret_pools, shared_secret_pool, SecretStore};

--- a/crates/screenpipe-secrets/src/store.rs
+++ b/crates/screenpipe-secrets/src/store.rs
@@ -84,6 +84,30 @@ pub async fn shared_secret_pool(db_path: &str) -> Result<SqlitePool> {
     Ok(pool)
 }
 
+/// Close every cached secret-store pool and clear the cache; pools recreate
+/// lazily on the next [`shared_secret_pool`] call.
+///
+/// This is the other half of DB-wedge recovery. A `code 522`
+/// (`SQLITE_IOERR_SHORT_READ`) / "disk image is malformed" wedge — typically a
+/// WAL-index (`-shm`) desync after macOS sleep/wake — is only cleared by
+/// rebuilding `-shm`, and SQLite rebuilds it only once the LAST connection to
+/// the db file closes. When recording restarts, the engine's `DatabaseManager`
+/// read/write pools are rebuilt — but this process-wide secret pool keeps a warm
+/// connection alive (`min_connections=1`, no idle/lifetime reaping), and with it
+/// the `-shm` mapping. So an in-process restart alone can't clear the wedge: the
+/// recovery must close these pools too, or recording stays down until a full
+/// process exit (quit + relaunch).
+pub async fn close_all_secret_pools() {
+    let mut cache = secret_pools().lock().await;
+    let count = cache.len();
+    for (_path, pool) in cache.drain() {
+        pool.close().await;
+    }
+    if count > 0 {
+        tracing::info!("closed {count} cached secret-store pool(s) for db-wedge recovery");
+    }
+}
+
 pub struct SecretStore {
     pool: SqlitePool,
     key: Option<[u8; 32]>, // None = encryption disabled (keychain unavailable)
@@ -342,6 +366,9 @@ impl SecretStore {
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
+    // Tests that touch the process-wide `SECRET_POOLS` cache run serially so the
+    // `close_all_secret_pools` drain test can't close another test's live pool.
+    use serial_test::serial;
 
     async fn make_store(key: Option<[u8; 32]>) -> SecretStore {
         let pool = SqlitePool::connect(":memory:").await.unwrap();
@@ -545,6 +572,7 @@ mod tests {
     /// `open()` returns a working store backed by the shared pool and creates
     /// the db file on open — preserving the old `?mode=rwc` behavior exactly.
     #[tokio::test]
+    #[serial]
     async fn shared_pool_open_roundtrips_and_creates_db() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("db.sqlite");
@@ -559,11 +587,41 @@ mod tests {
         );
     }
 
+    /// `close_all_secret_pools` closes every cached pool — releasing its handle
+    /// on the db file and the shared `-shm` WAL-index so a wedge recovery can
+    /// rebuild it — and the cache re-populates lazily on the next open.
+    #[tokio::test]
+    #[serial]
+    async fn close_all_secret_pools_closes_and_allows_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_str = dir.path().join("db.sqlite").to_string_lossy().into_owned();
+
+        let pool = shared_secret_pool(&db_str).await.unwrap();
+        assert!(!pool.is_closed());
+        // a second open returns the same cached, still-open pool
+        let cached = shared_secret_pool(&db_str).await.unwrap();
+        assert!(!cached.is_closed());
+
+        close_all_secret_pools().await;
+
+        // the previously-cached pool is now closed — its handle on the db file
+        // (and with it the shared `-shm` mapping) is released
+        assert!(pool.is_closed(), "cached pool must be closed after drain");
+
+        // a fresh, working pool is created lazily on the next open
+        let reopened = shared_secret_pool(&db_str).await.unwrap();
+        assert!(!reopened.is_closed());
+        let store = SecretStore::new(reopened, None).await.unwrap();
+        store.set("k", b"v").await.unwrap();
+        assert_eq!(store.get("k").await.unwrap().as_deref(), Some(&b"v"[..]));
+    }
+
     /// Repeated opens for the same path reuse ONE pool: total connections stay
     /// bounded by `max_connections` instead of growing per call. The old ad-hoc
     /// `SqlitePool::connect`-per-op pattern was unbounded churn — the WAL-index
     /// thrash this fixes.
     #[tokio::test]
+    #[serial]
     async fn shared_pool_is_reused_not_recreated() {
         let dir = tempfile::tempdir().unwrap();
         let db_str = dir.path().join("db.sqlite").to_string_lossy().into_owned();
@@ -587,6 +645,7 @@ mod tests {
     /// the exact concurrency (engine pool + checkpoints + secret writes) that
     /// corrupted db.sqlite when secrets used ad-hoc pools (#4263).
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[serial]
     async fn shared_pool_survives_concurrent_writes_and_checkpoints() {
         let dir = tempfile::tempdir().unwrap();
         let db_str = dir.path().join("db.sqlite").to_string_lossy().into_owned();
@@ -669,6 +728,7 @@ mod tests {
     /// regression the fix removes.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[ignore = "timing-dependent reproduction; run manually with --ignored"]
+    #[serial]
     async fn repro_adhoc_pool_churn_contends() {
         let dir = tempfile::tempdir().unwrap();
         let db_str = dir.path().join("db.sqlite").to_string_lossy().into_owned();


### PR DESCRIPTION
## what

Adds `screenpipe_secrets::close_all_secret_pools()` and calls it inside the DB-wedge auto-recovery (`recover_from_db_wedge`, recording.rs), between `stop_screenpipe` and `spawn_screenpipe`.

## why

A `code 522` (`SQLITE_IOERR_SHORT_READ`) / "disk image is malformed" wedge — typically a WAL-index (`-shm`) desync after macOS **sleep/wake** — wedges every DB write. The existing recovery restarts recording to rebuild the engine's read/write pools, but recording stayed **Stopped until a full app quit+relaunch**. Here's why:

- SQLite rebuilds `-shm` only when the **last** connection to the db file closes.
- The `SECRET_POOLS` cache in `screenpipe-secrets` is a **process-lifetime static** with a warm connection (`min_connections=1`, no idle/lifetime reaping) and **no close path**.
- So across stop→spawn that connection — and the poisoned `-shm` mapping — stays open. The respawn reopens against the same bad shared memory → 522 again → the circuit breaker trips and parks recording.

Observed live during an incident: after the engine tore down, **9+ `db.sqlite` handles were still open** on the app PID (incl. the `-shm` mapping). The DB file itself was intact (`quick_check` ok, 152k frames readable) — only the in-process shared-memory view was poisoned. A full process exit was the only thing that cleared it, precisely because exiting closes *every* handle at once.

The irony: the persistent secret pool was introduced (#4263/#4267) to stop WAL-index *churn* — but that same persistence is what blocks the in-process `-shm` rebuild here.

## the fix

```rust
pub async fn close_all_secret_pools() {
    let mut cache = secret_pools().lock().await;
    for (_path, pool) in cache.drain() { pool.close().await; }
}
```

Called between stop and spawn in the wedge recovery. With the engine's read/write pools rebuilt by the respawn **and** the secret pools closed, all handles drop → SQLite rebuilds `-shm` on reopen → recording resumes **in-process, no relaunch**. Pools recreate lazily on the next secret access.

## tests

- New unit test `close_all_secret_pools_closes_and_allows_reopen` (closes cached pool, lazy reopen works).
- The 4 tests that touch the process-wide `SECRET_POOLS` cache are marked `#[serial]` so the new drain test can't close another test's live pool.
- `cargo test -p screenpipe-secrets` → **28 passed**.

## verification scope

The `screenpipe-secrets` change is fully built + tested locally. The one-line wiring in `recording.rs` lives in the app crate, which doesn't build standalone locally (Swift `livetext` bridge) — it's compile-checked by CI's e2e build. **End-to-end wedge recovery wants on-device validation** (reproduce the post-wake 522 and confirm recording resumes without a relaunch).

## related

- The completing prevention (recycle/checkpoint pools on `on_did_wake` so the 522 never happens) is a sensible follow-up, not in this PR.
- Companion auth fix from the same incident: #4465 (recording also got gated off by a false sign-out on a local-engine 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)