### PR TITLE
fix(updater): stop the auto-update re-download loop (downloads-metric inflation)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/dock_menu.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/dock_menu.rs
@@ -58,7 +58,7 @@ pub fn setup_dock_menu(app_handle: AppHandle) {
                     let app = app.clone();
                     tauri::async_runtime::spawn(async move {
                         let state = app.state::<std::sync::Arc<crate::updates::UpdatesManager>>();
-                        if let Err(e) = state.check_for_updates(true).await {
+                        if let Err(e) = state.check_for_updates(true, true).await {
                             tracing::error!("dock menu: check for updates failed: {}", e);
                         }
                     });

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1027,7 +1027,7 @@ async fn main() {
                             let app = app_handle.clone();
                             tauri::async_runtime::spawn(async move {
                                 let state = app.state::<std::sync::Arc<crate::updates::UpdatesManager>>();
-                                if let Err(e) = state.check_for_updates(true).await {
+                                if let Err(e) = state.check_for_updates(true, true).await {
                                     tracing::error!("menu: check for updates failed: {}", e);
                                 }
                             });

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -1291,7 +1291,7 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                         let state = app.state::<std::sync::Arc<crate::updates::UpdatesManager>>();
                         if state.has_update_installed().await {
                             let _ = app.emit("update-now-clicked", ());
-                        } else if let Err(e) = state.check_for_updates(true).await {
+                        } else if let Err(e) = state.check_for_updates(true, true).await {
                             tracing::error!("tray menu: check for updates failed: {}", e);
                         }
                     });

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -226,6 +226,17 @@ const AUTO_UPDATE_GATE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// try again" than to block the click indefinitely.
 const BANNER_GATE_TIMEOUT_SECS: u64 = 60;
 
+/// Cooldown after an update *download/install* fails for a non-auth reason.
+/// The periodic check runs every 5 min; without this, a machine that can
+/// download the bundle but can't apply it (signature/Gatekeeper/permission
+/// issue) re-downloads the same version every cycle forever — one stuck
+/// machine produced ~1,400 re-downloads of a single version in 4 days and
+/// inflated the `app_downloaded` metric ~12x. While a version is in cooldown
+/// we still hit the cheap CHECK endpoint but skip the binary download until
+/// the window elapses, a newer version ships, or the user retries manually
+/// (which passes `force=true`). In-memory only — a restart re-attempts once.
+const UPDATE_FAILURE_COOLDOWN: Duration = Duration::from_secs(6 * 60 * 60);
+
 /// Wait for boot to reach "ready" or "error", with timeout. Logs the
 /// outcome with `label` so deferrals are searchable in support logs.
 pub async fn await_restart_gate(timeout: Duration, label: &str) -> RestartGate {
@@ -303,6 +314,19 @@ pub async fn restart_for_update(
     Ok("proceed".to_string())
 }
 
+/// Decide whether a detected update version is still inside the post-failure
+/// cooldown and should NOT be auto-re-downloaded. Pure (takes the elapsed
+/// duration rather than reading the clock) so it's unit-testable without an
+/// AppHandle. `last_failed` is `(version, time-since-failure)` for the most
+/// recent failed download, or `None` if nothing has failed.
+fn failed_version_in_cooldown(
+    last_failed: Option<(&str, Duration)>,
+    version: &str,
+    cooldown: Duration,
+) -> bool {
+    matches!(last_failed, Some((v, elapsed)) if v == version && elapsed < cooldown)
+}
+
 fn auto_update_enabled_from_settings(settings: Result<Option<SettingsStore>, String>) -> bool {
     settings
         .ok()
@@ -338,6 +362,10 @@ pub struct UpdatesManager {
     pending_update: Arc<Mutex<Option<PendingUpdateSnapshot>>>,
     /// Prevents concurrent check_for_updates calls (boot check + periodic race)
     is_checking: AtomicBool,
+    /// (version, when-it-failed) for the last update whose download/install
+    /// failed for a non-auth reason. Gates the periodic loop from re-downloading
+    /// the same broken version every 5 min — see `UPDATE_FAILURE_COOLDOWN`.
+    last_failed_update: Arc<Mutex<Option<(String, std::time::Instant)>>>,
 }
 
 impl UpdatesManager {
@@ -365,12 +393,17 @@ impl UpdatesManager {
             app: app.clone(),
             update_menu_item,
             is_checking: AtomicBool::new(false),
+            last_failed_update: Arc::new(Mutex::new(None)),
         })
     }
 
+    /// `force` = user-initiated check (tray/dock/Settings). Bypasses the
+    /// post-failure cooldown so "click to retry" always re-attempts the
+    /// download; periodic and boot checks pass `false`.
     pub async fn check_for_updates(
         &self,
         show_dialog: bool,
+        force: bool,
     ) -> Result<bool, Box<dyn std::error::Error>> {
         // Prevent concurrent update checks (boot check + periodic/manual race)
         if self
@@ -473,6 +506,38 @@ impl UpdatesManager {
             }
         }
         if let Ok(Some(update)) = check_result {
+            // Cooldown gate: if this exact version recently failed to
+            // download/install, don't auto-re-download it every 5 min. A
+            // user-initiated check (`force`) always bypasses this so "click to
+            // retry" works. We intentionally leave `update_available` false so
+            // the periodic loop keeps polling the cheap CHECK endpoint and
+            // resumes downloading once the window elapses or a newer version
+            // ships — but we skip the expensive binary fetch (and the
+            // `app_downloaded` event it triggers) until then.
+            if !force {
+                let in_cooldown = {
+                    let guard = self.last_failed_update.lock().await;
+                    failed_version_in_cooldown(
+                        guard.as_ref().map(|(v, at)| (v.as_str(), at.elapsed())),
+                        &update.version,
+                        UPDATE_FAILURE_COOLDOWN,
+                    )
+                };
+                if in_cooldown {
+                    info!(
+                        "update v{} recently failed to install; skipping auto-download \
+                         (cooldown {}h) — click 'check for updates' to retry",
+                        update.version,
+                        UPDATE_FAILURE_COOLDOWN.as_secs() / 3600
+                    );
+                    if let Some(ref item) = self.update_menu_item {
+                        item.set_enabled(true)?;
+                        item.set_text("Update failed — click to retry")?;
+                    }
+                    return Result::Ok(false);
+                }
+            }
+
             *self.update_available.lock().await = true;
             *self.pending_update.lock().await = Some(PendingUpdateSnapshot {
                 version: update.version.clone(),
@@ -643,8 +708,18 @@ impl UpdatesManager {
                                 || err_str.contains("403")
                                 || err_str.contains("Unauthorized")
                                 || err_str.contains("Forbidden");
+                            // Signature/verification/corrupt-bundle failures are not
+                            // transient either: re-downloading the same broken bundle
+                            // just wastes bandwidth and fires another app_downloaded.
+                            // Bail out immediately like auth errors do.
+                            let is_unrecoverable = is_auth
+                                || err_str.contains("signature")
+                                || err_str.contains("Signature")
+                                || err_str.contains("verif")
+                                || err_str.contains("minisign")
+                                || err_str.contains("corrupt");
                             let next_delay = retry_delays.get(attempt).copied();
-                            if is_auth || next_delay.is_none() {
+                            if is_unrecoverable || next_delay.is_none() {
                                 break result;
                             }
                             let delay = next_delay.unwrap();
@@ -669,6 +744,8 @@ impl UpdatesManager {
 
             match download_result {
                 Ok(_) => {
+                    // Clear any prior failure marker — this version is good now.
+                    *self.last_failed_update.lock().await = None;
                     *self.update_installed.lock().await = true;
                     if let Some(snap) = self.pending_update.lock().await.as_mut() {
                         snap.downloaded = true;
@@ -712,10 +789,15 @@ impl UpdatesManager {
                         }
                         return Ok(false);
                     }
-                    // Generic failure (network/disk/server). Clear latched state
-                    // so the periodic loop and tray can retry without an app
-                    // restart, and tell the user what happened.
+                    // Generic failure (network/disk/server/signature). Clear
+                    // latched state so the periodic loop and tray can retry
+                    // without an app restart, and tell the user what happened.
+                    // Record the failed version so the cooldown gate above stops
+                    // us from re-downloading this same broken bundle every 5 min
+                    // (the auto-update download-loop fix).
                     warn!("update download failed after retries: {}", err_str);
+                    *self.last_failed_update.lock().await =
+                        Some((update.version.clone(), std::time::Instant::now()));
                     *self.update_available.lock().await = false;
                     *self.pending_update.lock().await = None;
                     if let Some(ref item) = self.update_menu_item {
@@ -894,7 +976,7 @@ impl UpdatesManager {
             interval.tick().await;
             if !*self.update_available.lock().await {
                 // Don't show dialog for periodic checks - only for manual checks
-                if let Err(e) = self.check_for_updates(false).await {
+                if let Err(e) = self.check_for_updates(false, false).await {
                     // warn, not error — see updater check() note above.
                     warn!("Failed to check for updates: {}", e);
                 }
@@ -1028,7 +1110,9 @@ pub async fn trigger_update_check(
     state: tauri::State<'_, Arc<UpdatesManager>>,
 ) -> Result<bool, String> {
     state
-        .check_for_updates(false)
+        // User clicked "check for updates" in Settings — force past the
+        // post-failure cooldown so a manual retry always re-attempts.
+        .check_for_updates(false, true)
         .await
         .map_err(|e| e.to_string())
 }
@@ -1055,7 +1139,7 @@ pub fn start_update_check(
     tokio::spawn({
         let updates_manager = updates_manager.clone();
         async move {
-            if let Err(e) = updates_manager.check_for_updates(false).await {
+            if let Err(e) = updates_manager.check_for_updates(false, false).await {
                 // warn, not error — see updater check() note above.
                 warn!("Failed to check for updates: {}", e);
             }
@@ -1077,6 +1161,44 @@ pub fn start_update_check(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const HOUR: Duration = Duration::from_secs(3600);
+
+    #[test]
+    fn cooldown_blocks_same_version_within_window() {
+        // v2.5.57 failed 1h ago, 6h cooldown → still blocked (the loop fix).
+        assert!(failed_version_in_cooldown(
+            Some(("2.5.57", HOUR)),
+            "2.5.57",
+            UPDATE_FAILURE_COOLDOWN
+        ));
+    }
+
+    #[test]
+    fn cooldown_ignores_a_newer_version() {
+        // A newer version than the one that failed must download immediately.
+        assert!(!failed_version_in_cooldown(
+            Some(("2.5.57", HOUR)),
+            "2.5.62",
+            UPDATE_FAILURE_COOLDOWN
+        ));
+    }
+
+    #[test]
+    fn cooldown_absent_when_nothing_failed() {
+        assert!(!failed_version_in_cooldown(None, "2.5.57", UPDATE_FAILURE_COOLDOWN));
+    }
+
+    #[test]
+    fn cooldown_expires_after_window() {
+        // Same version, but the failure was longer ago than the cooldown →
+        // auto-download resumes.
+        assert!(!failed_version_in_cooldown(
+            Some(("2.5.57", Duration::from_secs(7 * 3600))),
+            "2.5.57",
+            UPDATE_FAILURE_COOLDOWN
+        ));
+    }
 
     #[test]
     fn auto_update_setting_respects_false() {


### PR DESCRIPTION
## what

PostHog showed a sudden spike in \`app_downloaded\`. Digging in: **~97% of that volume is the in-app auto-updater** (\`source=app-update\`), and a handful of machines are stuck in an unbounded **re-download loop**. Real installs (\`source=download-page\`) are flat.

Concentration (last 4 days, `app_downloaded`):

| IP | geo | what it's doing |
|---|---|---|
| 157.85.64.177 | Cambodia | re-downloaded **v2.5.57 1,409×** + v2.5.62 185× |
| 43.230.96.222 | Singapore | v2.5.57 758× + v2.5.62 56× |
| 184.64.31.247 | Canada | v2.5.62 431× |

All Apple Silicon. Those 3 IPs alone ≈ 2,860 of ~4,540 download events.

## root cause

In `updates.rs`, when `download_and_install` fails for a **non-auth** reason (the machine downloads the bundle but can't *apply* it — signature/Gatekeeper/permission):

1. the inner retry loop treats it as transient → re-downloads up to **4× per check** (30s/120s/300s backoff);
2. the generic-failure arm sets `update_available = false`, so the **5-min periodic loop re-triggers the whole thing** — forever.

Net: ~768 downloads/day from one stuck machine. Each re-download succeeds (the `/api/app-update/download` auth gate is currently commented out → 302 to R2) and fires `app_downloaded`, inflating the downloads metric ~12×.

## fix

- **Per-version failure cooldown (6h).** After a non-auth download/install failure, record `(version, time)`; periodic/boot checks skip auto-downloading that *same* version until the window elapses, a newer version ships, or the user retries manually. We still hit the cheap CHECK endpoint meanwhile — just not the binary fetch (or the `app_downloaded` it triggers).
- **`force` flag** on `check_for_updates`; tray/dock/Settings manual checks pass `force=true` so "click to retry" always re-attempts.
- **Signature/verification/corrupt-bundle errors are non-retryable** (like auth) — one failing cycle no longer burns 4 full downloads.
- Clear the marker on a successful install.
- Pure `failed_version_in_cooldown` helper + 4 unit tests.

Effect on a stuck machine: from ~768 downloads/day → ~4/day (one attempt per 6h), and it auto-recovers when a new version ships or the user clicks retry.

## related (separate)
- The admin downloads dashboard was counting auto-updates too; fixed separately on the website (now filters `source != app-update`).
- Deeper question still open: *why* these specific Macs can't apply the update (plausibly the macOS notarization-403 broken-release issue → bundles that download but fail signature/Gatekeeper). This PR bounds the damage regardless of that cause.

## test
- `failed_version_in_cooldown` unit tests cover: blocks same version in-window, ignores a newer version, no prior failure, expired window.
- ⚠️ The `screenpipe-app` crate is excluded from the workspace and only compiles in CI's Tauri build — relying on CI for full compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)