### PR TITLE
[codex] add team file ticket MCP tools

### DIFF
--- a/crates/screenpipe-core/assets/skills/screenpipe-team/SKILL.md
+++ b/crates/screenpipe-core/assets/skills/screenpipe-team/SKILL.md
@@ -9,7 +9,7 @@ Query the customer's team telemetry. Data lives in the customer's own Azure Blob
 
 ## Auth
 
-The skill authenticates with an **enterprise admin API token** the admin minted once on `https://screenpi.pe/enterprise?tab=tokens` (with scopes `read:devices`, `read:search`, `read:records`) and pasted into Settings → Privacy → Admin Team API Token. The desktop stored it in `~/.screenpipe/enterprise.json` under `team_api_token`.
+The skill authenticates with an **enterprise admin API token** the admin minted once on `https://screenpi.pe/enterprise?tab=tokens` (with scopes `read:devices`, `read:search`, `read:records`; add `read:files` and `read:files:raw` only for raw export/download-ticket workflows) and pasted into Settings → Privacy → Admin Team API Token. The desktop stored it in `~/.screenpipe/enterprise.json` under `team_api_token`.
 
 License-key + token are intentionally separate concerns:
 - `license_key` proves *which org* this machine belongs to (deployed by IT, same on every employee's device).
@@ -51,6 +51,7 @@ Escalate from cheap to expensive:
 | 2 | `GET /search?q=...&since_hours_ago=24` | The user has a topic (e.g. "atlas", "q3 forecast"). Default 24h, narrow further if results are noisy. |
 | 3 | `GET /search?q=...&device_id=...` | Once you know whose data you want, scope to that device. |
 | 4 | `GET /records?device_id=...&since_hours_ago=4` | "Walk me through what X did between Y and Z" — chronological dump. Use AFTER you know the device + window from steps 1–3. |
+| 5 | `GET /files` → `GET /files/<key>?ticket=1` | Raw audit/export only. List keys first, then mint a direct-download ticket for one key. Requires `read:files` + `read:files:raw`. |
 
 Default `since_hours_ago` to 24 unless the user implies otherwise. Max 720 (30d).
 
@@ -109,6 +110,31 @@ jq '.records[] | {t, app, window, text: (.text // "")[0:120]}' /tmp/sp_team_reco
 | `limit` | Default 50, max 200. |
 
 Records come oldest-first so you can describe a chronological flow.
+
+## 4. Raw files and download tickets
+
+Only use this path when the user explicitly asks for raw evidence, export, or a direct storage URL. Prefer `/search` and `/records` for normal questions.
+
+List raw files:
+
+```bash
+curl -s "${AUTH_HEADERS[@]}" \
+  "$SP_URL/files?since_hours_ago=24&page_size=25" \
+  -o /tmp/sp_team_files.json
+jq '.files[] | {key, size, last_modified, device_id}' /tmp/sp_team_files.json
+```
+
+Mint a direct-download ticket for one returned key:
+
+```bash
+KEY=$(jq -r '.files[0].key' /tmp/sp_team_files.json)
+curl -s "${AUTH_HEADERS[@]}" \
+  "$SP_URL/files/$KEY?ticket=1" \
+  -o /tmp/sp_team_ticket.json
+jq '{provider, key, url, expires_at, temporary, note}' /tmp/sp_team_ticket.json
+```
+
+R2/S3 responses are short-lived presigned GET URLs. Azure responses are direct Blob URLs using the configured read SAS; check `temporary` and `expires_at` before treating them as fresh per-call tokens.
 
 ---
 

--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -857,6 +857,43 @@ const TEAM_TOOLS: Tool[] = [
       },
     },
   },
+  {
+    name: "team-files",
+    description:
+      "List raw telemetry JSONL object keys for the org. Use only for audit/export " +
+      "or when you need a key to pass to team-file-ticket. Requires read:files.",
+    annotations: { title: "Team Files", readOnlyHint: true, openWorldHint: true, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        device_id: { type: "string", description: "Restrict to one device." },
+        since: { type: "string", description: "ISO 8601 lower bound. Default = now - 24h." },
+        until: { type: "string", description: "ISO 8601 upper bound. Default = now." },
+        since_hours_ago: { type: "integer", description: "Convenience: equivalent to since=now-N*h." },
+        page_size: { type: "integer", description: "Files to list (default 100, max 1000).", default: 100 },
+        cursor: { type: "string", description: "Opaque cursor from a previous response." },
+      },
+    },
+  },
+  {
+    name: "team-file-ticket",
+    description:
+      "Mint a direct-download ticket for one raw telemetry JSONL object key returned " +
+      "by team-files. R2/S3 tickets are short-lived presigned GET URLs; Azure returns " +
+      "the configured read SAS URL. Requires read:files:raw.",
+    annotations: { title: "Team File Ticket", readOnlyHint: true, openWorldHint: true, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        key: {
+          type: "string",
+          description:
+            "Raw object key exactly as returned by team-files, e.g. enterprise-telemetry/<license>/<device>/<file>.jsonl",
+        },
+      },
+      required: ["key"],
+    },
+  },
 ];
 
 // Pipe-output kinds map to /workflows/generated, raw kinds map to /records.
@@ -2073,7 +2110,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // ---------------------------------------------------------------------
       case "team-search":
       case "team-devices":
-      case "team-records": {
+      case "team-records":
+      case "team-files":
+      case "team-file-ticket": {
         if (!TEAM_TOKEN) {
           return {
             content: [
@@ -2089,6 +2128,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             ],
           };
         }
+        if (name === "team-file-ticket") {
+          const key = typeof args.key === "string" ? args.key.trim() : "";
+          if (!key) throw new Error("team-file-ticket requires key");
+          const encodedKey = key.split("/").map(encodeURIComponent).join("/");
+          const response = await fetchTeam(`/files/${encodedKey}?ticket=1`);
+          const body = await response.text();
+          if (!response.ok) {
+            throw new Error(
+              `team-file-ticket failed ${response.status}: ${body.slice(0, 500)}`
+            );
+          }
+          return {
+            content: [{ type: "text", text: body }],
+          };
+        }
+
         // Map MCP tool name → /api/enterprise/v1 path. team-records also
         // routes synthesized pipe outputs (kind=sop|skill|...) to the
         // workflows endpoint so callers see one tool surface for "give me
@@ -2097,6 +2152,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const subpath =
           name === "team-search" ? "/search"
           : name === "team-devices" ? "/devices"
+          : name === "team-files" ? "/files"
           : name === "team-records" && SYNTHESIZED_KINDS.has(kindArg) ? "/workflows/generated"
           : "/records";
         // Forward every primitive arg as a query param. The server validates;


### PR DESCRIPTION
## What changed
- Adds `team-files` to list raw telemetry object keys for audit/export workflows.
- Adds `team-file-ticket` to mint a direct-download ticket for one key returned by `team-files`.
- Updates the bundled `screenpipe-team` skill with the required scopes and R2/S3 vs Azure ticket behavior.

## Why
The team MCP surface can now expose the direct raw-file ticket flow without asking agents/users to handcraft `/api/enterprise/v1/files/<key>?ticket=1` calls.

## Validation
- `npm run build` in `packages/screenpipe-mcp`
- `npm test -- --run` in `packages/screenpipe-mcp`
- `git diff --check`
