### PR TITLE
feat(connections): one-click MCP OAuth for 10 connectors — no API key

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -3278,6 +3278,32 @@ function ApiIntegrationPanel({ integration, onRefresh }: {
 
 const KRISP_MCP_URL = "https://mcp.krisp.ai/mcp";
 const PLAUD_MCP_URL = "https://mcp.plaud.ai/mcp";
+// Providers that run a first-party remote MCP server whose OAuth supports
+// Dynamic Client Registration (RFC 7591). For these, the tile connects in
+// one click via OAuthMcpPanel — no API key and no human-created
+// client_id/secret — replacing the old API-key form (or the connector
+// OAuth flow + its registered app). URLs are the streamable-HTTP endpoint
+// (/mcp), NOT the legacy /sse transport the engine can't drive. Each id
+// must match a registered connector id so it lands on the right tile.
+// (DCR support verified live against each provider's OAuth metadata.)
+const MCP_OAUTH_PROVIDERS: {
+  id: string;
+  name: string;
+  url: string;
+  description: React.ReactNode;
+}[] = [
+  { id: "linear", name: "Linear", url: "https://mcp.linear.app/mcp", description: <>Connect Linear so your AI can search and manage your issues, projects, and cycles. Sign-in uses Linear&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "stripe", name: "Stripe", url: "https://mcp.stripe.com", description: <>Connect Stripe so your AI can query your customers, payments, invoices, and subscriptions. Sign-in uses Stripe&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "sentry", name: "Sentry", url: "https://mcp.sentry.dev/mcp", description: <>Connect Sentry so your AI can search your issues, events, and releases. Sign-in uses Sentry&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "intercom", name: "Intercom", url: "https://mcp.intercom.com/mcp", description: <>Connect Intercom so your AI can search your conversations, contacts, and help content. Sign-in uses Intercom&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "asana", name: "Asana", url: "https://mcp.asana.com/mcp", description: <>Connect Asana so your AI can search and manage your tasks, projects, and portfolios. Sign-in uses Asana&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "monday", name: "monday.com", url: "https://mcp.monday.com/mcp", description: <>Connect monday.com so your AI can work with your boards, items, and updates. Sign-in uses monday&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "clickup", name: "ClickUp", url: "https://mcp.clickup.com/mcp", description: <>Connect ClickUp so your AI can search and manage your tasks, docs, and spaces. Sign-in uses ClickUp&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "airtable", name: "Airtable", url: "https://mcp.airtable.com/mcp", description: <>Connect Airtable so your AI can read and update your bases, tables, and records. Sign-in uses Airtable&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "confluence", name: "Confluence", url: "https://mcp.atlassian.com/v1/mcp", description: <>Connect Atlassian so your AI can search and edit your Confluence pages (and Jira issues). Sign-in uses Atlassian&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "jira", name: "Jira", url: "https://mcp.atlassian.com/v1/mcp", description: <>Connect Atlassian so your AI can search and manage your Jira issues (and Confluence pages). Sign-in uses Atlassian&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+  { id: "notion", name: "Notion", url: "https://mcp.notion.com/mcp", description: <>Connect Notion so your AI can search, read, and write your pages and databases. Sign-in uses Notion&apos;s OAuth — no API key, and screenpipe never sees your password.</> },
+];
 // Excalidraw+ exposes the workspace (scenes, collections, search) over a
 // remote MCP gated by a static API key, not OAuth (no discovery metadata on
 // the host), so it uses the ApiKeyMcpPanel below instead of OAuthMcpPanel.
@@ -3763,6 +3789,8 @@ export function ConnectionsSection({
   const [customMcpEnabledCount, setCustomMcpEnabledCount] = useState(0);
   const [krispConnected, setKrispConnected] = useState(false);
   const [plaudConnected, setPlaudConnected] = useState(false);
+  // Per-provider connection status for the MCP-OAuth tiles (keyed by id).
+  const [mcpProviderConnected, setMcpProviderConnected] = useState<Record<string, boolean>>({});
   const [excalidrawConnected, setExcalidrawConnected] = useState(false);
   const [importedSkillsCount, setImportedSkillsCount] = useState(0);
 
@@ -3809,6 +3837,7 @@ export function ConnectionsSection({
         setCustomMcpEnabledCount(0);
         setKrispConnected(false);
         setPlaudConnected(false);
+        setMcpProviderConnected({});
         setExcalidrawConnected(false);
         return;
       }
@@ -3820,6 +3849,10 @@ export function ConnectionsSection({
       setCustomMcpConnected(enabled.length > 0);
       setKrispConnected(list.some(s => s.enabled && (s.url ?? "").replace(/\/+$/, "") === KRISP_MCP_URL));
       setPlaudConnected(list.some(s => s.enabled && (s.url ?? "").replace(/\/+$/, "") === PLAUD_MCP_URL));
+      const enabledUrls = new Set(list.filter(s => s.enabled).map(s => (s.url ?? "").replace(/\/+$/, "")));
+      setMcpProviderConnected(Object.fromEntries(
+        MCP_OAUTH_PROVIDERS.map(p => [p.id, enabledUrls.has(p.url.replace(/\/+$/, ""))])
+      ));
       setExcalidrawConnected(list.some(s => s.enabled && (s.url ?? "").replace(/\/+$/, "") === EXCALIDRAW_MCP_URL));
     }).catch(() => {
       setCustomMcpConnected(false);
@@ -3827,6 +3860,7 @@ export function ConnectionsSection({
       setCustomMcpEnabledCount(0);
       setKrispConnected(false);
       setPlaudConnected(false);
+      setMcpProviderConnected({});
       setExcalidrawConnected(false);
     });
     if (typeof window !== "undefined" && platform() === "macos") {
@@ -3951,7 +3985,12 @@ export function ConnectionsSection({
         id: i.id,
         name: i.name,
         icon: i.icon,
-        connected: i.connected,
+        // MCP-OAuth providers connect via their remote MCP server. The dot
+        // lights for the MCP connection OR an existing API-key/connector-OAuth
+        // connection, so users who connected the old way don't appear to lose it.
+        connected: MCP_OAUTH_PROVIDERS.some(p => p.id === i.id)
+          ? (!!mcpProviderConnected[i.id] || i.connected)
+          : i.connected,
         category: normalizeConnectionCategory(i.category),
         description: i.description || undefined,
       }));
@@ -3982,7 +4021,7 @@ export function ConnectionsSection({
       category: CONNECTION_CATEGORY_BY_ID[tile.id] ?? tile.category ?? "Other",
       description: tile.description ?? CONNECTION_HARDCODED_DESCRIPTIONS[tile.id],
     }));
-  }, [os, claudeInstalled, cursorInstalled, codexInstalled, grokInstalled, chatgptConnected, browserUrlConnected, browserUrlDetected, integrations, appleCalendarConnected, googleCalendarConnected, googleDocsConnected, googleSheetsConnected, gmailConnected, customMcpConnected, customMcpServerCount, krispConnected, plaudConnected, excalidrawConnected, importedSkillsCount, detectedConnectionIds]);
+  }, [os, claudeInstalled, cursorInstalled, codexInstalled, grokInstalled, chatgptConnected, browserUrlConnected, browserUrlDetected, integrations, appleCalendarConnected, googleCalendarConnected, googleDocsConnected, googleSheetsConnected, gmailConnected, customMcpConnected, customMcpServerCount, krispConnected, plaudConnected, mcpProviderConnected, excalidrawConnected, importedSkillsCount, detectedConnectionIds]);
 
   const isDefaultView = !search.trim() && categoryFilter === ALL_CONNECTION_CATEGORIES;
 
@@ -4037,6 +4076,54 @@ export function ConnectionsSection({
 
   const renderPanel = () => {
     if (!selected) return null;
+    // Providers with a first-party remote MCP (OAuth + DCR) connect in one
+    // click — this intercepts both old API-key tiles (Linear, Stripe, …) and
+    // connector-OAuth tiles (Notion, Jira) before the switch below.
+    const mcpProvider = MCP_OAUTH_PROVIDERS.find(p => p.id === selected);
+    if (mcpProvider) {
+      // Anyone already connected the old way (API key, or connector OAuth for
+      // Notion/Jira) keeps that connection — the credential and pipes are
+      // untouched. Surface it under an "advanced" disclosure so they can still
+      // see/rotate/remove it; otherwise the one-click OAuth is the primary path.
+      const existing = selectedIntegration;
+      const hasManual = !!existing && (existing.is_oauth || existing.fields.length > 0);
+      return (
+        <div className="space-y-3">
+          <OAuthMcpPanel
+            name={mcpProvider.name}
+            mcpUrl={mcpProvider.url}
+            description={mcpProvider.description}
+            onConnected={() => setMcpProviderConnected(m => ({ ...m, [mcpProvider.id]: true }))}
+            onDisconnected={() => setMcpProviderConnected(m => ({ ...m, [mcpProvider.id]: false }))}
+          />
+          {hasManual && existing && (
+            <details open={existing.connected && !mcpProviderConnected[mcpProvider.id]}>
+              <summary className="text-[11px] text-muted-foreground cursor-pointer select-none hover:text-foreground">
+                advanced: {existing.connected
+                  ? "manage your existing connection"
+                  : "connect with an API key instead"}
+              </summary>
+              <div className="pt-2">
+                {existing.is_oauth ? (
+                  <OAuthPanel
+                    integrationId={existing.id}
+                    integrationName={existing.name}
+                    supportsOAuthInstances={!!existing.supports_oauth_instances}
+                    onConnected={() => refreshIntegrationConnection(existing.id, true)}
+                    onDisconnected={() => refreshIntegrationConnection(existing.id, false)}
+                  />
+                ) : (
+                  <ApiIntegrationPanel
+                    integration={existing}
+                    onRefresh={fetchIntegrations}
+                  />
+                )}
+              </div>
+            </details>
+          )}
+        </div>
+      );
+    }
     switch (selected) {
       case "claude": return <ClaudePanel
         onConnected={() => setClaudeInstalled(true)}

--- a/apps/screenpipe-app-tauri/lib/__tests__/mcp-registry.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/mcp-registry.test.ts
@@ -226,4 +226,24 @@ describe("RECOMMENDED_SERVERS", () => {
       expect(displayName(s)).toBe(s.title);
     }
   });
+
+  it("only lists remotes the engine can drive (streamable HTTP, no legacy /sse)", () => {
+    // The engine's MCP client speaks streamable HTTP + stdio only. A legacy
+    // /sse endpoint would pass installKind() but fail at connect/OAuth time.
+    for (const s of RECOMMENDED_SERVERS) {
+      const remote = pickHttpRemote(s);
+      if (!remote) continue;
+      expect(
+        normalizeUrl(remote.url).endsWith("/sse"),
+        `${s.name} points at a legacy /sse endpoint`,
+      ).toBe(false);
+    }
+  });
+
+  it("maps Linear to its streamable-http MCP endpoint", () => {
+    const linear = RECOMMENDED_SERVERS.find((s) => s.title === "Linear")!;
+    const draft = mapRegistryEntryToDraft(linear, () => "id", () => 0)!;
+    expect(draft.server.url).toBe("https://mcp.linear.app/mcp");
+    expect(draft.server.transport).toBe("http");
+  });
 });

--- a/apps/screenpipe-app-tauri/lib/mcp-registry.ts
+++ b/apps/screenpipe-app-tauri/lib/mcp-registry.ts
@@ -265,9 +265,12 @@ export const RECOMMENDED_SERVERS: RegistryServer[] = [
   {
     name: "app.linear/linear",
     title: "Linear",
-    description: "Create and manage Linear issues, projects and cycles. OAuth sign-in.",
+    description: "Create and manage Linear issues, projects and cycles. OAuth sign-in — no API key.",
     repository: { url: "https://linear.app/docs/mcp" },
-    remotes: [{ type: "sse", url: "https://mcp.linear.app/sse" }],
+    // Streamable-HTTP endpoint (/mcp), NOT the legacy /sse transport — the
+    // engine's MCP client only drives streamable HTTP. OAuth here uses
+    // Dynamic Client Registration, so there's no client_id/secret to create.
+    remotes: [{ type: "streamable-http", url: "https://mcp.linear.app/mcp" }],
   },
   {
     name: "com.monday/monday.com",


### PR DESCRIPTION
## what

Ten connection tiles that needed an **API key** — or a connector-OAuth app + cross-repo website plumbing — now connect with a **single Connect button** over the provider's remote MCP server. No API key, no human-created `client_id`/`secret`.

Representative example (the panel is identical for every provider below):

![Linear connection: API-key form before, one-click Connect after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-mcp-oauth-quickconnect/linear-oauth.png)

## providers

Converted (each verified live to support OAuth **+ Dynamic Client Registration**):

| | currently | endpoint |
|---|---|---|
| **Linear** | API key | `mcp.linear.app/mcp` |
| **Stripe** | API key | `mcp.stripe.com` |
| **Sentry** | API key | `mcp.sentry.dev/mcp` |
| **Intercom** | API key | `mcp.intercom.com/mcp` |
| **Asana** | API key | `mcp.asana.com/mcp` |
| **monday.com** | API key | `mcp.monday.com/mcp` |
| **ClickUp** | API key | `mcp.clickup.com/mcp` |
| **Airtable** | API key | `mcp.airtable.com/mcp` |
| **Confluence** | API key | `mcp.atlassian.com/v1/mcp` |
| **Jira** | connector OAuth | `mcp.atlassian.com/v1/mcp` |
| **Notion** | connector OAuth | `mcp.notion.com/mcp` |

Confluence + Jira share the one Atlassian MCP server. All `/mcp` endpoints verified reachable (401, not 404 — no legacy `/sse` trap).

**Excluded:** PostHog and Todoist expose OAuth but **no DCR**, so they'd still need a baked-in `client_id` — left as-is.

## existing connections are not lost

For anyone already connected the old way:

- Their stored API key / connector-OAuth token is **untouched**, and **pipes hitting `/connections/<id>` keep working** (the Rust connectors stay registered).
- The tile's dot still lights for an existing connection (`mcpConnected || connectorConnected`), so it doesn't appear to disconnect.
- The old key/token form stays reachable under an **"advanced: manage your existing connection"** disclosure, so it can be viewed, rotated, or removed. One-click OAuth is just the new primary path.

## why

screenpipe already ships a complete MCP OAuth client in `crates/screenpipe-connect/src/mcp_servers.rs` — discovery (RFC 8414/9470), **Dynamic Client Registration (RFC 7591)**, PKCE. With DCR, `register_oauth_client` POSTs `token_endpoint_auth_method: "none"` and gets a `client_id` back, so nobody registers an OAuth app and there's no secret to store. For providers with a first-party remote MCP server, that removes both the API key *and* the per-provider connector-OAuth + website plumbing.

## how

- `connections-section.tsx`: a data-driven `MCP_OAUTH_PROVIDERS` table (id → name, streamable-HTTP `/mcp` URL, description). A pre-switch dispatch renders the existing one-click `OAuthMcpPanel` (the same one krisp/plaud use) for any listed tile, plus the existing-connection fallback described above; the tile's dot tracks status via one `mcpProviderConnected` map.
- `mcp-registry.ts`: fix the curated Linear entry (`/sse` → `/mcp`) + guard test so a legacy `/sse` endpoint can't slip back into the curated list.

## notes

- A connector exposes a normalized proxy; an MCP server exposes its own tools (callable via `sp_mcp_call`). This adds the MCP-tool path; it doesn't migrate pipes off the connector proxy.

## test

- `vitest lib/__tests__/mcp-registry.test.ts` — 26 passed (incl. 2 new)
- `tsc --noEmit` — clean on touched files
- All 11 `/mcp` endpoints probed: reachable + advertise OAuth/DCR metadata

> Image is an HTML mockup in the app's theme (faithful to `OAuthMcpPanel` / the API-key form markup), not a live capture.