### PR TITLE
fix(search): stop ~10s freeze when opening the search bar

### DIFF
--- a/apps/screenpipe-app-tauri/app/search/page.tsx
+++ b/apps/screenpipe-app-tauri/app/search/page.tsx
@@ -4,9 +4,9 @@
 
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { SearchModal } from "@/components/rewind/search-modal";
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { commands } from "@/lib/utils/tauri";
 import {
 	RECENT_CHAT_SEARCH_HANDOFF_EVENT,
@@ -21,6 +21,24 @@ export default function SearchPage() {
 
 	const handleClose = useCallback(async () => {
 		await commands.closeWindow({ Search: { query: null } });
+	}, []);
+
+	// The search window is reused across opens: Rust hides it on close (keeping
+	// the webview warm) and emits "search-reset" instead of reloading the page.
+	// Bumping the key remounts SearchModal, which replays the normal fresh-open
+	// path (clean state + autofocus) without paying a webview cold-boot — the
+	// fix for the ~10s freeze before you could type.
+	const [reopenNonce, setReopenNonce] = useState(0);
+	useEffect(() => {
+		const unlistenPromise = listen<{ query?: string | null }>("search-reset", (event) => {
+			const q = event.payload?.query ?? "";
+			const url = q ? `/search?q=${encodeURIComponent(q)}` : "/search";
+			window.history.replaceState(null, "", url);
+			setReopenNonce((n) => n + 1);
+		});
+		return () => {
+			unlistenPromise.then((f) => f());
+		};
 	}, []);
 
 	// Close on click outside
@@ -62,6 +80,7 @@ export default function SearchPage() {
 	return (
 		<div className="w-screen h-screen bg-transparent">
 			<SearchModal
+				key={reopenNonce}
 				isOpen={true}
 				standalone
 				onClose={handleClose}

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -466,15 +466,19 @@ impl ShowRewindWindow {
             }
 
             if id.label() == RewindWindowId::Search.label() {
-                // Navigate to /search to reset state (clear previous results)
-                let nav_url = if let Some(query) = self.metadata() {
-                    format!("/search/{}", query)
-                } else {
-                    "/search".to_string()
-                };
-                let _ = window
-                    .eval(&format!("window.location.replace(`{}`);", nav_url))
-                    .ok();
+                // Reset the modal IN PLACE instead of reloading the webview.
+                // The search window is kept warm across opens (close() hides it
+                // rather than destroying it — see `close()` below), so a full
+                // `location.replace("/search")` here would throw the warm webview
+                // away and force a multi-second Next.js cold-boot on every open,
+                // during which the input is unresponsive (the ~10s "stuck" bug).
+                // Emitting "search-reset" lets the React side clear previous
+                // results and refocus the input instantly. metadata() carries an
+                // optional prefill query (empty string when none).
+                let _ = window.emit(
+                    "search-reset",
+                    serde_json::json!({ "query": self.metadata() }),
+                );
 
                 // Reposition to center of primary monitor
                 if let Ok(Some(monitor)) = app.primary_monitor() {
@@ -1843,6 +1847,36 @@ impl ShowRewindWindow {
         //     }
         //     return Ok(());
         // }
+
+        // Search: hide instead of destroy so the webview stays warm. Recreating
+        // the window forces a full Next.js cold-boot on every open (the input is
+        // unresponsive for several seconds); reuse via show()'s existing-window
+        // branch makes reopen instant. `window.close()` on the class-swizzled
+        // NSPanel also risks a use-after-free SIGSEGV (see the creation path),
+        // which order_out avoids.
+        if id.label() == RewindWindowId::Search.label() {
+            if let Some(window) = id.get(app) {
+                #[cfg(target_os = "macos")]
+                {
+                    let window_clone = window.clone();
+                    run_on_main_thread_safe(app, move || {
+                        use objc::{msg_send, sel, sel_impl};
+                        use tauri_nspanel::cocoa::base::{id, nil};
+                        if let Ok(ns_win) = window_clone.ns_window() {
+                            let ns_win = ns_win as id;
+                            unsafe {
+                                let _: () = msg_send![ns_win, orderOut: nil];
+                            }
+                        }
+                    });
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    window.hide().ok();
+                }
+            }
+            return Ok(());
+        }
 
         if let Some(window) = id.get(app) {
             // On Windows, minimize the Settings window instead of closing it


### PR DESCRIPTION
## the bug

Opening the floating search bar leaves the input **frozen for ~10s before you can type**. Every open pays a full Next.js / WKWebView cold-boot.

## root cause

The search window is **destroyed on close and re-created on every open** — and even the (currently dead) reuse path did a full page reload:

- `close()` → `window.close()` **destroys** the Search webview ([`show.rs`](apps/screenpipe-app-tauri/src-tauri/src/window/show.rs)). So `id.get(app)` is `None` next time → it hits the **creation path** and boots a brand-new WKWebView, loads `/search`, parses the JS bundle, hydrates, and runs the on-open data effects. On a busy machine that's seconds of an unresponsive input — *every* open.
- The existing-window reuse branch (which never ran, because the window was always destroyed) did `window.location.replace("/search")` — i.e. a **full reload anyway**.

Notably the reuse branch's own comment already assumed the window persists (*"already class-swizzled to NSPanel"*), so persistent reuse was the intended design — it was just defeated by the destroy-on-close.

## the fix

Keep the webview **warm** and reset the modal **in place**:

| | before | after |
|---|---|---|
| **close** | `window.close()` → destroy | hide (`order_out` / `window.hide()`) |
| **reopen** | recreate webview → cold boot | reuse window + emit `search-reset` |
| **reset** | full page reload | remount `SearchModal` (key bump) |

```
BEFORE (every open):
  ⌘K ─▶ destroy old window ─▶ create webview ─▶ load /search ─▶ parse JS
        ─▶ hydrate React ─▶ run on-open effects ─▶ [input finally usable]
        └──────────────────  ~10s frozen  ──────────────────┘

AFTER:
  first open:  ⌘K ─▶ create webview … (one-time warm-up)
  every open:  ⌘K ─▶ show warm window ─▶ emit "search-reset"
               ─▶ remount modal (clean state + autofocus) ─▶ [usable, instant]
```

As a bonus, switching close → hide also sidesteps the use-after-free **SIGSEGV** that `window.close()` carries on the class-swizzled NSPanel (documented in the creation path).

## changes

- `src-tauri/src/window/show.rs`
  - `close()`: Search now **hides** instead of destroying (macOS `order_out` via `ns_window`, `window.hide()` elsewhere).
  - reuse branch: emit `search-reset` (with optional prefill query) instead of `location.replace`.
- `app/search/page.tsx`: listen for `search-reset` → remount `SearchModal` so it replays the normal fresh-open path (state reset + autofocus) without a webview boot.

## behavior notes

- First open after app launch still warms the webview **once**; every subsequent open is instant.
- No new Tauri commands → no `tauri.ts` binding changes.

## verification

- ✅ **Rust compiles clean locally** — `cargo check` on `screenpipe-app` exits 0 with my changes (had to stub the `bun`/`ffmpeg`/`ffprobe` sidecars + a frontend `out/` dir to get the tauri build script past its resource checks; no errors, no new warnings in `show.rs`).
- ⚠️ **Runtime not yet validated** — I have not run a patched build to observe the freeze actually go away (the diagnosis is static: traced that close → destroy and the reuse branch reloads). Reviewer/manual test below.

## testing checklist

- [ ] macOS: open search via ⌘K repeatedly — first open warms, subsequent opens type immediately; Esc / click-outside / pick-a-result all still close it; reopen state is clean.
- [ ] Windows/Linux: same (uses `window.hide()` + show/focus reuse path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)