### PR TITLE
fix(enterprise): actually hide the app UI when hidden-mode policy turns on at runtime

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
@@ -515,6 +515,12 @@ export function useEnterprisePolicy() {
       // Push hidden sections to Rust so tray menu can use them
       try {
         await commands.setEnterprisePolicy(result.hiddenSections);
+        // Reconcile the live app with the policy we just pushed: if it turns on
+        // hidden-UI mode, retract any windows already on screen and drop the
+        // dock icon now (set_enterprise_policy only updates state — it doesn't
+        // hide what's already visible). Also persists the decision so the next
+        // launch starts hidden before any window renders. No-op when not hidden.
+        await commands.applyEnterpriseUiVisibility();
       } catch (e) {
         console.warn("[enterprise] failed to push policy to Rust:", e);
       }

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -6,6 +6,16 @@
 
 export const commands = {
 /**
+ * Reconcile the live app + the next-boot config with the current enterprise
+ * hidden-UI policy. The frontend calls this right after pushing a freshly
+ * fetched policy via `set_enterprise_policy`, so the moment an admin turns on
+ * "hide app", the windows already on screen are retracted and the dock icon
+ * drops — without waiting for a restart. Best-effort: never returns an error.
+ */
+async applyEnterpriseUiVisibility() : Promise<void> {
+    await TAURI_INVOKE("apply_enterprise_ui_visibility");
+},
+/**
  * Frontend-callable gate. The banner awaits this before calling
  * `downloadAndInstall` (Windows: triggers process::exit internally) or
  * `relaunch`. Returns one of `"proceed"`, `"errored"`, or `"pending"`

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -886,6 +886,71 @@ pub fn save_enterprise_license_key(license_key: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Persist the resolved "hide app UI" decision into `~/.screenpipe/enterprise.json`
+/// so the NEXT launch starts hidden *before* any window is created.
+///
+/// `is_app_ui_hidden()` is true for the running session as soon as the policy
+/// is pushed (the hidden sections live in a process global), but Rust resolves
+/// it on the very first window-gate check at startup — before the frontend has
+/// fetched the network policy. Mirroring the decision into the same file that
+/// `enterprise_policy::enterprise_json_hides_app_ui()` already reads at boot
+/// closes that gap, so a managed-background device never flashes its UI on
+/// subsequent launches.
+///
+/// We only ever touch the user-writable file; a bundled MDM `enterprise.json`
+/// (checked first at boot) keeps precedence. To avoid littering consumer
+/// machines we skip writing a `false` when there's nothing to clear.
+fn persist_enterprise_hide_app(hidden: bool) {
+    let path = screenpipe_core::paths::default_screenpipe_data_dir().join("enterprise.json");
+
+    let mut json = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let currently_set = json
+        .get("hide_app")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if hidden == currently_set {
+        return; // already in sync — nothing to write
+    }
+    if !hidden && !path.exists() {
+        return; // never create a file just to record "not hidden"
+    }
+
+    if let Some(dir) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            warn!("enterprise: could not create dir for enterprise.json: {}", e);
+            return;
+        }
+    }
+    json["hide_app"] = serde_json::Value::Bool(hidden);
+    match serde_json::to_string_pretty(&json) {
+        Ok(body) => {
+            if let Err(e) = std::fs::write(&path, body) {
+                warn!("enterprise: failed to persist hide_app to {}: {}", path.display(), e);
+            } else {
+                info!("enterprise: persisted hide_app={} to {}", hidden, path.display());
+            }
+        }
+        Err(e) => warn!("enterprise: failed to serialize enterprise.json: {}", e),
+    }
+}
+
+/// Reconcile the live app + the next-boot config with the current enterprise
+/// hidden-UI policy. The frontend calls this right after pushing a freshly
+/// fetched policy via `set_enterprise_policy`, so the moment an admin turns on
+/// "hide app", the windows already on screen are retracted and the dock icon
+/// drops — without waiting for a restart. Best-effort: never returns an error.
+#[tauri::command]
+#[specta::specta]
+pub fn apply_enterprise_ui_visibility(app: tauri::AppHandle) {
+    let hidden = crate::enterprise_policy::is_app_ui_hidden();
+    persist_enterprise_hide_app(hidden);
+    crate::window::enforce_enterprise_ui_visibility(&app);
+}
+
 /// Read the enterprise admin API token (`team_api_token`) from
 /// `~/.screenpipe/enterprise.json`. Returns None when the file is
 /// missing, malformed, or the field is empty.

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
@@ -29,6 +29,67 @@ pub fn finalize_webview_window(window: tauri::WebviewWindow) -> tauri::WebviewWi
     window
 }
 
+/// Make the live app match the enterprise hidden-UI policy.
+///
+/// The startup window gate (`main.rs`) already honors `is_app_ui_hidden()` —
+/// but only when the policy is known *before* windows are created (env var or a
+/// bundled `enterprise.json`). When the admin flips "hide app" in the workspace
+/// policy, it reaches the device on the frontend's 5-minute poll and is pushed
+/// to Rust via `set_enterprise_policy` — long after the Home/Onboarding window
+/// has already been shown. `show()` then refuses *new* windows, but nothing
+/// retracts the ones already on screen, so the UI stayed visible.
+///
+/// This reconciles the running session with the current policy:
+///   * hidden  → order every user-facing window off-screen (so nothing is left
+///     visible) and drop the dock icon (macOS Accessory), then rebuild the tray
+///     so its "open app" entries disappear.
+///   * visible → restore the normal activation policy + full tray menu; windows
+///     reopen on demand via the tray/shortcut.
+///
+/// Permission-recovery is intentionally never hidden — a managed background
+/// device may still need the macOS permission flow to surface.
+///
+/// Windows are *hidden* (orderOut / `hide()`), never closed: closing the
+/// class-swizzled NSPanels (main/chat/search) risks a use-after-free SIGSEGV
+/// (see the close path in `show.rs`), and hiding keeps the webviews warm for a
+/// later policy reversal.
+pub fn enforce_enterprise_ui_visibility(app: &tauri::AppHandle) {
+    use tauri::Manager;
+
+    let hidden = crate::enterprise_policy::is_app_ui_hidden();
+
+    // The enterprise policy hook calls this on every 5-min poll. Only do work
+    // on an actual transition — otherwise we'd hide-already-hidden windows and
+    // (worse) rebuild the tray every poll, flickering the menu-bar icon.
+    // -1 = unknown (first call), 0 = visible, 1 = hidden.
+    static LAST_APPLIED: std::sync::atomic::AtomicI8 = std::sync::atomic::AtomicI8::new(-1);
+    let next = if hidden { 1 } else { 0 };
+    if LAST_APPLIED.swap(next, std::sync::atomic::Ordering::SeqCst) == next {
+        return;
+    }
+
+    if hidden {
+        let recovery = show::RewindWindowId::PermissionRecovery.label();
+        for (label, window) in app.webview_windows() {
+            if label.as_str() == recovery {
+                continue;
+            }
+            let _ = window.hide();
+        }
+        #[cfg(target_os = "macos")]
+        panel::MAIN_PANEL_SHOWN.store(false, std::sync::atomic::Ordering::SeqCst);
+        tracing::info!("enterprise: hidden-UI policy enforced — app windows hidden");
+    }
+
+    // Always re-apply the activation policy + tray so a policy change in EITHER
+    // direction is reflected immediately (Accessory+minimal tray when hidden,
+    // Regular+full tray when not).
+    #[cfg(target_os = "macos")]
+    panel::reset_to_regular_and_refresh_tray(app);
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    crate::tray::recreate_tray(app);
+}
+
 // These re-exports preserve the original public API surface. Some are only
 // consumed inside the `window` sub-modules (via `super::`) but external
 // callers (commands.rs, space_monitor.rs, etc.) may also reference them.


### PR DESCRIPTION
## problem

The enterprise **"hide app"** policy is supposed to make the app run as an invisible managed-background agent — no windows, no dock icon. But it only worked when the policy was known **before** windows were created (the `SCREENPIPE_ENTERPRISE_HIDE_APP` env var or a bundled `enterprise.json`).

When an admin turns on "hide app" in the **workspace policy**, it reaches the device on the frontend's 5-minute poll and is pushed to Rust via `set_enterprise_policy()` — which only updates a process-global set of hidden sections. From then on `window.show()` refuses *new* windows… but **nothing retracts the Home/Onboarding window already on screen**. So the UI stayed visible. That's the *"it doesn't hide the ui"* report.

```
BEFORE
──────
launch ─▶ Home window shown ─▶ (1-2s) policy poll says "hide app"
                                         │
                                         ▼
                              set_enterprise_policy()   ← updates state only
                                         │
                                         ▼
                              new show() calls blocked  ✅
                              window already on screen   ❌ still visible
                              dock icon                  ❌ still there
```

## fix

Add a reconciliation step that runs the instant the policy is pushed:

```
AFTER
─────
set_enterprise_policy()  ─▶  apply_enterprise_ui_visibility()
                                  │
                                  ├─ hide every user-facing window (orderOut/hide)   ✅ invisible
                                  ├─ macOS: drop dock icon (Accessory)               ✅ no dock
                                  ├─ rebuild tray (no "open app" entries)            ✅
                                  └─ persist hide_app → ~/.screenpipe/enterprise.json
                                          │
                                          ▼
                                   next launch starts hidden BEFORE any window renders  ✅ no flash
```

- New Tauri command **`apply_enterprise_ui_visibility`**, called by the enterprise policy hook right after `setEnterprisePolicy`. Hides every open window (except permission-recovery, which a managed device may still need), switches macOS to `Accessory` (no dock icon), and rebuilds the tray so its "open app" items disappear — **immediately, no restart**.
- Windows are **hidden** (`orderOut` / `hide()`), never closed: closing the class-swizzled NSPanels (main/chat/search) risks a use-after-free SIGSEGV (see the close path in `show.rs`), and hiding keeps the webviews warm for a later policy reversal.
- It also persists the resolved decision into `~/.screenpipe/enterprise.json` (`hide_app`) — the same file `enterprise_policy::enterprise_json_hides_app_ui()` already reads at boot — so the **next launch starts hidden before any window renders** (no UI flash). A bundled MDM `enterprise.json` keeps precedence.
- **Reversible:** when the policy turns hidden-UI off, the activation policy + full tray menu are restored and `hide_app` is cleared.

## files
- `src-tauri/src/window/mod.rs` — `enforce_enterprise_ui_visibility()` helper
- `src-tauri/src/commands.rs` — `apply_enterprise_ui_visibility` command + `persist_enterprise_hide_app` helper
- `lib/hooks/use-enterprise-policy.ts` — call it right after pushing the policy
- `lib/utils/tauri.ts` — generated binding for the new command

## testing
- `cargo check -p screenpipe-app` passes.
- `cargo fmt --all --check` clean for the changed files.
- Existing `enterprise_policy` unit tests cover `is_app_ui_hidden()` and are untouched (the `set_enterprise_policy` signature is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)