### PR TITLE
chore(gitignore): ignore local design-sync and meeting-detection notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,12 @@ packages/cli/*/LICENSE.md
 packages/screenpipe-mcp/LICENSE.md
 ee/sdk/LICENSE.md
 ee/sdk/npm/*/LICENSE.md
+# internal meeting-detection notes — kept entirely local, never committed
+docs/meeting-detection-windows-notes.md
+
+# claude.ai/design sync — kept entirely local, never committed
+.design-sync/
+.ds-sync/
+ds-bundle/
+apps/screenpipe-app-tauri/.ds-build/
+apps/screenpipe-app-tauri/.ds-build-tsconfig.json


### PR DESCRIPTION
## description

Carved out of #4613 (which Louis flagged for doing too many things).

Adds gitignore entries so local-only tooling artifacts never get accidentally committed:
- claude.ai/design sync working dirs: `.design-sync/`, `.ds-sync/`, `ds-bundle/`, `apps/screenpipe-app-tauri/.ds-build/`, `apps/screenpipe-app-tauri/.ds-build-tsconfig.json`
- local meeting-detection notes: `docs/meeting-detection-windows-notes.md`

`.gitignore`-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)