### PR TITLE
fix(search): prevent stale filter UI states

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -1838,10 +1838,12 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
           {/* UI event results — shown above screen results so infinite scroll doesn't push them away */}
           {uiEventResults.length > 0 && contentFilter !== "screen" && contentFilter !== "chats" && (
             <div className={cn(contentFilter === "all" && "mb-4")}>
-              <p className="text-xs text-muted-foreground mb-2 flex items-center gap-1.5">
-                <Keyboard className="w-3 h-3" />
-                keyboard & clipboard
-              </p>
+              {contentFilter === "all" && (
+                <p className="text-xs text-muted-foreground mb-2 flex items-center gap-1.5">
+                  <Keyboard className="w-3 h-3" />
+                  keyboard & clipboard
+                </p>
+              )}
               <div className="flex flex-col gap-2">
                 {(contentFilter === "all" ? uiEventResults.slice(0, 5) : uiEventResults).map((evt) => (
                   <UiEventItem

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -483,6 +483,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
   const recentChatRequestRef = useRef(0);
   // Recent chats shown in the suggestions area (loaded on open, independent of chats tab)
   const [recentChats, setRecentChats] = useState<ConversationMeta[]>([]);
+  const visibleRecentChats = contentFilter === "all" ? recentChats : [];
 
   // App filter (for screen results and speaker drill-down)
   const [appFilter, setAppFilter] = useState<string | null>(null);
@@ -1719,7 +1720,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
           )}
 
           {/* Inline chat section in "All" view — appears instantly (in-memory filter) while screen results load */}
-          {contentFilter !== "chats" && debouncedQuery.trim().length >= 1 && filteredChats.length > 0 && !isTagSearch && !isPeopleSearch && (
+          {contentFilter === "all" && debouncedQuery.trim().length >= 1 && filteredChats.length > 0 && !isTagSearch && !isPeopleSearch && (
             <div className="mb-4">
               <p className="text-xs text-muted-foreground mb-2 flex items-center gap-1.5">
                 <MessageSquare className="w-3 h-3" />
@@ -2082,14 +2083,14 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
           {!debouncedQuery && !isSearching && contentFilter !== "chats" && (
             <div className="py-4 px-2 space-y-4">
               {/* Recent chats — list with timestamps */}
-              {recentChats.length > 0 && (
+              {visibleRecentChats.length > 0 && (
                 <div>
                   <p className="text-xs text-muted-foreground/60 mb-1 flex items-center gap-1.5">
                     <MessageSquare className="w-3 h-3" />
                     recent chats
                   </p>
                   <div className="flex flex-col">
-                    {recentChats.map((chat) => {
+                    {visibleRecentChats.map((chat) => {
                       const ts = new Date(chat.lastUserMessageAt ?? chat.updatedAt).toISOString();
                       return (
                         <button
@@ -2127,7 +2128,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                   </div>
                 </div>
               )}
-              {!recentChats.length && !suggestionsLoading && (
+              {!visibleRecentChats.length && !suggestionsLoading && (
                 <div className="text-center text-sm text-muted-foreground py-4">
                   type to search your screen history
                 </div>

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -1532,7 +1532,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
               ] as const).map(({ key, label, icon: Icon }) => (
                 <button
                   key={key}
-                  onClick={() => { setContentFilter(key); setSelectedIndex(0); setSelectedChatIndex(0); }}
+                  onClick={() => { setContentFilter(key); setSelectedIndex(0); setSelectedChatIndex(0); setHoveredIndex(null); }}
                   className={cn(
                     "inline-flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-full border transition-colors",
                     contentFilter === key
@@ -2195,6 +2195,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
         {/* Results area — only shown when there's content */}
         {hasContent && (
           <div
+            key={contentFilter}
             ref={gridRef}
             className={cn(
               "flex-1 min-h-0 overflow-y-auto overscroll-contain touch-pan-y",
@@ -2304,6 +2305,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
 
         {/* Results area - isolate scroll to prevent timeline from scrolling */}
         <div
+          key={contentFilter}
           ref={gridRef}
           className="max-h-[60vh] overflow-y-auto p-4 overscroll-contain touch-pan-y"
           onWheel={(e) => {

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -2068,7 +2068,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
               </div>
 
               {/* Load more indicator */}
-              {(isLoadingMore || (hasMoreOcr && filteredResults.length > 0)) && (
+              {(isLoadingMore || (hasMoreOcr && filteredResults.length > 0 && searchResults.length >= OCR_PAGE_SIZE)) && (
                 <div className="flex justify-center py-4">
                   {isLoadingMore ? (
                     <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />


### PR DESCRIPTION
This PR fixes several UI issue on search page.

- Prevent chat results/recent chats from appearing inside the `Screen` and `Keyboard & Clipboard` filters.
- Keep mixed-section labels, like `Keyboard & Clipboard`, only in the `All` view instead of repeating them inside their own filter.
- Clear stale selected screen-card styling when switching between search filter chips.
- Hide the `scroll for more` hint when the screen results are too short to have another loaded page.


Before -

https://github.com/user-attachments/assets/057654b4-ef28-4ea2-b759-af337bf6188c



After -

https://github.com/user-attachments/assets/7aab87b6-620f-4e49-8ce8-8081ac2e78d5

## Testing

- Checked `All`, `Screen`, `Keyboard & Clipboard`, and `Chats` filter behavior.




