### PR TITLE
fix(slack): freshly connected Slack reads as disconnected (user-token shape)

### DIFF
--- a/crates/screenpipe-connect/src/oauth.rs
+++ b/crates/screenpipe-connect/src/oauth.rs
@@ -300,8 +300,22 @@ pub(crate) async fn load_oauth_json_with_instance(
     }
 }
 
+/// The usable bearer token from an OAuth JSON blob. Most providers store it at
+/// the top level, but Slack's user-token flow (`user_scope` only, no bot scope)
+/// nests it under `authed_user.access_token` and returns NO top-level
+/// `access_token` — so a freshly connected Slack account otherwise reads as
+/// unrecoverable and the whole connection looks dead. Checking both keeps
+/// connection-status and token reads working for Slack without a
+/// provider-specific branch in every caller. Other providers never populate
+/// `authed_user`, so the fallback is inert for them.
+fn oauth_access_token_str(v: &Value) -> Option<&str> {
+    v["access_token"]
+        .as_str()
+        .or_else(|| v["authed_user"]["access_token"].as_str())
+}
+
 fn oauth_json_has_valid_access_token(v: &Value) -> bool {
-    if v["access_token"].as_str().is_none() {
+    if oauth_access_token_str(v).is_none() {
         return false;
     }
 
@@ -403,7 +417,7 @@ pub async fn read_oauth_token_instance(
         }
     }
 
-    v["access_token"].as_str().map(String::from)
+    oauth_access_token_str(&v).map(String::from)
 }
 
 /// Check if an OAuth instance is recoverable — has a valid token or a
@@ -1525,6 +1539,33 @@ mod tests {
             .unwrap();
 
         assert!(is_oauth_instance_connected(Some(&store), id, None).await);
+    }
+
+    #[tokio::test]
+    async fn is_oauth_instance_connected_accepts_slack_nested_user_token() {
+        // Slack's user-token flow stores the usable token under
+        // authed_user.access_token with no top-level access_token and no
+        // refresh_token. Regression guard for #4286: a freshly connected
+        // Slack account must read as connected, not "default token is not
+        // recoverable".
+        let store = mem_store().await;
+        let id = "slack";
+        store
+            .set_json(
+                &format!("oauth:{}", id),
+                &json!({
+                    "authed_user": {"id": "U123", "access_token": "xoxp-user-token"},
+                    "team": {"name": "acme"},
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(is_oauth_instance_connected(Some(&store), id, None).await);
+        assert_eq!(
+            read_oauth_token_instance(Some(&store), id, None).await,
+            Some("xoxp-user-token".to_string()),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Symptom

\"Connect with Slack\" doesn't work. The OAuth dance completes — the app log even shows the success line — but the app immediately treats Slack as **not connected**: the UI never flips, and any send/test returns *\"not connected — use 'Connect with Slack' button\"*.

The backend log floods with:
```
WARN screenpipe_connect::oauth: oauth: slack default token is not recoverable, checking for a single healthy named instance
```
…even right after:
```
INFO screenpipe_app::oauth: OAuth connected: slack (instance=None, display=Some("screenpipe.com"))
```

## Root cause

Regression from #4286 (*"act as the user — no bot"*). Slack now requests `user_scope=chat:write` only (no bot scope), so Slack's OAuth response nests the usable token under `authed_user.access_token` and returns **no top-level `access_token` and no `refresh_token`**.

The generic recoverability gate only inspected the top level:

```rust
fn oauth_json_has_valid_access_token(v: &Value) -> bool {
    if v["access_token"].as_str().is_none() { return false; }  // ← Slack user token lives in authed_user
    ...
}
fn oauth_json_is_recoverable(v: &Value) -> bool {
    oauth_json_has_valid_access_token(v) || v["refresh_token"].as_str().is_some()  // ← also absent
}
```

So a perfectly valid Slack token in the default slot is judged *unrecoverable*:

| Caller | Result |
|---|---|
| `load_oauth_json("slack", None)` | `None` → logs `default token is not recoverable` |
| `is_oauth_instance_connected("slack")` (`connections_api.rs:552`) | `false` → UI shows disconnected |
| `slack.rs::test()` | never gets the JSON → `"not connected"` |

`slack.rs` already knows to read `authed_user.access_token`, but the generic gate rejects the token before `test()` runs.

## Fix

Add a small `oauth_access_token_str()` helper that falls back to `authed_user.access_token`, and use it in both the recoverability gate (`oauth_json_has_valid_access_token`) and `read_oauth_token_instance`. Other providers never populate `authed_user`, so the fallback is inert for them.

**Existing stored Slack tokens start working with no reconnect** — the token was always valid; only the read path was wrong.

## Test

New regression test `is_oauth_instance_connected_accepts_slack_nested_user_token`: a Slack-shaped blob with only `authed_user.access_token` (no top-level token, no refresh token) reads as connected and yields the user token. Full `screenpipe-connect` oauth suite (58 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)