### PR TITLE
fix(meetings): stop long titles breaking the "Coming up" card layout

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/coming-up.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/coming-up.tsx
@@ -294,7 +294,7 @@ function DayBlock({
   const rel = relativeDayLabel(date);
 
   return (
-    <div className="grid grid-cols-[64px_1fr] gap-5">
+    <div className="grid grid-cols-[64px_minmax(0,1fr)] gap-5">
       <div className="pt-1">
         <div className="text-3xl font-medium leading-none tracking-tight">
           {day}


### PR DESCRIPTION
## what

Long meeting titles broke the layout of the **Coming up** card on the Meetings screen — the title overflowed past the card and pushed the row's right-arrow outside the card border (reported in Discord, [#4480](https://github.com/screenpipe/screenpipe/issues/4480)).

## root cause

`DayBlock` lays out the date + events with `grid-cols-[64px_1fr]`. In CSS grid, a `1fr` track is `minmax(auto, 1fr)`, and that `auto` minimum won't shrink below the column's **min-content** width. The meeting title span is `truncate` (i.e. `white-space: nowrap`), so its min-content is the full title width — the second column blows out and the row overflows the card. The existing `min-w-0` + `truncate` inside the row never get a chance to clip, because the grid track itself is wider than the card.

## fix

One-token change: `grid-cols-[64px_1fr]` → `grid-cols-[64px_minmax(0,1fr)]`. Allowing the track to shrink below its content lets the existing truncation kick in, so long titles ellipsize and the arrow stays aligned inside the card.

```diff
-    <div className="grid grid-cols-[64px_1fr] gap-5">
+    <div className="grid grid-cols-[64px_minmax(0,1fr)] gap-5">
```

## before / after

Reproduced the exact symptom in an isolated harness (synthetic titles), narrow width to force overflow. Top = before (title overflows, `→` escapes the card). Bottom = after (`minmax(0,1fr)`, clean truncation, arrow stays put).

![before / after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/coming-up-4480/coming-up-4480.png)

## scope / notes

- Only `coming-up.tsx`'s `DayBlock` grid is affected. The past-meetings list rows already truncate correctly. The other `grid-cols-[88px_1fr]` in `index.tsx` is a loading skeleton with fixed-width placeholders (no long text) — left untouched.
- CSS-only change, no logic touched.

Closes #4480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
