### PR TITLE
fix(ui): make sidebar recording dot visible in light mode (translucent sidebar)

### DIFF
--- a/apps/screenpipe-app-tauri/components/recording-status.tsx
+++ b/apps/screenpipe-app-tauri/components/recording-status.tsx
@@ -137,10 +137,16 @@ export function RecordingStatus({
                 aria-hidden="true"
                 className={cn(
                   "h-2 w-2 rounded-full transition-all",
+                  // Drive the dot color off `currentColor` so it follows the
+                  // theme on the translucent sidebar: `vibrant-sidebar-fg`
+                  // resolves to black in light mode and white in dark mode
+                  // (with the same pre-JS system-preference fallbacks the rest
+                  // of the vibrant sidebar uses). A hardcoded white dot was
+                  // invisible on the light translucent background.
                   isTranslucent
                     ? allActive
-                      ? "bg-white"
-                      : "border border-white bg-transparent"
+                      ? "vibrant-sidebar-fg bg-current"
+                      : "vibrant-sidebar-fg border border-current bg-transparent"
                     : allActive
                       ? "bg-foreground"
                       : "border border-foreground bg-transparent",


### PR DESCRIPTION
## what

the recording status dot in the sidebar header was invisible in **light mode** when the **translucent (vibrant) sidebar** is on — it's the small dot next to the search icon.

| before | after |
|---|---|
| white dot on a light translucent background ≈ invisible | dot follows the theme foreground (black in light mode) |

![before / after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-sidebar-dot/dot-before-after.png)

> visual is a faithful mockup of the light-mode translucent sidebar header (real `rgba(255,255,255,0.08)` + backdrop blur, real lucide icons).

## why

`recording-status.tsx` hardcoded `bg-white` / `border-white` whenever `isTranslucent` was true. that's right for dark mode but produces white-on-light in light mode. every other element in the vibrant sidebar already uses theme-aware helper classes — the dot was the odd one out.

## how

drive the dot color off `currentColor` via the existing `vibrant-sidebar-fg` helper, so it resolves to **black in light mode** and **white in dark mode**, including the same pre-JS `prefers-color-scheme` fallbacks the rest of the vibrant sidebar relies on. opaque-sidebar behavior is unchanged (`bg-foreground`).

```diff
   isTranslucent
     ? allActive
-      ? "bg-white"
-      : "border border-white bg-transparent"
+      ? "vibrant-sidebar-fg bg-current"
+      : "vibrant-sidebar-fg border border-current bg-transparent"
     : allActive
       ? "bg-foreground"
       : "border border-foreground bg-transparent",
```

solid = recording, hollow = paused, pulse = meeting — all preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
