### PR TITLE
fix(release): make enterprise signing/notarization self-heal transient failures

### DIFF
--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -877,11 +877,22 @@ jobs:
           for dmg in "${BUNDLE_DIR}"/dmg/*.dmg; do
             if [ -f "$dmg" ]; then
               echo "Notarizing: $(basename "$dmg")"
-              xcrun notarytool submit "$dmg" \
-                --apple-id "$APPLE_ID" \
-                --password "$APPLE_PASSWORD" \
-                --team-id "$APPLE_TEAM_ID" \
-                --wait --timeout 15m
+              # Retry transient Apple-notary failures (same class as the .pkg
+              # step below). `if xcrun ...; then` keeps `set -e` from aborting
+              # mid-retry; fail loudly only if all attempts fail.
+              dmg_ok=0
+              for attempt in 1 2 3; do
+                if xcrun notarytool submit "$dmg" \
+                  --apple-id "$APPLE_ID" \
+                  --password "$APPLE_PASSWORD" \
+                  --team-id "$APPLE_TEAM_ID" \
+                  --wait --timeout 15m; then
+                  dmg_ok=1; break
+                fi
+                echo "DMG notarization attempt $attempt/3 failed."
+                [ "$attempt" -lt 3 ] && sleep $((attempt * 30))
+              done
+              [ "$dmg_ok" -eq 1 ] || { echo "ERROR: DMG notarization failed after 3 attempts"; exit 1; }
 
               echo "Stapling: $(basename "$dmg")"
               xcrun stapler staple "$dmg"
@@ -956,14 +967,27 @@ jobs:
           echo "Distribution pkg created: $(basename "$PKG_OUTPUT")"
           pkgutil --check-signature "$PKG_OUTPUT"
 
-          # Notarize the .pkg
+          # Notarize the .pkg. Retry transient notary failures: Apple's service
+          # occasionally fast-fails a submission (enterprise v2.5.80, build
+          # 28389355122 — the DMG submit moments earlier in this same job
+          # succeeded, so creds/agreement were fine). The `if VAR=$(...)` form
+          # also keeps `set -e` from aborting at the assignment before we can
+          # print the output / retry; the "status: Accepted" gate below is final.
           echo "Notarizing .pkg..."
-          SUBMIT_OUT=$(xcrun notarytool submit "$PKG_OUTPUT" \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait --timeout 15m 2>&1)
-          echo "$SUBMIT_OUT"
+          SUBMIT_OUT=""
+          for attempt in 1 2 3; do
+            if SUBMIT_OUT=$(xcrun notarytool submit "$PKG_OUTPUT" \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait --timeout 15m 2>&1); then :; fi
+            echo "$SUBMIT_OUT"
+            if echo "$SUBMIT_OUT" | grep -q "status: Accepted"; then
+              break
+            fi
+            echo "Notarization attempt $attempt/3 did not return Accepted."
+            [ "$attempt" -lt 3 ] && { echo "Retrying in $((attempt * 30))s..."; sleep $((attempt * 30)); }
+          done
 
           # Extract submission ID and check result
           SUBMISSION_ID=$(echo "$SUBMIT_OUT" | grep "id:" | head -1 | awk '{print $2}' || true)

--- a/apps/screenpipe-app-tauri/src-tauri/sign-ssl.ps1
+++ b/apps/screenpipe-app-tauri/src-tauri/sign-ssl.ps1
@@ -105,6 +105,17 @@ while (-not $signed -and $attempt -lt $maxAttempts) {
     }
 
     Push-Location $env:CODESIGNTOOL_PATH
+    # GitHub's `shell: powershell` injects `$ErrorActionPreference = 'Stop'`.
+    # When CodeSignTool's java writes the transient "Unexpected character (<)
+    # at position 0" (HTML-instead-of-JSON from SSL.com) to stderr, the `2>&1`
+    # merge turns it into a TERMINATING NativeCommandError under 'Stop' — which
+    # aborts this script on attempt 1 and BYPASSES the retry loop entirely (the
+    # exact transient this loop exists to ride out; confirmed on enterprise
+    # v2.5.80, build 28389355122 — no "Sign attempt 2/5" ever logged). Drop to
+    # 'Continue' just for the native call so its stderr is captured as data;
+    # control flow stays governed by the explicit $signExit / Test-Path checks.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     # Capture stdout+stderr so we can detect SSL.com QuotaExceededError
     # and fail fast — burning 5 retries × exponential backoff (~7.5 min)
     # on a quota wall is pure waste; the next attempt fails the same way.
@@ -122,6 +133,7 @@ while (-not $signed -and $attempt -lt $maxAttempts) {
         "-input_file_path=$FilePath" `
         "-output_dir_path=$signedDir" 2>&1
     $signExit = $LASTEXITCODE
+    $ErrorActionPreference = $prevEAP
     Pop-Location
 
     # Mirror output to the build log so we keep the existing visibility.


### PR DESCRIPTION
Enterprise release went red twice this week on transient signing/notary flakes that should self-heal but didn't.

**1. Windows SSL.com signing — retry loop silently bypassed.** `sign-ssl.ps1` has a 5-attempt retry for the `Unexpected character (<)` (HTML-not-JSON) transient, but GitHub's `shell: powershell` injects `ErrorActionPreference='Stop'`, so java's stderr via `2>&1` becomes a terminating NativeCommandError that aborts on attempt 1 (no `Sign attempt 2/5` in build 28389355122). Fix: scope `EAP='Continue'` to just the native call.

**2. macOS notarization — no retry + swallowed error.** Neither DMG nor `.pkg` `notarytool submit` had retry; the `.pkg`'s `set -e` aborted before printing the error. Apple notary fast-failed the `.pkg` on v2.5.80 while the DMG (same creds) succeeded. Wrapped both in a 3-attempt retry; `status: Accepted` gate stays final.

Validated: YAML parses, both bash blocks pass `bash -n`.