### PR TITLE
Open exact connection dialog from trigger setup

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -79,6 +79,7 @@ type MainSection = "home" | "timeline" | "brain" | "pipes" | "connections" | "me
 type ConnectionFocusRequest = {
   id: string | null;
   category: string | null;
+  scopeVariant: string | null;
   requestId: number;
 };
 
@@ -793,6 +794,7 @@ function HomeContent() {
         setConnectionFocusRequest({
           id: typeof detail?.connectionId === "string" ? detail.connectionId : null,
           category: typeof detail?.category === "string" ? detail.category : null,
+          scopeVariant: typeof detail?.scopeVariant === "string" ? detail.scopeVariant : null,
           requestId: Date.now(),
         });
         setActiveSection("connections");
@@ -842,6 +844,7 @@ function HomeContent() {
           <ConnectionsSection
             focusConnectionId={connectionFocusRequest?.id ?? null}
             focusCategory={connectionFocusRequest?.category ?? null}
+            focusScopeVariant={connectionFocusRequest?.scopeVariant ?? null}
             focusRequestId={connectionFocusRequest?.requestId ?? 0}
             onFocusRequestConsumed={clearConnectionFocusRequest}
           />

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -2349,12 +2349,14 @@ function OAuthPanel({
   integrationId,
   integrationName,
   supportsOAuthInstances,
+  initialScopeVariant,
   onConnected,
   onDisconnected,
 }: {
   integrationId: string;
   integrationName: string;
   supportsOAuthInstances: boolean;
+  initialScopeVariant?: string | null;
   onConnected?: () => void;
   onDisconnected?: () => void;
 }) {
@@ -2374,7 +2376,15 @@ function OAuthPanel({
   // to the first (least-privileged) variant; null when the integration offers
   // no choice, in which case the backend uses its default scopes.
   const scopeVariants = OAUTH_SCOPE_VARIANTS[integrationId];
-  const [scopeVariant, setScopeVariant] = useState(scopeVariants?.[0]?.id ?? null);
+  const defaultScopeVariant = scopeVariants?.some((v) => v.id === initialScopeVariant)
+    ? initialScopeVariant!
+    : scopeVariants?.[0]?.id ?? null;
+  const [scopeVariant, setScopeVariant] = useState(defaultScopeVariant);
+
+  useEffect(() => {
+    if (!scopeVariants?.some((v) => v.id === initialScopeVariant)) return;
+    setScopeVariant(initialScopeVariant!);
+  }, [initialScopeVariant, scopeVariants]);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -3728,6 +3738,7 @@ function ApiKeyMcpPanel({
 interface ConnectionsSectionProps {
   focusConnectionId?: string | null;
   focusCategory?: string | null;
+  focusScopeVariant?: string | null;
   focusRequestId?: number;
   onFocusRequestConsumed?: () => void;
 }
@@ -3735,6 +3746,7 @@ interface ConnectionsSectionProps {
 export function ConnectionsSection({
   focusConnectionId,
   focusCategory,
+  focusScopeVariant,
   focusRequestId = 0,
   onFocusRequestConsumed,
 }: ConnectionsSectionProps = {}) {
@@ -3742,6 +3754,10 @@ export function ConnectionsSection({
   const [categoryFilter, setCategoryFilter] = useState(ALL_CONNECTION_CATEGORIES);
 
   const [selected, setSelected] = useState<string | null>(null);
+  const [requestedScopeVariant, setRequestedScopeVariant] = useState<{
+    connectionId: string;
+    scopeVariant: string;
+  } | null>(null);
   const [integrations, setIntegrations] = useState<IntegrationInfo[]>([]);
   const [integrationsLoaded, setIntegrationsLoaded] = useState(false);
   const [detectedConnectionIds, setDetectedConnectionIds] = useState<Set<string>>(() => new Set());
@@ -3758,6 +3774,11 @@ export function ConnectionsSection({
   useEffect(() => {
     if (!focusRequestId) return;
     setSelected(focusConnectionId || null);
+    setRequestedScopeVariant(
+      focusConnectionId && focusScopeVariant
+        ? { connectionId: focusConnectionId, scopeVariant: focusScopeVariant }
+        : null,
+    );
     setCategoryFilter(
       focusCategory
         ? normalizeConnectionCategory(focusCategory)
@@ -3765,7 +3786,7 @@ export function ConnectionsSection({
     );
     setSearch("");
     onFocusRequestConsumed?.();
-  }, [focusCategory, focusConnectionId, focusRequestId, onFocusRequestConsumed]);
+  }, [focusCategory, focusConnectionId, focusRequestId, focusScopeVariant, onFocusRequestConsumed]);
 
   // Hardcoded connection status
   const [claudeInstalled, setClaudeInstalled] = useState(false);
@@ -4058,6 +4079,10 @@ export function ConnectionsSection({
   }, [allTiles, isDefaultView, suggested]);
 
   const selectedIntegration = integrations.find(i => i.id === selected);
+  const selectedScopeVariant =
+    selected && requestedScopeVariant?.connectionId === selected
+      ? requestedScopeVariant.scopeVariant
+      : null;
 
   const renderPanel = () => {
     if (!selected) return null;
@@ -4094,6 +4119,7 @@ export function ConnectionsSection({
                     integrationId={existing.id}
                     integrationName={existing.name}
                     supportsOAuthInstances={!!existing.supports_oauth_instances}
+                    initialScopeVariant={selectedScopeVariant}
                     onConnected={() => refreshIntegrationConnection(existing.id, true)}
                     onDisconnected={() => refreshIntegrationConnection(existing.id, false)}
                   />
@@ -4190,6 +4216,7 @@ export function ConnectionsSection({
                   integrationId={selectedIntegration.id}
                   integrationName={selectedIntegration.name}
                   supportsOAuthInstances={!!selectedIntegration.supports_oauth_instances}
+                  initialScopeVariant={selectedScopeVariant}
                   onConnected={() => refreshIntegrationConnection(selectedIntegration.id, true)}
                   onDisconnected={() => refreshIntegrationConnection(selectedIntegration.id, false)}
                 />

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -4408,7 +4408,10 @@ export function ConnectionsSection({
       <Dialog
         open={!!selected && !!selectedTile}
         onOpenChange={(open) => {
-          if (!open) setSelected(null);
+          if (!open) {
+            setSelected(null);
+            setRequestedScopeVariant(null);
+          }
         }}
       >
         <DialogContent

--- a/apps/screenpipe-app-tauri/components/settings/pipe-trigger-picker.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipe-trigger-picker.tsx
@@ -400,6 +400,17 @@ function accountsFor(conns: AvailableConnection[], app: string): { value: string
   }));
 }
 
+function openConnectionSetupForTrigger(app: "slack" | "notion") {
+  window.dispatchEvent(new CustomEvent("open-settings", {
+    detail: {
+      section: "connections",
+      connectionId: app,
+      category: app === "slack" ? "Communication" : "Notes",
+      scopeVariant: app === "slack" ? "read_write" : undefined,
+    },
+  }));
+}
+
 function SourceDetail({
   app,
   availableConnections,
@@ -442,11 +453,10 @@ function SourceDetail({
       }
       return;
     }
-    // Slack/Notion OAuth needs scope-variant + account selection (read access,
-    // not the send-only default) — hand off to the full Connections flow rather
-    // than reimplement it here. Reopen this picker once connected.
+    // Slack/Notion OAuth needs the full Connections flow: Pro gating,
+    // scope variants, account instances, reconnect/cancel handling.
     onClose();
-    window.dispatchEvent(new CustomEvent("open-settings", { detail: { section: "connections" } }));
+    openConnectionSetupForTrigger(app);
   }
 
   if (!connected) return <ConnectCard app={app} connecting={connecting} onConnect={doConnect} />;

--- a/apps/screenpipe-app-tauri/components/settings/pipe-trigger-picker.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipe-trigger-picker.tsx
@@ -400,12 +400,16 @@ function accountsFor(conns: AvailableConnection[], app: string): { value: string
   }));
 }
 
-function openConnectionSetupForTrigger(app: "slack" | "notion") {
+const TRIGGER_CONNECTION_SCOPE_VARIANTS: Partial<Record<string, string>> = {
+  slack: "read_write",
+};
+
+function openConnectionSetupForTrigger(connectionId: string) {
   window.dispatchEvent(new CustomEvent("open-settings", {
     detail: {
       section: "connections",
-      connectionId: app,
-      scopeVariant: app === "slack" ? "read_write" : undefined,
+      connectionId,
+      scopeVariant: TRIGGER_CONNECTION_SCOPE_VARIANTS[connectionId],
     },
   }));
 }
@@ -452,7 +456,7 @@ function SourceDetail({
       }
       return;
     }
-    // Slack/Notion OAuth needs the full Connections flow: Pro gating,
+    // OAuth connections need the full Connections flow: Pro gating,
     // scope variants, account instances, reconnect/cancel handling.
     onClose();
     openConnectionSetupForTrigger(app);

--- a/apps/screenpipe-app-tauri/components/settings/pipe-trigger-picker.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipe-trigger-picker.tsx
@@ -405,7 +405,6 @@ function openConnectionSetupForTrigger(app: "slack" | "notion") {
     detail: {
       section: "connections",
       connectionId: app,
-      category: app === "slack" ? "Communication" : "Notes",
       scopeVariant: app === "slack" ? "read_write" : undefined,
     },
   }));


### PR DESCRIPTION
The trigger modal says "connect Slack/Notion" but clicking it only routes to the generic Connections page. 

Expected behavior is: open the exact connection dialog, so the user can connect and return mentally to the trigger setup.

Before -

https://github.com/user-attachments/assets/7e80aeca-1bff-4974-869b-ac27d6ffec63




After -


https://github.com/user-attachments/assets/b62200e1-e8e5-4b8a-8eea-5f2f38b00fc2


