### PR TITLE
fix(hd): keep meeting HD recording bound to the whole call, not 30 min

### DIFF
--- a/crates/screenpipe-engine/src/high_fps_controller.rs
+++ b/crates/screenpipe-engine/src/high_fps_controller.rs
@@ -275,11 +275,19 @@ impl HighFpsController {
     /// that will never come.
     pub fn start_meeting_session(&self, meeting_id: i64) -> HighFpsSnapshot {
         let now = Instant::now();
-        let in_meeting = self
-            .detector
-            .as_ref()
-            .map(|d| d.is_in_meeting())
-            .unwrap_or(false);
+        // Use the same meeting signal as `snapshot()`: the desktop app builds
+        // this controller with NO detector handle and drives meeting state
+        // through `meeting_started`/`meeting_ended` events (`event_in_meeting`,
+        // set via `set_in_meeting`). Checking only `self.detector` here meant
+        // the app always saw "not in a meeting" and downgraded every
+        // meeting-triggered session to the bounded 30-min `STALE_MEETING_FALLBACK`
+        // timer — so HD stopped 30 min into any longer call instead of staying
+        // bound to the meeting. Fall back to the event flag when no detector is
+        // wired so a fresh meeting gets the proper meeting-bound session.
+        let in_meeting = match self.detector.as_ref() {
+            Some(d) => d.is_in_meeting(),
+            None => self.event_in_meeting.load(Ordering::Relaxed),
+        };
         let (kind, expires_at, log_reason) = if in_meeting {
             (
                 SessionKind::Meeting { meeting_id },
@@ -689,6 +697,45 @@ mod tests {
         ));
         let remaining = s.remaining_secs.unwrap();
         assert!(remaining >= MAX_MEETING_DURATION.as_secs() - 5);
+    }
+
+    #[test]
+    fn app_meeting_session_is_meeting_bound_via_event_flag() {
+        // Regression: the desktop app builds the controller with NO detector
+        // and signals meetings through set_in_meeting (event_in_meeting). The
+        // meeting_started handler calls set_in_meeting(true) and THEN
+        // start_meeting_session(id). Before the fix, start_meeting_session only
+        // consulted self.detector (None → false), so it downgraded every
+        // meeting to the 30-min STALE_MEETING_FALLBACK timer and HD stopped
+        // 30 min into any longer call. With the event-flag fallback, a fresh
+        // meeting must be meeting-bound with the ~4h cap.
+        let c = Arc::new(HighFpsController::new(None, DefaultMode::Always, 100));
+        c.set_in_meeting(true);
+        c.start_meeting_session(293);
+        let s = c.snapshot();
+        assert!(matches!(
+            s.kind,
+            Some(SessionKind::Meeting { meeting_id: 293 })
+        ));
+        let remaining = s.remaining_secs.unwrap();
+        assert!(remaining >= MAX_MEETING_DURATION.as_secs() - 5);
+        // And it ends when the matching meeting ends (not only on the cap).
+        c.handle_meeting_ended(293);
+        assert!(!c.snapshot().active);
+    }
+
+    #[test]
+    fn app_stale_click_without_meeting_still_falls_back_to_timer() {
+        // Counter-test: no detector AND no active meeting (event flag false) is
+        // a genuine stale click — must still downgrade to the bounded timer so
+        // it can't sit waiting for a meeting_ended that never comes.
+        let c = Arc::new(HighFpsController::new(None, DefaultMode::Always, 100));
+        c.start_meeting_session(42);
+        let s = c.snapshot();
+        assert!(matches!(s.kind, Some(SessionKind::Timer)));
+        let remaining = s.remaining_secs.unwrap();
+        assert!(remaining <= STALE_MEETING_FALLBACK.as_secs());
+        assert!(remaining >= STALE_MEETING_FALLBACK.as_secs() - 5);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

On the **desktop app**, HD meeting recording silently stops **30 minutes** into any longer call. Everything past the 30-min mark is captured only as sparse event-driven OCR frames, not smooth HD — so a long meeting "doesn't seem to be in HD" when you scrub past the first half hour. **The footage past 30 min is never recorded at HD** (not recoverable after the fact).

This affects every meeting > 30 min on the app. CLI/standalone builds were never affected.

## Evidence (real 65-min meeting, captured live)

Meeting ran `06:59:27 → 08:04:52` (~65 min). From the app log:

```
13:59:27  HD session started meeting_id=293 reason="stale-click fallback timer"
14:29:27  HD session auto-expired (deadline reached) kind=Timer elapsed_secs=1800   ← 1800s = 30 min
```

Six 5-min HD chunks on disk (`1920x1080 @ 10fps`, genuine HD) span `06:59:28 → 07:29:27` only — nothing for the remaining ~35 min of the call.

Two tells: the session was a `Timer` with `reason="stale-click fallback timer"` (should have been meeting-bound), and it expired at exactly 1800s.

## Root cause

The desktop app builds `HighFpsController` with **no detector handle** (`detector = None`) and drives meeting state through the `event_in_meeting` flag — `set_in_meeting(true)` is fired right before `start_meeting_session()` on every `meeting_started` event.

But `start_meeting_session` decided "are we in a meeting?" by reading **only `self.detector`**:

```rust
let in_meeting = self.detector.as_ref().map(|d| d.is_in_meeting()).unwrap_or(false);
```

With no detector, `unwrap_or(false)` is **always false** → every meeting fell into the bounded `STALE_MEETING_FALLBACK` (30-min) `Timer` branch instead of a meeting-bound session (4h safety cap, ends on `meeting_ended`).

`snapshot()` already handled the no-detector case by falling back to `event_in_meeting` (the app's meeting signal); `start_meeting_session` was just never given the same fallback.

## Fix

`start_meeting_session` now uses the **same meeting signal as `snapshot()`**:

```rust
let in_meeting = match self.detector.as_ref() {
    Some(d) => d.is_in_meeting(),
    None => self.event_in_meeting.load(Ordering::Relaxed),
};
```

So a fresh meeting becomes a proper meeting-bound HD session that lasts the whole call. A genuine stale notification click (no active meeting) still correctly downgrades to the bounded timer.

## Tests

Two new regression tests in `high_fps_controller.rs` (no-detector app path):
- `app_meeting_session_is_meeting_bound_via_event_flag` — event flag set → 4h meeting-bound session that ends on `meeting_ended`
- `app_stale_click_without_meeting_still_falls_back_to_timer` — no meeting → still the bounded 30-min timer

`cargo test -p screenpipe-engine --lib high_fps` → **35 passed, 0 failed**.

> Needs an app release to reach users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)