### PR TITLE
docs(readme): say "source-available" not "open source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ screenpipe turns your computer into a personal AI that knows everything you've d
 
 - **search with ai** - find anything using natural language
 - **100% local** - your data never leaves your machine
-- **open source** - inspect, modify, own
+- **source-available** - inspect, modify, audit ([LICENSE.md](LICENSE.md))
 
 <p align="center">
    <a href ="https://screenpi.pe">


### PR DESCRIPTION
## what

README line 79 still advertised the core as **"open source"**. the core license moved from MIT to the **Screenpipe Commercial License (source-available)** on 2026-06-10, and the rest of the README already reflects that (lines 162/167/244/255/264). this fixes the one stale line so our own docs stop contradicting the license.

```diff
- - **open source** - inspect, modify, own
+ - **source-available** - inspect, modify, audit ([LICENSE.md](LICENSE.md))
```

## why

a community member built from source on the strength of the "open source / free to self-host" wording, then hit the desktop app's paid-plan gate and (rightly) called the language misleading. "source-available" is the accurate term:

- **CLI / from-source core** — free for personal, non-commercial use, no account, fully local
- **signed desktop app** — the paid product

this is the first of two copy fixes; the website pricing page ("open source and free to self-host") is the other and is being addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)