### PR TITLE
fix(meetings): keep the live listening wave animated when audio level is 0

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/listening-sticks.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/listening-sticks.tsx
@@ -83,9 +83,13 @@ export function ListeningSticks({
     );
   }
 
-  // Keep a visible floor so the pause between words never reads as "stopped".
+  // Keep a lively floor so silence — or a missing/zero level reading, which is
+  // the common case — still reads as "listening", matching the constant wave
+  // the other indicators use. With the old 0.35 floor the level-driven
+  // bottom-left indicator collapsed to ~35% height and looked frozen whenever
+  // audio levels weren't flowing.
   const amplitude =
-    level == null ? 0.75 : 0.35 + 0.65 * Math.max(0, Math.min(1, level));
+    level == null ? 0.75 : 0.7 + 0.3 * Math.max(0, Math.min(1, level));
 
   return (
     <span


### PR DESCRIPTION
## what

The "listening" wave in the **bottom-left status dock** of the meeting note view looks frozen/dead, while the same wave in the transcript panel (and the list view / past-meetings rows) animates fine.

## why

All the "listening sticks" share one component and one CSS keyframe. The only difference is whether a measured `level` is passed in:

- Transcript panel, list view, past meetings → **no `level`** → ride the constant `0.75` baseline → always lively.
- Bottom-left dock indicator → **passes a `level`** from the `/health` audio RMS.

On the level-driven path the amplitude floor was `0.35`:

```js
const amplitude = level == null ? 0.75 : 0.35 + 0.65 * clamp(level);
```

So whenever the level reading is `0` — silence, or a device-name mismatch in the `/health` parse (`audioDeviceLevelFor` returns `0` for non-matching keys) — the entire wave is scaled to ~35% height and reads as frozen. That's the common case, which is why only the bottom-left one looked broken.

## fix

Raise the level-driven floor to `0.70` so the resting wave stays as lively as the constant baseline the other indicators use, while still boosting toward full height when audio is loud:

```js
const amplitude = level == null ? 0.75 : 0.7 + 0.3 * clamp(level);
```

One-line behavioral change, scoped to the single level-passing caller (the bottom-left dock indicator). No other call site passes `level`, so nothing else changes.

## files

- `apps/screenpipe-app-tauri/components/meeting-notes/listening-sticks.tsx`

> Note: it's a motion change, so a static screenshot doesn't capture it well — happy to attach a short screen recording if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)