### PR TITLE
fix(linux): strip bundled libavif/libsharpyuv so AppImage launches on Arch

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -754,6 +754,12 @@ jobs:
           # (e.g. g_variant_builder_init_static in GLib, MOUNT_2_40 in libmount).
           # Remove bundled GLib/GIO/GObject/GModule/libmount/libblkid/libpcre2
           # so system versions are used. These are core libs on all Linux desktops.
+          #
+          # Same class for libavif/libsharpyuv: linuxdeploy bundles the old Ubuntu
+          # 24.04 libsharpyuv but NOT libavif, so on Arch (libavif 1.4.2) the host
+          # libavif.so.16 loads against the stale bundled libsharpyuv and dies with
+          # "undefined symbol: SharpYuvConvertWithOptions". Strip both so the host's
+          # matched pair is used (the app already loads host libavif anyway).
           echo "Removing bundled system libraries to prevent ABI mismatch on newer distros..."
           # Install appimagetool for repacking
           curl -fsSL -o /tmp/appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
@@ -770,7 +776,9 @@ jobs:
                   squashfs-root/usr/lib/libgmodule-2.0.so* \
                   squashfs-root/usr/lib/libmount.so* \
                   squashfs-root/usr/lib/libblkid.so* \
-                  squashfs-root/usr/lib/libpcre2-8.so*
+                  squashfs-root/usr/lib/libpcre2-8.so* \
+                  squashfs-root/usr/lib/libsharpyuv.so* \
+                  squashfs-root/usr/lib/libavif.so*
             echo "Removed bundled GLib libs, repacking AppImage..."
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -462,6 +462,12 @@ jobs:
 
           bunx tauri build -v --target x86_64-unknown-linux-gnu --features enterprise-build,redact-onnx-cpu
 
+          # Strip bundled GLib/libmount/libblkid/libpcre2 (ABI mismatch on newer
+          # distros) plus libavif/libsharpyuv: linuxdeploy bundles the old Ubuntu
+          # 24.04 libsharpyuv but NOT libavif, so on Arch (libavif 1.4.2) the host
+          # libavif.so.16 loads against the stale bundled libsharpyuv and dies with
+          # "undefined symbol: SharpYuvConvertWithOptions". Strip both so the host's
+          # matched pair is used (the app already loads host libavif anyway).
           echo "Removing bundled system libraries to prevent ABI mismatch on newer distros..."
           curl -fsSL -o /tmp/appimagetool https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x /tmp/appimagetool
@@ -477,7 +483,9 @@ jobs:
                   squashfs-root/usr/lib/libgmodule-2.0.so* \
                   squashfs-root/usr/lib/libmount.so* \
                   squashfs-root/usr/lib/libblkid.so* \
-                  squashfs-root/usr/lib/libpcre2-8.so*
+                  squashfs-root/usr/lib/libpcre2-8.so* \
+                  squashfs-root/usr/lib/libsharpyuv.so* \
+                  squashfs-root/usr/lib/libavif.so*
             echo "Removed bundled GLib libs, repacking AppImage..."
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root


### PR DESCRIPTION
## summary
Add `libavif.so*` and `libsharpyuv.so*` to the existing AppImage library-strip list in both release workflows so the host's matched pair is used instead of an orphaned, stale bundled `libsharpyuv`.

## the bug (reported in Discord #support)
Arch users can't launch the AppImage:

```
screenpipe-app: symbol lookup error: /usr/lib/libavif.so.16: undefined symbol: SharpYuvConvertWithOptions
```

## root cause
`linuxdeploy` bundles the **old Ubuntu 24.04 `libsharpyuv.so.0`** into the AppImage, but **not** `libavif` (the actual consumer). At runtime the loader picks:

```
libavif.so.16    -> HOST  /usr/lib/libavif.so.16   (Arch 1.4.2, needs SharpYuvConvertWithOptions)
libsharpyuv.so.0 -> AppImage usr/lib/...           (Ubuntu 24.04, predates that symbol)  <-- wins via rpath
                                                     => undefined symbol => crash
```

So the bundled set is broken: an orphan `libsharpyuv` shadows the host one, while the host `libavif` it must pair with is loaded from `/usr/lib`.

This is the **same class** as the GLib / libmount / libblkid / libpcre2 ABI-mismatch strip already in these workflows (the "bundled Ubuntu lib shadows a newer host lib" pattern). libavif/libsharpyuv just weren't on the list.

## fix
```diff
   rm -f squashfs-root/usr/lib/libglib-2.0.so* \
         ...
-        squashfs-root/usr/lib/libpcre2-8.so*
+        squashfs-root/usr/lib/libpcre2-8.so* \
+        squashfs-root/usr/lib/libsharpyuv.so* \
+        squashfs-root/usr/lib/libavif.so*
```
in both `release-app.yml` and `release-enterprise.yml`. Safe because the symptom proves the host already ships a matching libavif/libsharpyuv pair (the loader was already reaching for host `/usr/lib/libavif.so.16`).

This is the CI equivalent of the manual workaround a user posted (extract AppImage → copy host `libavif.so.16` + `libsharpyuv.so.0` in → repack).

## regression guard
A companion change extends the **Linux AppImage smoke test (#4606)** with an Arch container that reproduces this exact scenario (Arch ships the newer libavif) and asserts no bundled `libavif.so`/`libsharpyuv.so` remain + the app launches without the symbol error.

## checks
- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflows ✅
- `git diff --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)