### PR TITLE
[pr] respect disabled audio capture

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -272,6 +272,8 @@ const SERVER_RESTART_SETTINGS = new Set<keyof SettingsStore>([
   "apiAuth",
   "apiKey",
   "listenOnLan",
+  "disableAudio",
+  "audioCaptureMode",
   "encryptStore",
   "asyncPiiRedaction",
   "asyncImagePiiRedaction",

--- a/apps/screenpipe-app-tauri/e2e/specs/api.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/api.spec.ts
@@ -23,7 +23,7 @@
  * exactly the regression we want CI to surface.
  */
 
-import { openHomeWindow, waitForAppReady, t } from "../helpers/test-utils.js";
+import { waitForAppReady, t } from "../helpers/test-utils.js";
 import { invokeOrThrow } from "../helpers/tauri.js";
 
 interface LocalApiConfig {
@@ -55,13 +55,18 @@ interface FetchResult {
 async function fetchJson(
   url: string,
   headers: Record<string, string> = {},
+  init: { method?: string; body?: string } = {},
 ): Promise<FetchResult> {
   const timeoutMs = t(5_000);
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const r = await fetch(url, { headers, signal: controller.signal });
+    const r = await fetch(url, {
+      ...init,
+      headers,
+      signal: controller.signal,
+    });
     let body: unknown = null;
     const text = await r.text();
     try {
@@ -95,17 +100,45 @@ describe("Local HTTP API", function () {
 
   before(async () => {
     await waitForAppReady();
-    // Need a Tauri-origin webview to invoke commands. Home is the canonical
-    // long-lived window and is already opened by sibling specs. Idempotent.
-    await openHomeWindow();
 
     // Server boot is on its own thread; in CI it can take a few seconds
-    // longer than the home window appearing. Poll until /health responds
-    // or the budget runs out.
+    // longer than the home window appearing. On a dev box another screenpipe
+    // may already own :3030, so honor SCREENPIPE_PORT and only accept the
+    // resolved config once it points at the isolated E2E server.
+    const expectedPort = process.env.SCREENPIPE_PORT
+      ? Number(process.env.SCREENPIPE_PORT)
+      : null;
     const deadline = Date.now() + t(30_000);
     let lastErr = "";
+    let cfg: LocalApiConfig | null = null;
     while (Date.now() < deadline) {
-      const res = await fetchJson("http://127.0.0.1:3030/health").catch(
+      const candidate = await getLocalApiConfig().catch(() => {
+        const envKey =
+          process.env.SCREENPIPE_API_KEY ??
+          process.env.SCREENPIPE_LOCAL_API_KEY ??
+          process.env.SCREENPIPE_API_AUTH_KEY ??
+          null;
+        return expectedPort && envKey
+          ? { key: envKey, port: expectedPort, auth_enabled: true }
+          : null;
+      });
+      if (!candidate?.port) {
+        lastErr = "get_local_api_config not ready";
+        await browser.pause(500);
+        continue;
+      }
+      if (expectedPort && candidate.port !== expectedPort) {
+        lastErr = `waiting for isolated port ${expectedPort}, got ${candidate.port}`;
+        await browser.pause(500);
+        continue;
+      }
+      if (candidate.auth_enabled && !candidate.key) {
+        lastErr = "local api auth enabled without key";
+        await browser.pause(500);
+        continue;
+      }
+
+      const res = await fetchJson(`http://127.0.0.1:${candidate.port}/health`).catch(
         (e: unknown) => ({
           ok: false,
           status: 0,
@@ -113,15 +146,17 @@ describe("Local HTTP API", function () {
           error: e instanceof Error ? e.message : String(e),
         }),
       );
-      if (res.ok) break;
+      if (res.ok) {
+        cfg = candidate;
+        break;
+      }
       lastErr = res.error ?? `status=${res.status}`;
       await browser.pause(500);
     }
-    if (Date.now() >= deadline) {
+    if (!cfg) {
       throw new Error(`Server /health did not respond within budget: ${lastErr}`);
     }
 
-    const cfg = await getLocalApiConfig();
     port = cfg.port;
     key = cfg.key;
   });
@@ -135,11 +170,44 @@ describe("Local HTTP API", function () {
     expect(res.body).toHaveProperty("status");
   });
 
-  it("GET /audio/device/status — unauthed, returns object with audio disabled", async () => {
+  it("GET /health — no-recording seed reports audio disabled", async () => {
+    const res = await fetchJson(`http://127.0.0.1:${port}/health`);
+    expect(res.ok).toBe(true);
+    expect(res.body).toHaveProperty("audio_status", "disabled");
+  });
+
+  it("GET /audio/device/status — unauthed, returns no devices with audio disabled", async () => {
     const res = await fetchJson(`http://127.0.0.1:${port}/audio/device/status`);
-    // 404 is acceptable here only if the route is gated off; status code
-    // shouldn't be a server error.
-    expect(res.status).toBeLessThan(500);
+    expect(res.ok).toBe(true);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toHaveLength(0);
+  });
+
+  it("POST /audio/start — rejects while audio is disabled", async () => {
+    if (!key) throw new Error("local api key not ready");
+    const res = await fetchJson(
+      `http://127.0.0.1:${port}/audio/start`,
+      { Authorization: `Bearer ${key}` },
+      { method: "POST" },
+    );
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty("message", "Audio capture is disabled in settings");
+  });
+
+  it("POST /audio/device/start — rejects before opening a device while audio is disabled", async () => {
+    if (!key) throw new Error("local api key not ready");
+    const res = await fetchJson(
+      `http://127.0.0.1:${port}/audio/device/start`,
+      { Authorization: `Bearer ${key}`, "content-type": "application/json" },
+      {
+        method: "POST",
+        body: JSON.stringify({ device_name: "E2E Disabled Microphone (input)" }),
+      },
+    );
+    expect(res.ok).toBe(false);
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty("message", "Audio capture is disabled in settings");
   });
 
   it("GET /connections — authed, returns 2xx with an array body", async function () {

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -250,7 +250,10 @@ impl AudioManager {
     /// live-meeting provider, devices, language, vocabulary, and batch mode
     /// update on a capture-level restart.
     pub async fn apply_options(&self, options: AudioManagerOptions) -> Result<()> {
-        if self.status().await == AudioManagerStatus::Running {
+        if self.status().await == AudioManagerStatus::Running
+            || options.is_disabled
+            || !self.recording_handles.is_empty()
+        {
             self.stop_internal().await?;
         }
 
@@ -488,11 +491,9 @@ impl AudioManager {
     }
 
     pub async fn stop(&self) -> Result<()> {
-        if self.status().await == AudioManagerStatus::Stopped {
+        if self.status().await == AudioManagerStatus::Stopped && self.recording_handles.is_empty() {
             return Ok(());
         }
-        *self.status.write().await = AudioManagerStatus::Stopped;
-        stop_device_monitor().await?;
         self.stop_internal().await
     }
 
@@ -548,6 +549,10 @@ impl AudioManager {
         self.status.read().await.clone()
     }
 
+    pub async fn is_disabled(&self) -> bool {
+        self.options.read().await.is_disabled
+    }
+
     /// Temporarily pause a device without changing the configured device list.
     /// Idempotent — safe to call if already paused. Never errors.
     pub async fn pause_device(&self, device_name: &str) -> Result<()> {
@@ -567,8 +572,20 @@ impl AudioManager {
 
     /// Resume a previously paused device. Idempotent — safe to call if already running.
     pub async fn resume_device(&self, device_name: &str) -> Result<()> {
+        if self.options.read().await.is_disabled {
+            return Err(anyhow!("audio capture is disabled"));
+        }
+
         // Remove from disabled FIRST so start_device gate allows it
         self.user_disabled_devices.write().await.remove(device_name);
+
+        if self.status().await != AudioManagerStatus::Running {
+            info!(
+                "user re-enabled audio device while audio manager is stopped: {}",
+                device_name
+            );
+            return Ok(());
+        }
 
         let device = match parse_audio_device(device_name) {
             Ok(device) => device,
@@ -600,6 +617,14 @@ impl AudioManager {
     }
 
     pub async fn start_device(&self, device: &AudioDevice) -> Result<()> {
+        if self.options.read().await.is_disabled {
+            debug!(
+                "skipping start of audio device because audio capture is disabled: {}",
+                device
+            );
+            return Ok(());
+        }
+
         // Don't restart devices that are paused due to DRM content detection.
         // The monitor watcher will call start_output_devices() when DRM clears.
         if self

--- a/crates/screenpipe-engine/src/routes/audio.rs
+++ b/crates/screenpipe-engine/src/routes/audio.rs
@@ -93,6 +93,16 @@ pub(crate) async fn start_audio_device(
 ) -> Result<Json<AudioDeviceControlResponse>, (StatusCode, JsonResponse<Value>)> {
     let device_name = payload.device_name.clone();
 
+    if state.audio_disabled || state.audio_manager.is_disabled().await {
+        return Err((
+            StatusCode::CONFLICT,
+            JsonResponse(json!({
+                "success": false,
+                "message": "Audio capture is disabled in settings"
+            })),
+        ));
+    }
+
     if let Err(e) = state.audio_manager.resume_device(&device_name).await {
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -187,6 +197,16 @@ pub(crate) async fn audio_device_status(
 pub(crate) async fn start_audio(
     State(state): State<Arc<AppState>>,
 ) -> Result<Response, (StatusCode, JsonResponse<Value>)> {
+    if state.audio_disabled || state.audio_manager.is_disabled().await {
+        return Err((
+            StatusCode::CONFLICT,
+            JsonResponse(json!({
+                "success": false,
+                "message": "Audio capture is disabled in settings",
+            })),
+        ));
+    }
+
     match state.audio_manager.start().await {
         Ok(_) => Ok(Response::builder().status(200).body(Body::empty()).unwrap()),
         Err(e) => Err((


### PR DESCRIPTION
## description

Fixes an audio privacy edge case reported by Andrew where the app could still open or keep an OS audio device active after audio recording was disabled.

Changes:
- Treat `disableAudio` and `audioCaptureMode` as full server-restart settings so the long-lived audio manager is rebuilt with the new global audio state.
- Block `/audio/device/start` and `/audio/start` when audio capture is disabled.
- Make `AudioManager` tear down lingering device handles when disabled options are applied, and refuse direct device start/resume while globally disabled or while the manager is stopped.

related issue: customer email / Andrew mic indicator report

## before

No screen recording attached. Repro was privacy/system-state based: audio could be disabled in settings while a stale server/audio-manager path still allowed a mic/device stream to remain active or be resumed.

## after

No screen recording attached. With audio disabled, server restart applies the new audio state and explicit audio/device start routes return a conflict instead of opening an audio stream.

## how to test

1. Disable Audio Recording in Settings > Recording, apply the change, and verify the OS mic indicator does not stay active.
2. While audio is disabled, call `/audio/start` or `/audio/device/start`; it should return conflict with `Audio capture is disabled in settings`.
3. Re-enable audio and apply the change; normal capture should start again.

Validated locally:

- `rustfmt --edition 2021 --check crates/screenpipe-engine/src/routes/audio.rs crates/screenpipe-audio/src/audio_manager/manager.rs`
- `git diff --check -- apps/screenpipe-app-tauri/components/settings/recording-settings.tsx crates/screenpipe-engine/src/routes/audio.rs crates/screenpipe-audio/src/audio_manager/manager.rs`
- `cargo check -p screenpipe-audio -p screenpipe-engine`

## desktop app checklist (if applicable)

This PR does not add or change Tauri commands or exported Rust types, so bindings were not regenerated.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`
