### PR TITLE
fix(telemetry): filter unactionable mic-permission denial from Sentry (CLI-F4)

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -493,6 +493,12 @@ async fn main() -> anyhow::Result<()> {
                         [
                             // User hasn't granted screen recording permission (CLI-49)
                             r"Screen recording permission denied",
+                            // User hasn't granted microphone access — Windows WASAPI
+                            // E_ACCESSDENIED building the input stream (CLI-F4: top live
+                            // engine issue, 45 users / 200+ events). The OS (or another
+                            // app holding the device exclusively) refuses capture;
+                            // retrying can't clear it, so it's not an actionable bug.
+                            r"backend-specific error has occurred: Access is denied",
                             // Local DB corruption — user dropped/restored part of their db.sqlite
                             r"no such table: main\.speaker_embeddings",
                             // Concurrent DB access / user ran CLI while app was running


### PR DESCRIPTION
## Problem — SCREENPIPE-CLI-F4 (top live engine Sentry issue: 45 users / 200+ events)

On Windows the audio input stream fails to build with WASAPI `E_ACCESSDENIED`:
```
Failed to build input stream: A backend-specific error has occurred: Access is denied. (0x80070005)
```
That's the OS (mic-privacy off / per-app denied) or another app holding the device exclusively **refusing microphone access**. Retrying can never clear it — it's a user-environment condition, not a code bug — yet it's the **#1 engine Sentry issue by volume**, burying real signal.

## Fix — filter it where noise is already filtered

Add the pattern to the existing `before_send` `USER_ENV_PATTERNS` list in the CLI's Sentry init — the same mechanism already suppressing screen-recording-permission, port-conflict, `database is locked`, missing-dylib, etc. (all "user environment, not our bug").

```rust
// User hasn't granted microphone access — Windows WASAPI E_ACCESSDENIED … (CLI-F4)
r"backend-specific error has occurred: Access is denied",
```

**Why this over a code change:** an earlier draft classified the error in `core/stream.rs` with a per-device dedup (`Mutex`/`OnceLock`). Per review, adding shared mutable state to the audio module for a *log-dedup* is unnecessary risk — the right layer for telemetry noise is the Sentry filter. The event still logs locally (so it's diagnosable via "send logs"); only the Sentry upload is dropped. Zero audio-path code.

## Tests
- Regex verified: matches the exact CLI-F4 message, does **not** match unrelated build errors (e.g. "device not found").
- `cargo check -p screenpipe-engine --bin screenpipe` clean; `rustfmt --edition 2021 --check` clean.

## Follow-up (not in this PR)
The real UX win is a user-facing "enable microphone access in OS privacy settings" toast (audio device event → app notification bridge). That needs frontend wiring + a Windows host to verify, so it's a deliberate follow-up rather than something shipped unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)