### PR TITLE
fix(enterprise): say "centralized data not enabled" instead of "license rejected" + fix Discriminant(0) mode logging

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
@@ -564,8 +564,8 @@ mod imp {
             let mut cfg = cfg;
             cfg.resolve_upload_mode().await;
             info!(
-                "enterprise sync: resolved upload mode = {:?}",
-                std::mem::discriminant(&cfg.upload_mode)
+                "enterprise sync: resolved upload mode = {}",
+                cfg.upload_mode.label()
             );
 
             ee_sync::run(cfg, local, rx).await;

--- a/ee/desktop-rust/enterprise_sync.rs
+++ b/ee/desktop-rust/enterprise_sync.rs
@@ -460,6 +460,8 @@ pub enum EnterpriseSyncError {
     Ingest(String),
     #[error("ingest auth rejected (license invalid / revoked)")]
     IngestAuthRejected,
+    #[error("centralized data not enabled for this org")]
+    CentralizedDataDisabled,
     #[error("ingest server error: status {0}")]
     IngestServerError(u16),
     #[error("control-plane network error: {0}")]
@@ -631,7 +633,15 @@ pub async fn post_jsonl(
     if status.is_success() {
         return Ok(());
     }
-    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+    if status == reqwest::StatusCode::FORBIDDEN {
+        // 403 = the license is valid, but centralized data is OFF for the org,
+        // so the ingest endpoint refuses (privacy-by-default). NOT a license
+        // problem — an admin must enable centralized data in the dashboard
+        // before any device can upload. Distinct from 401 so it isn't
+        // misreported as "license rejected".
+        return Err(EnterpriseSyncError::CentralizedDataDisabled);
+    }
+    if status == reqwest::StatusCode::UNAUTHORIZED {
         return Err(EnterpriseSyncError::IngestAuthRejected);
     }
     if status.is_server_error() {
@@ -1304,10 +1314,10 @@ async fn submit_stall_logs(cfg: &EnterpriseSyncConfig, http: &reqwest::Client) {
 
     // 3. confirm (this is what files it for support)
     let feedback = format!(
-        "auto: enterprise device recording but not landing data in org storage (license {}, device {}, mode {:?})",
+        "auto: enterprise device recording but not landing data in org storage (license {}, device {}, mode {})",
         cfg.license_key,
         cfg.device_id,
-        std::mem::discriminant(&cfg.upload_mode)
+        cfg.upload_mode.label()
     );
     let _ = http
         .post(format!("{base}/api/logs/confirm"))
@@ -1420,7 +1430,20 @@ pub async fn run(
             }
             Err(EnterpriseSyncError::IngestAuthRejected) => {
                 error!(
-                    "enterprise sync: license rejected by ingest endpoint, sleeping {}s",
+                    "enterprise sync: license rejected by ingest endpoint (license invalid / revoked), sleeping {}s",
+                    RETRY_AFTER_AUTH_FAIL.as_secs()
+                );
+                if sleep_or_shutdown(RETRY_AFTER_AUTH_FAIL, &mut shutdown).await {
+                    break;
+                }
+                continue;
+            }
+            Err(EnterpriseSyncError::CentralizedDataDisabled) => {
+                // The device is recording but the org hasn't turned on
+                // centralized data, so nothing can upload. Say exactly that —
+                // the fix is an admin toggle in the dashboard, not a license issue.
+                error!(
+                    "enterprise sync: centralized data is NOT enabled for this org — an admin must enable it in the dashboard before devices can upload; pausing {}s",
                     RETRY_AFTER_AUTH_FAIL.as_secs()
                 );
                 if sleep_or_shutdown(RETRY_AFTER_AUTH_FAIL, &mut shutdown).await {

--- a/ee/desktop-rust/enterprise_upload.rs
+++ b/ee/desktop-rust/enterprise_upload.rs
@@ -70,6 +70,18 @@ pub enum EnterpriseUploadMode {
     DirectReadable(DirectUploadConfig),
 }
 
+impl EnterpriseUploadMode {
+    /// Stable, human-readable mode name for logs / support output. Avoids the
+    /// `{:?}`-on-`discriminant` footgun that printed a bare `Discriminant(0)`.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::HostedIngest => "hosted_ingest",
+            Self::DirectEncrypted(_) => "direct_encrypted",
+            Self::DirectReadable(_) => "direct_readable",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DirectUploadConfig {
     pub ticket_url: String,
@@ -675,6 +687,19 @@ mod tests {
     // ever drift (or our encryptor mis-flows the nonce/key), this test
     // breaks loudly before any customer sees corrupt ciphertext.
     use screenpipe_core::sync::crypto::decrypt;
+
+    #[test]
+    fn upload_mode_label_is_readable_not_a_discriminant() {
+        assert_eq!(EnterpriseUploadMode::HostedIngest.label(), "hosted_ingest");
+        assert_eq!(
+            EnterpriseUploadMode::DirectReadable(direct_cfg()).label(),
+            "direct_readable"
+        );
+        assert_eq!(
+            EnterpriseUploadMode::DirectEncrypted(direct_cfg()).label(),
+            "direct_encrypted"
+        );
+    }
 
     fn direct_cfg() -> DirectUploadConfig {
         DirectUploadConfig {


### PR DESCRIPTION
## what this fixes

When an enterprise org hasn't enabled **centralized data**, hosted ingest correctly returns **403** — but the device logged a misleading **"license rejected"** (the license is fine) and printed `Discriminant(0)` for the upload mode.

- **`post_jsonl`**: split **403 → `CentralizedDataDisabled`** vs **401 → `IngestAuthRejected`**, so the `run()` loop logs the actionable reason ("centralized data is NOT enabled for this org — an admin must enable it in the dashboard before devices can upload") instead of "license rejected".
- **`EnterpriseUploadMode::label()`**: readable mode name (`hosted_ingest` / `direct_readable` / `direct_encrypted`) replacing `{:?}` on `std::mem::discriminant`, which printed a bare `Discriminant(0)` in the log and in the auto-submit feedback text.

+1 unit test (`upload_mode_label_is_readable_not_a_discriminant`).

Follow-up to #4563.