### PR TITLE
docs: fix stale Google OAuth 'app blocked' guidance + Gmail expectation

### DIFF
--- a/docs/mintlify/docs-mintlify-mig-tmp/connections.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/connections.mdx
@@ -45,7 +45,7 @@ this takes you straight to where you need to be — no more hunting through docs
 | **Slack** | access messages, channels, and threads |
 | **Discord** | access server messages and channels |
 | **Email** | connect your email for context |
-| **Gmail** | OAuth connection to your Google email |
+| **Gmail** | OAuth connection to your Google email (Google connections are temporarily blocked pending Google verification — see [troubleshooting](#google-oauth-this-app-is-blocked)) |
 | **Telegram** | access Telegram messages |
 | **WhatsApp** | access WhatsApp conversations |
 | **Microsoft Teams** | access Teams messages and channels |
@@ -183,19 +183,18 @@ this makes pipes significantly more accurate and useful.
 
 ## troubleshooting
 
-### Google OAuth: "app isn't verified" or "unsafe"
+### Google OAuth: "This app is blocked"
 
-when connecting Gmail, Google Calendar, or Google Docs, you may see a warning that says the app is "unverified" or "unsafe." this is normal — screenpipe is a local app and Google requires additional verification steps for third-party apps.
+when connecting a Google service (Gmail, Google Calendar, or Google Docs) you may see **"This app is blocked — this app tried to access sensitive info in your Google account."** with no way to continue.
 
-**how to proceed:**
-1. on the Google warning screen, click **Advanced** (bottom-left corner)
-2. click **Go to Screenpipe (unsafe)** to continue with the connection
-3. screenpipe will not be marked unsafe once you verify the connection — this is a standard OAuth security flow
+this is a **known issue on our side, not something you can fix**: screenpipe's Google OAuth app is pending Google's verification review for sensitive scopes, so Google currently blocks the connection. restarting, reinstalling, or disabling your VPN/firewall will not change this — the block comes from Google.
 
-if the page closes or doesn't load, check that:
-- you have internet connectivity
-- no browser extensions are blocking the OAuth redirect
-- your firewall isn't blocking `localhost:3030` (the local callback endpoint)
+**what to do in the meantime:**
+- use a non-Google calendar instead — **Apple Calendar** (macOS), **Microsoft 365 / Outlook**, or an **ICS subscription link** — these are unaffected.
+- if you specifically need Google data captured, note that screenpipe already captures whatever is on your screen (including Gmail/Calendar open in a browser) through normal screen capture.
+- the Google connection will work as soon as verification is approved. if you'd like to be notified, reach out in [Discord](https://discord.gg/screenpipe) or via in-app support with the email you sign in with.
+
+<Note>an older "app isn't verified / unsafe → click **Advanced**" warning no longer applies — Google now hard-blocks the flow until verification completes, so there is no "proceed anyway" option to click.</Note>
 
 ### connection fails silently
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/troubleshooting.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/troubleshooting.mdx
@@ -71,6 +71,14 @@ try this before reinstalling:
 
 if the app still says free after purchase, include the purchase email and the currently signed-in email when contacting support.
 
+### Google connection shows "This app is blocked"
+
+connecting Gmail, Google Calendar, or Google Docs fails with **"This app is blocked — this app tried to access sensitive info in your Google account"** and gives you no way to continue.
+
+this is a **known server-side issue, not fixable on your end**: screenpipe's Google OAuth app is pending Google's verification review. restarting, reinstalling, or disabling a VPN/firewall will not help — the block comes from Google.
+
+in the meantime, connect a non-Google calendar — **Apple Calendar**, **Microsoft 365 / Outlook**, or an **ICS link** — which are unaffected. the Google connection starts working once verification is approved. see [connections → Google OAuth](/connections#google-oauth-this-app-is-blocked).
+
 ### screenpipe is running but not capturing
 
 check the health endpoint:


### PR DESCRIPTION
## why

Surfaced from a sweep of recent Intercom support chats. Multiple users (Google Calendar + Gmail) hit Google's **"This app is blocked — this app tried to access sensitive info in your Google account"** error and got stuck. Our docs described the *old* failure mode (the soft "app isn't verified / unsafe" warning with an **Advanced → Go to Screenpipe (unsafe)** click-through), which no longer exists — Google now **hard-blocks** the flow while our OAuth app is pending verification for sensitive scopes. The stale docs led support (and Fin) to send users through useless restart / reinstall / disable-VPN loops.

## what changed

**`connections.mdx`**
- Replaced the stale *"app isn't verified / unsafe"* section with a **"This app is blocked"** section: states it's a pending-Google-verification issue (server-side, not user-fixable), gives the real workaround (**Apple Calendar / Microsoft 365 / ICS**), and adds a `<Note>` that the old "Advanced → proceed" path is gone.
- Flagged the **Gmail** row in the connections table so it no longer over-promises while Google connections are blocked.

**`troubleshooting.mdx`**
- New entry **"Google connection shows 'This app is blocked'"** next to the existing login/account entry, cross-linked to the connections section.

## before → after (connections troubleshooting)

```
- ### Google OAuth: "app isn't verified" or "unsafe"
- 1. click **Advanced** (bottom-left corner)
- 2. click **Go to Screenpipe (unsafe)** to continue
+ ### Google OAuth: "This app is blocked"
+ known pending-Google-verification issue (not user-fixable).
+ workaround: use Apple Calendar / Microsoft 365 / ICS until approval.
+ <Note> the old "Advanced → proceed" path no longer applies — Google hard-blocks it. </Note>
```

Docs-only (`.mdx`); no code or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
