### PR TITLE
fix(permissions): grace permission monitor on screen unlock / display reconfig

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-permission-monitor.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-permission-monitor.tsx
@@ -15,6 +15,10 @@ interface PermissionLostPayload {
   microphone: boolean;
   accessibility: boolean;
   browser_automation?: boolean;
+  // Diagnostic context from the engine emission site ("poll", or the raw
+  // ScreenCaptureKit error string for the eager path). Lets us tell a real
+  // revoke from an un-graced transient in telemetry. May be absent.
+  reason?: string | null;
 }
 
 interface PermissionNeededPayload {
@@ -38,7 +42,7 @@ export function usePermissionMonitor() {
     if (skipPaths.some((p) => pathname?.startsWith(p))) return;
 
     const unlisten = listen<PermissionLostPayload>("permission-lost", async (event) => {
-      const { screen_recording, microphone, accessibility, browser_automation } = event.payload;
+      const { screen_recording, microphone, accessibility, browser_automation, reason } = event.payload;
 
       if (hasShownRef.current) return;
 
@@ -54,6 +58,7 @@ export function usePermissionMonitor() {
         microphone_lost: microphone,
         accessibility_lost: accessibility,
         browser_automation_lost: browser_automation,
+        reason: reason ?? null,
       });
 
       try {

--- a/apps/screenpipe-app-tauri/src-tauri/src/engine_events/permission.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/engine_events/permission.rs
@@ -48,6 +48,11 @@ fn handle_lost(app: &AppHandle, data: &Value) {
     }
 
     info!(event = %data, "permission-lost (from engine)");
+    // Diagnostic context from the emission site ("poll", or the raw
+    // ScreenCaptureKit error string for the eager path). Forwarded to
+    // telemetry so a residual loss can be explained (real revoke vs a
+    // transient we haven't yet graced). Absent → null.
+    let reason = data.get("reason").and_then(|v| v.as_str());
     // Shape the payload to match what the Tauri webview already listens for.
     // Existing recovery modal expects `screen_recording` / `microphone` /
     // `accessibility` booleans.
@@ -56,6 +61,7 @@ fn handle_lost(app: &AppHandle, data: &Value) {
         "microphone":       kind == "microphone",
         "accessibility":    kind == "accessibility",
         "browser_automation": false,
+        "reason": reason,
     });
     if let Err(e) = app.emit("permission-lost", payload) {
         warn!("failed to emit permission-lost: {}", e);

--- a/crates/screenpipe-engine/src/permission_monitor.rs
+++ b/crates/screenpipe-engine/src/permission_monitor.rs
@@ -215,6 +215,16 @@ pub fn notify_wake() {
     );
 }
 
+/// Returns `true` while the wake grace period is active (permission-loss
+/// emissions are currently suppressed). Diagnostic/test accessor — lets the
+/// sleep monitor's unit tests assert that an unlock/display-reconfig actually
+/// armed the grace without waiting out [`WAKE_GRACE`].
+#[allow(dead_code)] // consumed by sleep_monitor's (test-only) unlock-grace assertion
+pub(crate) fn wake_grace_active() -> bool {
+    let state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+    matches!(state.wake_grace_until, Some(until) if Instant::now() < until)
+}
+
 async fn run() {
     let mut ticker = tokio::time::interval(POLL_INTERVAL);
     // First tick fires immediately — skip it, we already seeded state.

--- a/crates/screenpipe-engine/src/sleep_monitor.rs
+++ b/crates/screenpipe-engine/src/sleep_monitor.rs
@@ -189,6 +189,26 @@ fn check_screen_locked_cgsession() -> bool {
     }
 }
 
+/// Shared handling for a screen-unlock transition.
+///
+/// Invalidates persistent SCStream handles so the capture loop recreates them
+/// with fresh frames, AND arms the permission-monitor wake grace. The grace is
+/// the load-bearing part: re-creating an SCStream transiently reports `denied`
+/// before ScreenCaptureKit re-registers, which the eager permission detector
+/// would otherwise surface as a spurious `permission_lost`. That false positive
+/// is the dominant cause of the recurring screen-recording permission-loss
+/// telemetry — users lock/unlock several times a day. System *wake* already
+/// arms this grace via [`mark_recently_woke`]; unlock did not, until now.
+///
+/// Also wakes any `monitor_watcher` parked on [`SCREEN_UNLOCK_NOTIFY`] so it
+/// re-scans immediately instead of waiting for its poll tick.
+#[cfg(target_os = "macos")]
+fn handle_screen_unlock_transition() {
+    screenpipe_screen::stream_invalidation::request();
+    crate::permission_monitor::notify_wake();
+    SCREEN_UNLOCK_NOTIFY.notify_one();
+}
+
 /// Start the sleep/wake monitor on macOS
 /// This sets up NSWorkspace notification observers for sleep and wake events,
 /// plus a polling thread that checks `CGSessionCopyCurrentDictionary` every
@@ -283,12 +303,11 @@ pub fn start_sleep_monitor() {
             let was_locked = SCREEN_IS_LOCKED.swap(false, Ordering::SeqCst);
             screenpipe_config::set_screen_locked(false);
             if was_locked {
-                // State change logged via safety-net poll below if needed.
-                // Request invalidation of persistent SCStream handles so
-                // the capture loop recreates them with fresh frames.
-                #[cfg(target_os = "macos")]
-                screenpipe_screen::stream_invalidation::request();
-                SCREEN_UNLOCK_NOTIFY.notify_one();
+                // Recreate the SCStream with fresh frames AND arm the
+                // permission-monitor grace (re-creation transiently reports
+                // `denied`). catch_unwind: never let a panic unwind across the
+                // C boundary — this runs in a CFNotificationCenter callback.
+                let _ = std::panic::catch_unwind(handle_screen_unlock_transition);
             }
         }
 
@@ -348,9 +367,7 @@ pub fn start_sleep_monitor() {
                 info!("Screen locked (CGSession safety-net poll)");
             } else {
                 info!("Screen unlocked (CGSession safety-net poll)");
-                #[cfg(target_os = "macos")]
-                screenpipe_screen::stream_invalidation::request();
-                SCREEN_UNLOCK_NOTIFY.notify_one();
+                handle_screen_unlock_transition();
             }
         }
     });
@@ -396,6 +413,11 @@ pub fn start_sleep_monitor() {
             #[cfg(target_os = "macos")]
             screenpipe_screen::stream_invalidation::request();
             screenpipe_audio::stream_invalidation::request();
+            // SCStream re-creation after a reconfiguration transiently reports
+            // `denied`; arm the permission-monitor grace so it isn't surfaced
+            // as a false permission_lost. catch_unwind: never unwind across the
+            // C boundary (this runs in a CGDisplay reconfiguration callback).
+            let _ = std::panic::catch_unwind(crate::permission_monitor::notify_wake);
             // Wake any waiters (e.g. monitor_watcher) so they re-scan the
             // monitor list immediately instead of waiting on a poll timer.
             DISPLAY_RECONFIG_NOTIFY.notify_one();
@@ -531,9 +553,7 @@ fn on_did_wake(handle: &tokio::runtime::Handle) {
         screenpipe_config::set_screen_locked(locked);
         if was_locked && !locked {
             info!("Screen unlocked after wake (CGSession safety-net cleared SCREEN_IS_LOCKED)");
-            #[cfg(target_os = "macos")]
-            screenpipe_screen::stream_invalidation::request();
-            SCREEN_UNLOCK_NOTIFY.notify_one();
+            handle_screen_unlock_transition();
         }
 
         // Resume DB write queue now that the system is stable.
@@ -816,6 +836,20 @@ mod tests {
         assert!(
             !screenpipe_audio::stream_invalidation::take(),
             "Audio flag should be cleared after take()"
+        );
+    }
+
+    /// A screen-unlock transition must arm the permission-monitor wake grace,
+    /// so the SCStream re-creation it triggers does not surface as a spurious
+    /// `permission_lost`. This is the #1 cause of recurring screen-recording
+    /// permission-loss telemetry (users lock/unlock several times a day).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_screen_unlock_arms_permission_wake_grace() {
+        handle_screen_unlock_transition();
+        assert!(
+            crate::permission_monitor::wake_grace_active(),
+            "screen unlock must arm the permission-monitor wake grace"
         );
     }
 


### PR DESCRIPTION
## description

Screen-recording `permission_lost` is the **#1 user-facing telemetry signal** (PostHog: 570 users, ~6.4k events) and was overwhelmingly **false positives**, not real revokes. The merged Sentry filters (#4615/#4577) only silenced the telemetry — this fixes the actual cause.

**Root cause.** In the desktop app the *only* screen-recording emitter is the eager `monitor_watcher` path, which fires on transient ScreenCaptureKit "denied" errors. On every **screen unlock** (and **display reconfiguration**) the app invalidates and re-creates the `SCStream`; during re-creation ScreenCaptureKit briefly reports `denied` before it re-registers the process. System *wake* already suppressed this via a 10s grace (`notify_wake`), but **unlock and display-reconfig did not** — so users who lock/unlock several times a day emitted a spurious `permission_lost` (and a recovery-modal flash) each time.

Evidence that these are false positives, not real losses: median **5** losses/user (max 83), **~daily** cadence with intra-hour bursts, and 79% of affected users had thousands of `vision_pipeline_health` events *before* the "loss" — i.e. capture was working, then briefly blipped on an unlock.

**Fix — one invariant: wherever we invalidate the SCStream, arm the permission grace.**
- Add `handle_screen_unlock_transition()` and route all three unlock sites through it (the `com.apple.screenIsUnlocked` CFNotification callback, the CGSession safety-net poll, and the post-wake re-check).
- Arm the grace in the display-reconfiguration callback too.
- The two `extern "C"` callbacks wrap the call in `catch_unwind` (never unwind across the FFI boundary).
- Forward the engine `reason` (`"poll"` vs the raw SCK error string) into the `permission_lost` PostHog event so any *residual* loss stays diagnosable (real revoke vs an un-graced transient).

**Safety:** onboarding is unaffected — it reads via the separate `check_screen_recording_tauri` command, and the monitor's `STATE` is private to `permission_monitor`. Per `TESTING.md:227` ("revoke → red banner within 10s"), a *normal* revoke still emits immediately; the grace is armed **only** around unlock/reconfig, so just the rare revoke-coincides-with-unlock case is delayed to ~grace-expiry — consistent with the existing sleep/wake-grace precedent (`TESTING.md:144,160d`).

related issue: _no GitHub issue filed yet; corresponds to Sentry `SCREENPIPE-CLI-WH` and the PostHog `permission_lost / screen_recording` signal._

## before

No UI surface change. Behaviorally, **before** this PR: locking and unlocking the Mac (or sleeping/waking a display, plugging/unplugging a monitor) intermittently popped the permission-recovery modal and emitted a `permission_lost` event, even though screen recording was still granted.

```
screen unlock ──> SCStream invalidated + re-created
                        │  (during re-register, ScreenCaptureKit briefly returns "denied")
   BEFORE:  eager detector ─> report_state(ScreenRecording, denied) ─> permission_lost  ❌ false positive
```

## after

```
screen unlock ──> handle_screen_unlock_transition()
                        ├─ invalidate SCStream (recreate w/ fresh frames)
                        ├─ permission_monitor::notify_wake()  ← 10s grace armed
                        └─ wake monitor_watcher
   AFTER:   eager detector ─> report_state(...) suppressed by grace ──> (no event)        ✅
```

> _Maintainer: a short before/after screen recording (lock → unlock, watch for the modal flash) can be dropped here._

## how to test

1. Build/run the desktop app with screen recording **granted**.
2. Lock the screen (Ctrl+Cmd+Q), wait ~3s, unlock. Repeat a few times; also try sleeping/waking an external display or plugging/unplugging a monitor.
3. **Before:** the permission-recovery modal flashes and a `permission_lost` event fires on unlock. **After:** no modal, no event — recording just resumes.
4. Confirm a *real* revoke still works: with the app running, revoke Screen Recording in System Settings → the red permission banner still appears within ~10s.
5. Unit test: `cargo test -p screenpipe-engine --lib sleep_monitor::tests::test_screen_unlock_arms_permission_wake_grace`.

## desktop app checklist (if applicable)

**N/A** — no `#[tauri::command]` handlers or frontend-exported Rust types changed. The one `src-tauri` edit (`engine_events/permission.rs`) only adds a field to a runtime `app.emit` JSON payload, so `tauri.ts` bindings are unaffected.
