### PR TITLE
fix(enterprise): enforce "Audio recording: Always off" — disableAudio was never applied to the device

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
@@ -204,15 +204,19 @@ async function applyPiiPolicy(lockedSettings: Record<string, unknown>): Promise<
 }
 
 /**
- * Apply enterprise-forced input-capture settings (keyboard / click rows) to
- * the local settings store so the recording engine honors them. The admin
- * sets these in the workspace policy's Managed settings
- * (lockedSettings.disableKeyboardCapture / disableClickCapture — "true" |
- * "false" strings like every managed value). Unlike the PII policy, the
- * engine only reads these at spawn, so when a forced value actually changes
- * the device's effective setting we restart the engine once. The matching
- * privacy-section toggles are disabled separately so the employee can't
- * override a forced value.
+ * Apply enterprise-forced capture settings (keyboard / click / audio) to the
+ * local settings store so the recording engine honors them. The admin sets
+ * these in the workspace policy's Managed settings (lockedSettings.
+ * disableKeyboardCapture / disableClickCapture / disableAudio — "true" | "false"
+ * strings like every managed value). Unlike the PII policy, the engine only
+ * reads these at spawn, so when a forced value actually changes the device's
+ * effective setting we restart the engine once. The matching privacy-section
+ * toggles are disabled separately so the employee can't override a forced value.
+ *
+ * `disableAudio` ("Audio recording: Always off") was previously NOT applied here
+ * at all, so the managed toggle was silently a no-op — devices kept recording
+ * and uploading audio despite the policy. It's handled exactly like the other
+ * capture toggles now.
  */
 let inputCaptureRestartInFlight = false;
 
@@ -229,15 +233,21 @@ async function applyInputCapturePolicy(lockedSettings: Record<string, unknown>):
     updates.disableClickCapture = clicks === "true";
   }
 
+  const audio = lockedSettings.disableAudio;
+  if (audio === "true" || audio === "false") {
+    updates.disableAudio = audio === "true";
+  }
+
   if (Object.keys(updates).length === 0) return;
 
   const store = await getStore();
   const settings = (await store.get<Record<string, unknown>>("settings")) || {};
   // Defaults when the key was never persisted mirror the app defaults:
-  // keyboard rows off, click rows on.
+  // keyboard rows off, click rows on, audio on (disableAudio off).
   const current: Record<string, boolean> = {
     disableKeyboardCapture: (settings.disableKeyboardCapture as boolean | undefined) ?? true,
     disableClickCapture: (settings.disableClickCapture as boolean | undefined) ?? false,
+    disableAudio: (settings.disableAudio as boolean | undefined) ?? false,
   };
   const changed = Object.entries(updates).some(([key, value]) => current[key] !== value);
   if (!changed) return;


### PR DESCRIPTION
## the bug (hit live)

An org set **Managed settings → Audio recording → Always off** ~14h ago, yet **every** upload batch since still contains audio transcripts — audio is being recorded *and* uploaded despite the policy.

Root cause: the toggle writes `locked_settings.disableAudio = "true"`, but the device's policy-application hook (`apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts`) **never applied it.** `applyInputCapturePolicy` enforces `disableKeyboardCapture` / `disableClickCapture` (writes the setting + restarts the engine) but silently dropped `disableAudio` — so "Always off" was a **no-op**.

## the fix

Handle `disableAudio` in that same function, identical to the other managed capture toggles:

```ts
const audio = lockedSettings.disableAudio;
if (audio === "true" || audio === "false") {
  updates.disableAudio = audio === "true";
}
// …included in the default-compare + engine restart
```

The engine already honors it — `capture_session.rs` gates audio capture on `config.disable_audio`, read at spawn (hence the one-time engine restart on change). So once the setting is written, no audio is captured or uploaded. tsc clean.

## also worth noting (follow-up, server-side)

When audio is forced off, the dashboard still leaves `sync_streams.audio = true` (upload audio) — contradictory but harmless once capture is disabled. Worth setting it off too for consistency.

## immediate mitigation (no app release)

This is a device fix, so it ships with the next app release. To stop audio **uploads** right now without waiting: flip the **audio sync stream off** in the policy — the device honors the per-stream sync gate on its next ~5-min poll. (Capture-disable still needs the release to stop local recording.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)