### PR TITLE
fix(search): authenticate frame <img> loads so thumbnails don't 403 when API auth is on

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/prefill-context-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/prefill-context-banner.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { X } from "lucide-react";
-import { getApiBaseUrl } from "@/lib/api";
+import { getApiBaseUrl, appendAuthToken } from "@/lib/api";
 import type { PrefillComposerProps } from "./composer-types";
 
 export function PrefillContextBanner({
@@ -22,7 +22,7 @@ export function PrefillContextBanner({
             <div className="relative group">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={`${getApiBaseUrl()}/frames/${prefill.frameId}`}
+                src={appendAuthToken(`${getApiBaseUrl()}/frames/${prefill.frameId}`)}
                 alt="Attached frame"
                 className="w-16 h-12 object-cover rounded border border-border/50"
               />

--- a/apps/screenpipe-app-tauri/components/rewind/hooks/use-frame-loading.ts
+++ b/apps/screenpipe-app-tauri/components/rewind/hooks/use-frame-loading.ts
@@ -5,7 +5,7 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { StreamTimeSeriesResponse } from "@/components/rewind/timeline";
 import posthog from "posthog-js";
-import { getApiBaseUrl } from "@/lib/api";
+import { getApiBaseUrl, appendAuthToken } from "@/lib/api";
 
 // Debounce delay for frame loading (ms) — reduced for arrow keys
 const FRAME_LOAD_DEBOUNCE_MS = 80;
@@ -420,15 +420,15 @@ export function useFrameLoading(opts: {
 		if (!debouncedFrame) return null;
 		// Force HTTP JPEG for search navigation (skip slow video seek)
 		if (searchNavFrame) {
-			return `${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`;
+			return appendAuthToken(`${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`);
 		}
 		// Snapshot failed to load from disk — need HTTP fallback regardless of video mode
 		if (isSnapshotFrame && snapshotFailed) {
-			return `${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`;
+			return appendAuthToken(`${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`);
 		}
 		if (useVideoMode) return null;
 		if (isSnapshotFrame) return null;
-		return `${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`;
+		return appendAuthToken(`${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`);
 	}, [useVideoMode, debouncedFrame, isSnapshotFrame, snapshotFailed, searchNavFrame]);
 
 	// Preload fallback image — only swap displayed URL when the new image loads successfully

--- a/apps/screenpipe-app-tauri/components/rewind/hooks/use-live-text.ts
+++ b/apps/screenpipe-app-tauri/components/rewind/hooks/use-live-text.ts
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { commands } from "@/lib/utils/tauri";
-import { getApiBaseUrl } from "@/lib/api";
+import { getApiBaseUrl, appendAuthToken } from "@/lib/api";
 
 export function useLiveText(opts: {
 	debouncedFrame: { filePath: string; offsetIndex: number; fps: number; frameId: string } | null;
@@ -132,7 +132,7 @@ export function useLiveText(opts: {
 			if (isSearchModalOpen) return;
 			const fid = debouncedFrame?.frameId;
 			if (!fid) return;
-			const imagePath = `${getApiBaseUrl()}/frames/${fid}`;
+			const imagePath = appendAuthToken(`${getApiBaseUrl()}/frames/${fid}`);
 			const fidStr = String(fid);
 			commands
 				.livetextAnalyze(imagePath, fidStr, 0, 0, 0, 0)
@@ -172,7 +172,7 @@ export function useLiveText(opts: {
 
 		// For snapshot frames, use the local file path directly (instant).
 		// For video-chunk frames, fall back to HTTP endpoint (requires ffmpeg extraction).
-		const imagePath = `${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`;
+		const imagePath = appendAuthToken(`${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`);
 
 		// Position is managed exclusively by livetext_update_position.
 		// The analyze call only sets the analysis + shows the overlay.
@@ -289,7 +289,7 @@ export function useLiveText(opts: {
 		} else if (debouncedFrame?.frameId) {
 			// Re-analyze to show overlay again, then send position update
 			// to apply the pending analysis with correct geometry.
-			const imagePath = `${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`;
+			const imagePath = appendAuthToken(`${getApiBaseUrl()}/frames/${debouncedFrame.frameId}`);
 			const fid = String(debouncedFrame.frameId);
 			commands.livetextAnalyze(
 				imagePath,

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -21,7 +21,7 @@ import { cn } from "@/lib/utils";
 import { commands } from "@/lib/utils/tauri";
 import { showChatWithPrefill } from "@/lib/chat-utils";
 import { ThumbnailHighlightOverlay } from "./thumbnail-highlight-overlay";
-import { localFetch, getApiBaseUrl } from "@/lib/api";
+import { localFetch, getApiBaseUrl, appendAuthToken } from "@/lib/api";
 import { buildBoundedFacetSql, sanitizeFts5Query } from "@/lib/search/facet-sql";
 
 interface SpeakerResult {
@@ -260,11 +260,16 @@ function useSuggestions(isOpen: boolean) {
 const FrameThumbnail = ({ frameId, alt }: { frameId: number; alt: string }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
-  const [src, setSrc] = useState(`${getApiBaseUrl()}/frames/${frameId}`);
+  // <img> can't send an Authorization header, so when API auth is enabled we
+  // pass the key as a ?token= query param (server accepts header/cookie/token).
+  // Without this every thumbnail 403s and shows "unavailable" on packaged
+  // builds, where the webview origin (tauri://localhost) differs from the API
+  // host (localhost:3030) so the screenpipe_auth cookie isn't sent.
+  const [src, setSrc] = useState(appendAuthToken(`${getApiBaseUrl()}/frames/${frameId}`));
   const retryCount = useRef(0);
 
   useEffect(() => {
-    setSrc(`${getApiBaseUrl()}/frames/${frameId}`);
+    setSrc(appendAuthToken(`${getApiBaseUrl()}/frames/${frameId}`));
     setIsLoading(true);
     setHasError(false);
     retryCount.current = 0;
@@ -298,7 +303,7 @@ const FrameThumbnail = ({ frameId, alt }: { frameId: number; alt: string }) => {
             if (retryCount.current < 3) {
               retryCount.current += 1;
               setTimeout(() => {
-                setSrc(`${getApiBaseUrl()}/frames/${frameId}?retry=${retryCount.current}`);
+                setSrc(appendAuthToken(`${getApiBaseUrl()}/frames/${frameId}?retry=${retryCount.current}`));
               }, 1000 * retryCount.current);
             } else {
               setIsLoading(false);

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline.tsx
@@ -19,7 +19,7 @@ import { type TemplatePipe } from "@/lib/hooks/use-pipes";
 import { AppContextPopover } from "./app-context-popover";
 import { TimelineTagToolbar } from "./timeline-tag-toolbar";
 import { extractDomain, FaviconImg } from "./favicon-utils";
-import { localFetch, getApiBaseUrl } from "@/lib/api";
+import { localFetch, getApiBaseUrl, appendAuthToken } from "@/lib/api";
 
 // Global cache: preloads app-icon images so they render instantly on scroll.
 // Maps app name → "loaded" | "error" | Promise (in-flight).
@@ -1962,7 +1962,7 @@ export const TimelineSlider = ({
 														<div className="mb-2 w-64 aspect-video rounded-md overflow-hidden bg-muted border border-border/40">
 															{/* eslint-disable-next-line @next/next/no-img-element */}
 															<img
-																src={`${getApiBaseUrl()}/frames/${frameId}`}
+																src={appendAuthToken(`${getApiBaseUrl()}/frames/${frameId}`)}
 																alt="frame preview"
 																className="w-full h-full object-cover select-none"
 																loading="lazy"


### PR DESCRIPTION
## what broke

With **Require authentication** on (every enterprise/admin build), the local API gates `/frames/{id}`. Confirmed live:

```
$ curl -s -o /dev/null -w "%{http_code} %{time_total}s\n" http://localhost:3030/frames/<id>
403 0.0004s          # no token
$ curl ... "http://localhost:3030/frames/<id>?token=<key>"
200 0.001s           # ?token= works
```

Search **query** results load fine — `fetch()` is patched to attach `Authorization: Bearer`. But thumbnails render as plain `<img src>`, and **an `<img>` cannot send an auth header**. The cookie fallback (`screenpipe_auth`) is never sent either: on packaged builds the webview origin (`tauri://localhost`) differs from the API host (`localhost:3030`), so the cookie isn't attached cross-origin. → every frame `<img>` 403s → **"unavailable"**.

This affects not just search but the timeline, hover preview, Live Text overlay, and the chat prefill banner. It silently passed review because in **dev** the origin is `http://localhost:1420` (same `localhost` host → cookie works); it only breaks in the **packaged** build.

## the fix

The repo already had [`appendAuthToken()`](https://github.com/screenpipe/screenpipe/blob/main/apps/screenpipe-app-tauri/lib/api.ts) (appends `?token=<key>`, a server-accepted auth path that works for `<img>`), already used by `meeting-notes/replay-strip.tsx`. These 5 `<img>`/`Image()` frame loaders were missed when API auth landed — now wrapped. **No-op when auth is disabled**, so dev is unchanged.

## before / after (search results grid)

```
   BEFORE (auth on)              AFTER
 ┌──────────────┐            ┌──────────────┐
 │              │            │  ▓▓▒▒░░ Arc   │
 │ unavailable  │    →       │  ▒▒░░▓▓ frame │
 │   7:32 AM    │            │   7:32 AM     │
 └──────────────┘            └──────────────┘
   (every tile 403)            (real thumbnail)
```

## files
- `components/rewind/search-modal.tsx` — search thumbnails (the reported bug)
- `components/rewind/hooks/use-frame-loading.ts` — main timeline frames
- `components/rewind/timeline/timeline.tsx` — timeline hover preview
- `components/rewind/hooks/use-live-text.ts` — macOS Live Text overlay
- `components/chat/standalone/prefill-context-banner.tsx` — chat attached-frame thumb

`tsc --noEmit` clean on all changed files. TS-only; no Rust/bindings impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)