### PR TITLE
fix(notifications): raise Chat window when "automate something" notification is clicked

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat-utils.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-utils.ts
@@ -258,7 +258,14 @@ export async function showChatWithPrefill(data: ChatPrefillData): Promise<void> 
     // drop prefill events because no chat listener exists yet.
     await commands.showWindow({ Home: { page: "home" } });
   } else {
-    await commands.showWindow("Chat");
+    // Use show_window_activated, not show_window: this path is reached from
+    // notification clicks (e.g. the "automate something" pipe-suggestion
+    // action), which fire from outside the app's active space. The Chat
+    // overlay is a NonActivating panel, so plain show_window resolves Ok
+    // without ever raising the window — the prefilled prompt then runs with
+    // the window hidden and the user sees nothing happen. Matches the
+    // open_chat / open_timeline notification handlers.
+    await commands.showWindowActivated("Chat");
   }
 
   await waitForChatReady(targetWindow);


### PR DESCRIPTION
## Problem

Clicking the **"automate something today → show me ideas"** notification did nothing visible. The action *did* run — the request fired and a pi/chat session started ~7s after the click in the logs — but the Chat window never came to the foreground, so it looked dead.

```
18:01:55  native notification action: {"action":"open_pipe_suggestions",...}
18:02:02  pi_request_state: session=109c2246…        ← agent started, window hidden
```

## Root cause

`open_pipe_suggestions` → `showChatWithPrefill()` opened the Chat overlay with `show_window`. Notifications are clicked from **outside** the app's active space, and on macOS the Chat overlay is a **NonActivating** panel — `show_window` resolves `Ok` without ever raising the window. The prefilled prompt then auto-sends with the window hidden.

The sibling notification handlers `open_chat` / `open_timeline` already use `show_window_activated` for exactly this reason ([`notification-handler.tsx`](https://github.com/screenpipe/screenpipe/blob/main/apps/screenpipe-app-tauri/components/notification-handler.tsx#L284)). This aligns the prefill path with them, fixing the same latent bug for **all** notification-driven chat prefills (e.g. the `pipe` + `open_in_chat` action too).

## Fix

One line in `showChatWithPrefill` (chat-overlay branch): `show_window` → `show_window_activated`. TS-only, no Rust surface / bindings change.

## Flow — before vs after

```
BEFORE                                AFTER
click notification                    click notification
   │                                     │
   ▼                                     ▼
show_window("Chat")  ──► Ok           show_window_activated("Chat")
   │   (panel stays hidden)              │   (panel raised to front)
   ▼                                     ▼
prompt auto-sends, window hidden      prompt auto-sends, chat visible
   │                                     │
   ▼                                     ▼
user sees NOTHING  ✗                  user sees the chat answer  ✓
```

## Notes
- Verified clean typecheck on the changed file.
- Existing e2e specs call `showWindow("Chat")` directly in their own harness; unaffected.
- Separate from this: the user hitting this also had a corrupt local DB (`code 11 malformed`) which would have failed the advisor's `/search` queries even with the window up — that's the known FD-exhaustion corruption, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)