### PR TITLE
[codex] fix Teams meeting detection and stop

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -103,6 +103,18 @@ import { listenTyped, TAURI_EVENTS } from "@/lib/events/tauri-events";
 import { writeBrowserLogNow } from "@/lib/logging/browser-log";
 
 const AUTOSAVE_DEBOUNCE_MS = 800;
+const SAVE_BEFORE_STOP_TIMEOUT_MS = 1500;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error("save timed out")), ms);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+}
 
 interface NoteViewProps {
   meeting: MeetingRecord;
@@ -698,21 +710,40 @@ export function NoteView({
   const handleStopClick = async () => {
     if (savingBeforeStop) return;
     setSavingBeforeStop(true);
+    let noteSaveFailed = false;
     try {
       const current = { title, attendees, note };
       if (!sameMeetingNoteDraft(current, lastSavedRef.current)) {
-        await save(current, { throwOnError: true });
+        await withTimeout(
+          save(current, { throwOnError: true }),
+          SAVE_BEFORE_STOP_TIMEOUT_MS,
+        );
       }
+    } catch (err) {
+      noteSaveFailed = true;
+      console.warn("meeting note save before stop failed; stopping anyway", err);
+    }
+
+    try {
       await onStop();
     } catch (err) {
-      console.error("failed to save meeting note before stop", err);
+      console.error("failed to stop meeting", err);
       toast({
-        title: "couldn't save notes",
-        description: "try again before stopping the meeting.",
+        title: "couldn't stop meeting",
+        description: "try again from the meeting menu.",
         variant: "destructive",
       });
+      return;
     } finally {
       setSavingBeforeStop(false);
+    }
+
+    if (noteSaveFailed) {
+      toast({
+        title: "meeting stopped",
+        description: "notes did not save before stopping. edit them and try saving again.",
+        variant: "destructive",
+      });
     }
   };
 

--- a/apps/screenpipe-app-tauri/components/share-logs-button.tsx
+++ b/apps/screenpipe-app-tauri/components/share-logs-button.tsx
@@ -15,6 +15,7 @@ import {
   platform as osPlatform,
 } from "@tauri-apps/plugin-os";
 import { Textarea } from "./ui/textarea";
+import { ToastAction } from "./ui/toast";
 import {
   Tooltip,
   TooltipContent,
@@ -338,6 +339,7 @@ export const ShareLogsButton = ({
       const supportId = confirmPayload?.data?.id;
       const followUpChannel = confirmPayload?.data?.follow_up;
       const reference = supportId ? ` #${supportId}` : "";
+      const copyReference = supportId ? String(supportId) : identifier;
 
       toast({
         title: "feedback sent",
@@ -345,6 +347,18 @@ export const ShareLogsButton = ({
           followUpChannel === "email"
             ? `we emailed you a receipt${reference} and will reply there.`
             : `we posted it to support${reference}; mention that ID in Discord if you need an update.`,
+        action: (
+          <ToastAction
+            altText="copy feedback id"
+            onClick={() => {
+              void commands.copyTextToClipboard(copyReference).then(() => {
+                toast({ title: "feedback id copied" });
+              });
+            }}
+          >
+            copy id
+          </ToastAction>
+        ),
       });
       setFeedbackText("");
       setScreenshot(null);

--- a/crates/screenpipe-db/src/db/meetings.rs
+++ b/crates/screenpipe-db/src/db/meetings.rs
@@ -195,6 +195,11 @@ impl DatabaseManager {
             return Ok(());
         }
 
+        self.append_meeting_context(id).await
+    }
+
+    /// Append auto-collected context to an already-ended meeting note.
+    pub async fn append_meeting_context(&self, id: i64) -> Result<(), SqlxError> {
         // Build the auto-injected suffix from the available signals. Each
         // signal is independently optional — a meeting where the user only
         // edited files but typed nothing still gets the files block, and

--- a/crates/screenpipe-engine/src/meeting_detector.rs
+++ b/crates/screenpipe-engine/src/meeting_detector.rs
@@ -138,6 +138,10 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             },
             call_signals: vec![
                 CallSignal::AutomationId("hangup-button"),
+                CallSignal::AutomationIdContains("hangup"),
+                CallSignal::AutomationIdContains("hang-up"),
+                CallSignal::AutomationIdContains("hang_up"),
+                CallSignal::AutomationIdContains("call-end"),
                 CallSignal::KeyboardShortcut("Ctrl+Shift+H"),
                 CallSignal::KeyboardShortcut("\u{2318}\u{21e7}H"), // Cmd+Shift+H
                 CallSignal::RoleWithName {
@@ -146,11 +150,21 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
                 },
                 CallSignal::RoleWithName {
                     role: "AXButton",
+                    name_contains: "leave call",
+                },
+                CallSignal::RoleWithName {
+                    role: "AXButton",
                     name_contains: "leave",
+                },
+                CallSignal::RoleWithName {
+                    role: "AXButton",
+                    name_contains: "end call",
                 },
                 // Fallback: Teams on some Windows machines exposes "Leave" as a
                 // non-Button control type (Custom, Text, etc.). Match by name only.
                 CallSignal::NameContains("leave"),
+                CallSignal::NameContains("hang up"),
+                CallSignal::NameContains("end call"),
                 // Teams web (browser): mute is AXCheckBox with keyboard shortcut in name.
                 // "Mute mic (⇧ ⌘ M)" is only present during an active call.
                 CallSignal::RoleWithName {
@@ -2305,6 +2319,13 @@ fn contains_case_insensitive(haystack: &str, needle: &str) -> bool {
     haystack.to_lowercase().contains(&needle.to_lowercase())
 }
 
+fn macos_app_name_matches(app_name_lower: &str, candidates: &[&str]) -> bool {
+    candidates.iter().any(|candidate| {
+        app_name_lower == *candidate
+            || (candidate.contains(' ') && app_name_lower.contains(candidate))
+    })
+}
+
 /// Match a `browser_url_patterns` entry against a URL or window-title string at
 /// host-name boundaries.
 ///
@@ -2464,11 +2485,8 @@ pub fn find_running_meeting_apps(
 
             for (idx, profile) in profiles.iter().enumerate() {
                 // Check native app names
-                let matches_native = profile
-                    .app_identifiers
-                    .macos_app_names
-                    .iter()
-                    .any(|n| name_lower == *n);
+                let matches_native =
+                    macos_app_name_matches(&name_lower, profile.app_identifiers.macos_app_names);
 
                 if matches_native {
                     results.push(RunningMeetingApp {
@@ -4360,6 +4378,54 @@ mod tests {
                 .contains(&"msteams"),
             "MSTeams not added to macos_app_names"
         );
+    }
+
+    #[test]
+    fn test_macos_native_app_match_accepts_teams_qualified_name() {
+        let profiles = load_detection_profiles();
+        let teams = profiles
+            .iter()
+            .find(|p| {
+                p.app_identifiers
+                    .macos_app_names
+                    .contains(&"microsoft teams")
+            })
+            .expect("Teams profile not found");
+
+        assert!(macos_app_name_matches(
+            "microsoft teams (work or school)",
+            teams.app_identifiers.macos_app_names
+        ));
+        assert!(macos_app_name_matches(
+            "microsoft teams classic",
+            teams.app_identifiers.macos_app_names
+        ));
+        assert!(!macos_app_name_matches(
+            "teams helper",
+            teams.app_identifiers.macos_app_names
+        ));
+    }
+
+    #[test]
+    fn test_teams_profile_has_modern_hangup_signals() {
+        let profiles = load_detection_profiles();
+        let teams = profiles
+            .iter()
+            .find(|p| {
+                p.app_identifiers
+                    .macos_app_names
+                    .contains(&"microsoft teams")
+            })
+            .expect("Teams profile not found");
+
+        assert!(teams
+            .call_signals
+            .iter()
+            .any(|s| matches!(s, CallSignal::AutomationIdContains(id) if *id == "hangup")));
+        assert!(teams
+            .call_signals
+            .iter()
+            .any(|s| matches!(s, CallSignal::NameContains(name) if *name == "end call")));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -65,8 +65,8 @@ pub struct StartMeetingRequest {
 pub struct StopMeetingRequest {
     pub id: Option<i64>,
     /// When false, skip auto-appending the user's typed text (and edited
-    /// files) to the meeting note. Defaults to true to preserve historical
-    /// behavior.
+    /// files) to the meeting note. Defaults to true; the append runs after
+    /// the meeting is stopped so cleanup cannot block the stop action.
     #[serde(default = "default_append_typed_text")]
     pub append_typed_text: bool,
 }
@@ -710,12 +710,7 @@ pub(crate) async fn stop_meeting_handler(
 
     state
         .db
-        .end_meeting_with_typed_text(
-            id,
-            &now,
-            body.append_typed_text,
-            Some(MEETING_END_REASON_EXPLICIT_STOP),
-        )
+        .end_meeting(id, &now, Some(MEETING_END_REASON_EXPLICIT_STOP))
         .await
         .map_err(|e| {
             (
@@ -769,6 +764,19 @@ pub(crate) async fn stop_meeting_handler(
             id,
             e
         );
+    }
+
+    if body.append_typed_text {
+        let db = state.db.clone();
+        tokio::spawn(async move {
+            if let Err(e) = db.append_meeting_context(id).await {
+                tracing::warn!(
+                    "failed to append meeting context after explicit stop for meeting {}: {}",
+                    id,
+                    e
+                );
+            }
+        });
     }
 
     Ok(JsonResponse(meeting))


### PR DESCRIPTION
## What changed
- Broaden Teams meeting detection for newer macOS Teams app names like `Microsoft Teams (work or school)` and modern hangup/end-call controls.
- Make explicit meeting stop immediate by ending the meeting and notifying detector/UI before optional typed-text/file note enrichment.
- Let meeting-page stop proceed even when pre-stop note saving is slow or fails.
- Add a copy-id action to the feedback success toast.

## Why
A user on macOS 26.5 / app 2.5.62 reported Teams meetings failing to auto-start and manually-started meetings that could not be stopped. The stop handler was doing optional note enrichment before emitting the explicit stop state, so slow DB/note work could make the UI look stuck.

## Validation
- `rustfmt --edition 2021 --check crates/screenpipe-db/src/db/meetings.rs crates/screenpipe-engine/src/meeting_detector.rs crates/screenpipe-engine/src/routes/meetings.rs`
- `git diff --check`
- `cargo test -p screenpipe-engine test_teams --lib`
- `cargo test -p screenpipe-engine test_macos_native_app_match_accepts_teams_qualified_name --lib`
- `cargo test -p screenpipe-db meeting_context_uses_absolute_time_for_offset_meeting_start`
- `cargo test -p screenpipe-db explicit_stop_then_new_meeting_does_not_merge`
- `cargo test -p screenpipe-db end_meeting_with_typed_text_persists_reason`

Frontend caveat:
- `bun run typecheck` currently fails in a clean worktree on unrelated existing app issues: `components/chat-sidebar.tsx(2227,22)` implicit `any`, and missing `@radix-ui/react-context-menu` types/dependency resolution.
