### PR TITLE
fix(calendar): stop defaulting untitled events to "(no title)" + dedup prewarm toast

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/meeting_live_notes.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/meeting_live_notes.rs
@@ -405,7 +405,17 @@ async fn was_prewarmed(
         .and_then(|m| m.start.as_deref())
         .filter(|s| !s.trim().is_empty())
     {
-        if guard.contains_key(&format!("|{start}")) {
+        // The bare `|{start}` key is only ever emitted by an *untitled*
+        // event's prewarm. Honor it only when this started event is itself
+        // untitled, so a stray untitled prewarm can't swallow a distinct
+        // *titled* meeting that merely shares the same start instant
+        // (e.g. a double-booked slot).
+        let calendar_title_empty = calendar_match
+            .as_ref()
+            .and_then(|m| m.title.as_deref())
+            .map(|t| t.trim().is_empty())
+            .unwrap_or(true);
+        if calendar_title_empty && guard.contains_key(&format!("|{start}")) {
             return true;
         }
         return candidate_titles
@@ -814,6 +824,30 @@ mod tests {
         assert!(
             was_prewarmed(&suppressed, &calendar_match, "Google Meet", "Google Meet").await,
             "untitled calendar prewarm should still suppress the matching started toast"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedup_untitled_prewarm_does_not_suppress_titled_meeting_at_same_start() {
+        let suppressed: Arc<RwLock<HashMap<String, Instant>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let start = "2026-05-25T09:00:00+00:00";
+        // An untitled event prewarmed at this start → guard holds `|{start}`.
+        suppressed
+            .write()
+            .await
+            .insert(prewarm_key("", start), Instant::now());
+
+        // A distinct, *titled* meeting starts at the same instant (double-booked).
+        // The bare `|{start}` key belongs to the untitled event, not this one,
+        // so this started toast must still fire.
+        let titled_match = Some(CalendarMatch {
+            title: Some("Standup".into()),
+            start: Some(start.into()),
+        });
+        assert!(
+            !was_prewarmed(&suppressed, &titled_match, "Standup", "Standup").await,
+            "a titled meeting must not be suppressed by an untitled event's prewarm at the same start"
         );
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/meeting_live_notes.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/meeting_live_notes.rs
@@ -300,12 +300,7 @@ pub fn start(app: AppHandle) {
                 }
             }
 
-            let title = calendar_match
-                .as_ref()
-                .and_then(|m| m.title.as_ref())
-                .filter(|s| !s.trim().is_empty())
-                .cloned()
-                .unwrap_or_else(|| event.data.display_title());
+            let title = choose_started_notification_title(calendar_match.as_ref(), &event.data);
 
             // Dedup: if a prewarm toast already fired for this calendar
             // event, don't fire a second toast when audio/UI later
@@ -364,6 +359,17 @@ fn forward_screenpipe_event(app: AppHandle, source: &'static str, target: &'stat
     });
 }
 
+fn choose_started_notification_title(
+    calendar_match: Option<&CalendarMatch>,
+    event: &MeetingStartedEvent,
+) -> String {
+    calendar_match
+        .and_then(|m| m.title.as_deref())
+        .filter(|s| !s.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| event.display_title())
+}
+
 /// Returns true when we have already prewarmed the live-note toast for the
 /// calendar event that this `meeting_started` corresponds to. Prefers an
 /// exact `title|start` match when the start time is known so back-to-back
@@ -399,6 +405,9 @@ async fn was_prewarmed(
         .and_then(|m| m.start.as_deref())
         .filter(|s| !s.trim().is_empty())
     {
+        if guard.contains_key(&format!("|{start}")) {
+            return true;
+        }
         return candidate_titles
             .iter()
             .any(|t| guard.contains_key(&format!("{t}|{start}")));
@@ -715,6 +724,40 @@ mod tests {
         assert!(find_calendar_match(&events, &MeetingStartedEvent::default()).is_none());
     }
 
+    #[test]
+    fn started_notification_title_uses_app_when_calendar_title_absent() {
+        let calendar_match = CalendarMatch {
+            title: None,
+            start: Some("2026-06-11T09:00:00Z".to_string()),
+        };
+        let meeting = MeetingStartedEvent {
+            app: Some("Google Meet".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            choose_started_notification_title(Some(&calendar_match), &meeting),
+            "Google Meet"
+        );
+    }
+
+    #[test]
+    fn started_notification_title_preserves_literal_no_title() {
+        let calendar_match = CalendarMatch {
+            title: Some("No Title".to_string()),
+            start: Some("2026-06-11T09:00:00Z".to_string()),
+        };
+        let meeting = MeetingStartedEvent {
+            app: Some("Google Meet".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            choose_started_notification_title(Some(&calendar_match), &meeting),
+            "No Title"
+        );
+    }
+
     #[tokio::test]
     async fn dedup_distinguishes_recurring_same_title_events() {
         let suppressed: Arc<RwLock<HashMap<String, Instant>>> =
@@ -750,6 +793,27 @@ mod tests {
         assert!(
             !was_prewarmed(&suppressed, &match_nine_thirty, "Standup", "Standup").await,
             "9:30 started toast must fire — its prewarm never did"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedup_suppresses_untitled_prewarm_by_start() {
+        let suppressed: Arc<RwLock<HashMap<String, Instant>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        let start = "2026-05-25T09:00:00+00:00";
+        suppressed
+            .write()
+            .await
+            .insert(prewarm_key("", start), Instant::now());
+
+        let calendar_match = Some(CalendarMatch {
+            title: None,
+            start: Some(start.into()),
+        });
+
+        assert!(
+            was_prewarmed(&suppressed, &calendar_match, "Google Meet", "Google Meet").await,
+            "untitled calendar prewarm should still suppress the matching started toast"
         );
     }
 }

--- a/crates/screenpipe-connect/src/ics_calendar.rs
+++ b/crates/screenpipe-connect/src/ics_calendar.rs
@@ -314,7 +314,7 @@ pub fn parse_ics_to_events(
             continue;
         }
 
-        let title = event.get_summary().unwrap_or("(no title)").to_string();
+        let title = event.get_summary().unwrap_or_default().to_string();
         let location = event.get_location().map(|s| s.to_string());
         let meeting_url = normalize_meeting_url(event.get_url().map(str::to_string))
             .or_else(|| extract_meeting_url(location.as_deref()))
@@ -540,5 +540,37 @@ mod tests {
 
         assert!(parse_ics_to_events(&ics_data, "test", now, 0, 8).is_empty());
         assert_eq!(parse_ics_to_events(&ics_data, "test", now, 0, 72).len(), 1);
+    }
+
+    #[test]
+    fn event_without_summary_keeps_empty_title() {
+        let now = Utc::now();
+        let starts_at = now + chrono::Duration::hours(1);
+        let ends_at = now + chrono::Duration::hours(2);
+        let ics_data = format!(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:empty-title-test\r\nDTSTAMP:20241010T101010Z\r\nDTSTART:{}\r\nDTEND:{}\r\nEND:VEVENT\r\nEND:VCALENDAR",
+            starts_at.format("%Y%m%dT%H%M%SZ"),
+            ends_at.format("%Y%m%dT%H%M%SZ")
+        );
+
+        let events = parse_ics_to_events(&ics_data, "test", now, 0, 8);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].title, "");
+    }
+
+    #[test]
+    fn literal_no_title_summary_is_preserved() {
+        let now = Utc::now();
+        let starts_at = now + chrono::Duration::hours(1);
+        let ends_at = now + chrono::Duration::hours(2);
+        let ics_data = format!(
+            "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:literal-no-title-test\r\nDTSTAMP:20241010T101010Z\r\nDTSTART:{}\r\nDTEND:{}\r\nSUMMARY:No Title\r\nEND:VEVENT\r\nEND:VCALENDAR",
+            starts_at.format("%Y%m%dT%H%M%SZ"),
+            ends_at.format("%Y%m%dT%H%M%SZ")
+        );
+
+        let events = parse_ics_to_events(&ics_data, "test", now, 0, 8);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].title, "No Title");
     }
 }

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -1278,44 +1278,46 @@ async fn gcal_fetch_events(
     let items = resp["items"].as_array().cloned().unwrap_or_default();
     let events: Vec<Value> = items
         .into_iter()
-        .map(|item| {
-            let start = item["start"]["dateTime"]
-                .as_str()
-                .or_else(|| item["start"]["date"].as_str())
-                .unwrap_or("")
-                .to_string();
-            let end = item["end"]["dateTime"]
-                .as_str()
-                .or_else(|| item["end"]["date"].as_str())
-                .unwrap_or("")
-                .to_string();
-            let is_all_day = item["start"]["date"].is_string();
-
-            let attendees: Vec<String> = item["attendees"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|a| a["email"].as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let meeting_url = google_calendar_meeting_url(&item);
-
-            json!({
-                "id": item["id"].as_str().unwrap_or(""),
-                "title": item["summary"].as_str().unwrap_or("(No title)"),
-                "start": start,
-                "end": end,
-                "attendees": attendees,
-                "location": item["location"].as_str(),
-                "meetingUrl": meeting_url,
-                "calendarName": calendar_label,
-                "isAllDay": is_all_day,
-            })
-        })
+        .map(|item| google_calendar_event_json(&item, calendar_label))
         .collect();
 
     Ok(events)
+}
+
+fn google_calendar_event_json(item: &Value, calendar_label: &str) -> Value {
+    let start = item["start"]["dateTime"]
+        .as_str()
+        .or_else(|| item["start"]["date"].as_str())
+        .unwrap_or("")
+        .to_string();
+    let end = item["end"]["dateTime"]
+        .as_str()
+        .or_else(|| item["end"]["date"].as_str())
+        .unwrap_or("")
+        .to_string();
+    let is_all_day = item["start"]["date"].is_string();
+
+    let attendees: Vec<String> = item["attendees"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| a["email"].as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let meeting_url = google_calendar_meeting_url(item);
+
+    json!({
+        "id": item["id"].as_str().unwrap_or(""),
+        "title": item["summary"].as_str().unwrap_or(""),
+        "start": start,
+        "end": end,
+        "attendees": attendees,
+        "location": item["location"].as_str(),
+        "meetingUrl": meeting_url,
+        "calendarName": calendar_label,
+        "isAllDay": is_all_day,
+    })
 }
 
 /// Merge per-account Google Calendar event lists into one timeline. An invite
@@ -3530,6 +3532,37 @@ mod tests {
             google_calendar_meeting_url(&item).as_deref(),
             Some("https://meet.google.com/abc-defg-hij")
         );
+    }
+
+    #[test]
+    fn google_calendar_event_without_summary_has_empty_title() {
+        let item = json!({
+            "id": "untitled",
+            "start": { "dateTime": "2026-06-11T09:00:00Z" },
+            "end": { "dateTime": "2026-06-11T09:30:00Z" },
+            "conferenceData": {
+                "entryPoints": [
+                    { "entryPointType": "video", "uri": "meet.google.com/abc-defg-hij" }
+                ]
+            }
+        });
+
+        let event = google_calendar_event_json(&item, "primary");
+        assert_eq!(event["title"], "");
+        assert_eq!(event["meetingUrl"], "https://meet.google.com/abc-defg-hij");
+    }
+
+    #[test]
+    fn google_calendar_event_preserves_literal_no_title_summary() {
+        let item = json!({
+            "id": "literal-no-title",
+            "summary": "No Title",
+            "start": { "dateTime": "2026-06-11T09:00:00Z" },
+            "end": { "dateTime": "2026-06-11T09:30:00Z" }
+        });
+
+        let event = google_calendar_event_json(&item, "primary");
+        assert_eq!(event["title"], "No Title");
     }
 
     // -- resolve_base_url ---------------------------------------------------


### PR DESCRIPTION
## description

Carved out of #4613 (which Louis flagged for doing too many things).

Two small calendar/notification fixes:

1. **Untitled events no longer get a fake placeholder title.** Both the ICS parser (`ics_calendar.rs`) and the Google Calendar path (`connections_api.rs`) were defaulting a missing `SUMMARY` to the literal string `"(no title)"` / `"(No title)"`, which leaked into meeting records and notifications. They now default to an empty title and let downstream UI decide how to render untitled events. A genuine `"No Title"` summary is still preserved (tests cover both cases).
2. **Dedup the live-notes prewarm toast.** In `meeting_live_notes.rs`, when a calendar match has a start time, `was_prewarmed` now short-circuits on the `|{start}` key so back-to-back meetings don't fire a second toast. Also extracts `choose_started_notification_title` for the title-selection logic.

## how to test

- Add a calendar event with no title → confirm the meeting/notification shows an empty title rather than "(no title)".
- Add an event literally titled "No Title" → confirm it's preserved.
- `cargo test -p screenpipe-connect` and the `connections_api` / `meeting_live_notes` tests cover the title cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)