### PR TITLE
fix(artifacts): case-insensitive search query (unbreaks test-ubuntu on main)

### DIFF
--- a/crates/screenpipe-engine/src/routes/artifacts.rs
+++ b/crates/screenpipe-engine/src/routes/artifacts.rs
@@ -790,6 +790,13 @@ pub(crate) struct ArtifactListResponse {
 }
 
 fn artifact_matches_query(item: &ArtifactItem, q: &str) -> bool {
+    // Case-insensitive on BOTH sides: lowercase the query too, not just the
+    // fields. Without this, a query with any uppercase (e.g. "Weekly Summary")
+    // never matches because the haystack is lowercased but the needle isn't —
+    // case-sensitive artifact search. The HTTP caller already lowercases, so
+    // this is defensive (and is what the unit tests rely on).
+    let q = q.to_lowercase();
+    let q = q.as_str();
     item.title.to_lowercase().contains(q)
         || item.source.to_lowercase().contains(q)
         || item.path.to_lowercase().contains(q)


### PR DESCRIPTION
## Problem — `test-ubuntu` is RED on `main`, blocking every PR

`routes::artifacts::tests::chat_artifacts_visible_in_unified_listing` fails:
```
assertion failed: artifact_matches_query(&item, "Weekly Summary")
```
Every open PR branched off the affected `main` inherits the red `test-ubuntu` (confirmed: #4561/#4562/#4564 fail it; the fix is unrelated to their changes).

## Root cause

`artifact_matches_query` lowercases the item **fields** but not the **query**:
```rust
item.title.to_lowercase().contains(q)   // q is NOT lowercased
```
So `item.title.to_lowercase() == "weekly summary"`, `.contains("Weekly Summary")` → **false**. Artifact search is accidentally **case-sensitive on the query side** — any uppercase in the query misses. The HTTP caller happens to `map(str::to_lowercase)` before calling, so production search works by luck, but the unit test calls the function directly with a mixed-case query (the reasonable contract) and fails.

## Fix

Lowercase the query inside the function too — defensive, independent of any caller. Genuinely case-insensitive search + the test passes.

```rust
let q = q.to_lowercase();
let q = q.as_str();
item.title.to_lowercase().contains(q) || …
```

## Tests

`cargo test -p screenpipe-engine routes::artifacts::tests` → **33 pass**, incl. the previously-failing `chat_artifacts_visible_in_unified_listing`. `rustfmt --edition 2021 --check` clean.

Merging this turns `test-ubuntu` green again for the whole PR queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)