### PR TITLE
Bump CLI to v0.4.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8190,7 +8190,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio-eval"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8228,7 +8228,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8284,7 +8284,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8336,7 +8336,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8364,7 +8364,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8438,7 +8438,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8456,7 +8456,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-meeting-eval"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "clap",
@@ -8468,7 +8468,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -8505,7 +8505,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-rfdetr-mlx"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "image",
  "mlx-rs",
@@ -8516,7 +8516,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8576,7 +8576,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8598,7 +8598,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-team-memory"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -8607,7 +8607,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.24"
+version = "0.4.25"
 authors = ["louis030195 <hi@louis030195.com>"]
 description = ""
 repository = "https://github.com/screenpipe/screenpipe"


### PR DESCRIPTION
Patch bump of the workspace/engine version (0.4.24 → 0.4.25) to **release the CLI** — the merged engine fixes are stuck behind a release; users are still on 0.4.24.

Ships:
- **CLI-RC / CLI-SR / CLI-SQ** — write-queue clears a stale txn before BEGIN IMMEDIATE (#4607)
- **CLI-T0 / CLI-V3** — tesseract pre-flight so a missing binary can't panic the worker (`85611d861`)
- **CLI-F4** — mic-permission denial filtered from Sentry (#4577)
- **CLI-W3** — macOS ffmpeg auto-install loop fixed (#4530)
- AppImage runtime-deps bundle

Only `Cargo.toml` + `Cargo.lock` (workspace version). The `Bump CLI to v` message triggers `release-cli.yml` on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)