### PR TITLE
fix(sidebar): hide left-sidebar scrollbars off macOS (Windows/Linux)

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { useIsFullscreen } from "@/lib/hooks/use-is-fullscreen";
 import { useSidebarWidth } from "@/lib/hooks/use-sidebar-width";
+import { usePlatform } from "@/lib/hooks/use-platform";
 
 // ─── Context ─────────────────────────────────────────────────────────────────
 // Provides `isTranslucent` to any descendant without prop-drilling.
@@ -83,6 +84,13 @@ export function AppSidebar({ children, className }: AppSidebarProps) {
   // fullscreen — content shifts to where the traffic lights used to be.
   const fullscreen = useIsFullscreen();
   const { width, isResizing, beginResize } = useSidebarWidth();
+  // macOS (WKWebView) renders an unstyled overflow-auto scrollbar as an
+  // auto-hiding overlay, so it stays invisible when idle. Windows/Linux
+  // (WebView2 / Chromium) render it as a persistent, space-reserving classic
+  // scrollbar — so expanding a pipe section in the embedded list pops a bar
+  // into the left sidebar. Hide it off macOS (scrolling still works via
+  // wheel/trackpad); leave macOS untouched.
+  const { isMac } = usePlatform();
 
   return (
     <div
@@ -104,7 +112,7 @@ export function AppSidebar({ children, className }: AppSidebarProps) {
       {/* Inner scroll container keeps the resize handle pinned to the
        *  viewport edge — putting overflow on the outer would let the
        *  absolute-positioned handle scroll with the content. */}
-      <div className="flex flex-col min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+      <div className={cn("flex flex-col min-h-0 flex-1 overflow-x-hidden overflow-y-auto", !isMac && "scrollbar-hide")}>
         {children}
       </div>
       <div

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -48,6 +48,7 @@ import {
 } from "lucide-react";
 import { useRunningPipes } from "@/lib/hooks/use-running-pipes";
 import { useUpcomingPipes, type UpcomingPipe } from "@/lib/hooks/use-upcoming-pipes";
+import { usePlatform } from "@/lib/hooks/use-platform";
 import { localFetch } from "@/lib/api";
 import { emit, listen } from "@tauri-apps/api/event";
 import { cn } from "@/lib/utils";
@@ -223,6 +224,13 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
   const actions = useChatActions();
   const queueDepths = useQueueDepths();
   const [openConversationMenuId, setOpenConversationMenuId] = useState<string | null>(null);
+  // macOS (WKWebView) auto-hides styled overlay scrollbars, so the minimal
+  // scrollbar only flashes while actually scrolling. Windows/Linux (WebView2
+  // / Chromium) render styled scrollbars as persistent, space-reserving
+  // classic scrollbars — so expanding a pipe section (which grows the sidebar
+  // past the viewport) makes a scrollbar pop in. Hide it off macOS to match,
+  // mirroring the html/body `scrollbar-hide` convention in globals.css.
+  const { isMac } = usePlatform();
 
   // Sync currentId from standalone-chat. Whenever the chat panel switches
   // its piSessionIdRef (new chat, prefill auto-send, history click in the
@@ -776,7 +784,8 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     // (Timeline / Memories / ...) and look misaligned.
     <div
       className={cn(
-        "flex flex-col min-h-0 text-sm px-2 overflow-y-auto overflow-x-hidden scrollbar-minimal",
+        "flex flex-col min-h-0 text-sm px-2 overflow-y-auto overflow-x-hidden",
+        isMac ? "scrollbar-minimal" : "scrollbar-hide",
         className
       )}
       data-testid="chat-sidebar"


### PR DESCRIPTION
## what

On Windows, a scrollbar pops into the **left sidebar** when you expand (uncollapse) a pipe. On macOS it doesn't. This makes the left sidebar match across platforms.

## why

The left sidebar has two nested scroll layers, and the two webviews render scrollbars differently:

- **macOS (WKWebView)** renders scrollbars as auto-hiding overlays — invisible when idle, only flash while actively scrolling.
- **Windows / Linux (WebView2 / Chromium)** render them as persistent, space-reserving *classic* scrollbars. So the moment expanding a pipe grows content past the viewport, a bar appears and stays.

Two containers were affected:

1. **Embedded chat/pipe list** (`chat-sidebar.tsx`) — where the `scheduled` / `upcoming` pipe sections and pipe-groups expand. Per the design (`home/page.tsx`), this list owns its own scroll, so expanding a pipe grows *this* container. It used `scrollbar-minimal`.
2. **Outer left-sidebar shell** (`app-sidebar.tsx`) — had **no scrollbar styling at all**, so Windows rendered a raw default scrollbar.

## fix

Gate the scrollbar styling on platform via the existing `usePlatform()` hook:

- `chat-sidebar.tsx`: `scrollbar-minimal` on macOS, `scrollbar-hide` elsewhere.
- `app-sidebar.tsx`: unchanged (overlay) on macOS, `scrollbar-hide` elsewhere.

Scrolling still works everywhere (wheel/trackpad) — only the persistent bar is hidden, matching macOS's idle look. This mirrors the `html, body` → `scrollbar-hide` convention already in `globals.css` for suppressing unwanted Windows scrollbars. **macOS behavior is unchanged.**

## test plan

- [ ] macOS: left sidebar unchanged — expanding a pipe still scrolls, overlay bar behaves as before
- [ ] Windows: no scrollbar appears in the left sidebar when expanding a pipe; sidebar still scrolls via wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)