### PR TITLE
fix(meetings): stop tolerates empty body + UI resyncs on stop failure

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -663,6 +663,26 @@ function HomeContent() {
           return meeting;
         }
         const bodyText = await res.text().catch(() => "");
+        // Stop failed — most commonly because the cached `stoppableMeetingId`
+        // is stale (the backend's active meeting changed underneath us, e.g.
+        // the auto-detector ended a manually-started meeting). Without a
+        // resync the UI would keep showing an "active" meeting and re-send the
+        // same failing id forever — the "manually started meeting cannot be
+        // stopped" bug. Clear the optimistic grace window and refetch the
+        // authoritative status so the next click targets the real meeting (or
+        // the icon clears if nothing is active).
+        manualMeetingStartedAt.current = 0;
+        try {
+          const sres = await localFetch("/meetings/status");
+          if (sres.ok) {
+            const status = (await sres.json()) as MeetingStatusResponse;
+            setMeetingState(
+              computeMeetingActive(status, manualMeetingStartedAt.current),
+            );
+          }
+        } catch {
+          // ignore resync failures; websocket remains source of truth
+        }
         throw new Error(
           `stop meeting failed: HTTP ${res.status}${bodyText ? ` — ${bodyText}` : ""}`,
         );

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -75,6 +75,58 @@ fn default_append_typed_text() -> bool {
     true
 }
 
+impl Default for StopMeetingRequest {
+    fn default() -> Self {
+        Self {
+            id: None,
+            append_typed_text: default_append_typed_text(),
+        }
+    }
+}
+
+/// Body extractor for `POST /meetings/stop` that tolerates a missing/empty
+/// request body, treating it as `StopMeetingRequest::default()` ("stop whatever
+/// meeting is currently active"). The plain `axum::Json` extractor rejects an
+/// empty body with an opaque 400 ("EOF while parsing"), which made the endpoint
+/// impossible to use for any client that didn't send a body (e.g. the MCP
+/// `stop-meeting` tool). Deriving `OaSchema` keeps the request documented in the
+/// generated OpenAPI spec.
+#[derive(OaSchema)]
+pub struct StopBody(pub StopMeetingRequest);
+
+#[axum::async_trait]
+impl<S> axum::extract::FromRequest<S> for StopBody
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, JsonResponse<Value>);
+
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let bytes = axum::body::Bytes::from_request(req, state)
+            .await
+            .map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    JsonResponse(json!({"error": "failed to read request body"})),
+                )
+            })?;
+        let parsed = if bytes.is_empty() {
+            StopMeetingRequest::default()
+        } else {
+            serde_json::from_slice(&bytes).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    JsonResponse(json!({"error": format!("invalid request body: {e}")})),
+                )
+            })?
+        };
+        Ok(StopBody(parsed))
+    }
+}
+
 #[derive(OaSchema, Deserialize, Debug)]
 pub struct ListMeetingsRequest {
     #[serde(
@@ -683,7 +735,7 @@ pub(crate) async fn start_meeting_handler(
 #[oasgen]
 pub(crate) async fn stop_meeting_handler(
     State(state): State<Arc<AppState>>,
-    axum::Json(body): axum::Json<StopMeetingRequest>,
+    StopBody(body): StopBody,
 ) -> Result<JsonResponse<MeetingRecord>, (StatusCode, JsonResponse<Value>)> {
     let requested_id = body.id;
     let status = resolve_meeting_status(&state).await?;
@@ -692,6 +744,17 @@ pub(crate) async fn stop_meeting_handler(
             if status.stoppable_meeting_id == Some(id) || status.active_meeting_id == Some(id) {
                 id
             } else {
+                // Idempotency: a client can hold a stale meeting id after the
+                // backend's active meeting changed underneath it (e.g. the
+                // auto-detector ended a manually-started meeting). If the id
+                // refers to a meeting that is already ended, treat the stop as
+                // a success so the UI can resync instead of wedging on a 400
+                // ("manually started meeting cannot be stopped").
+                if let Ok(meeting) = state.db.get_meeting_by_id(id).await {
+                    if meeting.meeting_end.is_some() {
+                        return Ok(JsonResponse(meeting));
+                    }
+                }
                 return Err((
                     StatusCode::BAD_REQUEST,
                     JsonResponse(json!({"error": "requested meeting is not the active meeting"})),
@@ -882,6 +945,25 @@ pub(crate) async fn export_handler(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_stop_meeting_request_tolerant_body() {
+        // A missing body falls back to the default: stop the active meeting,
+        // appending typed text (historical behavior).
+        let d = StopMeetingRequest::default();
+        assert_eq!(d.id, None);
+        assert!(d.append_typed_text);
+
+        // An empty JSON object parses to the same defaults (the `{}` path).
+        let empty: StopMeetingRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(empty.id, None);
+        assert!(empty.append_typed_text);
+
+        // A partial body still works and keeps the default for omitted fields.
+        let partial: StopMeetingRequest = serde_json::from_str(r#"{"id":5}"#).unwrap();
+        assert_eq!(partial.id, Some(5));
+        assert!(partial.append_typed_text);
+    }
 
     #[test]
     fn test_list_meetings_request_relative_dates() {


### PR DESCRIPTION
## Problem

User feedback (app v2.5.62, macOS): *"Meetings failing to auto-start. The ones I manually start cannot be stopped."*

I reproduced the **"manually started meetings cannot be stopped"** half deterministically against a live instance (the auto-start half needs a machine with a locally-rendered call — see Notes). The root cause is a **frontend↔backend state desync**, not the stop logic itself.

## Reproduction (against a running `localhost:3030`)

`POST /meetings/stop` behaviour before this PR:

| request body | result | meeting |
|---|---|---|
| *(none)* — what the MCP `stop-meeting` tool sends | **400** `EOF while parsing` | stays active ❌ |
| `""` | **400** `EOF while parsing` | stays active ❌ |
| `{}` | 200 | ends ✅ |
| `{"id": <stale>}` while a *different* meeting is active | **400** `requested meeting is not the active meeting` | stays active ❌ |

The desktop Stop button sends `{"id": stoppableMeetingId}`, so it doesn't hit the empty-body case — but it caches that id. Sequence that wedges the UI:

```
UI                         backend (auto-detector running)
 |  start manual  -------->  meeting #5 active   (UI caches stoppableId=5)
 |                           detector ends #5 / starts ui_scan #6
 |  click Stop {id:5} ---->  400 "not the active meeting"   (#6 still active)
 |  <-- throw, state untouched: still active, still id=5
 |  click Stop {id:5} ---->  400 ... (forever)
```

On top of that, `computeMeetingActive` returns `active:true` with `stoppableMeetingId:null` during the 10s post-start grace window, so a Stop click then sends `{id:null}` → `400 "no active meeting"` → same wedge. (Both verified; the grace branch was unit-checked against the pure function.)

## Fix

**Backend — `crates/screenpipe-engine/src/routes/meetings.rs`**
- New tolerant `StopBody` extractor: a missing/empty body is treated as `StopMeetingRequest::default()` ("stop the active meeting"). Genuinely malformed JSON is still rejected. Derives `OaSchema`, so the body stays in the generated OpenAPI spec.
- Stopping a stale-but-already-ended id is now **idempotent** (returns 200 with the meeting) instead of 400, so a desynced client recovers.
- Added a unit test for the tolerant-body parsing.

**Frontend — `apps/screenpipe-app-tauri/app/home/page.tsx`**
- On a stop failure, clear the optimistic grace timer and refetch `/meetings/status` to resync, instead of throwing and leaving the UI showing an unstoppable meeting with a stale id.

## Verification
- `cargo check -p screenpipe-engine` ✅
- `cargo test -p screenpipe-engine ... test_stop_meeting_request_tolerant_body` ✅
- `bunx tsc --noEmit` ✅ (no new errors in touched files)

## Notes
- The *"failing to auto-start"* half was not reproducible on my box: it's a Parsec remote-desktop session where GPU-composited windows (Zoom, the app WebView) render black in screen capture, so I couldn't drive a live call by UI. The detector itself is healthy and running (`meeting v2: detection loop started, profiles=12`), correctly scanning Zoom (`signals=0 in_call=false` when not in a call). Auto-start likely needs a separate repro on a local machine.
- Not touched here: `app/shortcut-reminder/page.tsx` also calls `/meetings/stop` but optimistically clears state regardless of the response, so it doesn't wedge (it can, separately, clear the icon while a meeting is still running — follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)