### PR TITLE
fix(ocr): catch_unwind around tesseract so it can't crash the worker (CLI-V3/T0)

### DIFF
--- a/crates/screenpipe-screen/src/tesseract.rs
+++ b/crates/screenpipe-screen/src/tesseract.rs
@@ -132,11 +132,28 @@ pub fn perform_ocr_tesseract(
         }
     };
 
-    // Extract data output
-    let data_output = match rusty_tesseract::image_to_data(&ocr_image, &args) {
-        Ok(data) => data,
-        Err(e) => {
+    // Extract data output.
+    //
+    // rusty_tesseract shells out to the `tesseract` binary and unwraps its
+    // output internally; when the binary is missing or misbehaving (common on
+    // Linux without a system tesseract) it PANICS with `Option::unwrap()` on a
+    // `None` value (rusty-tesseract command.rs:108) rather than returning Err,
+    // taking down the calling worker. Guard with catch_unwind so a panic becomes
+    // an empty OCR result instead of an unwind — the established pattern for
+    // panicky deps (fbank #4159, ort #3290). SCREENPIPE-CLI-V3 / CLI-T0.
+    let ocr_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        rusty_tesseract::image_to_data(&ocr_image, &args)
+    }));
+    let data_output = match ocr_result {
+        Ok(Ok(data)) => data,
+        Ok(Err(e)) => {
             warn!("tesseract: OCR failed: {}", e);
+            return (String::new(), "[]".to_string(), None);
+        }
+        Err(_) => {
+            warn!(
+                "tesseract: OCR panicked (tesseract binary missing or misbehaving) — skipping frame"
+            );
             return (String::new(), "[]".to_string(), None);
         }
     };
@@ -246,5 +263,18 @@ mod tests {
         let (bin_dir, tessdata) = bundled_tesseract(dir.path()).expect("binary present");
         assert_eq!(bin_dir, dir.path());
         assert_eq!(tessdata, Some(dir.path().join("tessdata")));
+    }
+
+    // SCREENPIPE-CLI-V3 / CLI-T0: rusty_tesseract panics (unwrap on None) when
+    // the tesseract binary is unavailable. perform_ocr_tesseract must absorb that
+    // via catch_unwind and return an empty result instead of unwinding the
+    // worker. Runs whether or not tesseract is installed: missing → exercises the
+    // catch_unwind path; present → normal OCR of a blank image. Either way it
+    // must return (not panic) with structured JSON.
+    #[test]
+    fn perform_ocr_tesseract_is_panic_safe() {
+        let img = image::DynamicImage::ImageRgb8(image::RgbImage::new(8, 8));
+        let (_text, json, _conf) = perform_ocr_tesseract(&img, vec![]);
+        assert!(json.starts_with('['), "expected JSON array, got: {json}");
     }
 }


### PR DESCRIPTION
## Problem — SCREENPIPE-CLI-V3 / CLI-T0 (Linux, ~22 users, firing today)

`panic on thread 'tokio-rt-worker' at rusty-tesseract/src/tesseract/command.rs:108:43: called Option::unwrap() on a None value`

`rusty_tesseract` shells out to the `tesseract` binary and unwraps its output internally. When the binary is **missing or misbehaving** (common on Linux without a system tesseract) it **panics** instead of returning `Err`, unwinding the calling tokio worker rather than just failing the one frame. CLI-T0 is the same panic without symbolication (identical Linux + tesseract breadcrumbs).

## Fix

Wrap the `image_to_data` call in `std::panic::catch_unwind(AssertUnwindSafe(…))` and fall back to the existing empty-OCR result `(String::new(), "[]", None)` on panic — the **established pattern for panicky deps** in this repo (fbank #4159, ort #3290). The frame yields no text instead of taking down the worker.

```rust
let ocr_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
    rusty_tesseract::image_to_data(&ocr_image, &args)
}));
match ocr_result {
    Ok(Ok(data)) => data,
    Ok(Err(e)) => { warn!("tesseract: OCR failed: {e}"); return (…empty…); }
    Err(_)      => { warn!("tesseract: OCR panicked …"); return (…empty…); }
}
```

## Tests

`cargo test -p screenpipe-screen tesseract::` → **4 pass**, incl. new `perform_ocr_tesseract_is_panic_safe` (calls `perform_ocr_tesseract` on a blank image and asserts it returns structured JSON without unwinding — exercises the catch_unwind path when tesseract is absent). `rustfmt --edition 2021 --check` clean on pinned 1.93.1.

## Notes

Complements **#4386** (Linux CLI tesseract bundling), which *reduces* but can't fully prevent the missing-binary case. This is defense-in-depth so a panicking OCR call degrades to "no text on this frame" instead of crashing the worker. Ships next engine release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)