### PR TITLE
fix(app): show "Business" not "Enterprise" for org-derived plans on consumer build

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -33,6 +33,7 @@ import { toast } from "@/components/ui/use-toast";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { commands } from "@/lib/utils/tauri";
 import { planDisplayName, isSignedInCloudSubscriber } from "@/lib/app-entitlement";
+import { useIsEnterpriseBuild } from "@/lib/hooks/use-is-enterprise-build";
 import { Card } from "../ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
@@ -223,6 +224,10 @@ export function AccountSection() {
 
   const subscriptionPlan = settings.user?.subscription_plan ?? null;
   const hasNamedPlan = !!subscriptionPlan && subscriptionPlan !== "none";
+  // Consumer build collapses org/license-derived team/enterprise → "Business";
+  // only the enterprise build shows the real org label. Mirrors plan_display_name
+  // in src-tauri/src/tray.rs.
+  const isEnterpriseBuild = useIsEnterpriseBuild();
 
   return (
     <div className="space-y-6">
@@ -286,7 +291,7 @@ export function AccountSection() {
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
               <Sparkles className="h-5 w-5 text-primary" />
-              <h3 className="text-lg font-semibold">Screenpipe {hasNamedPlan ? planDisplayName(subscriptionPlan) : "Business"}</h3>
+              <h3 className="text-lg font-semibold">Screenpipe {hasNamedPlan ? planDisplayName(subscriptionPlan, isEnterpriseBuild) : "Business"}</h3>
               <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full font-medium">active</span>
             </div>
           </div>
@@ -617,7 +622,7 @@ export function AccountSection() {
               <div className="flex items-center gap-2">
                 <Sparkles className="h-5 w-5 text-primary" />
                 <h3 className="text-lg font-semibold">
-                  Screenpipe {planDisplayName(subscriptionPlan)}
+                  Screenpipe {planDisplayName(subscriptionPlan, isEnterpriseBuild)}
                 </h3>
                 <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full font-medium">
                   active

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -11,6 +11,7 @@ import {
   isTokenHydrationPending,
   needsAppEntitlementRefresh,
   normalizeAppUser,
+  planDisplayName,
 } from "@/lib/app-entitlement";
 
 const NOW = new Date("2026-06-05T12:00:00.000Z");
@@ -219,5 +220,27 @@ describe("hasPersistedEntitlementEvidence", () => {
       ),
     ).toBe(false);
     expect(hasPersistedEntitlementEvidence(null)).toBe(false);
+  });
+});
+
+describe("planDisplayName", () => {
+  it("maps the self-serve tiers the same on every build", () => {
+    expect(planDisplayName("standard")).toBe("Basic");
+    expect(planDisplayName("pro")).toBe("Business");
+    expect(planDisplayName("lifetime")).toBe("Lifetime");
+    expect(planDisplayName("none")).toBe("Free");
+    expect(planDisplayName(null)).toBe("Free");
+  });
+
+  it("collapses org/license-derived team/enterprise to Business on the consumer build", () => {
+    // Default (consumer build): an account entitled via an enterprise org gets
+    // Business-equivalent features, so it should never read "Enterprise"/"Team".
+    expect(planDisplayName("team")).toBe("Business");
+    expect(planDisplayName("enterprise")).toBe("Business");
+  });
+
+  it("surfaces the real org label on the enterprise build", () => {
+    expect(planDisplayName("team", true)).toBe("Team");
+    expect(planDisplayName("enterprise", true)).toBe("Enterprise");
   });
 });

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -231,16 +231,25 @@ export function normalizePlanLabel(plan: string | null | undefined) {
 // The pricing page (app/onboarding) renames the tiers: standard→"Basic",
 // pro→"Business", enterprise→"Enterprise". Keep this in sync with the Rust
 // `plan_display_name` in src-tauri/src/tray.rs.
-export function planDisplayName(plan: string | null | undefined): string {
+//
+// `team`/`enterprise` are org/license-derived: the consumer build has no
+// self-serve Team/Enterprise product, so an account entitled via an enterprise
+// org (which still gets Business-equivalent features here) is shown as
+// "Business". Pass `isEnterpriseBuild` (the enterprise build) to surface the
+// real org label.
+export function planDisplayName(
+  plan: string | null | undefined,
+  isEnterpriseBuild = false,
+): string {
   switch ((plan || "none").toLowerCase()) {
     case "standard":
       return "Basic";
     case "pro":
       return "Business";
     case "team":
-      return "Team";
+      return isEnterpriseBuild ? "Team" : "Business";
     case "enterprise":
-      return "Enterprise";
+      return isEnterpriseBuild ? "Enterprise" : "Business";
     case "lifetime":
       return "Lifetime";
     default:

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -147,12 +147,31 @@ fn prefetch_tray_menu_data(app: &AppHandle) -> TrayMenuData {
 /// The pricing page renames the tiers: standard→"Basic", pro→"Business",
 /// enterprise→"Enterprise". Keep in sync with `planDisplayName` in
 /// lib/app-entitlement.ts.
+///
+/// `team`/`enterprise` are org/license-derived: the consumer build has no
+/// self-serve Team/Enterprise product, so an account entitled via an enterprise
+/// org (e.g. an admin or member of an active license) — which still gets
+/// Business-equivalent features here — is shown as "Business" rather than
+/// "Enterprise". Only the enterprise build surfaces the real org label.
 fn plan_display_name(plan: Option<&str>) -> &'static str {
+    let enterprise_build = cfg!(feature = "enterprise-build");
     match plan.unwrap_or("none").to_ascii_lowercase().as_str() {
         "standard" => "Basic",
         "pro" => "Business",
-        "team" => "Team",
-        "enterprise" => "Enterprise",
+        "team" => {
+            if enterprise_build {
+                "Team"
+            } else {
+                "Business"
+            }
+        }
+        "enterprise" => {
+            if enterprise_build {
+                "Enterprise"
+            } else {
+                "Business"
+            }
+        }
         "lifetime" => "Lifetime",
         _ => "Free",
     }


### PR DESCRIPTION
## Problem

A **consumer** build was showing **"Enterprise plan"** in the tray (and account settings) for accounts that are merely a member/admin of an enterprise license org.

The desktop never decides the plan — it renders whatever `subscription_plan` `/api/user` returns. The website's `resolveAppEntitlement()` checks `enterprise_members` first and returns `plan: "enterprise"` for any active membership, so an account whose DB `users.plan` is actually `pro` still surfaced as "Enterprise" on the consumer app. There is no self-serve Enterprise/Team product on the consumer build, and those accounts already get Business-equivalent features there.

## Tray: before → after (consumer build)

```
        BEFORE                              AFTER
┌─────────────────────────┐      ┌─────────────────────────┐
│ Your data stays local   │      │ Your data stays local   │
│ ○ Starting…             │      │ ○ Starting…             │
│ ─────────────────────── │      │ ─────────────────────── │
│ Enterprise plan         │ ───▶ │ Business plan           │
│ ─────────────────────── │      │ ─────────────────────── │
│ screenpipe v2.5.65      │      │ screenpipe v2.5.65      │
└─────────────────────────┘      └─────────────────────────┘
```

The **enterprise build** is unchanged — it still shows the real "Enterprise"/"Team" label.

## Change

Collapse org/license-derived `team`/`enterprise` → **"Business"** on the consumer build only:

- `src-tauri/src/tray.rs` — `plan_display_name` gated on `cfg!(feature = "enterprise-build")`
- `lib/app-entitlement.ts` — `planDisplayName(plan, isEnterpriseBuild = false)` (kept in sync with the Rust map)
- `components/settings/account-section.tsx` — passes `useIsEnterpriseBuild()` to both call sites
- `lib/app-entitlement.test.ts` — coverage for consumer vs enterprise-build labels

## Verification

- Ran `planDisplayName` directly — all cases pass (`enterprise → Business` consumer, `enterprise → Enterprise` enterprise build).
- `rustfmt` clean (no-op, already canonical).

## Note (out of scope)

The website still returns `subscription_plan: "enterprise"` while `users.plan` is `pro` — an internal `/api/user` inconsistency. This PR fixes the consumer-facing label; aligning the server response is a separate website change.