### PR TITLE
fix(enterprise): unify device id across heartbeat + sync (one device row, fixes seat over-count)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
@@ -492,7 +492,14 @@ mod imp {
         use tauri::Manager;
 
         let app_data_dir = app.path().app_data_dir().ok()?;
-        let device_id = resolve_device_id(&app_data_dir);
+        // Use the same device id the heartbeat reports under (settings `deviceId`)
+        // so a machine is a single enterprise_devices row, not two.
+        let settings_device_id = crate::store::SettingsStore::get(app)
+            .ok()
+            .flatten()
+            .map(|s| s.device_id)
+            .filter(|s| !s.trim().is_empty());
+        let device_id = resolve_device_id(settings_device_id.as_deref(), &app_data_dir);
         let device_label = hostname::get()
             .ok()
             .and_then(|h| h.into_string().ok())
@@ -574,17 +581,36 @@ mod imp {
         Some(tx)
     }
 
-    /// Stable device id, persisted in app data dir on first call. Format is
-    /// `dev-<uuid v4>`. We deliberately don't read the OS hardware UUID — that
-    /// would let an admin correlate across orgs, which is a privacy regression
-    /// vs a local random uuid scoped to this install.
-    fn resolve_device_id(app_data_dir: &std::path::Path) -> String {
-        let path = app_data_dir.join("enterprise_device_id");
-        if let Ok(existing) = std::fs::read_to_string(&path) {
-            let trimmed = existing.trim();
-            if !trimmed.is_empty() {
-                return trimmed.to_string();
+    /// Pure: pick the canonical enterprise device id from the candidates, in
+    /// priority order. The settings `deviceId` wins — that's the id the
+    /// heartbeat reports under (`use-enterprise-policy.ts`), so sync and
+    /// heartbeat register the SAME `enterprise_devices` row. Before this, sync
+    /// minted its own `dev-<uuid>`, so every machine showed up as TWO rows
+    /// (version/recording-status on the heartbeat row, uploads on the sync row),
+    /// which also double-counted devices toward the seat total. Returns None
+    /// when no usable id exists yet (caller mints a fresh one).
+    fn choose_device_id(settings_device_id: Option<&str>, legacy_file_id: Option<&str>) -> Option<String> {
+        for cand in [settings_device_id, legacy_file_id] {
+            if let Some(c) = cand {
+                let c = c.trim();
+                if !c.is_empty() {
+                    return Some(c.to_string());
+                }
             }
+        }
+        None
+    }
+
+    /// Stable device id. Prefers the settings `deviceId` (shared with the
+    /// heartbeat) so a machine is ONE device row; falls back to the legacy
+    /// `dev-<uuid>` persisted in app data dir, then a fresh `dev-<uuid>`. We
+    /// deliberately don't read the OS hardware UUID — that would let an admin
+    /// correlate across orgs, a privacy regression vs a local random uuid.
+    fn resolve_device_id(settings_device_id: Option<&str>, app_data_dir: &std::path::Path) -> String {
+        let path = app_data_dir.join("enterprise_device_id");
+        let legacy = std::fs::read_to_string(&path).ok();
+        if let Some(id) = choose_device_id(settings_device_id, legacy.as_deref()) {
+            return id;
         }
         let id = format!("dev-{}", uuid::Uuid::new_v4());
         // Best-effort persist; on failure we just regenerate next launch (the
@@ -596,6 +622,33 @@ mod imp {
             warn!("enterprise sync: could not persist device_id: {}", e);
         }
         id
+    }
+
+    #[cfg(test)]
+    mod device_id_tests {
+        use super::choose_device_id;
+
+        #[test]
+        fn settings_id_wins_so_sync_matches_heartbeat() {
+            // the whole point: prefer the settings deviceId (heartbeat's id) over
+            // the legacy dev- id, so a machine is one row not two.
+            assert_eq!(
+                choose_device_id(Some("11112222-aaaa"), Some("dev-legacy")).as_deref(),
+                Some("11112222-aaaa")
+            );
+        }
+
+        #[test]
+        fn falls_back_to_legacy_then_none() {
+            assert_eq!(choose_device_id(None, Some("dev-legacy")).as_deref(), Some("dev-legacy"));
+            assert_eq!(choose_device_id(None, None), None);
+        }
+
+        #[test]
+        fn blank_candidates_are_skipped() {
+            assert_eq!(choose_device_id(Some("   "), Some("dev-legacy")).as_deref(), Some("dev-legacy"));
+            assert_eq!(choose_device_id(Some(""), None), None);
+        }
     }
 }
 


### PR DESCRIPTION
## the bug

The same physical machine registers as **two** `enterprise_devices` rows because the heartbeat and the upload pipeline derive `device_id` independently:

| path | code | device_id |
|---|---|---|
| **heartbeat** (reports version + recording_status) | `use-enterprise-policy.ts` | `settings.deviceId` — **bare uuid** |
| **enterprise sync** (does the uploads) | `enterprise_sync.rs::resolve_device_id` | `format!("dev-{uuid}")` — **`dev-` uuid** |

So a single machine shows up as e.g. `a1d3ec4c…` (v2.5.79, recording_status, **no uploads**) **and** `dev-01412639…` (**uploads**, null version/status). Consequences:
1. **Split tracking** — you can never see a machine recording *and* uploading on one row (looked like "the online device never uploaded").
2. **Seat over-count** — the heartbeat sets `current_seats` = device-row count, so duplicate rows inflate it (e.g. **8/7** on a 7-seat license).
3. **Watchdog/dashboard can't correlate** a recording device with its uploads.

## the fix

`resolve_device_id` now **prefers the settings `deviceId`** (the heartbeat's id) so sync and heartbeat register the **same** row. Priority: `settings deviceId → legacy persisted dev-<uuid> → fresh`. Existing installs heal on next launch — uploads move onto the shared id; the old `dev-` rows go stale.

Pure `choose_device_id(settings_id, legacy_id)` helper + 3 unit tests (settings wins · legacy fallback · blanks skipped).

## follow-up (not in this PR)
- Data cleanup (post-release): prune the now-orphaned `dev-` device rows so seat counts reflect real machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)