### PR TITLE
feat(onboarding): humanize the pipe-pick step for non-technical users

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.test.tsx
@@ -89,16 +89,18 @@ describe("PickPipe", () => {
     });
 
     fireEvent.click(
-      screen.getByRole("checkbox", { name: /digital-clone: your ai you/i }),
+      screen.getByRole("checkbox", {
+        name: /your ai twin: writes and acts like you/i,
+      }),
     );
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /personal-crm: remember everyone you meet/i,
+        name: /people memory: remember everyone you meet/i,
       }),
     );
 
     expect(
-      screen.getByRole("button", { name: /install 0 pipes/i }),
+      screen.getByRole("button", { name: /turn them on/i }),
     ).toBeDisabled();
 
     await act(async () => {
@@ -141,11 +143,13 @@ describe("PickPipe", () => {
     });
 
     fireEvent.click(
-      screen.getByRole("checkbox", { name: /digital-clone: your ai you/i }),
+      screen.getByRole("checkbox", {
+        name: /your ai twin: writes and acts like you/i,
+      }),
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /install 1 pipe/i }));
+      fireEvent.click(screen.getByRole("button", { name: /turn it on/i }));
     });
 
     await waitFor(() => {

--- a/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.tsx
@@ -31,13 +31,13 @@ type Pipe = {
 const PIPES: Pipe[] = [
   {
     slug: "digital-clone",
-    title: "digital-clone",
-    subtitle: "your AI you",
+    title: "Your AI twin",
+    subtitle: "writes and acts like you",
     defaultOn: true,
   },
   {
     slug: "personal-crm",
-    title: "personal-crm",
+    title: "People memory",
     subtitle: "remember everyone you meet",
     defaultOn: true,
   },
@@ -259,7 +259,7 @@ export default function PickPipe() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            title: `🚀 ${slugs.length} pipe${slugs.length === 1 ? "" : "s"} enabled`,
+            title: "🚀 You're all set",
             body: "Screenpipe is set up. Your first results arrive shortly.",
           }),
         });
@@ -268,7 +268,7 @@ export default function PickPipe() {
       const msg =
         (err as Error)?.stack ?? (err as Error)?.message ?? String(err);
       console.error("failed to enable pipes:", msg);
-      setError("Couldn't install all pipes — try again or skip");
+      setError("Couldn't set everything up — try again or skip");
       setPhase("choose");
       // Release guard on failure so retry works; success path keeps it set
       // because onboarding completion will close the window.
@@ -361,7 +361,7 @@ export default function PickPipe() {
           disabled={count === 0}
           className="w-full border border-foreground p-3 font-mono text-sm font-semibold disabled:opacity-30 disabled:cursor-not-allowed hover:bg-foreground hover:text-background transition-colors"
         >
-          install {count} pipe{count === 1 ? "" : "s"} →
+          turn {count === 1 ? "it" : "them"} on →
         </button>
 
         <AnimatePresence>
@@ -392,7 +392,7 @@ export default function PickPipe() {
         </AnimatePresence>
 
         <p className="font-mono text-[9px] text-muted-foreground/30 text-center">
-          you can add more from the pipe store anytime.
+          you can add more anytime.
         </p>
       </motion.div>
     </div>


### PR DESCRIPTION
## why

Inbound is trending non-technical (CPAs, photographers, trades, an indigenous association paid this week) and the people now buying increasingly can't self-activate — Intercom keeps getting *"do I need to know how to code?"*. The **final onboarding step** was a small but real offender: it showed raw store **slugs as titles** (`digital-clone`, `personal-crm`) and a **`install 2 pipes →`** button. "pipe" is internal dev jargon, and kebab-case slugs read as broken UI to a non-technical first-time user.

This is the first, contained slice of a larger "make activation less technical" pass (full `pipe → automation` rename is intentionally left as follow-up — too broad for one PR).

## what

In [`pick-pipe.tsx`](https://github.com/screenpipe/screenpipe/blob/claude/thirsty-varahamihira-c50962/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.tsx) (the last onboarding slide):

- **Card titles** → plain names: `digital-clone` → **"Your AI twin"**, `personal-crm` → **"People memory"**
- **Primary button**: `install {n} pipe(s) →` → **`turn it/them on →`**
- **Success notification** title: `🚀 {n} pipes enabled` → **`🚀 You're all set`**
- **Footer hint**: dropped "pipe store" jargon → *"you can add more anytime."*
- **Install-error** copy softened: *"Couldn't set everything up — try again or skip"*

## no behavior change

- **Slugs are untouched** — `slug` still drives `/pipes/store/install` + `/pipes/{slug}/enable`, so the actual installs are identical.
- **All PostHog events unchanged** (`onboarding_path_selected`, `pipes: slugs`, etc.).
- Only the **display copy** changed.

## before / after

![before and after of the onboarding pick-pipe step](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-onboarding-humanize/pickpipe-before-after.png)

## tests

`pick-pipe.test.tsx` keyed off the display copy (checkbox aria-labels + button text), so it's updated to the new strings. Suite green locally:

```
✓ components/onboarding/pick-pipe.test.tsx (3 tests) 76ms
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)