### PR TITLE
fix(macOS): handle Apple OCR nil errors causing app desktop crash etc 

### DIFF
--- a/crates/screenpipe-screen/src/apple.rs
+++ b/crates/screenpipe-screen/src/apple.rs
@@ -180,9 +180,21 @@ pub fn perform_ocr_apple(
         request.set_recognition_langs(&languages_array);
         request.set_uses_lang_correction(false);
         let requests = ns::Array::<vn::Request>::from_slice(&[&request]);
-        let result = handler.perform(&requests);
-
-        if result.is_err() {
+        // Apple documents the BOOL/nil return value as the success signal for
+        // NSError-by-reference APIs: "Success or failure is indicated by the
+        // return value of the method." The NSError out-param is diagnostic.
+        // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html
+        //
+        // Use the raw API so a false return with no NSError is still a normal
+        // OCR miss instead of going through cidre's convenience wrapper.
+        let mut perform_error = None;
+        let performed = unsafe { handler.perform_request_err(&requests, &mut perform_error) };
+        if !performed {
+            if let Some(error) = perform_error {
+                warn!("Apple Vision OCR request failed: {}", error);
+            } else {
+                warn!("Apple Vision OCR request failed without NSError");
+            }
             return default_ocr_result;
         }
 


### PR DESCRIPTION

## Summary

Fix a macOS desktop crash in the Apple Vision OCR path when OCR fails without returning an `NSError`.

- Before

`handler.perform(...)` went through cidre's convenience wrapper. When Vision returned failure without an NSError, that path could abort the desktop app instead of treating the frame as an OCR miss.

- After

The OCR request now calls the raw NSError-by-reference API, checks the boolean success result directly, logs any available NSError, and returns an empty OCR result when Vision fails without details.

## Crash stack

Crash report: `EXC_CRASH (SIGABRT)`, triggered by `Thread 70: screenpipe-worker`.

```text
Thread 70 Crashed:: screenpipe-worker
...
cidre::vn::request_handler::ImageRequestHandler::perform_request_err
cidre::vn::request_handler::ImageRequestHandler::perform::{closure}
cidre::ns::error::if_false
cidre::vn::request_handler::ImageRequestHandler::perform
screenpipe_screen::apple::perform_ocr_apple::{closure}
cidre::objc::ar_pool
screenpipe_screen::apple::perform_ocr_apple
screenpipe_engine::routes::frames::run_frame_ocr::{closure}
tokio::runtime::blocking::task::BlockingTask::poll
```

## Validation

- `cargo check -p screenpipe-screen --locked`

## Media

No video attached. This is a non-visual macOS crash-handling change; the crash stack and targeted Rust check above are the relevant validation.
