### PR TITLE
docs: add Ukrainian (Українська) README translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Thanks to all contributors:
 - [Español (Spanish)](translated_readmes/README-es.md)
 - [Português BR (Brazilian Portuguese)](translated_readmes/README-pt_BR.md)
 - [Deutsch (German)](translated_readmes/README-de.md)
+- [Українська (Ukrainian)](translated_readmes/README-uk.md)
 
 Want to translate screenpipe into another language? See [`translated_readmes/`](translated_readmes/README.md).
 

--- a/translated_readmes/README-es.md
+++ b/translated_readmes/README-es.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a>
+   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a> | <a href="README-uk.md">Українська</a>
 </p>
 
 <h1 align="center">[ screenpipe ]</h1>

--- a/translated_readmes/README-fr.md
+++ b/translated_readmes/README-fr.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a>
+   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a> | <a href="README-uk.md">Українська</a>
 </p>
 
 <h1 align="center">[ screenpipe ]</h1>

--- a/translated_readmes/README-ja.md
+++ b/translated_readmes/README-ja.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a>
+   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a> | <a href="README-uk.md">Українська</a>
 </p>
 
 <h1 align="center">[ screenpipe ]</h1>

--- a/translated_readmes/README-pt_BR.md
+++ b/translated_readmes/README-pt_BR.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a>
+   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a> | <a href="README-uk.md">Українська</a>
 </p>
 
 <h1 align="center">[ screenpipe ]</h1>

--- a/translated_readmes/README-uk.md
+++ b/translated_readmes/README-uk.md
@@ -13,8 +13,8 @@
 <h1 align="center">[ screenpipe ]</h1>
 
 
-<p align="center">das 24/7-Gedächtnis deines Computers</p>
-<p align="center">Open-Source-rewind. 100% lokal. Deine Daten gehören dir.</p>
+<p align="center">пам'ять твого комп'ютера 24/7</p>
+<p align="center">Open-source rewind. 100% локально. Твої дані належать тобі.</p>
 
 
 
@@ -26,10 +26,10 @@
 
 <p align="center">
     <a href="https://screenpi.pe" target="_blank">
-        <img src="https://img.shields.io/badge/herunterladen-Desktop--App-black?style=for-the-badge" alt="herunterladen">
+        <img src="https://img.shields.io/badge/завантажити-Desktop%20застосунок-black?style=for-the-badge" alt="завантажити">
     </a>
     <a href="https://github.com/screenpipe/screenpipe/releases?q=mcp-v&expanded=true" target="_blank">
-        <img src="https://img.shields.io/badge/installieren-Claude--Extension-D97706?style=for-the-badge&logo=anthropic&logoColor=white" alt="claude extension installieren">
+        <img src="https://img.shields.io/badge/встановити-Claude%20розширення-D97706?style=for-the-badge&logo=anthropic&logoColor=white" alt="встановити розширення claude">
     </a>
 </p>
 
@@ -38,7 +38,7 @@
         <img src="https://img.shields.io/discord/823813159592001537?color=5865F2&logo=discord&logoColor=white&style=flat-square" alt="discord">
     </a>
     <a href="https://twitter.com/screenpipe">
-        <img alt="x" src="https://img.shields.io/twitter/url/https/twitter.com/diffuserslib.svg?style=social&label=folgen%20%40screenpipe">
+        <img alt="x" src="https://img.shields.io/twitter/url/https/twitter.com/diffuserslib.svg?style=social&label=стежити%20%40screenpipe">
     </a>
 </p>
 
@@ -50,36 +50,36 @@
 
 ---
 
-## was ist das?
+## що це?
 
-screenpipe zeichnet deinen Bildschirm und dein Audio rund um die Uhr auf, speichert alles lokal und verbindet deinen digitalen Verlauf mit KI.
+screenpipe записує твій екран та аудіо цілодобово, зберігає все локально та з'єднує твою цифрову історію зі штучним інтелектом.
 
 ```
 ┌─────────────────────────────────────────┐
-│  Bildschirm + Audio → lokal → KI        │
+│  екран + аудіо → локально → ШІ          │
 └─────────────────────────────────────────┘
 ```
 
-- **alles merken** — vergiss nie wieder, was du gesehen, gehört oder getan hast
-- **KI-Suche** — finde alles in natürlicher Sprache
-- **100% lokal** — deine Daten verlassen niemals deinen Rechner
-- **Open Source** — überprüfbar, anpassbar, dein
+- **пам'ятати все** — більше ніколи не забувай, що ти бачив, чув чи робив
+- **пошук зі ШІ** — знаходь будь-що природною мовою
+- **100% локально** — твої дані ніколи не залишають твій комп'ютер
+- **відкритий код** — перевіряй, змінюй, володій
 
-## installation
+## встановлення
 
-[Desktop-App herunterladen](https://screenpi.pe) — macOS, Windows, Linux
+[завантаж десктоп-застосунок](https://screenpi.pe) — macOS, Windows, Linux
 
-## anforderungen
+## вимоги
 
 - 10% CPU
-- 4 GB RAM
-- ~15 GB Speicher pro Monat
-- offline-fähig
+- 4 ГБ RAM
+- ~15 ГБ пам'яті на місяць
+- працює офлайн
 
 ---
 
 <p align="center">
-    <a href="https://docs.screenpi.pe">Dokumentation</a> ·
+    <a href="https://docs.screenpi.pe">Документація</a> ·
     <a href="https://discord.gg/screenpipe">discord</a> ·
     <a href="https://twitter.com/screenpipe">x</a>
 </p>

--- a/translated_readmes/README-zh_CN.md
+++ b/translated_readmes/README-zh_CN.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a>
+   <a href="../README.md">English</a> | <a href="README-zh_CN.md">简体中文</a> | <a href="README-ja.md">日本語</a> | <a href="README-fr.md">Français</a> | <a href="README-es.md">Español</a> | <a href="README-pt_BR.md">Português (BR)</a> | <a href="README-de.md">Deutsch</a> | <a href="README-uk.md">Українська</a>
 </p>
 
 <h1 align="center">[ screenpipe ]</h1>

--- a/translated_readmes/README.md
+++ b/translated_readmes/README.md
@@ -11,6 +11,7 @@ we're actively looking for contributors to translate the screenpipe README to mo
 - [Español (Spanish)](README-es.md)
 - [Português BR (Brazilian Portuguese)](README-pt_BR.md)
 - [Deutsch (German)](README-de.md)
+- [Українська (Ukrainian)](README-uk.md)
 
 ## adding a new language
 


### PR DESCRIPTION
adds a Ukrainian (Українська) translation of the README, following the documented "adding a new language" steps in `translated_readmes/README.md`.

- new `translated_readmes/README-uk.md`, mirroring the structure of the existing translations (used `README-de.md` as the template)
- adds Українська to the language switcher at the top of every file in `translated_readmes/`
- adds it to the "available translations" list in the index and the "Translations" section of the root `README.md`

translation is by a native Ukrainian speaker. images, URLs, and the scarf pixel are untouched — only prose is translated. the ASCII diagram keeps the box alignment (Cyrillic is single-width, padded to the same interior width as the other Latin-script translations); badge labels use Cyrillic in the shields.io URLs, matching the existing Japanese/Chinese translations.

no media files committed.
