### PR TITLE
fix(enterprise): don't force hidden-mode auto-update when updates are MDM/Intune-managed

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -358,10 +358,23 @@ fn auto_update_enabled_from_settings(settings: Result<Option<SettingsStore>, Str
 /// on, and no "Restart to update" banner to click. So if auto-update resolved to
 /// off (an admin disabled it, or `allow_employee_override` left the device's own
 /// setting off), a hidden device would be stranded on whatever version it
-/// installed — silently, forever, with no recourse. Force auto-update ON whenever
-/// the app UI is hidden: the employee-override only makes sense when there's a UI
-/// to honor it. Visible installs keep honoring the stored setting.
-fn resolve_auto_update_enabled(settings_enabled: bool, app_ui_hidden: bool) -> bool {
+/// installed — silently, forever, with no recourse. Force auto-update ON when the
+/// app UI is hidden: the employee-override only makes sense when there's a UI to
+/// honor it.
+///
+/// EXCEPTION — never force when updates are managed externally (`mode = mdm |
+/// manual`, or `auto_detect` with MDM detected). There the in-app updater is
+/// intentionally off so it doesn't fight Intune/MDM, and `check_for_updates`
+/// already bails before reaching here; we gate again so this can't regress if
+/// that ordering ever changes. Visible installs always honor the stored setting.
+fn resolve_auto_update_enabled(
+    settings_enabled: bool,
+    app_ui_hidden: bool,
+    updates_managed_externally: bool,
+) -> bool {
+    if updates_managed_externally {
+        return settings_enabled;
+    }
     app_ui_hidden || settings_enabled
 }
 
@@ -377,13 +390,17 @@ fn load_auto_update_enabled(app: &tauri::AppHandle) -> bool {
     }
     let settings_enabled = auto_update_enabled_from_settings(settings);
     let app_ui_hidden = crate::enterprise_policy::is_app_ui_hidden();
-    if app_ui_hidden && !settings_enabled {
+    // mdm/manual (and auto_detect-with-MDM) => updates are managed outside the
+    // app; don't override that even when hidden.
+    let updates_managed_externally =
+        is_enterprise_build(app) && enterprise_updates_managed_locally(app);
+    if app_ui_hidden && !settings_enabled && !updates_managed_externally {
         info!(
             "enterprise: forcing auto-update ON in hidden UI mode \
              (no banner/settings exist to trigger it otherwise)"
         );
     }
-    resolve_auto_update_enabled(settings_enabled, app_ui_hidden)
+    resolve_auto_update_enabled(settings_enabled, app_ui_hidden, updates_managed_externally)
 }
 
 pub struct UpdatesManager {
@@ -1274,15 +1291,25 @@ mod tests {
     #[test]
     fn hidden_ui_forces_auto_update_on_even_when_setting_off() {
         // a "run hidden" device has no banner/settings to update otherwise — it
-        // must auto-update or it's stranded forever
-        assert!(resolve_auto_update_enabled(false, true));
-        assert!(resolve_auto_update_enabled(true, true));
+        // must auto-update or it's stranded forever (self-update mode)
+        assert!(resolve_auto_update_enabled(false, true, false));
+        assert!(resolve_auto_update_enabled(true, true, false));
     }
 
     #[test]
     fn visible_ui_respects_the_stored_setting() {
-        assert!(!resolve_auto_update_enabled(false, false));
-        assert!(resolve_auto_update_enabled(true, false));
+        assert!(!resolve_auto_update_enabled(false, false, false));
+        assert!(resolve_auto_update_enabled(true, false, false));
+    }
+
+    #[test]
+    fn mdm_managed_updates_are_never_forced_even_when_hidden() {
+        // updates managed by Intune/MDM (or manual): the in-app updater is
+        // intentionally off so it doesn't fight the external manager — hidden
+        // must NOT override that.
+        assert!(!resolve_auto_update_enabled(false, true, true));
+        // and an explicitly-on setting is still honored
+        assert!(resolve_auto_update_enabled(true, true, true));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #4570 (already merged).

## the gap

#4570 forces the in-app auto-updater **on** for any "Run hidden" device (so a hidden device can't get stranded on an old version with no UI to update it). But that's too broad: an org that manages updates via **MDM/Intune** (`mode = mdm | manual`, or `auto_detect` with MDM detected) **intentionally keeps the in-app updater off** so it doesn't fight the external manager. Forcing it on under hidden mode would override that and cause the app to self-update underneath Intune.

## why it was already safe (but fragile)

`check_for_updates` bails for externally-managed updates at the top:

```rust
if is_enterprise_build(&self.app) && enterprise_updates_managed_locally(&self.app) {
    return Ok(false);   // mdm | manual | auto_detect+managed
}
```

…which runs **before** `load_auto_update_enabled`, so an MDM hidden device never reached the force-on. But that relied entirely on call-ordering.

## the fix

Gate the force-on explicitly so it can't regress:

```rust
fn resolve_auto_update_enabled(settings_enabled, app_ui_hidden, updates_managed_externally) -> bool {
    if updates_managed_externally { return settings_enabled; } // defer to MDM/manual
    app_ui_hidden || settings_enabled
}
```

`load_auto_update_enabled` passes `is_enterprise_build(app) && enterprise_updates_managed_locally(app)`. So the hidden force-on now applies **only** to self-update (`screenpipe`) mode.

| mode | hidden + setting off | result |
|---|---|---|
| `screenpipe` (self-update) | yes | forced on (the original fix) |
| `mdm` / `manual` | yes | **left off — defers to Intune/MDM** |
| any | visible | honors stored setting |

+1 unit test (`mdm_managed_updates_are_never_forced_even_when_hidden`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)