### PR TITLE
feat(pipes): Company Brain bundled pipe (capture → share → ask)

### DIFF
--- a/crates/screenpipe-core/assets/pipes/company-brain/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/company-brain/pipe.md
@@ -1,0 +1,116 @@
+---
+schedule: manual
+enabled: true
+template: true
+title: Company Brain
+description: "Turn your team's work into one shared, searchable brain — set up the capture → share → ask loop in a few clicks"
+icon: "🧠"
+featured: true
+---
+
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (the shared destination this team chose, a pipe that already exists, a user correction, a stable fact about this team's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
+<role>
+You are screenpipe's Company Brain setup agent. A "company brain" is one shared, searchable place that fills up automatically with how a team actually works — decisions, SOPs, open loops, who-knows-what — captured from each person's screen locally and synced to ONE shared destination the whole team can read.
+
+Your job this run is to set up that loop for this user: **capture → share → ask.** You do not lecture; you wire it up. But you NEVER move data off this machine without an explicit, one-click yes. Local-first is the law (see `VISION.md`): data leaves the device only when the user opts in, every time, until they tell you to make it automatic.
+</role>
+
+Read the screenpipe skill first so you know the API and how pipes work. Then follow every step in order. Do not skip steps.
+
+## Step 1: Understand this person's work (read-only, max 6 API calls, last 7 days)
+
+You are designing a brain around what this team actually does, so look before you build.
+
+1. Top apps:
+   GET http://localhost:3030/raw_sql?query=SELECT app_name, COUNT(*) as n FROM frames WHERE timestamp > datetime('now','-7 days') AND app_name IS NOT NULL GROUP BY app_name ORDER BY n DESC LIMIT 15
+2. Meetings/calls in the window:
+   GET http://localhost:3030/search?content_type=audio&limit=5&start_time=[7d ago ISO]&end_time=[now ISO]
+3. For the top 2–3 work apps, sample what they actually do:
+   GET http://localhost:3030/search?content_type=ocr&app_name=[app]&limit=5&start_time=[7d ago ISO]&end_time=[now ISO]
+
+Stop at 6 calls. If there is little data, still proceed — design a broadly useful brain and say so.
+
+## Step 2: Find the shared destination (this is the whole game)
+
+A brain is only a *company* brain if everyone writes to ONE shared place. Find what this team can already share into:
+
+```
+curl -s -H "Authorization: Bearer $SCREENPIPE_LOCAL_API_KEY" "http://localhost:3030/connections"   # keep only "connected": true
+```
+
+- **If a shareable destination is connected** (Notion, Slack, Linear, …): that is the brain's home. Prefer a destination the team clearly works in (rank by the apps you saw in Step 1).
+- **If nothing shareable is connected:** do NOT silently fall back to a local-only file and call it a "company brain" — that is just a personal brain. Tell the user plainly: "A company brain needs one shared place your team can read. Connect Notion or Slack and I'll wire it up." Offer the connection, then continue with the local digest (Step 3) so they still get value today.
+
+When a destination needs a specific target you can't infer (a Notion parent page, a Slack channel), ask for it once and remember it in `./memory.md` — never guess where team data lands.
+
+## Step 3: Build the capture half (read-only, safe, local)
+
+Create a per-person **workday digest** pipe that turns raw screen/audio into the structured knowledge a brain is made of. Create the file `~/.screenpipe/pipes/workday-digest/pipe.md` (if that slug exists in GET /pipes, add a short suffix). Use exactly this frontmatter so it runs hourly, enabled, read-only:
+
+```
+---
+schedule: every 1h
+enabled: true
+permissions: reader
+title: Workday Digest
+description: Rolling log of decisions made, SOP-worthy steps, and open loops
+icon: "📓"
+---
+```
+
+Its body must make at most 3 short searches (limit ≤ 10) over the last hour and produce a compact entry with these sections, named with the actual apps/people seen:
+- **Decisions** — what was decided, by whom, with the one-line why
+- **How-to / SOP** — any repeatable sequence worth capturing as a procedure
+- **Open loops** — unfinished threads, follow-ups, blockers
+- **Who knows what** — which teammate touched which system/customer
+
+It writes that entry to `~/.screenpipe/pipes/workday-digest/digest.md` (local, append-only). No outbound calls in this pipe — capture stays read-only and on-device.
+
+## Step 4: Build the share half (opt-in, ask-never-push)
+
+This is where the brain becomes shared. Do NOT auto-send. Surface the digest as a one-click push to the destination from Step 2, exactly like the meeting-summary pipe does:
+
+- Map the destination to its endpoint from `/connections`: `POST /connections/<id>/send` for slack/gmail/telegram/discord, `POST /connections/<id>/proxy/...` for notion/linear/etc.
+- Post a desktop notification whose action buttons are the real destination(s), so the ask renders as buttons in the UI:
+
+```
+POST http://localhost:3030/notifications
+{
+  "title": "Company Brain",
+  "body": "Today's digest is ready — push to the team brain?",
+  "actions": [
+    {"label": "push to notion", "type": "api", "method": "POST", "url": "http://localhost:3030/connections/notion/proxy/v1/pages", "body": { /* page built from digest.md, under the team parent page from memory */ }},
+    {"label": "review in chat", "type": "chat"}
+  ]
+}
+```
+
+- If the destination needs a target you can't infer, make the button `"review in chat"` so the user confirms before anything leaves the machine.
+- If nothing shareable is connected, skip the notification and tell the user connecting Notion or Slack is the one step that turns their personal digest into a team brain.
+
+**Only** make sharing automatic if the user explicitly says so this run (e.g. "yes, post it every day"). If they do, set the share step to run on a schedule and record that consent in `./memory.md`. Otherwise it stays ask-first, every time.
+
+## Step 5: Wire the ask half + confirm
+
+The brain is only useful if people can ask it. Confirm the loop in one short message:
+- **Capture:** Workday Digest is enabled and writing `digest.md` hourly (read-only, local).
+- **Share:** <destination> — pushes are one-click (or: automatic, since you asked), or "connect Notion/Slack to share."
+- **Ask:** anyone can query the shared destination, or ask screenpipe chat / the MCP server over their own digest.
+
+Then state the single next step that unlocks the most: usually "get one teammate to run this same setup so the brain has more than one person in it." Keep it to a few lines. No marketing fluff.
+
+## Guardrails (do not violate)
+- Local-first: nothing leaves this machine without an explicit per-run yes, unless the user turned on automatic sharing this run.
+- Read-only capture: the digest pipe only reads screenpipe data and writes a local file.
+- Progressive disclosure: set up the simplest working loop first; mention deeper options only if asked.
+- Never invent a destination, channel, or parent page — ask, then remember.

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -4949,6 +4949,10 @@ impl PipeManager {
                 include_str!("../../assets/pipes/automate-my-work/pipe.md"),
             ),
             (
+                "company-brain",
+                include_str!("../../assets/pipes/company-brain/pipe.md"),
+            ),
+            (
                 "missed-todos",
                 include_str!("../../assets/pipes/missed-todos/pipe.md"),
             ),

--- a/docs/COMPANY_BRAIN_SPEC.md
+++ b/docs/COMPANY_BRAIN_SPEC.md
@@ -1,0 +1,121 @@
+# Company Brain — Spec
+
+## Problem
+
+Teams install screenpipe on every machine and expect a "company brain": one place that fills up
+automatically with how the team actually works — decisions, SOPs, open loops, who-knows-what.
+
+Today each person's data stays siloed on their own machine, and the value (sharing knowledge,
+automating shared work) requires assembling the right pipes + connections by hand. Our healthiest
+team deployments hit this wall: the champion runs 13 pipes, the rest of the team runs none, and
+nobody has a *shared* brain — just N personal ones.
+
+This is an **activation** problem (a north-star metric in `VISION.md`), not a missing-feature problem.
+The pieces mostly exist; they aren't wired into one loop a team can turn on in a few clicks.
+
+## The loop
+
+A company brain is three verbs, same as the product (Record, Rewind, Ask):
+
+```
+  capture            share                 ask
+  (per person,   →   (one shared,     →    (anyone queries
+   local, RO)        opt-in dest)          the shared brain)
+```
+
+- **capture** — each person's screen/audio → structured knowledge (decisions, SOPs, open loops),
+  read-only, on-device.
+- **share** — that structured knowledge syncs to ONE shared destination the team already uses
+  (Notion teamspace, Slack channel, …). This is the only genuinely new piece, and the one that
+  turns N personal brains into one company brain.
+- **ask** — anyone queries the shared destination, or asks screenpipe chat / the MCP server.
+
+Local-first is non-negotiable: nothing leaves a machine without an explicit opt-in (`VISION.md`).
+
+## Non-goals
+
+- Not a new capture engine. Reuses existing screen/audio capture and the `/connections` layer.
+- Not a god-pipe. A single do-everything pipe is an unconfigurable black box; we compose small pipes.
+- Not a surveillance tool. The employer never sees raw screen/audio — only what each person opts to share.
+
+---
+
+## Phase 1 — bundled `company-brain` pipe (this PR)
+
+Ship the loop as one guided, bundled pipe: `crates/screenpipe-core/assets/pipes/company-brain/pipe.md`,
+registered in `install_builtin_pipes()` like the other featured templates.
+
+It is an **installer + orchestrator**, mirroring the existing `automate-my-work` pattern (a manual pipe
+that creates and enables other pipes) plus the `meeting-summary` ask-never-push connection pattern:
+
+1. reads the user's last 7 days (read-only, ≤6 calls) to design around real work
+2. finds the shared destination via `GET /connections`; if none is shareable, says so plainly
+   (a personal digest is not a company brain) and offers to connect Notion/Slack
+3. creates a read-only **workday-digest** pipe (hourly, local `digest.md`: decisions / SOPs / open
+   loops / who-knows-what)
+4. surfaces the digest as a **one-click** push to the shared destination — ask-never-push, exactly
+   like meeting-summary; automatic only if the user explicitly opts in this run
+5. confirms the capture → share → ask loop and names the single highest-leverage next step
+   (usually: get one teammate to run the same setup)
+
+This is shippable today, follows existing conventions, and is low-risk (capture is read-only; every
+outbound action is opt-in). It is the thin slice that proves the loop with a real design-partner team.
+
+---
+
+## Phase 2 — brain manifest (declarative bundle)
+
+A brain should be declarative, not a sequence of clicks. A manifest names the connections it needs,
+the shared destination, the pipes it installs, and the skills it exposes:
+
+```json
+{
+  "name": "consulting-brain",
+  "version": "1.0.0",
+  "connections": { "required": ["notion"], "optional": ["slack", "gmail"] },
+  "shared_destination": { "type": "notion", "space": "${prompted_at_install}" },
+  "pipes": [
+    "workday-digest",
+    { "id": "team-knowledge-sync", "to": "shared_destination" },
+    "personal-crm",
+    "todo"
+  ],
+  "skills": ["company-brain-query"]
+}
+```
+
+Install = read the manifest, prompt only for what's missing (the required connection + the
+destination target), install the pipes pointed at that destination. Every teammate runs the same
+install → the same brain. Progressive disclosure: the manifest declares dependencies; the installer
+asks lazily.
+
+`team-knowledge-sync` generalizes Phase 1's share step into a reusable pipe (dedup + attribution +
+routing are deterministic; only the summarization is model work).
+
+## Phase 3 — marketplace + git change-control
+
+Distribute brains like Claude Code plugins: a marketplace is a git repo of manifests. This splits
+cleanly along the existing two tiers:
+
+- **Consumer / self-serve** → the current Supabase pipe store. Click-install, no git.
+- **Enterprise / private** → a git repo per company holding that company's brain manifest.
+
+The git path is the unlock for regulated buyers (the team-brain ICP):
+
+- the company's brain config is **code** in their private repo
+- any change — add a pipe, swap destination, tweak a capture prompt — is a **pull request**
+- an admin reviews + merges; devices reconcile from the repo (reuses the existing enterprise/MDM
+  policy-deploy loop)
+- every change to *what is captured and shared* is reviewable and auditable — a buying criterion in
+  regulated environments, not a nice-to-have
+
+Agentic extension: when a team needs a pipe that doesn't exist, the autofix agent drafts it and opens
+a PR against the brain repo. Human review stays the gate.
+
+## Rollout
+
+1. **Phase 1 (this PR):** bundled `company-brain` pipe. Prove the loop with one design-partner team.
+2. **Phase 2:** manifest format + a guided installer that consumes it + the `team-knowledge-sync` pipe.
+3. **Phase 3:** git-backed brain repos for enterprise; PR-based change-control + MDM reconcile.
+
+Gate each phase on the previous one working for a real team. Stability over features (`VISION.md`).


### PR DESCRIPTION
![company brain — capture, share, ask](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-company-brain/company-brain-loop.png)

## why

Teams install screenpipe on every machine and expect a **company brain**: one shared place that fills up automatically with how the team actually works — decisions, SOPs, open loops, who-knows-what.

Today each person's data stays siloed on their own machine, and assembling the right pipes + a shared destination is manual. Our healthiest team deployments hit this exact wall — the champion runs 13 pipes, the rest of the team runs none, and nobody has a *shared* brain, just N personal ones.

This is an **activation** problem (a north-star in `VISION.md`), not a missing-feature one. The pieces already exist; they just aren't wired into one loop a team can turn on in a few clicks.

## what (phase 1, this PR)

One guided, bundled pipe — `company-brain` — registered alongside the other featured templates. It mirrors two patterns already in the repo: the **`automate-my-work`** installer (a manual pipe that creates + enables other pipes) and the **`meeting-summary`** ask-never-push connection flow.

```
  capture            share                 ask
  (per person,   →   (one shared,     →    (anyone queries
   local, RO)        opt-in dest)          the shared brain)
```

On run it:
1. reads the user's last 7 days (read-only, ≤6 calls) to design around real work
2. finds the shared destination via `GET /connections`; if none is shareable, says so plainly (a personal digest is **not** a company brain) and offers to connect Notion/Slack
3. creates a read-only hourly **`workday-digest`** pipe → local `digest.md` (decisions / SOPs / open loops / who-knows-what)
4. surfaces the digest as a **one-click** push to the shared destination — ask-never-push, automatic only on explicit opt-in
5. confirms the loop and names the single highest-leverage next step (usually: get one teammate to run the same setup)

## safety / VISION alignment

- **Local-first:** capture is read-only and on-device; nothing leaves the machine without a per-run opt-in.
- **No god-pipe:** composes small pipes instead of one black box (progressive disclosure).
- **Not surveillance:** the employer never sees raw screen/audio — only what each person opts to share.

## changes

- `crates/screenpipe-core/assets/pipes/company-brain/pipe.md` — the bundled pipe
- `crates/screenpipe-core/src/pipes/mod.rs` — register it in `install_builtin_pipes()` (one tuple, same `include_str!` pattern as the other 8)
- `docs/COMPANY_BRAIN_SPEC.md` — full architecture: phase 2 declarative **brain manifest**, phase 3 git-backed **marketplace** with PR-based change-control for the enterprise tier (maps onto the consumer/Supabase-store vs enterprise/private-repo split). Each phase gated on the previous working for a real team.

## test plan

- bundled pipe installs on first run via `install_builtin_pipes()` and appears as a featured template (same path as `automate-my-work`)
- run it with a Notion/Slack connection → creates + enables `workday-digest`, fires the one-click push notification
- run it with **no** shareable connection → explains the gap, still sets up the local digest, does not exfiltrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)