### PR TITLE
fix(e2e): add missing coverage entry + retry transient ffmpeg/tesseract HTTP errors

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -233,6 +233,16 @@
       "notes": "Cross-window prefill duplicate regression."
     },
     {
+      "spec": "chat-prefill-context-leak.spec.ts",
+      "platforms": ["windows", "macos", "linux"],
+      "layers": ["chat-ai"],
+      "features": ["chat", "chat-prefill"],
+      "criticality": "medium",
+      "confidence": "partial",
+      "ux": "synthetic",
+      "notes": "Pending auto-send prefill must render only the clean prompt, not the internal model context, as the user message."
+    },
+    {
       "spec": "chat-streaming-performance.spec.ts",
       "platforms": ["macos"],
       "layers": ["chat-ai", "performance"],

--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -316,7 +316,10 @@ async function downloadStaticLinuxFfmpeg() {
 		}
 	}
 
-	await $`wget --no-config ${config.linux.ffmpegUrl} -O ${archive}`
+	// johnvansickle.com intermittently returns a transient HTTP 415 (and the odd
+	// 5xx). wget does NOT retry HTTP error responses by default — one 415 then
+	// hard-fails the whole build — so opt those codes into the retry budget.
+	await $`wget --no-config --tries=5 --waitretry=10 --retry-on-http-error=415,429,500,502,503,504 --timeout=60 ${config.linux.ffmpegUrl} -O ${archive}`
 	await $`tar xf ${archive}`
 
 	const entries = await fs.readdir(cwd, { withFileTypes: true });
@@ -556,7 +559,7 @@ if (platform == 'linux') {
 		// Setup TESSERACT
 	if (!(await fs.exists(config.linux.tesseractName)) || (await isSymlink(config.linux.tesseractName))) {
 		await fs.rm(config.linux.tesseractName, { force: true });
-		await $`wget --no-config -nc ${config.linux.tesseractUrl} -O ${config.linux.tesseractName}`
+		await $`wget --no-config -nc --tries=5 --waitretry=10 --retry-on-http-error=415,429,500,502,503,504 --timeout=60 ${config.linux.tesseractUrl} -O ${config.linux.tesseractName}`
 		await $`chmod +x ${config.linux.tesseractName}` // Make the Tesseract binary executable
 	} else {
 		console.log('TESSERACT already exists');


### PR DESCRIPTION
Quarantining the 4 chronic specs (#4611) let the E2E job run far enough to surface two **other** breakages that were masked behind the earlier failures:

1. **Coverage report failed** — `missing coverage entry for spec: chat-prefill-context-leak.spec.ts`. `validateManifest` requires every `*.spec.ts` to have a `coverage-map.json` entry; this one was added without it. Added (mirrors sibling `chat-prefill-duplicate`). Verified: 58 specs = 58 entries, no missing/stale/dup.

2. **Linux build failed** downloading ffmpeg from johnvansickle.com → transient **HTTP 415**. `wget` doesn't retry HTTP errors by default, so one 415 killed the build (URL serves 200 on retry). Added `--tries/--waitretry/--retry-on-http-error` to the Linux ffmpeg + tesseract fetches.

Both validated locally (JSON valid, `node --check` clean). This should get **E2E Tests** green on main.