### PR TITLE
fix(ocr): pre-flight tesseract so a missing binary can't panic the capture worker (CLI-V3/T0)

### DIFF
--- a/crates/screenpipe-screen/src/tesseract.rs
+++ b/crates/screenpipe-screen/src/tesseract.rs
@@ -7,7 +7,7 @@ use rusty_tesseract::{Args, DataOutput, Image};
 use screenpipe_core::{Language, TESSERACT_LANGUAGES};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Once;
+use std::sync::{Once, OnceLock};
 use tracing::warn;
 
 /// Ensure TESSDATA_PREFIX is set so tesseract can find language data files.
@@ -95,12 +95,53 @@ fn ensure_bundled_tesseract_on_path() {
     });
 }
 
+/// Whether a `tesseract` binary is resolvable, probed once per process.
+///
+/// rusty-tesseract's `get_tesseract_command()` does `find_tesseract_path().unwrap()`
+/// (command.rs:108) — when no binary is found it PANICS ("called `Option::unwrap()`
+/// on a `None` value") instead of returning Err, unwinding the tokio capture
+/// worker (SCREENPIPE-CLI-V3 / CLI-T0: Linux/npx hosts with no system tesseract
+/// and no bundled one). #4564's `catch_unwind` stops the crash, but the panic
+/// hook still fires on every frame → continued Sentry noise plus stack-unwind +
+/// backtrace cost ~30×/sec for the whole session. Pre-flighting the *same*
+/// resolution rusty-tesseract uses lets us disable OCR cleanly and log exactly
+/// once, so the panic never happens in the common missing-binary case. The
+/// `catch_unwind` below stays as a belt-and-suspenders net for other tesseract
+/// misbehavior (e.g. a present-but-broken binary).
+///
+/// Cached because the binary's presence does not change within a process run and
+/// `find_tesseract_path()` stats several locations + walks PATH each call. The
+/// `ensure_bundled_tesseract_on_path()` / `ensure_tessdata_prefix()` env setup
+/// runs (once) before the first probe, so the bundled CLI binary is on PATH by
+/// the time we look.
+fn tesseract_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        let found = rusty_tesseract::find_tesseract_path().is_some();
+        if !found {
+            warn!(
+                "tesseract binary not found (no system install and none bundled next to \
+                 the engine); OCR disabled for this session — install tesseract-ocr to \
+                 enable screen text capture"
+            );
+        }
+        found
+    })
+}
+
 pub fn perform_ocr_tesseract(
     image: &DynamicImage,
     languages: Vec<Language>,
 ) -> (String, String, Option<f64>) {
     ensure_bundled_tesseract_on_path();
     ensure_tessdata_prefix();
+
+    // No tesseract binary → skip OCR instead of letting rusty-tesseract panic on
+    // every frame (SCREENPIPE-CLI-V3 / CLI-T0). Returns the same empty sentinel
+    // as a failed OCR so the rest of the capture pipeline is unaffected.
+    if !tesseract_available() {
+        return (String::new(), "[]".to_string(), None);
+    }
 
     let language_string = match languages.is_empty() {
         true => "eng".to_string(),
@@ -267,14 +308,31 @@ mod tests {
 
     // SCREENPIPE-CLI-V3 / CLI-T0: rusty_tesseract panics (unwrap on None) when
     // the tesseract binary is unavailable. perform_ocr_tesseract must absorb that
-    // via catch_unwind and return an empty result instead of unwinding the
-    // worker. Runs whether or not tesseract is installed: missing → exercises the
-    // catch_unwind path; present → normal OCR of a blank image. Either way it
-    // must return (not panic) with structured JSON.
+    // and return an empty result instead of unwinding the worker. Runs whether or
+    // not tesseract is installed: missing → exercises the tesseract_available()
+    // pre-flight skip; present → normal OCR of a blank image. The catch_unwind
+    // around image_to_data backs both paths up. Either way it must return (not
+    // panic) with structured JSON.
     #[test]
     fn perform_ocr_tesseract_is_panic_safe() {
         let img = image::DynamicImage::ImageRgb8(image::RgbImage::new(8, 8));
         let (_text, json, _conf) = perform_ocr_tesseract(&img, vec![]);
         assert!(json.starts_with('['), "expected JSON array, got: {json}");
+    }
+
+    // The availability probe is cached for the process, so the enable/disable-OCR
+    // decision must be stable: no flapping between frames, and it must agree with
+    // a direct resolution probe. (Whether tesseract is actually present depends on
+    // the test host — we assert consistency, not a specific value.)
+    #[test]
+    fn tesseract_available_is_stable() {
+        let a = tesseract_available();
+        let b = tesseract_available();
+        assert_eq!(a, b, "cached availability must not flap");
+        assert_eq!(
+            a,
+            rusty_tesseract::find_tesseract_path().is_some(),
+            "probe must match rusty-tesseract's own resolution"
+        );
     }
 }


### PR DESCRIPTION
## what

Stops `SCREENPIPE-CLI-V3` / `SCREENPIPE-CLI-T0` — the `Option::unwrap()`-on-`None` panic on `tokio-rt-worker` — at its source instead of only catching the unwind.

| | |
|---|---|
| **Issues** | [CLI-V3](https://mediar.sentry.io/issues/7536190224/) · [CLI-T0](https://mediar.sentry.io/issues/7500318164/) — 12 users **each**, `fatal` |
| **Release** | `screenpipe-engine@0.4.24`, Linux (npx `@screenpipe/cli-linux-x64`) |
| **Panic** | `rusty-tesseract .../src/tesseract/command.rs:108:43: called Option::unwrap() on a None value` |

## root cause (pinned to the locked rev)

`command.rs:108` at the pinned rev `08346c1` is:

```rust
pub(crate) fn get_tesseract_command() -> Command {
    let tesseract = find_tesseract_path().unwrap();   // ← L108:43
    Command::new(tesseract)
}
```

`find_tesseract_path()` returns `None` when no `tesseract` binary is resolvable (no system install **and** none bundled next to the engine — the common npx-on-Linux case). rusty-tesseract `unwrap()`s it, so OCR **panics** instead of returning `Err`, unwinding the tokio capture worker. Release builds are `strip = true`, which is why CLI-T0's frames are all `<unknown>` and it grouped separately from CLI-V3 (same panic, two captures: the tracing message vs. the panic hook).

> The symbolless Sentry payload couldn't pin the site on its own — confirmed by reading the dependency at its locked git rev (`08346c1`), where line 108 is the unguarded `unwrap()`.

## why it's still firing after #4564

Two distinct reasons:

1. **The guard doesn't fully silence it.** #4564 wrapped `image_to_data` in `catch_unwind`, which stops the *crash* — but `catch_unwind` does **not** suppress the panic hook. On a tesseract-less host the panic still fires **every frame**, so Sentry keeps recording events and the worker pays stack-unwind + backtrace cost ~30×/sec for the whole session.
2. **The published CLI predates the fix.** `Bump CLI to v0.4.24` was cut `2026-06-25 07:46`, ~10h **before** #4564 merged (`17:53`). #4564 shipped to the desktop **app** (v2.5.74) but **the CLI has not been re-released since** — so npx users still run the un-guarded 0.4.24 binary. → **these users only get relief once a new CLI is published** (see below).

## the fix

Pre-flight the **same** resolution rusty-tesseract uses, cached once per process, and skip OCR cleanly when it's absent — so the panic never happens in the common case:

```rust
fn tesseract_available() -> bool {
    static AVAILABLE: OnceLock<bool> = OnceLock::new();
    *AVAILABLE.get_or_init(|| {
        let found = rusty_tesseract::find_tesseract_path().is_some();
        if !found { warn!("tesseract binary not found ...; OCR disabled for this session"); }
        found
    })
}
```

```
before (#4564 only)                  after (this PR)
─────────────────────                ──────────────────────────
every frame:                         first frame: probe once → cache
  image_to_data                        missing? warn ONCE, OCR off
    get_tesseract_command              every frame thereafter:
      find_tesseract_path() → None       tesseract_available() → false
      .unwrap() → PANIC                  return empty, no panic
    panic hook fires → Sentry          (catch_unwind kept as a net
    catch_unwind → empty                for present-but-broken binaries)
  (repeats ~30×/sec, forever)
```

`#4564`'s `catch_unwind` is kept as belt-and-suspenders for *other* tesseract misbehavior (e.g. a present-but-broken binary). Returns the existing empty sentinel, so the rest of the capture pipeline is unaffected.

## testing

`cargo test -p screenpipe-screen tesseract::` → **5 passed**:
- `tesseract_available_is_stable` (new) — cached decision doesn't flap and matches rusty-tesseract's own resolution
- `perform_ocr_tesseract_is_panic_safe` (#4564) — still green; now also exercises the pre-flight skip
- 3 existing `bundled_tesseract_*`

fmt + clippy clean on the crate.

## ⚠️ to actually reach the 12+12 affected users

This source fix (and #4564) only land for npx CLI users on a **new CLI release** — 0.4.24 was published before #4564. **Recommend cutting a CLI release** so the guard ships to `@screenpipe/cli-linux-x64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)