### PR TITLE
fix(telemetry): filter localized macOS TCC capture-denial from Sentry (CLI-WH)

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -499,6 +499,16 @@ async fn main() -> anyhow::Result<()> {
                             // app holding the device exclusively) refuses capture;
                             // retrying can't clear it, so it's not an actionable bug.
                             r"backend-specific error has occurred: Access is denied",
+                            // device_monitor's periodic capture-device check failing with an
+                            // OS backend error — overwhelmingly a denied macOS TCC permission
+                            // (screen/audio capture), which the OS reports in the user's
+                            // LOCALE, so the English "Screen recording permission denied"
+                            // pattern above misses it (CLI-WH: 1 user / 126 events, a
+                            // Japanese TCC-denied string). The check re-runs each cycle, so a
+                            // standing denial floods Sentry. Matching the English wrapper
+                            // prefix catches every locale; device-check backend errors
+                            // (permission, unplugged) are user-environment, not our bug.
+                            r"device check error: A backend-specific error has occurred",
                             // Local DB corruption — user dropped/restored part of their db.sqlite
                             r"no such table: main\.speaker_embeddings",
                             // Concurrent DB access / user ran CLI while app was running


### PR DESCRIPTION
## Problem — SCREENPIPE-CLI-WH (1 user, **126 events**)

`device_monitor.rs:1313` logs `error!("device check error: {e}")` when the periodic capture-device check hits an OS backend error. On macOS that's overwhelmingly a **denied TCC permission** (screen/audio capture) — and macOS returns it in the **user's locale**, so CLI-WH is a Japanese string:
```
device check error: A backend-specific error has occurred: ユーザがアプリケーション、ウインドウ、ディスプレイ取り込みのTCCを拒否しました
```
The existing English noise filter (`Screen recording permission denied`) doesn't match it, and the check re-runs every cycle while the denial stands → a standing user permission choice floods Sentry.

## Fix

Add the **English wrapper prefix** `device check error: A backend-specific error has occurred` to the `before_send` `USER_ENV_PATTERNS` list. The localized text is only in the *suffix*, so matching the prefix catches **every locale**. Device-check backend errors (permission denied, device unplugged) are user-environment conditions, not actionable bugs; the event still logs locally — only the Sentry upload is dropped. Same proven approach as the CLI-F4 mic-permission filter (#4577).

## Tests
- Regex verified: matches the real localized CLI-WH message, not unrelated errors.
- `cargo check -p screenpipe-engine --bin screenpipe` clean; `rustfmt --check` clean.

## Context
Part of clearing the live CLI Sentry tier after the v0.4.25 release. CLI-4R (tesseract-not-found, Linux) is fixed by 0.4.25's #4386 bundle and resolved separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)