### PR TITLE
fix(connections): fold OpenClaw/Hermes into the unified Remote agent card

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -3937,9 +3937,16 @@ export function ConnectionsSection({
     // embedded sidebar, no user-facing controls. obsidian-memories is hidden
     // too: it's a memory-sync destination surfaced as a subsection inside the
     // Obsidian card, not a standalone connection tile.
+    // openclaw + hermes are hidden as standalone tiles too: both are surfaced
+    // inside the unified "Remote agent" card (RemoteAgentCard), which owns their
+    // MCP/skill/sync setup AND the outbound "Connect" credential flow. Showing
+    // separate Productivity tiles next to "Remote agent" duplicated them and
+    // confused users. The backend integrations stay registered so pipes calling
+    // /connections/{openclaw,hermes} keep working.
+    const REMOTE_AGENT_TILE_IDS = new Set(["openclaw", "hermes"]);
     const hardcodedIds = new Set(hardcoded.map(h => h.id));
     const apiTiles: ConnectionTile[] = integrations
-      .filter(i => !hardcodedIds.has(i.id) && i.id !== "owned-default" && i.id !== "obsidian-memories")
+      .filter(i => !hardcodedIds.has(i.id) && i.id !== "owned-default" && i.id !== "obsidian-memories" && !REMOTE_AGENT_TILE_IDS.has(i.id))
       .map(i => ({
         id: i.id,
         name: i.name,

--- a/apps/screenpipe-app-tauri/components/settings/remote-agent-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/remote-agent-card.tsx
@@ -114,6 +114,25 @@ const TARGETS: { id: TargetId; label: string; props: AgentCardProps }[] = [
       mcp: { format: "yaml", configPath: "~/.hermes/config.yaml", snippet: YAML_SNIPPET },
       skills: skillVariants("~/.hermes/skills"),
       sync: { defaultRemotePath: "~/screenpipe-data", storageKeyPrefix: "hermes" },
+      connect: {
+        integrationId: "hermes",
+        fields: [
+          {
+            key: "endpoint",
+            label: "API Server URL",
+            secret: false,
+            placeholder: "http://127.0.0.1:8642",
+            helpUrl: "https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server",
+          },
+          {
+            key: "token",
+            label: "API Server Key",
+            secret: true,
+            placeholder: "API_SERVER_KEY (optional)",
+            helpUrl: "https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server",
+          },
+        ],
+      },
     },
   },
   {


### PR DESCRIPTION
## what

The **Remote agent** tile (Agent group) already covers OpenClaw, Hermes, Claude and Codex — its header comment even says it _"supersedes the separate OpenClaw and Hermes cards."_ But the standalone **OpenClaw** and **Hermes** integration tiles were never removed, so they kept rendering in the **Productivity** group right next to it.

Result, as a user hit it: _"it's so confusing to have both the remote agent and this."_

- OpenClaw's Connect flow was **100% duplicated** (Remote agent → OpenClaw → Connect tab **and** the standalone tile).
- Hermes was **split** — setup/sync in the unified card, credentials only on the standalone tile. #4461 quietly re-introduced the split by giving Hermes a Connect tab on the old tile.

![before / after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/remote-agent-dedup-54957ce0e/sp-remote-agent-ba.png)

## changes

- **`connections-section.tsx`** — stop rendering `openclaw`/`hermes` as standalone tiles (added to the same exclusion filter as `owned-default`/`obsidian-memories`). The backend `IntegrationDef`s stay registered, so pipes calling `/connections/{openclaw,hermes}` keep working unchanged.
- **`remote-agent-card.tsx`** — add the Hermes **Connect** tab so its outbound credential flow (endpoint + API server key) survives the tile removal, matching the OpenClaw entry.

Net: everything agent-related lives in **one** card. No backend integration removed, no pipe behavior changed.

## reversible

Drop the ids from `REMOTE_AGENT_TILE_IDS` to bring the standalone tiles back.

## test plan

- [ ] Settings → Connections: no `OpenClaw`/`Hermes` tiles under **Productivity**.
- [ ] **Agent → Remote agent → Hermes**: `MCP · Skill · Sync (remote) · Connect` tabs all present; **Connect** saves endpoint + key and the dot reflects connection state.
- [ ] **Remote agent → OpenClaw → Connect** still works (unchanged path).
- [ ] An existing pipe that posts to a connected Hermes/OpenClaw still resolves credentials (`/connections/{id}` unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)