### PR TITLE
feat(pipes): self-improving memory layer (content) + fix store update UX

### DIFF
--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -52,6 +52,7 @@ import {
   Upload,
   AlertTriangle,
   ArrowLeft,
+  ArrowUpCircle,
   ExternalLink,
   GitFork,
   Star,
@@ -464,6 +465,14 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
   // Available updates from store
   const [availableUpdates, setAvailableUpdates] = useState<Record<string, { latest_version: number; installed_version: number; locally_modified: boolean }>>({});
 
+  // Confirm dialog before overwriting a locally-modified pipe on update.
+  const [updateConfirm, setUpdateConfirm] = useState<{
+    slug: string;
+    pipeName: string;
+    installedVersion: number;
+    latestVersion: number;
+  } | null>(null);
+
   // First-visit banner — show once, dismiss permanently
   // Initialize false to match server render, set true after mount if not dismissed
   const [showWelcome, setShowWelcome] = useState(false);
@@ -593,13 +602,65 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
   };
 
   const requestInstall = (pipe: StorePipe | PipeDetail) => {
+    // Already installed with an update available → run the in-place UPDATE flow
+    // (preserves schedule/model/enabled, keeps a pipe.md.bak, never switches
+    // tabs) instead of a fresh install. A locally-edited pipe asks first.
+    const upd = availableUpdates[pipe.slug];
+    if (upd) {
+      const pipeName = ("title" in pipe && pipe.title) || pipe.slug;
+      if (upd.locally_modified) {
+        setUpdateConfirm({
+          slug: pipe.slug,
+          pipeName,
+          installedVersion: upd.installed_version,
+          latestVersion: upd.latest_version,
+        });
+      } else {
+        void handleStoreUpdate(pipe.slug, pipeName);
+      }
+      return;
+    }
     const risk = getPipeInstallRisk(pipe);
-    if (risk === "safe" || availableUpdates[pipe.slug]) {
+    if (risk === "safe") {
       void handleInstall(pipe.slug);
       return;
     }
     setPendingInstall(pipe);
     setInstallRiskAcknowledged(false);
+  };
+
+  // Update an already-installed store pipe in place. Unlike install, this
+  // preserves the user's schedule/model/enabled/connections, keeps a backup,
+  // and — crucially — only clears THIS card's update badge instead of yanking
+  // the user to the My Pipes tab.
+  const handleStoreUpdate = async (slug: string, pipeName: string) => {
+    setInstalling(slug);
+    try {
+      const res = await localFetch("/pipes/store/update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ slug }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+      posthog.capture("pipe_updated_from_store", { slug });
+      // Clear just this card's update state → re-renders one card, no reload.
+      setAvailableUpdates((prev) => {
+        const next = { ...prev };
+        delete next[slug];
+        return next;
+      });
+      apiCache.invalidate("pipes/installed");
+      toast({ title: `"${pipeName}" updated` });
+    } catch (err: any) {
+      toast({
+        title: "failed to update pipe",
+        description: err.message,
+        variant: "destructive",
+      });
+    } finally {
+      setInstalling(null);
+    }
   };
 
   const closeInstallGate = () => {
@@ -989,6 +1050,45 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
 
       {installGateDialog}
 
+      {/* Confirm overwrite when updating a locally-edited pipe */}
+      <Dialog open={!!updateConfirm} onOpenChange={(open) => !open && setUpdateConfirm(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>update {updateConfirm?.pipeName}?</DialogTitle>
+            <DialogDescription>
+              <span className="inline-flex items-center gap-2 mt-2">
+                <Badge variant="outline">v{updateConfirm?.installedVersion}</Badge>
+                <span>→</span>
+                <Badge variant="outline">v{updateConfirm?.latestVersion}</Badge>
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-start gap-2 p-3 rounded-none bg-muted border border-border">
+            <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              you have local edits to this pipe. updating overwrites your prompt changes.
+              a backup is saved as <code className="text-xs">pipe.md.bak</code>, and your
+              schedule, model, and enabled state are preserved.
+            </p>
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="ghost" onClick={() => setUpdateConfirm(null)}>
+              skip
+            </Button>
+            <Button
+              onClick={() => {
+                if (updateConfirm) {
+                  void handleStoreUpdate(updateConfirm.slug, updateConfirm.pipeName);
+                  setUpdateConfirm(null);
+                }
+              }}
+            >
+              update &amp; discard my edits
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
     </div>
   );
 }
@@ -1032,8 +1132,7 @@ function PipeCard({
           variant={isInstalled && !hasUpdate ? "outline" : "default"}
           className={cn(
             "h-7 px-3 text-xs font-semibold rounded-none uppercase tracking-wide flex-shrink-0",
-            isInstalled && !hasUpdate && "pointer-events-none",
-            hasUpdate && "bg-amber-500 hover:bg-amber-600 text-white"
+            isInstalled && !hasUpdate && "pointer-events-none"
           )}
           disabled={installing || (isInstalled && !hasUpdate)}
           onClick={(e) => {
@@ -1044,7 +1143,10 @@ function PipeCard({
           {installing ? (
             <Loader2 className="h-3 w-3 animate-spin" />
           ) : hasUpdate ? (
-            "UPDATE"
+            <>
+              <ArrowUpCircle className="h-3 w-3 mr-1" />
+              UPDATE
+            </>
           ) : isInstalled ? (
             "INSTALLED"
           ) : (
@@ -1347,8 +1449,7 @@ if the pipe's final user-facing file lives outside the pipe's own \`./output/\` 
                 variant={isInstalled && !hasUpdate ? "outline" : "default"}
                 className={cn(
                   "h-9 px-5 text-sm font-semibold rounded-none uppercase tracking-wide flex-shrink-0",
-                  isInstalled && !hasUpdate && "pointer-events-none",
-                  hasUpdate && "bg-amber-500 hover:bg-amber-600 text-white"
+                  isInstalled && !hasUpdate && "pointer-events-none"
                 )}
                 disabled={
                   installing === pipe.slug || (isInstalled && !hasUpdate)
@@ -1361,7 +1462,10 @@ if the pipe's final user-facing file lives outside the pipe's own \`./output/\` 
                     {hasUpdate ? "UPDATING..." : "INSTALLING..."}
                   </>
                 ) : hasUpdate ? (
-                  "UPDATE"
+                  <>
+                    <ArrowUpCircle className="h-4 w-4 mr-1.5" />
+                    UPDATE
+                  </>
                 ) : isInstalled ? (
                   "INSTALLED"
                 ) : (

--- a/crates/screenpipe-core/assets/pipes/ai-habits/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/ai-habits/pipe.md
@@ -8,6 +8,17 @@ icon: "🤖"
 featured: true
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 Search my recordings from the last 24 hours for AI tool usage. Use app_name filter for each tool separately: ChatGPT, Claude, Copilot, Cursor, Gemini, Perplexity. Use limit=5 per search, max 6 searches total.
 
 Read screenpipe skill first.

--- a/crates/screenpipe-core/assets/pipes/ai-prompt-journal/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/ai-prompt-journal/pipe.md
@@ -10,6 +10,17 @@ connections: [obsidian]
 permissions: writer
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 You are a prompt extraction agent. Your job is to find every prompt the user typed and sent to an AI tool in the last 1 hour, extract the exact text, and save it to a daily markdown journal.
 
 Read screenpipe skill first.

--- a/crates/screenpipe-core/assets/pipes/automate-my-work/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/automate-my-work/pipe.md
@@ -8,6 +8,17 @@ icon: "⚡"
 featured: true
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 <role>
 You are a screenpipe automation expert. Look at the user's ACTUAL computer activity, then build and turn on 3 high-value, LOW-RISK automations ("pipes") that quietly run in the background to make them more productive. You do not just suggest — you create the pipes and enable them.
 </role>

--- a/crates/screenpipe-core/assets/pipes/day-recap/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/day-recap/pipe.md
@@ -8,6 +8,17 @@ icon: "📋"
 featured: true
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 Analyze my screen and audio recordings from today (last 16 hours). Read the screenpipe skill first. Use limit=10 per search, max 5 searches total. Prefer /raw_sql with COUNT/GROUP BY for app usage. Use the API only — do not write or run code.
 
 Use this exact format:

--- a/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
@@ -13,6 +13,17 @@ icon: "🤝"
 featured: false
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 a meeting just ended. find it, summarize it, and save the summary back onto its record so the user sees it next time they open the meeting.
 
 keep the wording of this prompt in sync with `buildMeetingSummarizeInstructions` in `apps/screenpipe-app-tauri/lib/utils/meeting-context.ts` (used by the in-app "summarize with AI" button) — the two surfaces should produce the same behavior.

--- a/crates/screenpipe-core/assets/pipes/missed-todos/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/missed-todos/pipe.md
@@ -8,6 +8,17 @@ icon: "✅"
 featured: true
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 Find action items and to-dos from the last 3 days that I may have missed. Read the screenpipe skill first. Use limit=10 per search, max 5 searches over the last 3 days. Query the API only — do not write or run code.
 
 Look across messages, email, meetings, docs, and issue trackers (e.g. Slack, Gmail, Notion, Linear, GitHub) for commitments and tasks — phrases like "I'll", "can you", "TODO", "follow up", "by Friday", action items, and unchecked checkboxes.

--- a/crates/screenpipe-core/assets/pipes/standup-update/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/standup-update/pipe.md
@@ -8,6 +8,17 @@ icon: "🏢"
 featured: true
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 Based on my recordings from the last 24 hours, generate a standup update. Use limit=10 per search, max 3 searches total.
 
 Read screenpipe skill first.

--- a/crates/screenpipe-core/assets/pipes/time-breakdown/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/time-breakdown/pipe.md
@@ -8,6 +8,17 @@ icon: "⏱"
 featured: true
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 Analyze my app usage from today (last 12 hours). Read the screenpipe skill first. Use limit=10 per search, max 4 searches. Prefer /raw_sql with COUNT(*) and GROUP BY app_name over the frames table — query the API only, do not write or run code.
 
 Use this exact format with durations and percentages:

--- a/crates/screenpipe-core/assets/pipes/video-export/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/video-export/pipe.md
@@ -8,6 +8,17 @@ icon: "🎬"
 featured: false
 ---
 
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
 Export a video of my screen activity from the last 5 minutes.
 
 Read screenpipe skill first.


### PR DESCRIPTION
## what & why

Two related changes from making store pipes **get better over time**, plus a fix for the update UX that the rollout surfaced.

### 1) self-improving "memory layer" for pipes (content only — no engine change)
Every store pipe (all 22, version-bumped server-side) and the 9 bundled template **assets** now open with a small, bounded block:

> **🧠 Continuous improvement (memory)** — read `./memory.md` at the start of a run and apply its lessons; at the end, append ≤1–3 dated one-line lessons. Append-only, ~150-line/8KB cap, **never edits its own prompt**, never saves risky/outbound lessons.

Why a **memory sidecar** and not self-rewriting the prompt: editing the body flips a store pipe's `source_hash` → `locally_modified`, which fights the store update mechanism. The sidecar lets a pipe improve without ever diverging its own instructions. (A few pipes already used this ad-hoc — `learnings.md`, `MEMORY.md`.)

This is purely the `pipe.md` content — **no Rust / engine change**. `install_builtin_pipes` seeds the bundled assets on **fresh install**; existing installs are left untouched (no migration, no boot-time file rewrites).

### 2) fix the store "UPDATE" button UX

![before / after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/pipe-update-ux/pipe-update-ux.png)

**Before:** off-brand amber button; clicking it re-installed the pipe (resetting schedule/enabled), bounced you to **My Pipes**, and left the badge lingering.

**After:**
- grayscale + ↑ icon, per `DESIGN.md` (no color — differentiate by icon/shape)
- calls the real `/pipes/store/update` (preserves schedule/model/enabled, keeps a `pipe.md.bak`)
- **updates in place** — clears just that card's badge, no whole-page refresh, no forced jump out of Discover
- a locally-edited pipe gets an overwrite-confirm dialog (mirrors the existing My-Pipes flow)

### note on "auto-update isn't auto-updating"
It's working as designed. The only two pipes showing an update locally (`toggl-time-tracker`, `brand-listening`) are both `locally_modified=true`, and auto-update deliberately skips edited pipes (that's what the toggle says: "pipes you haven't modified"). They now show a clear UPDATE affordance + the overwrite-confirm above.

## test plan
- `bun run typecheck` — clean
- manual: Discover → UPDATE on an unmodified pipe updates in place; on an edited pipe shows the confirm dialog; no tab switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
