### PR TITLE
fix(onboarding): grant window show/focus ACL so the app refocuses after macOS permission grant (#4635)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/capabilities/main.json
+++ b/apps/screenpipe-app-tauri/src-tauri/capabilities/main.json
@@ -73,6 +73,9 @@
     "core:window:allow-close",
     "core:window:allow-destroy",
     "core:window:allow-start-dragging",
+    "core:window:allow-show",
+    "core:window:allow-unminimize",
+    "core:window:allow-set-focus",
     {
       "identifier": "fs:scope",
       "allow": [


### PR DESCRIPTION
## Problem — "Onboarding stuck - automatic log submission" (persistent, Win+Mac, activation blocker)

This feedback is **auto-submitted** when the onboarding engine-startup screen sees no progress for 15s. I pulled the actual uploaded logs from the feedback store. On **macOS**, a stuck user's log shows:

```
WARN  Screen recording permission not granted: Denied. Cannot start server.
[ERROR] failed to refocus screenpipe window after permission flow:
        Command plugin:window|show not allowed by ACL
```

`reclaimScreenpipeWindow()` in [lib/utils/permission-flow.ts](apps/screenpipe-app-tauri/lib/utils/permission-flow.ts) runs after the user returns from System Settings and calls — **from the webview (JS)** — `window.show()`, `window.unminimize()`, `window.setFocus()` to bring the app forward. But [capabilities/main.json](apps/screenpipe-app-tauri/src-tauri/capabilities/main.json) granted only `core:window:default` (+ close/destroy/get-all/start-dragging) — **none of show / unminimize / set-focus**. So the refocus is **denied by ACL**, the window never comes forward, and onboarding looks stuck even after the user grants permission.

(Rust-side `.show()` calls are unaffected — Tauri ACL only gates webview/JS invokes.)

## Fix
Grant the three window permissions the refocus actually uses:
```json
"core:window:allow-show",
"core:window:allow-unminimize",
"core:window:allow-set-focus",
```
These let the app's own (trusted, local) frontend bring its window forward after the permission flow — benign and necessary.

## Verification
- `main.json` is valid JSON; all three are real Tauri v2 permission identifiers (present in `gen/schemas`).
- I can't fully e2e-build the Tauri app here, so this is a declarative capability change verified against the schema + matched directly to the ACL error string in the user log. The macOS permission-grant → refocus path should now succeed.

## Out of scope (tracked in #4635)
The **Windows** variant of "onboarding stuck" is different — the onboarding webview repeatedly `failed to fetch (screenpipe.com)` and the engine is slow to come up. That needs separate work (offline-tolerant onboarding / content reachability) and is noted in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)