### PR TITLE
Fix chat grouping, menu overflow, header, and inspector state

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/chat-sidebar-grouping.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/chat-sidebar-grouping.test.ts
@@ -409,10 +409,10 @@ describe("applySidebarRecentsCap", () => {
     const result = applySidebarRecentsCap(sections, new Set(), 15);
     expect(result.map((section) => section.title)).toEqual(["product", "other"]);
     expect(result[0].items).toHaveLength(2);
-    expect(result[1].items).toHaveLength(11);
+    expect(result[1].items).toHaveLength(13);
   });
 
-  it("counts a collapsed manual group as one visible row", () => {
+  it("counts a collapsed manual group as zero visible rows", () => {
     const sections = buildSidebarRecentsSections([
       ...Array.from({ length: 5 }, (_, i) =>
         s(`m-${i}`, `manual ${i}`, undefined, "product"),
@@ -431,7 +431,7 @@ describe("applySidebarRecentsCap", () => {
     expect(result[0].title).toBe("product");
     expect(result[0].items).toHaveLength(0);
     expect(result[1].title).toBe("other");
-    expect(result[1].items).toHaveLength(13);
+    expect(result[1].items).toHaveLength(15);
   });
 
   it("treats a pipe group row as one visible row regardless of child count", () => {

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -417,7 +417,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
       cancelled = true;
       for (const unlisten of unlistenFns) unlisten();
     };
-  }, []);
+  }, [actions]);
 
   const runningPipes = useRunningPipes();
   const {
@@ -2048,8 +2048,9 @@ function RowMenuItems({
   existingGroups?: string[];
 }) {
   const P = ROW_MENU_PARTS[variant];
+  const { isMac } = usePlatform();
   const itemCls = "text-[11px] h-[30px] px-2 gap-2 rounded-none focus:bg-muted/30";
-  const groupItemCls = "text-[11px] h-[30px] px-2 rounded-none focus:bg-muted/30";
+  const groupItemCls = "min-w-0 text-[11px] h-[30px] px-2 rounded-none whitespace-nowrap focus:bg-muted/30";
   const shortcutCls = "text-[10px] tracking-normal text-muted-foreground/55";
   return (
     <>
@@ -2087,49 +2088,62 @@ function RowMenuItems({
             Move to group
           </P.SubTrigger>
           <P.SubContent
-            className="w-[156px] p-1 rounded-none border border-border bg-background shadow-none"
+            className="w-[196px] rounded-none border border-border bg-background p-0 shadow-none overflow-hidden"
             data-testid={`chat-row-move-to-group-menu-${session.id}`}
           >
-            {availableMoveGroups.map((g) => (
+            {availableMoveGroups.length > 0 && (
+              <div
+                className={cn(
+                  "max-h-[min(18rem,calc(100vh-10rem))] overflow-y-auto overflow-x-hidden overscroll-contain p-1",
+                  isMac ? "scrollbar-minimal" : "scrollbar-hide"
+                )}
+              >
+                {availableMoveGroups.map((g) => (
+                  <P.Item
+                    key={g}
+                    className={groupItemCls}
+                    onSelect={(e: Event) => {
+                      e.stopPropagation();
+                      onMoveToGroup(session.id, g);
+                    }}
+                  >
+                    <span className="block flex-1 truncate" title={g}>
+                      {g}
+                    </span>
+                  </P.Item>
+                ))}
+              </div>
+            )}
+            <div className="p-1">
+              {session.sidebarGroup && (
+                <>
+                  {availableMoveGroups.length > 0 && (
+                    <P.Separator className="my-1 bg-border/70" />
+                  )}
+                  <P.Item
+                    className={groupItemCls}
+                    onSelect={(e: Event) => {
+                      e.stopPropagation();
+                      onMoveToGroup(session.id, undefined);
+                    }}
+                  >
+                    Remove from group
+                  </P.Item>
+                </>
+              )}
+              {(availableMoveGroups.length > 0 || session.sidebarGroup) && (
+                <P.Separator className="my-1 bg-border/70" />
+              )}
               <P.Item
-                key={g}
                 className={groupItemCls}
                 onSelect={(e: Event) => {
                   e.stopPropagation();
-                  onMoveToGroup(session.id, g);
+                  onNewGroupRequest?.(session.id);
                 }}
               >
-                {g}
+                New group...
               </P.Item>
-            ))}
-            {session.sidebarGroup && (
-              <>
-                {availableMoveGroups.length > 0 && (
-                  <P.Separator className="my-1 bg-border/70" />
-                )}
-                <P.Item
-                  className={groupItemCls}
-                  onSelect={(e: Event) => {
-                    e.stopPropagation();
-                    onMoveToGroup(session.id, undefined);
-                  }}
-                >
-                  Remove from group
-                </P.Item>
-              </>
-            )}
-            {(availableMoveGroups.length > 0 || session.sidebarGroup) && (
-              <P.Separator className="my-1 bg-border/70" />
-            )}
-            <P.Item
-              className={groupItemCls}
-              onSelect={(e: Event) => {
-                e.stopPropagation();
-                onNewGroupRequest?.(session.id);
-              }}
-            >
-              New group...
-            </P.Item>
+            </div>
           </P.SubContent>
         </P.Sub>
       )}

--- a/apps/screenpipe-app-tauri/components/chat/chat-history-view.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/chat-history-view.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { emit, listen } from "@tauri-apps/api/event";
 import { Archive, CheckSquare, FolderOpen, Loader2, MessageSquare, MoreVertical, Pin, Plus, Search, Trash2, Undo2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { usePlatform } from "@/lib/hooks/use-platform";
 import { isConversationHistorySyncPrompt } from "@/lib/chat-utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -62,6 +63,7 @@ export function ChatHistoryView({
   onNewChat: () => void;
   onSelectConversation: (conversationId: string) => void;
 }) {
+  const { isMac } = usePlatform();
   const [tab, setTab] = useState<HistoryTab>("active");
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);
@@ -522,38 +524,51 @@ export function ChatHistoryView({
                     <FolderOpen className="h-3 w-3 text-muted-foreground" />
                     Move to group
                   </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="w-[156px] p-1 rounded-none border border-border bg-background shadow-none">
-                    {availableMoveGroups.map((g) => (
-                        <DropdownMenuItem
-                          key={g}
-                          className="text-[11px] h-[30px] px-2 rounded-none focus:bg-muted/30"
-                          onSelect={() => void handleMoveToGroup(conv.id, g)}
-                        >
-                          {g}
-                        </DropdownMenuItem>
-                      ))}
-                    {currentSidebarGroup && (
-                      <>
-                        {availableMoveGroups.length > 0 && (
-                          <DropdownMenuSeparator className="my-1 bg-border/70" />
+                  <DropdownMenuSubContent className="w-[196px] rounded-none border border-border bg-background p-0 shadow-none overflow-hidden">
+                    {availableMoveGroups.length > 0 && (
+                      <div
+                        className={cn(
+                          "max-h-[min(18rem,calc(100vh-10rem))] overflow-y-auto overflow-x-hidden overscroll-contain p-1",
+                          isMac ? "scrollbar-minimal" : "scrollbar-hide"
                         )}
-                        <DropdownMenuItem
-                          className="text-[11px] h-[30px] px-2 rounded-none focus:bg-muted/30"
-                          onSelect={() => void handleMoveToGroup(conv.id, undefined)}
-                        >
-                          Remove from group
-                        </DropdownMenuItem>
-                      </>
+                      >
+                        {availableMoveGroups.map((g) => (
+                          <DropdownMenuItem
+                            key={g}
+                            className="min-w-0 text-[11px] h-[30px] px-2 rounded-none whitespace-nowrap focus:bg-muted/30"
+                            onSelect={() => void handleMoveToGroup(conv.id, g)}
+                          >
+                            <span className="block flex-1 truncate" title={g}>
+                              {g}
+                            </span>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
                     )}
-                    {(availableMoveGroups.length > 0 || currentSidebarGroup) && (
-                      <DropdownMenuSeparator className="my-1 bg-border/70" />
-                    )}
-                    <DropdownMenuItem
-                      className="text-[11px] h-[30px] px-2 rounded-none focus:bg-muted/30"
-                      onSelect={() => setNewGroupSessionId(conv.id)}
-                    >
-                      New group...
-                    </DropdownMenuItem>
+                    <div className="p-1">
+                      {currentSidebarGroup && (
+                        <>
+                          {availableMoveGroups.length > 0 && (
+                            <DropdownMenuSeparator className="my-1 bg-border/70" />
+                          )}
+                          <DropdownMenuItem
+                            className="text-[11px] h-[30px] px-2 rounded-none whitespace-nowrap focus:bg-muted/30"
+                            onSelect={() => void handleMoveToGroup(conv.id, undefined)}
+                          >
+                            Remove from group
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {(availableMoveGroups.length > 0 || currentSidebarGroup) && (
+                        <DropdownMenuSeparator className="my-1 bg-border/70" />
+                      )}
+                      <DropdownMenuItem
+                        className="text-[11px] h-[30px] px-2 rounded-none whitespace-nowrap focus:bg-muted/30"
+                        onSelect={() => setNewGroupSessionId(conv.id)}
+                      >
+                        New group...
+                      </DropdownMenuItem>
+                    </div>
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
                 {!conv.hidden ? (

--- a/apps/screenpipe-app-tauri/components/chat/standalone/standalone-chat-header.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/standalone-chat-header.tsx
@@ -8,10 +8,12 @@ import { History, Plus } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Button } from "@/components/ui/button";
 import { ChatTitleMenu } from "@/components/chat/standalone/chat-title-menu";
-import { formatShortcutDisplay } from "@/lib/chat-utils";
+import { formatShortcutDisplay, isConversationHistorySyncPrompt, isInjectedTitleSourcePrompt } from "@/lib/chat-utils";
+import { isPlaceholderConversationTitle } from "@/lib/chat/message-rendering";
 import { cn } from "@/lib/utils";
 import type { Message } from "@/lib/chat/types";
 import { useChatStore } from "@/lib/stores/chat-store";
+import { deriveFallbackConversationTitle } from "@/lib/utils/chat-title";
 
 interface StandaloneChatHeaderProps {
   className?: string;
@@ -53,18 +55,34 @@ export function StandaloneChatHeader({
   startNewConversation,
   onNewChat,
 }: StandaloneChatHeaderProps) {
-  const hasChatTitle = useChatStore((s) => {
-    if (!conversationId) return false;
-    const session = s.sessions[conversationId];
-    return !!(session?.streamingTitle || session?.title);
-  }) || messages.length > 0;
+  const storeTitle = useChatStore((s) =>
+    conversationId ? s.sessions[conversationId]?.title : undefined
+  );
+  const streamingTitle = useChatStore((s) =>
+    conversationId ? s.sessions[conversationId]?.streamingTitle : undefined
+  );
+  const firstUserMsg = messages.find(
+    (m) => m.role === "user" && !isInjectedTitleSourcePrompt(m.content)
+  );
+  const derivedTitle = firstUserMsg
+    ? deriveFallbackConversationTitle(firstUserMsg)
+    : undefined;
+  const hasMessages = messages.length > 0;
+  const visibleTitle =
+    streamingTitle ||
+    (storeTitle &&
+      !isPlaceholderConversationTitle(storeTitle) &&
+      !isConversationHistorySyncPrompt(storeTitle)
+        ? storeTitle
+        : derivedTitle || (hasMessages ? "untitled" : ""));
+  const useCompactHeaderPadding = !className || Boolean(conversationId && visibleTitle);
 
   return (
     <div
       className={cn(
         "relative flex items-center gap-3 px-4 py-3.5 border-b border-border/50 bg-gradient-to-r from-background to-muted/30",
         !className && "cursor-grab active:cursor-grabbing",
-        (!className || (conversationId && hasChatTitle)) && "py-0.5",
+        useCompactHeaderPadding && "py-0.5",
         sidebarCollapsed && conversationId && messages.length > 0 && "!pl-[58px]",
         sidebarCollapsed && isMac && !isFullscreen && "!pl-[128px]",
         !className && isMac && !isFullscreen && "!pl-[78px]"

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -483,14 +483,14 @@ export function StandaloneChat({
   const sidePanelHasContent = filePreviewOpen || browserPanelState.hasUrl;
   const sidePanelOpen = activeSideView === "side" && sidePanelHasContent;
   const inspectorHasContent =
-    inspectorOpen ||
     inspectorOutputs.length > 0 ||
     inspectorSources.length > 0;
 
   useEffect(() => {
+    setInspectorOpen(false);
     setActiveSideView(null);
     setBrowserHiddenBehindInspector(false);
-  }, [conversationId]);
+  }, [conversationId, setInspectorOpen]);
 
   // Auto-show side panel when a file preview is opened externally
   // (e.g. clicking an artifact in the brain section emits

--- a/apps/screenpipe-app-tauri/components/ui/context-menu.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/context-menu.tsx
@@ -45,11 +45,12 @@ ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
 const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, collisionPadding = 8, ...props }, ref) => (
   <ContextMenuPrimitive.SubContent
     ref={ref}
+    collisionPadding={collisionPadding}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] max-w-[calc(100vw-1rem)] max-h-[calc(100vh-1rem)] overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -60,12 +61,13 @@ ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
 const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+>(({ className, collisionPadding = 8, ...props }, ref) => (
   <ContextMenuPrimitive.Portal>
     <ContextMenuPrimitive.Content
       ref={ref}
+      collisionPadding={collisionPadding}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] max-w-[calc(100vw-1rem)] max-h-[calc(100vh-1rem)] overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/apps/screenpipe-app-tauri/components/ui/dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/dialog.tsx
@@ -48,7 +48,7 @@ const DialogContent = React.forwardRef<
       ref={ref}
       className={cn(
         // Screenpipe Brand: Sharp corners, 1px border, no shadow, fast animation
-        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border border-border bg-background p-6 duration-150 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className
       )}
       {...props}

--- a/apps/screenpipe-app-tauri/components/ui/dropdown-menu.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/dropdown-menu.tsx
@@ -43,11 +43,12 @@ DropdownMenuSubTrigger.displayName =
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, collisionPadding = 8, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
+    collisionPadding={collisionPadding}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] max-w-[calc(100vw-1rem)] max-h-[calc(100vh-1rem)] overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -59,13 +60,14 @@ DropdownMenuSubContent.displayName =
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, collisionPadding = 8, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      collisionPadding={collisionPadding}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] max-w-[calc(100vw-1rem)] max-h-[calc(100vh-1rem)] overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/apps/screenpipe-app-tauri/lib/utils/chat-sidebar-grouping.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-sidebar-grouping.ts
@@ -327,8 +327,8 @@ export function buildSidebarRecentsSections(
  * sections.
  *
  * Counting rules:
- * - titled subsection header = 1 visible row
- * - collapsed subsection = header only
+ * - manual subsection headers do not consume the cap
+ * - collapsed manual subsections consume 0 rows
  * - top-level item inside an expanded subsection = 1 visible row
  * - pipe-group children do not count here; once the parent row is
  *   visible, expansion is a free reveal handled by the render layer
@@ -344,18 +344,14 @@ export function applySidebarRecentsCap(
   const capped: SidebarRecentsSection[] = [];
 
   for (const section of sections) {
-    if (remaining <= 0) break;
-
     const hasHeader = section.title.length > 0;
     const isCollapsed = hasHeader && collapsedSectionKeys.has(section.key);
 
-    if (hasHeader) {
-      if (remaining <= 0) break;
-      remaining -= 1;
-      if (isCollapsed) {
-        capped.push({ ...section, items: [] });
-        continue;
-      }
+    if (!hasHeader && remaining <= 0) break;
+
+    if (isCollapsed) {
+      capped.push({ ...section, items: [] });
+      continue;
     }
 
     const visibleItems: SidebarItem[] = [];


### PR DESCRIPTION
This PR fixes a set of related chat UI issues across the sidebar and standalone chat experience.

### Changes

- fixed the "Move to group" submenu so it stays within the viewport
- made only the group list scroll while keeping "Remove from group" and "New group..." fixed
- widened the submenu and prevented long group names from wrapping awkwardly
- tightened shared dropdown, context menu, and dialog bounds to prevent overflow
- improved standalone chat header title display and spacing
- fixed a bug where the inspector button could appear in a blank chat
- cleaned up chat sidebar grouping behavior and updated the related tests


### Testing

- checked the sidebar and chat history "Move to group" menus
- checked standalone chat header behavior
- checked blank chat inspector visibility
- updated grouping-related tests

Before - 


https://github.com/user-attachments/assets/5bd7d69c-f82a-4534-9e83-71fe8e1bbfcd



After -


https://github.com/user-attachments/assets/77bd81cf-0f8e-4a24-9203-2ad6a1790fd8

