### PR TITLE
fix(meetings): stop releases audio deferral before the DB write so a wedged pool can't deadlock it (#4525)

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -702,14 +702,27 @@ export function NoteView({
     try {
       const current = { title, attendees, note };
       if (!sameMeetingNoteDraft(current, lastSavedRef.current)) {
-        await save(current, { throwOnError: true });
+        // Best-effort: a failed note save must NEVER block the stop. If the DB
+        // write pool is wedged the save can 500, and gating stop on it leaves
+        // the meeting permanently un-stoppable (#4525). Warn and stop anyway —
+        // stopping is what releases the deferral pressure that wedged the pool.
+        try {
+          await save(current, { throwOnError: true });
+        } catch (saveErr) {
+          console.error("failed to save meeting note before stop", saveErr);
+          toast({
+            title: "couldn't save notes",
+            description: "stopping anyway — your latest edits may not be saved.",
+            variant: "destructive",
+          });
+        }
       }
       await onStop();
     } catch (err) {
-      console.error("failed to save meeting note before stop", err);
+      console.error("failed to stop meeting", err);
       toast({
-        title: "couldn't save notes",
-        description: "try again before stopping the meeting.",
+        title: "couldn't stop meeting",
+        description: String(err),
         variant: "destructive",
       });
     } finally {

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -768,6 +768,46 @@ pub(crate) async fn stop_meeting_handler(
 
     let now = Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
 
+    // Release runtime state BEFORE persisting. An explicit stop is a runtime
+    // intent — the audio batch-deferral flag and detector tracking must release
+    // even when the write pool is wedged. If they only release *after* the
+    // end-write (as before), a stalled write pool turns the stop into a
+    // deadlock: audio stays in batch-deferral, the transcription/write queue
+    // never drains, so the end-write can never acquire a connection
+    // ("pool timed out while waiting for an open connection"), so the flag
+    // never clears — leaving the meeting permanently unstoppable with hundreds
+    // of transcription segments stranded (#4525). These three releases touch
+    // no DB (RwLock + AtomicBool + in-process event bus), so a stalled write
+    // pool cannot block them.
+    {
+        let mut lock = state.manual_meeting.write().await;
+        if *lock == Some(id) {
+            *lock = None;
+        }
+    }
+    if let Some(detector) = state.audio_manager.meeting_detector().await {
+        detector.set_v2_in_meeting(false);
+    }
+    // Signal the detector loop to drop tracking immediately (skip grace period).
+    // The app comes from the already-resolved status so this needs no DB read
+    // and fires even when the pool is wedged.
+    if let Err(e) = screenpipe_events::send_event(
+        "detector_stop_tracking",
+        serde_json::json!({
+            "meeting_id": id,
+            "app": status.meeting_app.clone().unwrap_or_default(),
+        }),
+    ) {
+        tracing::warn!(
+            "failed to emit detector_stop_tracking event for meeting {}: {}",
+            id,
+            e
+        );
+    }
+
+    // Persist the end best-effort. The runtime is already released above, so
+    // even if this times out (pool wedged), the deferral drains and a retry —
+    // or the detector's own grace-timeout end — completes persistence.
     state
         .db
         .end_meeting_with_typed_text(
@@ -783,16 +823,6 @@ pub(crate) async fn stop_meeting_handler(
                 JsonResponse(json!({"error": e.to_string()})),
             )
         })?;
-
-    {
-        let mut lock = state.manual_meeting.write().await;
-        if *lock == Some(id) {
-            *lock = None;
-        }
-    }
-    if let Some(detector) = state.audio_manager.meeting_detector().await {
-        detector.set_v2_in_meeting(false);
-    }
 
     if let Ok(status) = resolve_meeting_status(&state).await {
         emit_meeting_status_changed(&status);
@@ -818,18 +848,6 @@ pub(crate) async fn stop_meeting_handler(
         std::slice::from_ref(&meeting),
         None,
     );
-
-    // Signal detector to stop tracking this meeting immediately (skip grace period)
-    if let Err(e) = screenpipe_events::send_event(
-        "detector_stop_tracking",
-        serde_json::json!({ "meeting_id": id, "app": &meeting.meeting_app }),
-    ) {
-        tracing::warn!(
-            "failed to emit detector_stop_tracking event for meeting {}: {}",
-            id,
-            e
-        );
-    }
 
     Ok(JsonResponse(meeting))
 }


### PR DESCRIPTION
Closes #4525.

## Symptom

A user's Microsoft Teams **calendar notification** for a 168-hour recurring "PCard" meeting (with a 200+ person attendee roster) gets read by the AX scanner as a live call — a false positive with **zero audio**. From then on the meeting is **permanently unstoppable**: the Stop button returns `HTTP 500 "pool timed out while waiting for an open connection"`, `audio_db_write_stalled=true`, and 400+ transcription segments pile up pending. Only an app restart clears it (`I think it killd itself`).

## Root cause — a deadlock between runtime release and persistence

A detected meeting puts audio into **batch-deferral** (`meeting_detected → set_v2_in_meeting(true)`; transcription is intentionally held while a live session is active). That flag is only released on a clean stop.

But the stop handler released it in the **wrong order** — runtime release came *after* a DB write:

```
POST /meetings/stop
  1. end_meeting_with_typed_text(id)   ← write-pool UPDATE, acquire_timeout=10s
        └─ pool wedged → 500, handler `?`-returns HERE ──────────┐
  2. clear manual_meeting lock          (never reached)          │
  3. set_v2_in_meeting(false)           (never reached) ← the    │
  4. emit detector_stop_tracking        (never reached)   release│
                                                                 │
   flag stays TRUE ─→ audio stays deferred ─→ write queue never  │
   drains ─→ write pool stays wedged ─→ end-write keeps timing ──┘
   out ─→ meeting can never be stopped.  (deadlock)
```

The one thing that un-wedges the system (releasing deferral so the queue drains) was gated behind the very write the wedge was blocking.

## Fix

**Backend — `stop_meeting_handler`:** release runtime state **first, independent of persistence**, then persist best-effort.

```
POST /meetings/stop
  1. clear manual_meeting lock          (RwLock — no DB)
  2. set_v2_in_meeting(false)           (AtomicBool — no DB)  ← un-wedges
  3. emit detector_stop_tracking        (event bus — no DB; app from status)
  4. end_meeting_with_typed_text(id)    (best-effort; queue now draining)
        └─ if it still times out, a retry — or the detector's own
           grace-timeout end — completes persistence.
```

None of steps 1–3 touch the DB, so a stalled write pool can't block them. Clearing the deferral is exactly what lets the transcription/write queue drain and the pool recover.

**Frontend — `handleStopClick`:** the pre-stop note save is now **best-effort**. It used to `await save(..., {throwOnError:true})` *before* `onStop()`, so a save that 500s on the same wedged pool threw and the meeting stayed live (the `couldn't save notes / try again before stopping` toast in the report). Now a failed save warns `stopping anyway — your latest edits may not be saved` and **still stops**; a genuine stop failure gets its own toast.

## Why this is distinct from the other open PRs

- **#4499** moved *note enrichment* to after the stop, but still calls the `end_meeting` write **first** and still `?`-returns on pool timeout — the wedged-pool deadlock survives it.
- **#4512** fixed the empty-body / stale-id frontend↔backend desync — a different failure mode.

This closes the permanent-stuck-on-wedged-pool case neither covers. Minimal overlap (both touch `meetings.rs`); happy-path behavior is unchanged (a successful stop ends in the same final state).

## Validation

- `cargo check -p screenpipe-engine --lib` → clean (only a pre-existing unrelated dead-code warning)
- `cargo fmt --all --check` → clean
- `cargo test -p screenpipe-engine --lib meeting` → **149 passed, 0 failed**

## Follow-up (not in this PR)

The detection *trigger* — a zero-audio Teams notification satisfying the 1-signal threshold — is separate. Worth a guard (e.g. require audio corroboration before confirming, or bump `min_signals_required` for Teams), but pinning the exact matched AX element needs the reporter's logs/AX dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)