### PR TITLE
feat(meetings): add summarize button to the note dock (top + bottom)

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -1286,6 +1286,21 @@ export function NoteView({
               >
                 <FileText className="h-3.5 w-3.5" />
               </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleSummarize}
+                disabled={summarizing}
+                title="summarize meeting"
+                aria-label="summarize meeting"
+                className="h-9 w-9 rounded-none p-0"
+              >
+                {summarizing ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Sparkles className="h-3.5 w-3.5" />
+                )}
+              </Button>
               {!isLive && (
                 <Button
                   variant="default"


### PR DESCRIPTION
## what

The **summarize** action only lived in the top toolbar of the meeting note view. This adds it to the **bottom dock** too, right next to the **stop** button — so it's reachable from both the top and the bottom of a note without scrolling back up.

- Reuses the existing `handleSummarize` handler + `summarizing` state (no new logic, no new imports).
- Renders in both live and saved states: it sits **beside stop** while a meeting is live, and beside resume/delete once the meeting is saved.
- Same `Sparkles` icon, `h-9 w-9` ghost button matching the rest of the dock controls.

## screenshot

The new button is highlighted (black ring) in both states:

![summarize button top + bottom](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/meeting-summarize-btn/meeting-summarize.png)

_Mockup rendered from the actual component markup + theme tokens (placeholder data only — public repo)._

## files

- `apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx` — add summarize button to the footer dock cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)