### PR TITLE
• fix: preserve search results after timeline navigation

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -544,8 +544,13 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
     searchQuery,
     searchKeywords,
     resetSearch,
+    saveSearchSession,
+    restoreSearchSession,
+    updateSavedSearchScrollTop,
     setCurrentResultIndex,
   } = useKeywordSearchStore();
+  const restoredSearchSessionRef = useRef(false);
+  const pendingRestoreScrollTopRef = useRef<number | null>(null);
 
   // --- Facet state (loaded async, independent of paginated results) ---
   const [facetApps, setFacetApps] = useState<[string, number][]>([]);
@@ -828,26 +833,49 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
       const initialQuery = standalone
         ? new URLSearchParams(window.location.search).get("q") ?? ""
         : "";
-      setQuery(initialQuery);
-      resetSearch();
+      const restoredSession = !initialQuery && standalone
+        ? restoreSearchSession()
+        : null;
+      setQuery(restoredSession?.query ?? initialQuery);
+      if (restoredSession) {
+        restoredSearchSessionRef.current = true;
+        pendingRestoreScrollTopRef.current = restoredSession.scrollTop;
+        setContentFilter((restoredSession.filters.contentFilter as ContentFilter) || "all");
+        setAppFilter(restoredSession.filters.appFilter);
+        setDomainFilter(restoredSession.filters.domainFilter);
+        setTimeFilter(restoredSession.filters.timeFilter);
+        setOcrOffset(restoredSession.ocrOffset);
+        setHasMoreOcr(restoredSession.hasMoreOcr);
+      } else {
+        resetSearch();
+        setAppFilter(null);
+        setDomainFilter(null);
+        setTimeFilter(null);
+        setContentFilter("all");
+        setOcrOffset(0);
+        setHasMoreOcr(true);
+      }
       setSearchEpoch(e => e + 1);
       clearHighlight();
-      setAppFilter(null);
-      setDomainFilter(null);
-      setTimeFilter(null);
-      setContentFilter("all");
       setSpeakerResults([]);
       setTagResults([]);
       setAllTags([]);
       setSelectedSpeaker(null);
       setSpeakerTranscriptions([]);
       setSelectedTranscriptionIndex(0);
-      setOcrOffset(0);
-      setHasMoreOcr(true);
       setTranscriptionOffset(0);
       setHasMoreTranscriptions(true);
     }
-  }, [isOpen, resetSearch, standalone]);
+  }, [isOpen, resetSearch, restoreSearchSession, standalone]);
+
+  useEffect(() => {
+    if (!isOpen || pendingRestoreScrollTopRef.current === null || !gridRef.current) return;
+    const scrollTop = pendingRestoreScrollTopRef.current;
+    pendingRestoreScrollTopRef.current = null;
+    requestAnimationFrame(() => {
+      if (gridRef.current) gridRef.current.scrollTop = scrollTop;
+    });
+  }, [isOpen, searchResults.length, uiEventResults.length]);
 
   // Perform search when query changes
   useEffect(() => {
@@ -864,6 +892,11 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
 
     // Require at least 3 chars to avoid wasteful FTS queries while typing
     if (q.length < 3) return;
+
+    if (restoredSearchSessionRef.current && q === searchQuery && (searchResults.length > 0 || uiEventResults.length > 0)) {
+      restoredSearchSessionRef.current = false;
+      return;
+    }
 
     setAppFilter(null);
     setDomainFilter(null);
@@ -1184,6 +1217,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
   const handleScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
     e.stopPropagation();
     const target = e.currentTarget;
+    updateSavedSearchScrollTop(target.scrollTop);
     const nearBottom = target.scrollHeight - target.scrollTop - target.clientHeight < 200;
 
     if (nearBottom) {
@@ -1193,7 +1227,44 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
         loadMoreOcr();
       }
     }
-  }, [selectedSpeaker, loadMoreOcr, loadMoreTranscriptions]);
+  }, [selectedSpeaker, loadMoreOcr, loadMoreTranscriptions, updateSavedSearchScrollTop]);
+
+  const saveCurrentSearchSession = useCallback((selectedResult?: SearchMatch, selectedTimestamp?: string) => {
+    if (!standalone || !query.trim()) return;
+    saveSearchSession({
+      query,
+      searchResults,
+      searchGroups,
+      uiEventResults,
+      currentResultIndex: useKeywordSearchStore.getState().currentResultIndex,
+      lastRequest: useKeywordSearchStore.getState().lastRequest,
+      ocrOffset,
+      hasMoreOcr,
+      scrollTop: gridRef.current?.scrollTop ?? 0,
+      selectedResultFrameId: selectedResult?.frame_id ?? null,
+      selectedTimestamp: selectedResult?.timestamp ?? selectedTimestamp ?? null,
+      filters: {
+        contentFilter,
+        appFilter,
+        domainFilter,
+        timeFilter,
+      },
+      cameFromTimeline: Boolean(selectedResult || selectedTimestamp),
+    });
+  }, [
+    standalone,
+    query,
+    searchResults,
+    searchGroups,
+    uiEventResults,
+    ocrOffset,
+    hasMoreOcr,
+    contentFilter,
+    appFilter,
+    domainFilter,
+    timeFilter,
+    saveSearchSession,
+  ]);
 
   const handleSelectResult = useCallback((result: SearchMatch) => {
     if (queryTokens.length > 0) {
@@ -1203,9 +1274,10 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
     const idx = searchResults.findIndex((r) => r.frame_id === result.frame_id);
     if (idx >= 0) setCurrentResultIndex(idx);
     const resultsJson = JSON.stringify(searchResults);
+    saveCurrentSearchSession(result);
     onNavigateToTimestamp(result.timestamp, result.frame_id, queryTokens, resultsJson, query);
     onClose();
-  }, [onNavigateToTimestamp, onClose, queryTokens, setHighlight, searchResults, query, setCurrentResultIndex]);
+  }, [onNavigateToTimestamp, onClose, queryTokens, setHighlight, searchResults, query, setCurrentResultIndex, saveCurrentSearchSession]);
 
   // Keyboard navigation — uses refs for data arrays to avoid re-mounting when results change
   useEffect(() => {
@@ -1234,6 +1306,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
             e.preventDefault();
             setSelectedTranscriptionIndex(i => {
               if (transcriptions[i]?.timestamp) {
+                saveCurrentSearchSession(undefined, transcriptions[i].timestamp);
                 onNavigateToTimestamp(transcriptions[i].timestamp);
                 onClose();
               }
@@ -1325,7 +1398,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
       window.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("keydown", captureEscape, true);
     };
-  }, [isOpen, selectedSpeaker, onClose, onNavigateToTimestamp, handleSelectResult, handleSendToAI, handleBackFromSpeaker]);
+  }, [isOpen, selectedSpeaker, onClose, onNavigateToTimestamp, handleSelectResult, handleSendToAI, handleBackFromSpeaker, saveCurrentSearchSession]);
 
   // Scroll selected item into view (only on arrow-key navigation, not on new page load)
   const prevSelectedIndex = useRef(selectedIndex);
@@ -1466,6 +1539,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                     data-index={index}
                     onClick={() => {
                       if (t.timestamp) {
+                        saveCurrentSearchSession(undefined, t.timestamp);
                         onNavigateToTimestamp(t.timestamp);
                         if (!embedded) onClose();
                       }
@@ -1592,6 +1666,10 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                   key={frame.frame_id}
                   onClick={() => {
                     const resultsJson = JSON.stringify(searchResults);
+                    saveCurrentSearchSession(
+                      searchResults.find((result) => result.frame_id === frame.frame_id),
+                      frame.timestamp,
+                    );
                     onNavigateToTimestamp(frame.timestamp, frame.frame_id, queryTokens, resultsJson, query);
                     if (!embedded) onClose();
                   }}
@@ -1847,6 +1925,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                     key={evt.id}
                     evt={evt}
                     onNavigate={() => {
+                      saveCurrentSearchSession(undefined, evt.timestamp);
                       onNavigateToTimestamp(evt.timestamp);
                       if (!embedded) onClose();
                     }}

--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-keyword-search-store.test.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-keyword-search-store.test.ts
@@ -28,9 +28,21 @@ function jsonResponse(body: unknown) {
 	});
 }
 
+const screenResult = {
+	frame_id: 1,
+	timestamp: "2026-06-19T00:00:00.000Z",
+	text_positions: [],
+	app_name: "Cursor",
+	window_name: "screenpipe",
+	confidence: 1,
+	text: "abc search result",
+	url: "",
+};
+
 describe("useKeywordSearchStore search scheduling", () => {
 	beforeEach(() => {
 		vi.mocked(localFetch).mockReset();
+		window.sessionStorage.clear();
 		useKeywordSearchStore.getState().resetSearch();
 	});
 
@@ -109,5 +121,167 @@ describe("useKeywordSearchStore search scheduling", () => {
 			expect(useKeywordSearchStore.getState().isSearchingUiEvents).toBe(false);
 		});
 		expect(useKeywordSearchStore.getState().uiEventResults).toHaveLength(1);
+	});
+
+	it("saves query, results, selected result, filters, and scroll for timeline return", () => {
+		useKeywordSearchStore.setState({
+			searchResults: [screenResult],
+			searchGroups: [{
+				representative: screenResult,
+				group_size: 1,
+				start_time: screenResult.timestamp,
+				end_time: screenResult.timestamp,
+				frame_ids: [screenResult.frame_id],
+			}],
+			uiEventResults: [],
+			currentResultIndex: 0,
+			searchQuery: "abc",
+			lastRequest: {
+				query: "abc",
+				params: {
+					offset: 0,
+					limit: 24,
+					fuzzy_match: true,
+					order: "descending",
+					app_names: [],
+				},
+			},
+		});
+
+		useKeywordSearchStore.getState().saveSearchSession({
+			query: "abc",
+			searchResults: [screenResult],
+			searchGroups: useKeywordSearchStore.getState().searchGroups,
+			uiEventResults: [],
+			currentResultIndex: 0,
+			lastRequest: useKeywordSearchStore.getState().lastRequest,
+			ocrOffset: 24,
+			hasMoreOcr: true,
+			scrollTop: 320,
+			selectedResultFrameId: screenResult.frame_id,
+			selectedTimestamp: screenResult.timestamp,
+			filters: {
+				contentFilter: "screen",
+				appFilter: "Cursor",
+				domainFilter: null,
+				timeFilter: "2026-06-19",
+			},
+			cameFromTimeline: true,
+		});
+
+		const saved = useKeywordSearchStore.getState().getSavedSearchSession();
+
+		expect(saved?.query).toBe("abc");
+		expect(saved?.searchResults).toHaveLength(1);
+		expect(saved?.selectedResultFrameId).toBe(1);
+		expect(saved?.scrollTop).toBe(320);
+		expect(saved?.filters.appFilter).toBe("Cursor");
+		expect(saved?.cameFromTimeline).toBe(true);
+	});
+
+	it("restores saved search state after returning from timeline", () => {
+		const group = {
+			representative: screenResult,
+			group_size: 1,
+			start_time: screenResult.timestamp,
+			end_time: screenResult.timestamp,
+			frame_ids: [screenResult.frame_id],
+		};
+
+		useKeywordSearchStore.getState().saveSearchSession({
+			query: "abc",
+			searchResults: [screenResult],
+			searchGroups: [group],
+			uiEventResults: [{
+				id: 7,
+				timestamp: "2026-06-19T00:00:01.000Z",
+				event_type: "keyboard",
+				text_content: "abc",
+				app_name: "Cursor",
+				window_title: "screenpipe",
+			}],
+			currentResultIndex: 0,
+			lastRequest: {
+				query: "abc",
+				params: {
+					offset: 0,
+					limit: 24,
+					fuzzy_match: true,
+					order: "descending",
+					app_names: [],
+				},
+			},
+			ocrOffset: 0,
+			hasMoreOcr: true,
+			scrollTop: 120,
+			selectedResultFrameId: screenResult.frame_id,
+			selectedTimestamp: screenResult.timestamp,
+			filters: {
+				contentFilter: "all",
+				appFilter: null,
+				domainFilter: null,
+				timeFilter: null,
+			},
+			cameFromTimeline: true,
+		});
+
+		useKeywordSearchStore.getState().resetSearch();
+		const restored = useKeywordSearchStore.getState().restoreSearchSession();
+		const state = useKeywordSearchStore.getState();
+
+		expect(restored?.query).toBe("abc");
+		expect(restored?.scrollTop).toBe(120);
+		expect(state.searchQuery).toBe("abc");
+		expect(state.searchResults).toEqual([screenResult]);
+		expect(state.searchGroups).toEqual([group]);
+		expect(state.uiEventResults).toHaveLength(1);
+		expect(state.currentResultIndex).toBe(0);
+	});
+
+	it("does not refetch when restored query and request are still cached", async () => {
+		useKeywordSearchStore.getState().saveSearchSession({
+			query: "abc",
+			searchResults: [screenResult],
+			searchGroups: [{
+				representative: screenResult,
+				group_size: 1,
+				start_time: screenResult.timestamp,
+				end_time: screenResult.timestamp,
+				frame_ids: [screenResult.frame_id],
+			}],
+			uiEventResults: [],
+			currentResultIndex: 0,
+			lastRequest: {
+				query: "abc",
+				params: {
+					offset: 0,
+					limit: 24,
+					fuzzy_match: true,
+					order: "descending",
+					app_names: [],
+				},
+			},
+			ocrOffset: 0,
+			hasMoreOcr: true,
+			scrollTop: 0,
+			selectedResultFrameId: screenResult.frame_id,
+			selectedTimestamp: screenResult.timestamp,
+			filters: {
+				contentFilter: "all",
+				appFilter: null,
+				domainFilter: null,
+				timeFilter: null,
+			},
+			cameFromTimeline: true,
+		});
+
+		useKeywordSearchStore.getState().restoreSearchSession();
+		await useKeywordSearchStore.getState().searchKeywords("abc", {
+			limit: 24,
+			offset: 0,
+		});
+
+		expect(localFetch).not.toHaveBeenCalled();
+		expect(useKeywordSearchStore.getState().searchResults).toEqual([screenResult]);
 	});
 });

--- a/apps/screenpipe-app-tauri/lib/hooks/use-keyword-search-store.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-keyword-search-store.tsx
@@ -58,6 +58,28 @@ export interface SearchRequest {
 	};
 }
 
+export interface SavedKeywordSearchSession {
+	query: string;
+	searchResults: SearchMatch[];
+	searchGroups: SearchMatchGroup[];
+	uiEventResults: UiEventResult[];
+	currentResultIndex: number;
+	lastRequest: SearchRequest | null;
+	ocrOffset: number;
+	hasMoreOcr: boolean;
+	scrollTop: number;
+	selectedResultFrameId: number | null;
+	selectedTimestamp: string | null;
+	filters: {
+		contentFilter: string;
+		appFilter: string | null;
+		domainFilter: string | null;
+		timeFilter: string | null;
+	};
+	cameFromTimeline: boolean;
+	savedAt: number;
+}
+
 export interface KeywordSearchState {
 	searchResults: SearchMatch[];
 	searchGroups: SearchMatchGroup[];
@@ -87,12 +109,40 @@ export interface KeywordSearchState {
 	) => Promise<void>;
 	setCurrentResultIndex: (index: number) => void;
 	resetSearch: () => void;
+	saveSearchSession: (session: Omit<SavedKeywordSearchSession, "savedAt">) => void;
+	restoreSearchSession: () => SavedKeywordSearchSession | null;
+	getSavedSearchSession: () => SavedKeywordSearchSession | null;
+	updateSavedSearchScrollTop: (scrollTop: number) => void;
 	nextResult: () => void;
 	previousResult: () => void;
 }
 
 const fuzzy_default = true;
 const offset_default = 0;
+const saved_search_session_key = "screenpipe.keywordSearch.savedSession";
+
+function readSavedSearchSession(): SavedKeywordSearchSession | null {
+	if (typeof window === "undefined") return null;
+	try {
+		const raw = window.sessionStorage.getItem(saved_search_session_key);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as SavedKeywordSearchSession;
+		if (!parsed || typeof parsed.query !== "string") return null;
+		if (!Array.isArray(parsed.searchResults)) return null;
+		return parsed;
+	} catch {
+		return null;
+	}
+}
+
+function writeSavedSearchSession(session: SavedKeywordSearchSession): void {
+	if (typeof window === "undefined") return;
+	try {
+		window.sessionStorage.setItem(saved_search_session_key, JSON.stringify(session));
+	} catch {
+		// Session restore is a convenience; ignore storage quota/private-mode errors.
+	}
+}
 
 export const useKeywordSearchStore = create<KeywordSearchState>((set, get) => ({
 	searchResults: [],
@@ -370,6 +420,51 @@ export const useKeywordSearchStore = create<KeywordSearchState>((set, get) => ({
 			lastRequest: null,
 			activeRequestId: null,
 			currentAbortController: null,
+		});
+	},
+
+	saveSearchSession: (session) => {
+		writeSavedSearchSession({
+			...session,
+			savedAt: Date.now(),
+		});
+	},
+
+	restoreSearchSession: () => {
+		const session = readSavedSearchSession();
+		if (!session || !session.cameFromTimeline) return null;
+
+		const { currentAbortController } = get();
+		if (currentAbortController) {
+			currentAbortController.abort();
+		}
+
+		set({
+			searchResults: session.searchResults,
+			searchGroups: session.searchGroups,
+			uiEventResults: session.uiEventResults,
+			isSearchingUiEvents: false,
+			currentResultIndex: session.currentResultIndex,
+			isSearching: false,
+			searchQuery: session.query,
+			error: null,
+			lastRequest: session.lastRequest,
+			activeRequestId: null,
+			currentAbortController: null,
+		});
+
+		return session;
+	},
+
+	getSavedSearchSession: () => readSavedSearchSession(),
+
+	updateSavedSearchScrollTop: (scrollTop) => {
+		const session = readSavedSearchSession();
+		if (!session) return;
+		writeSavedSearchSession({
+			...session,
+			scrollTop,
+			savedAt: Date.now(),
 		});
 	},
 


### PR DESCRIPTION
 ## Summary
  - persist the standalone search session before navigating from a search result to the timeline
  - restore the previous query, cached results, filters, selected result, paging state, and scroll position when search is
  reopened
  - skip unnecessary refetches when the restored cached search state is still valid

  ## Testing
  - `bunx vitest run --config vitest.config.ts lib/hooks/__tests__/use-keyword-search-store.test.ts`
  - `bunx tsc --noEmit`

  ## Notes
  - Manual Windows Tauri validation was not completed locally because `bun tauri dev` is blocked by low disk space on C:
  (`no space on device`).