### PR TITLE
fix(pipes): handle AI quota errors without retrying as rate limits

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/clean-pipe-stdout.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/clean-pipe-stdout.test.ts
@@ -124,7 +124,16 @@ describe("cleanPipeStdout", () => {
       '{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error","timestamp":1772385731429,"errorMessage":"429 credits_exhausted"}}',
     ].join("\n");
 
-    expect(cleanPipeStdout(stdout)).toBe("error: 429 credits_exhausted");
+    expect(cleanPipeStdout(stdout)).toBe("daily AI limit reached — upgrade or wait until tomorrow");
+  });
+
+  it("renders daily_cost_limit_exceeded as friendly text", () => {
+    const stdout = [
+      '{"type":"message_start","message":{"role":"assistant","content":[],"stopReason":"error","errorMessage":"429 \\"daily_cost_limit_exceeded\\""}}',
+      '{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error","errorMessage":"429 \\"daily_cost_limit_exceeded\\""}}',
+    ].join("\n");
+
+    expect(cleanPipeStdout(stdout)).toBe("daily AI usage limit reached");
   });
 
   it("extracts error from agent_end last assistant message", () => {
@@ -132,7 +141,7 @@ describe("cleanPipeStdout", () => {
       '{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]},{"role":"assistant","content":[],"stopReason":"error","errorMessage":"429 credits_exhausted"}]}',
     ].join("\n");
 
-    expect(cleanPipeStdout(stdout)).toBe("error: 429 credits_exhausted");
+    expect(cleanPipeStdout(stdout)).toBe("daily AI limit reached — upgrade or wait until tomorrow");
   });
 
   it("extracts error from turn_end", () => {
@@ -196,7 +205,7 @@ describe("cleanPipeStdout", () => {
       '{"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error","errorMessage":"429 credits_exhausted"}}',
     ].join("\n");
 
-    expect(cleanPipeStdout(stdout)).toBe("error: 429 credits_exhausted");
+    expect(cleanPipeStdout(stdout)).toBe("daily AI limit reached — upgrade or wait until tomorrow");
   });
 
   // ─── auto_compaction events ─────────────────────────────────────────

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-foreground-events.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-foreground-events.ts
@@ -366,12 +366,15 @@ export function usePiForegroundEvents({
         } else if (data.type === "auto_retry_end" && data.success === false) {
           // Pi exhausted retries on a transient error (rate limit, overloaded, etc.)
           const errorStr = stringValue(data.finalError, "Request failed after retries");
-          console.error("[Pi] Auto-retry failed:", errorStr);
+          const quotaErrorType = classifyQuotaError(errorStr);
+          const logAutoRetryFailure = quotaErrorType === "daily" || quotaErrorType === "rate" || errorStr.includes("model_not_allowed")
+            ? console.warn
+            : console.error;
+          logAutoRetryFailure("[Pi] Auto-retry failed:", errorStr);
           piLastErrorRef.current = errorStr;
           emitSessionActivity({ status: "error", lastError: errorStr });
 
           // Detect rate limit or daily limit from the error
-          const quotaErrorType = classifyQuotaError(errorStr);
           if (quotaErrorType === "daily" || quotaErrorType === "rate") {
             if (quotaErrorType === "daily") {
               posthog.capture("wall_hit", { reason: "daily_limit", source: "chat" });
@@ -596,7 +599,11 @@ export function usePiForegroundEvents({
                    data.message?.role === "assistant" && data.message?.stopReason === "error") {
           // LLM returned an error (credits_exhausted, rate limit, provider error, etc.)
           const errMsg = stringValue(data.message.errorMessage, stringValue(data.message.error, "Unknown error"));
-          console.error("[Pi] LLM error via", data.type, ":", errMsg);
+          const quotaErrorType = classifyQuotaError(errMsg);
+          const logLlmError = quotaErrorType === "daily" || quotaErrorType === "rate" || errMsg.includes("model_not_allowed")
+            ? console.warn
+            : console.error;
+          logLlmError("[Pi] LLM error via", data.type, ":", errMsg);
           piLastErrorRef.current = errMsg;
           emitSessionActivity({ status: "error", lastError: errMsg });
           const authTokenInvalidated = isInvalidatedAuthTokenError(errMsg);
@@ -607,7 +614,6 @@ export function usePiForegroundEvents({
           if (piMessageIdRef.current) {
             const msgId = piMessageIdRef.current;
 
-            const quotaErrorType = classifyQuotaError(errMsg);
             const providerError = buildProviderErrorMessage(errMsg, activePreset);
             if (authTokenInvalidated) {
               setMessages((prev) =>

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -770,7 +770,8 @@ export function cleanPipeStdout(raw: string): string {
   flushText();
   const text = parts.join("\n\n").trim();
   if (!text && errorMessage) {
-    return `error: ${errorMessage}`;
+    const parsed = parsePipeError(errorMessage);
+    return parsed.type === "unknown" ? `error: ${errorMessage}` : parsed.message;
   }
   return text;
 }

--- a/apps/screenpipe-app-tauri/lib/__tests__/pipe-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pipe-errors.test.ts
@@ -21,8 +21,41 @@ describe("parsePipeError", () => {
     expect(parsePipeError(stderr(429, { error: "daily_cost_limit_exceeded" })).type).toBe("daily_limit");
   });
 
+  it("classifies compact daily limit code from Pi", () => {
+    expect(parsePipeError(`429 "daily_cost_limit_exceeded"`).type).toBe("daily_limit");
+  });
+
+  it("classifies unescaped gateway JSON and preserves its message", () => {
+    const r = parsePipeError(
+      `429 ${JSON.stringify({
+        error: "daily_cost_limit_exceeded",
+        message: "You've hit today's AI usage limit.",
+      })}`,
+    );
+    expect(r.type).toBe("daily_limit");
+    expect(r.message).toBe("You've hit today's AI usage limit.");
+  });
+
   it("classifies credits_exhausted", () => {
     expect(parsePipeError(stderr(429, { error: "credits_exhausted", credits_remaining: 0 })).type).toBe("credits_exhausted");
+  });
+
+  it("classifies compact credits code from Pi", () => {
+    expect(parsePipeError(`429 "credits_exhausted"`).type).toBe("credits_exhausted");
+  });
+
+  it("classifies provider quota exhaustion", () => {
+    const r = parsePipeError(
+      `429 ${JSON.stringify({
+        error: {
+          type: "insufficient_quota",
+          code: "insufficient_quota",
+          message: "You exceeded your current quota, please check your plan and billing details.",
+        },
+      })}`,
+    );
+    expect(r.type).toBe("quota_exhausted");
+    expect(r.message).toContain("current quota");
   });
 
   it("classifies model_not_allowed (new) with a friendly upgrade message", () => {
@@ -44,6 +77,7 @@ describe("isActionablePipeError — what's worth a proactive advisory", () => {
   it("true for the cases a user can act on (budget / plan)", () => {
     expect(isActionablePipeError("daily_limit")).toBe(true);
     expect(isActionablePipeError("credits_exhausted")).toBe(true);
+    expect(isActionablePipeError("quota_exhausted")).toBe(true);
     expect(isActionablePipeError("model_not_allowed")).toBe(true);
   });
 

--- a/apps/screenpipe-app-tauri/lib/__tests__/pipe-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pipe-errors.test.ts
@@ -68,6 +68,29 @@ describe("parsePipeError", () => {
     expect(parsePipeError(stderr(429, { error: "rate limit exceeded" })).type).toBe("rate_limit");
   });
 
+  it("keeps a transient rate limit that merely mentions quota/billing as rate_limit", () => {
+    // quota is classified before rate_limit, so a bare "quota"/"billing"
+    // substring match here would wrongly suppress the retry.
+    const r = parsePipeError(
+      `429 ${JSON.stringify({
+        error: {
+          type: "rate_limit_error",
+          message: "Rate limited — see your quota and billing dashboard for details.",
+        },
+      })}`,
+    );
+    expect(r.type).toBe("rate_limit");
+  });
+
+  it("still classifies a terminal billing hard limit as quota_exhausted", () => {
+    const r = parsePipeError(
+      `429 ${JSON.stringify({
+        error: { type: "billing_hard_limit", message: "billing_hard_limit reached" },
+      })}`,
+    );
+    expect(r.type).toBe("quota_exhausted");
+  });
+
   it("falls back to unknown for non-gateway stderr", () => {
     expect(parsePipeError("TypeError: undefined is not a function").type).toBe("unknown");
   });

--- a/apps/screenpipe-app-tauri/lib/pipe-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/pipe-errors.ts
@@ -11,6 +11,7 @@
 export type PipeErrorType =
   | "daily_limit"
   | "credits_exhausted"
+  | "quota_exhausted"
   | "rate_limit"
   | "model_not_allowed"
   | "unknown";
@@ -25,51 +26,154 @@ export interface ParsedPipeError {
 }
 
 export function parsePipeError(stderr: string): ParsedPipeError {
-  // stderr format: '429 "{\"error\":...}"\n' — inner quotes are backslash-escaped
-  const jsonMatch = stderr.match(/\d{3}\s+"(.+)"/s);
-  if (jsonMatch) {
-    try {
-      const raw = jsonMatch[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\");
-      const parsed = JSON.parse(raw);
-      if (parsed.error === "daily_limit_exceeded") {
-        return {
-          type: "daily_limit",
-          message: `daily limit reached (${parsed.used_today}/${parsed.limit_today})`,
-          used: parsed.used_today,
-          limit: parsed.limit_today,
-          resets_at: parsed.resets_at,
-        };
-      }
-      if (parsed.error === "daily_cost_limit_exceeded") {
-        return {
-          type: "daily_limit",
-          message: `daily ai usage limit reached — try a lighter model or wait until tomorrow`,
-        };
-      }
-      if (parsed.error === "rate limit exceeded") {
-        return {
-          type: "rate_limit",
-          message: `rate limited — retrying automatically`,
-        };
-      }
-      if (parsed.error === "credits_exhausted") {
-        return {
-          type: "credits_exhausted",
-          message: parsed.message || "daily ai limit reached — upgrade or wait until tomorrow",
-          credits_remaining: parsed.credits_remaining ?? 0,
-        };
-      }
-      if (parsed.error === "model_not_allowed") {
-        return {
-          type: "model_not_allowed",
-          message: "uses a model that needs business — switch to a free model (auto) or upgrade",
-        };
-      }
-    } catch {
-      // fall through to the generic case
-    }
+  for (const parsed of parseErrorJsonCandidates(stderr)) {
+    const classified = classifyStructuredPipeError(parsed);
+    if (classified) return classified;
+  }
+  const normalized = stderr.toLowerCase();
+  if (
+    normalized.includes("daily_cost_limit_exceeded") ||
+    normalized.includes("daily_limit_exceeded")
+  ) {
+    return {
+      type: "daily_limit",
+      message: "daily AI usage limit reached",
+    };
+  }
+  if (normalized.includes("credits_exhausted")) {
+    return {
+      type: "credits_exhausted",
+      message: "daily AI limit reached — upgrade or wait until tomorrow",
+      credits_remaining: 0,
+    };
+  }
+  if (normalized.includes("model_not_allowed")) {
+    return {
+      type: "model_not_allowed",
+      message: "uses a model that needs business — switch to a free model (auto) or upgrade",
+    };
+  }
+  if (
+    normalized.includes("insufficient_quota") ||
+    normalized.includes("quota_exhausted") ||
+    normalized.includes("exceeded your current quota") ||
+    normalized.includes("billing")
+  ) {
+    return {
+      type: "quota_exhausted",
+      message: "provider quota or billing limit reached",
+    };
+  }
+  if (
+    normalized.includes("rate_limit") ||
+    normalized.includes("rate limit") ||
+    normalized.includes("429")
+  ) {
+    return {
+      type: "rate_limit",
+      message: "rate limited — retrying automatically",
+    };
   }
   return { type: "unknown", message: stderr.slice(0, 150) };
+}
+
+function parseErrorJsonCandidates(stderr: string): unknown[] {
+  const candidates = new Set<string>();
+  const quoted = stderr.match(/\d{3}\s+"(.+)"/s);
+  if (quoted) candidates.add(quoted[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\"));
+  const firstBrace = stderr.indexOf("{");
+  if (firstBrace >= 0) candidates.add(stderr.slice(firstBrace));
+  candidates.add(stderr);
+
+  const parsed: unknown[] = [];
+  for (const candidate of candidates) {
+    try {
+      parsed.push(JSON.parse(candidate));
+    } catch {
+      // Not a JSON-shaped error; try the next candidate.
+    }
+  }
+  return parsed;
+}
+
+function classifyStructuredPipeError(value: unknown): ParsedPipeError | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const nested = record.error && typeof record.error === "object"
+    ? (record.error as Record<string, unknown>)
+    : null;
+  const errorName = typeof record.error === "string" ? record.error : undefined;
+  const code = stringValue(nested?.code) || stringValue(record.code);
+  const errorType = stringValue(nested?.type) || stringValue(record.type);
+  const message = stringValue(nested?.message) || stringValue(record.message) || errorName;
+  const combined = [errorName, code, errorType, message]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (combined.includes("daily_limit_exceeded")) {
+    return {
+      type: "daily_limit",
+      message:
+        typeof record.used_today === "number" && typeof record.limit_today === "number"
+          ? `daily limit reached (${record.used_today}/${record.limit_today})`
+          : message || "daily AI usage limit reached",
+      used: numberValue(record.used_today),
+      limit: numberValue(record.limit_today),
+      resets_at: stringValue(record.resets_at),
+    };
+  }
+  if (combined.includes("daily_cost_limit_exceeded")) {
+    return {
+      type: "daily_limit",
+      message:
+        message ||
+        "daily AI usage limit reached — try a lighter model or wait until tomorrow",
+      resets_at: stringValue(record.resets_at),
+    };
+  }
+  if (combined.includes("credits_exhausted")) {
+    return {
+      type: "credits_exhausted",
+      message: message || "daily AI limit reached — upgrade or wait until tomorrow",
+      credits_remaining: numberValue(record.credits_remaining) ?? 0,
+    };
+  }
+  if (combined.includes("model_not_allowed")) {
+    return {
+      type: "model_not_allowed",
+      message: "uses a model that needs business — switch to a free model (auto) or upgrade",
+    };
+  }
+  if (
+    combined.includes("insufficient_quota") ||
+    combined.includes("quota") ||
+    combined.includes("billing")
+  ) {
+    return {
+      type: "quota_exhausted",
+      message: message || "provider quota or billing limit reached",
+    };
+  }
+  if (
+    combined.includes("rate_limit") ||
+    combined.includes("rate limit") ||
+    combined.includes("too many requests")
+  ) {
+    return {
+      type: "rate_limit",
+      message: message || "rate limited — retrying automatically",
+    };
+  }
+  return null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
 }
 
 /**
@@ -82,6 +186,7 @@ export function isActionablePipeError(type: PipeErrorType): boolean {
   return (
     type === "daily_limit" ||
     type === "credits_exhausted" ||
+    type === "quota_exhausted" ||
     type === "model_not_allowed"
   );
 }

--- a/apps/screenpipe-app-tauri/lib/pipe-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/pipe-errors.ts
@@ -25,6 +25,28 @@ export interface ParsedPipeError {
   credits_remaining?: number;
 }
 
+/**
+ * Specific tokens that mean a terminal provider quota/billing gate (no point
+ * retrying or falling back). Deliberately NOT a bare "quota"/"billing" match:
+ * transient rate-limit messages often mention those words (e.g. "rate limited —
+ * see your quota/billing dashboard"), and since quota is classified before
+ * rate_limit, a loose match would suppress a legitimate retry.
+ */
+const QUOTA_EXHAUSTED_TOKENS = [
+  "insufficient_quota",
+  "quota_exhausted",
+  "quota exceeded",
+  "exceeded your current quota",
+  "billing_hard_limit",
+  "billing_not_active",
+  "check your plan and billing",
+  "credit balance is too low",
+] as const;
+
+function hasQuotaExhaustedToken(text: string): boolean {
+  return QUOTA_EXHAUSTED_TOKENS.some((token) => text.includes(token));
+}
+
 export function parsePipeError(stderr: string): ParsedPipeError {
   for (const parsed of parseErrorJsonCandidates(stderr)) {
     const classified = classifyStructuredPipeError(parsed);
@@ -53,12 +75,7 @@ export function parsePipeError(stderr: string): ParsedPipeError {
       message: "uses a model that needs business — switch to a free model (auto) or upgrade",
     };
   }
-  if (
-    normalized.includes("insufficient_quota") ||
-    normalized.includes("quota_exhausted") ||
-    normalized.includes("exceeded your current quota") ||
-    normalized.includes("billing")
-  ) {
+  if (hasQuotaExhaustedToken(normalized)) {
     return {
       type: "quota_exhausted",
       message: "provider quota or billing limit reached",
@@ -145,11 +162,7 @@ function classifyStructuredPipeError(value: unknown): ParsedPipeError | null {
       message: "uses a model that needs business — switch to a free model (auto) or upgrade",
     };
   }
-  if (
-    combined.includes("insufficient_quota") ||
-    combined.includes("quota") ||
-    combined.includes("billing")
-  ) {
+  if (hasQuotaExhaustedToken(combined)) {
     return {
       type: "quota_exhausted",
       message: message || "provider quota or billing limit reached",

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -57,6 +57,15 @@ fn parse_rate_limit_reset_secs(text: &str) -> Option<u64> {
 /// Whether a pi failure was caused by provider rate limiting (HTTP 429).
 fn is_rate_limit_error(text: &str) -> bool {
     let lower = text.to_lowercase();
+    if lower.contains("daily_cost_limit_exceeded")
+        || lower.contains("daily_limit_exceeded")
+        || lower.contains("credits_exhausted")
+        || lower.contains("insufficient_quota")
+        || lower.contains("quota_exhausted")
+        || lower.contains("model_not_allowed")
+    {
+        return false;
+    }
     lower.contains("429")
         || lower.contains("rate limit")
         || lower.contains("rate_limit")
@@ -3294,6 +3303,11 @@ mod tests {
         assert!(is_rate_limit_error(r#"{"reset_in":12}"#));
         assert!(!is_rate_limit_error("model not found"));
         assert!(!is_rate_limit_error("credits_exhausted"));
+        assert!(!is_rate_limit_error(r#"429 "daily_cost_limit_exceeded""#));
+        assert!(!is_rate_limit_error(r#"429 "credits_exhausted""#));
+        assert!(!is_rate_limit_error(
+            r#"429 {"error":{"type":"insufficient_quota"}}"#
+        ));
     }
 
     #[tokio::test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -60,9 +60,8 @@ fn is_rate_limit_error(text: &str) -> bool {
     if lower.contains("daily_cost_limit_exceeded")
         || lower.contains("daily_limit_exceeded")
         || lower.contains("credits_exhausted")
-        || lower.contains("insufficient_quota")
-        || lower.contains("quota_exhausted")
         || lower.contains("model_not_allowed")
+        || crate::pipes::has_quota_exhausted_token(&lower)
     {
         return false;
     }

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -1519,6 +1519,38 @@ fn parse_error_type_from_output(stderr: &str, stdout: &str) -> (Option<String>, 
 /// Parse structured error types from a single output string.
 fn parse_error_type(stderr: &str) -> (Option<String>, Option<String>) {
     let lower = stderr.to_lowercase();
+    if let Some(parsed) = parse_structured_llm_error(stderr) {
+        return parsed;
+    }
+    if lower.contains("daily_cost_limit_exceeded") || lower.contains("daily_limit_exceeded") {
+        return (
+            Some("daily_limit".to_string()),
+            Some("daily AI usage limit reached".to_string()),
+        );
+    }
+    if lower.contains("credits_exhausted") {
+        return (
+            Some("credits_exhausted".to_string()),
+            Some("AI credits exhausted".to_string()),
+        );
+    }
+    if lower.contains("model_not_allowed") {
+        return (
+            Some("model_not_allowed".to_string()),
+            Some("model not available on current tier".to_string()),
+        );
+    }
+    if lower.contains("insufficient_quota")
+        || lower.contains("quota_exhausted")
+        || lower.contains("quota exceeded")
+        || lower.contains("exceeded your current quota")
+        || lower.contains("billing")
+    {
+        return (
+            Some("quota_exhausted".to_string()),
+            Some("provider quota or billing limit reached".to_string()),
+        );
+    }
     if lower.contains("rate limit") || lower.contains("429") || lower.contains("rate_limit") {
         return (
             Some("rate_limited".to_string()),
@@ -1557,6 +1589,120 @@ fn parse_error_type(stderr: &str) -> (Option<String>, Option<String>) {
         );
     }
     (None, None)
+}
+
+fn parse_structured_llm_error(input: &str) -> Option<(Option<String>, Option<String>)> {
+    for candidate in json_candidates(input) {
+        if let Some(parsed) = parse_llm_error_json(&candidate) {
+            return Some(parsed);
+        }
+    }
+    None
+}
+
+fn json_candidates(input: &str) -> Vec<String> {
+    let mut candidates = vec![input.to_string()];
+    let unescaped = input.replace("\\\"", "\"").replace("\\\\", "\\");
+    if unescaped != input {
+        candidates.push(unescaped);
+    }
+    candidates
+}
+
+fn parse_llm_error_json(input: &str) -> Option<(Option<String>, Option<String>)> {
+    for (idx, ch) in input.char_indices() {
+        if ch != '{' {
+            continue;
+        }
+        let slice = &input[idx..];
+        let mut stream = serde_json::Deserializer::from_str(slice).into_iter::<serde_json::Value>();
+        let Ok(value) = stream.next()? else {
+            continue;
+        };
+        if let Some(parsed) = classify_llm_error_value(&value) {
+            return Some(parsed);
+        }
+    }
+    None
+}
+
+fn classify_llm_error_value(value: &serde_json::Value) -> Option<(Option<String>, Option<String>)> {
+    let error_value = value.get("error").unwrap_or(value);
+    let error_name = value
+        .get("error")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let code = string_field(error_value, "code").or_else(|| string_field(value, "code"));
+    let error_type = string_field(error_value, "type").or_else(|| string_field(value, "type"));
+    let message = string_field(error_value, "message")
+        .or_else(|| string_field(value, "message"))
+        .or_else(|| error_name.clone());
+    let combined = [
+        error_name.as_deref(),
+        code.as_deref(),
+        error_type.as_deref(),
+        message.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(" ")
+    .to_lowercase();
+
+    if combined.contains("daily_cost_limit_exceeded") || combined.contains("daily_limit_exceeded") {
+        return Some((
+            Some("daily_limit".to_string()),
+            Some(message.unwrap_or_else(|| "daily AI usage limit reached".to_string())),
+        ));
+    }
+    if combined.contains("credits_exhausted") {
+        return Some((
+            Some("credits_exhausted".to_string()),
+            Some(message.unwrap_or_else(|| "AI credits exhausted".to_string())),
+        ));
+    }
+    if combined.contains("model_not_allowed") {
+        return Some((
+            Some("model_not_allowed".to_string()),
+            Some(message.unwrap_or_else(|| "model not available on current tier".to_string())),
+        ));
+    }
+    if combined.contains("insufficient_quota")
+        || combined.contains("quota")
+        || combined.contains("billing")
+    {
+        return Some((
+            Some("quota_exhausted".to_string()),
+            Some(message.unwrap_or_else(|| "provider quota or billing limit reached".to_string())),
+        ));
+    }
+    if combined.contains("rate_limit")
+        || combined.contains("rate limit")
+        || combined.contains("too many requests")
+    {
+        return Some((
+            Some("rate_limited".to_string()),
+            Some(message.unwrap_or_else(|| "rate limited by LLM provider".to_string())),
+        ));
+    }
+    None
+}
+
+fn string_field(value: &serde_json::Value, key: &str) -> Option<String> {
+    value.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn should_try_fallback_preset(error_type: Option<&str>) -> bool {
+    !matches!(
+        error_type,
+        Some(
+            "auth_failed"
+                | "credits_exhausted"
+                | "daily_limit"
+                | "model_not_allowed"
+                | "quota_exhausted"
+        )
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -3351,6 +3497,12 @@ impl PipeManager {
                 cleanup_pipe_token(token, self.token_registry.as_ref());
             }
 
+            let retry_error_type = if log.success {
+                None
+            } else {
+                parse_error_type_from_output(&log.stderr, &log.stdout).0
+            };
+
             // Immediate fallback retry: if the run failed and there is another
             // fallback preset we haven't tried this run, retry now with the next
             // one instead of waiting for the next scheduled run.
@@ -3362,9 +3514,12 @@ impl PipeManager {
             // crashes — so gating fallback on it meant the next model silently
             // never ran when the main one timed out or errored (#3914).
             let max_attempts = config.preset.len().min(preset_fallback::MAX_FALLBACK_DEPTH);
-            if let (false, Some(cur_idx), false) =
-                (log.success, active_preset_idx, cancelled_for_retry)
-            {
+            if let (false, Some(cur_idx), false, true) = (
+                log.success,
+                active_preset_idx,
+                cancelled_for_retry,
+                should_try_fallback_preset(retry_error_type.as_deref()),
+            ) {
                 let next_idx = cur_idx + 1;
                 if next_idx < max_attempts {
                     if let Some(next_preset_id) = config.preset.get(next_idx) {
@@ -6610,6 +6765,71 @@ mod tests {
     fn test_parse_error_type_rate_limited_429() {
         let (etype, _msg) = parse_error_type("429 rate limit exceeded");
         assert_eq!(etype.as_deref(), Some("rate_limited"));
+    }
+
+    #[test]
+    fn test_parse_error_type_daily_cost_limit_json() {
+        let (etype, msg) = parse_error_type(
+            r#"429 "{\"error\":\"daily_cost_limit_exceeded\",\"message\":\"You've hit today's AI usage limit.\",\"tier\":\"subscribed\"}""#,
+        );
+        assert_eq!(etype.as_deref(), Some("daily_limit"));
+        assert_eq!(msg.as_deref(), Some("You've hit today's AI usage limit."));
+    }
+
+    #[test]
+    fn test_parse_error_type_daily_cost_limit_code_string() {
+        let (etype, msg) = parse_error_type(r#"429 "daily_cost_limit_exceeded""#);
+        assert_eq!(etype.as_deref(), Some("daily_limit"));
+        assert_eq!(msg.as_deref(), Some("daily AI usage limit reached"));
+    }
+
+    #[test]
+    fn test_parse_error_type_credits_exhausted_json() {
+        let (etype, msg) = parse_error_type(
+            r#"429 {"error":"credits_exhausted","message":"You've used all free queries and have no credits remaining."}"#,
+        );
+        assert_eq!(etype.as_deref(), Some("credits_exhausted"));
+        assert_eq!(
+            msg.as_deref(),
+            Some("You've used all free queries and have no credits remaining.")
+        );
+    }
+
+    #[test]
+    fn test_parse_error_type_credits_exhausted_code_string() {
+        let (etype, msg) = parse_error_type(r#"429 "credits_exhausted""#);
+        assert_eq!(etype.as_deref(), Some("credits_exhausted"));
+        assert_eq!(msg.as_deref(), Some("AI credits exhausted"));
+    }
+
+    #[test]
+    fn test_parse_error_type_openai_insufficient_quota_json() {
+        let (etype, msg) = parse_error_type(
+            r#"429 {"error":{"message":"You exceeded your current quota, please check your plan and billing details.","type":"insufficient_quota","code":"insufficient_quota"}}"#,
+        );
+        assert_eq!(etype.as_deref(), Some("quota_exhausted"));
+        assert_eq!(
+            msg.as_deref(),
+            Some("You exceeded your current quota, please check your plan and billing details.")
+        );
+    }
+
+    #[test]
+    fn test_parse_error_type_anthropic_rate_limit_json() {
+        let (etype, msg) = parse_error_type(
+            r#"429 {"type":"error","error":{"type":"rate_limit_error","message":"Your account has hit a rate limit."}}"#,
+        );
+        assert_eq!(etype.as_deref(), Some("rate_limited"));
+        assert_eq!(msg.as_deref(), Some("Your account has hit a rate limit."));
+    }
+
+    #[test]
+    fn test_daily_limit_does_not_try_fallback_preset() {
+        assert!(!should_try_fallback_preset(Some("daily_limit")));
+        assert!(!should_try_fallback_preset(Some("credits_exhausted")));
+        assert!(!should_try_fallback_preset(Some("quota_exhausted")));
+        assert!(should_try_fallback_preset(Some("rate_limited")));
+        assert!(should_try_fallback_preset(Some("timeout")));
     }
 
     #[test]

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -1516,6 +1516,29 @@ fn parse_error_type_from_output(stderr: &str, stdout: &str) -> (Option<String>, 
     parse_error_type(stdout)
 }
 
+/// Specific tokens that mean a terminal provider quota/billing gate (no point
+/// retrying or falling back). Deliberately NOT a bare "quota"/"billing" match:
+/// transient rate-limit messages often mention those words (e.g. "rate limited —
+/// see your quota/billing dashboard"), and since quota is classified before
+/// rate_limit, a loose match would suppress a legitimate retry.
+pub(crate) const QUOTA_EXHAUSTED_TOKENS: &[&str] = &[
+    "insufficient_quota",
+    "quota_exhausted",
+    "quota exceeded",
+    "exceeded your current quota",
+    "billing_hard_limit",
+    "billing_not_active",
+    "check your plan and billing",
+    "credit balance is too low",
+];
+
+/// `text` must already be lowercased.
+pub(crate) fn has_quota_exhausted_token(text: &str) -> bool {
+    QUOTA_EXHAUSTED_TOKENS
+        .iter()
+        .any(|token| text.contains(token))
+}
+
 /// Parse structured error types from a single output string.
 fn parse_error_type(stderr: &str) -> (Option<String>, Option<String>) {
     let lower = stderr.to_lowercase();
@@ -1540,12 +1563,7 @@ fn parse_error_type(stderr: &str) -> (Option<String>, Option<String>) {
             Some("model not available on current tier".to_string()),
         );
     }
-    if lower.contains("insufficient_quota")
-        || lower.contains("quota_exhausted")
-        || lower.contains("quota exceeded")
-        || lower.contains("exceeded your current quota")
-        || lower.contains("billing")
-    {
+    if has_quota_exhausted_token(&lower) {
         return (
             Some("quota_exhausted".to_string()),
             Some("provider quota or billing limit reached".to_string()),
@@ -1667,10 +1685,7 @@ fn classify_llm_error_value(value: &serde_json::Value) -> Option<(Option<String>
             Some(message.unwrap_or_else(|| "model not available on current tier".to_string())),
         ));
     }
-    if combined.contains("insufficient_quota")
-        || combined.contains("quota")
-        || combined.contains("billing")
-    {
+    if has_quota_exhausted_token(&combined) {
         return Some((
             Some("quota_exhausted".to_string()),
             Some(message.unwrap_or_else(|| "provider quota or billing limit reached".to_string())),
@@ -6821,6 +6836,28 @@ mod tests {
         );
         assert_eq!(etype.as_deref(), Some("rate_limited"));
         assert_eq!(msg.as_deref(), Some("Your account has hit a rate limit."));
+    }
+
+    #[test]
+    fn test_parse_error_type_rate_limit_mentioning_quota_billing_stays_rate_limited() {
+        // quota is classified before rate_limit, so a bare "quota"/"billing"
+        // substring match would wrongly mark this terminal and suppress retry.
+        let (etype, _) = parse_error_type(
+            r#"429 {"error":{"type":"rate_limit_error","message":"Rate limited — see your quota and billing dashboard for details."}}"#,
+        );
+        assert_eq!(etype.as_deref(), Some("rate_limited"));
+
+        let (etype, _) =
+            parse_error_type("Error: rate limit reached — check your quota/billing dashboard");
+        assert_eq!(etype.as_deref(), Some("rate_limited"));
+    }
+
+    #[test]
+    fn test_parse_error_type_billing_hard_limit_is_quota_exhausted() {
+        let (etype, _) = parse_error_type(
+            r#"429 {"error":{"type":"billing_hard_limit","message":"billing_hard_limit reached"}}"#,
+        );
+        assert_eq!(etype.as_deref(), Some("quota_exhausted"));
     }
 
     #[test]

--- a/crates/screenpipe-core/src/pipes/preset_fallback.rs
+++ b/crates/screenpipe-core/src/pipes/preset_fallback.rs
@@ -334,6 +334,16 @@ impl PresetFallbackRegistry {
     pub fn record_failure_from_output(&self, preset_id: &str, stderr: &str, stdout: &str) -> bool {
         let combined = format!("{} {}", stderr, stdout).to_lowercase();
 
+        if combined.contains("daily_cost_limit_exceeded")
+            || combined.contains("daily_limit_exceeded")
+            || combined.contains("credits_exhausted")
+            || combined.contains("insufficient_quota")
+            || combined.contains("quota")
+            || combined.contains("billing")
+        {
+            return false;
+        }
+
         let reason = if combined.contains("rate limit")
             || combined.contains("rate_limit")
             || combined.contains("usage limit")
@@ -542,6 +552,18 @@ mod tests {
     fn test_retryable_errors() {
         let registry = PresetFallbackRegistry::new(Path::new("/tmp"));
         assert!(registry.record_failure("test", Some("rate_limited")));
+    }
+
+    #[test]
+    fn test_daily_limit_output_does_not_trip_breaker() {
+        let registry = fresh_registry("daily_limit_no_trip");
+        assert!(!registry.record_failure_from_output(
+            "test",
+            r#"429 "{\"error\":\"daily_cost_limit_exceeded\",\"message\":\"You've hit today's AI usage limit.\"}""#,
+            ""
+        ));
+        let presets = vec!["test".to_string()];
+        assert_eq!(registry.pick_preset(&presets), Some(("test", 0)));
     }
 
     /// Hermetic registry in a unique temp dir so persisted state can't leak

--- a/crates/screenpipe-core/src/pipes/preset_fallback.rs
+++ b/crates/screenpipe-core/src/pipes/preset_fallback.rs
@@ -334,12 +334,13 @@ impl PresetFallbackRegistry {
     pub fn record_failure_from_output(&self, preset_id: &str, stderr: &str, stdout: &str) -> bool {
         let combined = format!("{} {}", stderr, stdout).to_lowercase();
 
+        // Bare "quota"/"billing" is deliberately avoided here: a transient rate
+        // limit that merely mentions those words (checked below) must still fall
+        // back rather than being treated as a terminal, non-retryable gate.
         if combined.contains("daily_cost_limit_exceeded")
             || combined.contains("daily_limit_exceeded")
             || combined.contains("credits_exhausted")
-            || combined.contains("insufficient_quota")
-            || combined.contains("quota")
-            || combined.contains("billing")
+            || super::has_quota_exhausted_token(&combined)
         {
             return false;
         }


### PR DESCRIPTION
### Description:

- before:

<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/4bf1d181-da8c-4b24-bfad-1b8c416d1207" />

- after:

1. Daily Cost Limit

https://github.com/user-attachments/assets/d50308c0-332b-4a31-a496-30080dfa31e7

2. Credits Exhausted


https://github.com/user-attachments/assets/c10e2034-5591-444d-97f5-d2b5243f2f8b

3. Insufficient Quota



https://github.com/user-attachments/assets/eaca9bfc-f4c6-46ac-be07-73f3ee50f5d2



- tests passing:

<img width="1188" height="826" alt="image" src="https://github.com/user-attachments/assets/4c543076-2ede-45be-adbf-04210c930127" />

<img width="997" height="411" alt="image" src="https://github.com/user-attachments/assets/14f7b15d-148b-4356-b88f-f6ea65e777d3" />

<img width="1051" height="232" alt="image" src="https://github.com/user-attachments/assets/ac835403-503c-4047-84c5-3f0695f2d3ab" />


  - Classifies provider quota/budget errors separately from transient rate limits.
  - Stops retrying or falling back when the error is non-retryable, like daily_cost_limit_exceeded, credits_exhausted, or insufficient_quota.
  - Preserves real rate-limit behavior for temporary 429 throttling.
  - Improves pipe run UI output so known quota errors show friendly messages instead of raw 429 "..."
  - Avoids surfacing expected Pi quota/rate failures as frontend console.error noise.
  - Adds coverage for compact Pi error strings like 429 "daily_cost_limit_exceeded" and structured provider JSON errors.