### PR TITLE
fix(db): clear stale txn before BEGIN IMMEDIATE (CLI-RC / CLI-SR write wedge)

### DIFF
--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -801,12 +801,21 @@ async fn execute_batch(
         // "cannot start a transaction within a transaction" (SQLITE code 1) and
         // the batch errors out *before* the reactive rollback handler can recover
         // it — the first-failure event still reaching Sentry as
-        // SCREENPIPE-CLI-RC / CLI-SR. A ROLLBACK on a clean connection is a
-        // harmless no-op ("cannot rollback - no transaction is active"), so the
-        // result is ignored; it never discards committed data, only an orphaned
-        // uncommitted transaction that was already doomed. The reactive handler
-        // below stays as a belt-and-suspenders net.
-        let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        // SCREENPIPE-CLI-RC / CLI-SR. It never discards committed data, only an
+        // orphaned uncommitted transaction that was already doomed. The reactive
+        // handler below stays as a belt-and-suspenders net.
+        //
+        // `Ok` means the ROLLBACK actually cleared an orphaned transaction — i.e.
+        // a poisoned connection was detected and recovered. Surface that at warn!
+        // (a breadcrumb, NOT a Sentry issue under the default tracing
+        // EventFilter), so the poisoning stays observable instead of silently
+        // masked — without re-flooding Sentry. The common `Err` is the harmless
+        // "no transaction is active" no-op on a clean connection; ignore it.
+        if sqlx::query("ROLLBACK").execute(&mut *conn).await.is_ok() {
+            warn!(
+                "write_queue: cleared an orphaned transaction on a pooled connection before BEGIN (recovered a poisoned connection that would have failed 'cannot start a transaction within a transaction')"
+            );
+        }
 
         match sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await {
             Ok(_) => {

--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -795,6 +795,19 @@ async fn execute_batch(
             }
         };
 
+        // Proactively clear any transaction a prior batch left open on this
+        // pooled connection (sqlx's SQLite pool does not reset connections on
+        // release). Without this, the BEGIN IMMEDIATE below fails with
+        // "cannot start a transaction within a transaction" (SQLITE code 1) and
+        // the batch errors out *before* the reactive rollback handler can recover
+        // it — the first-failure event still reaching Sentry as
+        // SCREENPIPE-CLI-RC / CLI-SR. A ROLLBACK on a clean connection is a
+        // harmless no-op ("cannot rollback - no transaction is active"), so the
+        // result is ignored; it never discards committed data, only an orphaned
+        // uncommitted transaction that was already doomed. The reactive handler
+        // below stays as a belt-and-suspenders net.
+        let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+
         match sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await {
             Ok(_) => {
                 conn_opt = Some(conn);
@@ -2554,6 +2567,41 @@ mod tests {
         assert!(
             !(should_recycle_sqlite_connection(&benign) || is_nested_transaction_error(&benign))
         );
+    }
+
+    /// Proves the proactive `ROLLBACK` before `BEGIN IMMEDIATE` in the drain
+    /// loop: a connection left mid-transaction (the poison behind CLI-RC/CLI-SR)
+    /// makes the next BEGIN fail with the nested-transaction error; a ROLLBACK
+    /// clears it so BEGIN then succeeds, and a ROLLBACK on a clean connection is
+    /// a harmless ignorable error (never a panic, never data loss).
+    #[tokio::test]
+    async fn rollback_before_begin_clears_a_stale_transaction() {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+
+        // Poison: leave a transaction open (as a returned-mid-batch connection would).
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        // Without clearing, the next BEGIN IMMEDIATE fails as a nested transaction.
+        let nested = sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await;
+        assert!(is_nested_transaction_error(&nested.unwrap_err()));
+
+        // The proactive rollback clears the orphaned transaction...
+        let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
+        // ...so BEGIN IMMEDIATE now succeeds.
+        sqlx::query("BEGIN IMMEDIATE")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        // Clean-up, then confirm a ROLLBACK with no active txn is a harmless error.
+        sqlx::query("ROLLBACK").execute(&mut *conn).await.unwrap();
+        assert!(sqlx::query("ROLLBACK").execute(&mut *conn).await.is_err());
     }
 
     /// `Database` errors flow through `is_fatal_sqlite_message`: a


### PR DESCRIPTION
## Problem — recurring across two top Sentry issues (~50 users)

`error returned from database: (code: 1) cannot start a transaction within a transaction` shows up on:
- **SCREENPIPE-CLI-RC** — "audio chunk DB insert failed after 3 retries"
- **SCREENPIPE-CLI-SR / SQ** — "Failed to insert UI events batch: … cannot start a transaction within a transaction"

## Root cause

sqlx's SQLite pool does **not** reset a connection when it's released. If a prior batch returned a connection while a transaction was still open (an early-return path, a wedge, a missed COMMIT/ROLLBACK), that connection comes back **poisoned**, and the next batch's `BEGIN IMMEDIATE` fails with the nested-transaction error.

The drain loop already recovers **reactively** (`is_nested_transaction_error` → `ROLLBACK` → retry, escalate to `FatalConnection`) — but only *after* the first `BEGIN` fails, so that first failure still propagates to the caller and Sentry, and the batch churns.

## Fix

Issue a `ROLLBACK` on the freshly-acquired connection **before** `BEGIN IMMEDIATE`, clearing any orphaned transaction so the BEGIN succeeds on the first try:

```rust
// harmless no-op on a clean connection; clears poison on a dirty one
let _ = sqlx::query("ROLLBACK").execute(&mut *conn).await;
match sqlx::query("BEGIN IMMEDIATE").execute(&mut *conn).await { … }
```

A `ROLLBACK` with no active transaction is a harmless ignorable error; it never discards committed data — only an already-doomed uncommitted transaction. The reactive handler stays as a belt-and-suspenders net.

**Overhead:** one extra local SQLite statement per *batch* flush (batches coalesce ~100 writes; no fsync) — negligible vs the batch's INSERTs + COMMIT.

## Tests

`cargo test -p screenpipe-db write_queue` → **20 pass**, including new `rollback_before_begin_clears_a_stale_transaction` (poison a connection → next `BEGIN` is the nested-txn error → `ROLLBACK` clears it → `BEGIN` succeeds; `ROLLBACK` on a clean conn is a harmless error). Normal/coalescing/concurrent/nested-txn paths all still pass. `rustfmt --check` clean.

## Honest scope

This defensively guarantees a clean connection **at point of use**. It does not pin the exact *source* that returns a connection mid-transaction (elusive across prior CLI-RC iterations) — but clearing it before every BEGIN makes the symptom unreachable regardless of source, which is the safe, robust mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)