### PR TITLE
fix(app): don't init PostHog in E2E (stops announcement modal over every spec)

### DIFF
--- a/apps/screenpipe-app-tauri/app/providers.tsx
+++ b/apps/screenpipe-app-tauri/app/providers.tsx
@@ -61,7 +61,12 @@ export const Providers = forwardRef<
   useEffect(() => {
     if (typeof window !== "undefined") {
       const isDebug = process.env.TAURI_ENV_DEBUG === "true";
-      if (isDebug) return;
+      // Skip in E2E too: the suite runs a release-like build, so posthog would
+      // otherwise init, load the live `app-announcement` flag, and pop a modal
+      // over every spec (clean localStorage each run = empty dismissed-set) —
+      // plus pollute prod analytics with test traffic.
+      const isE2E = process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
+      if (isDebug || isE2E) return;
       // Bootstrap with the stable per-install id (mirrors settings.analyticsId,
       // cached by the identify() effect in use-settings) so EVERY event — incl.
       // ones fired by overlay windows like the floating search bar before the


### PR DESCRIPTION
## what

PostHog no longer initializes during E2E. Fixes the `app-announcement` modal popping over every E2E spec.

## why

The E2E suite runs a **release-like build**, so `posthog.init` ran (it's only gated on `TAURI_ENV_DEBUG`), loaded the live `app-announcement` feature flag, and rendered the announcement modal on every run — each run starts with clean `localStorage`, so the per-id dismissed-set is always empty and it shows again. It also meant **E2E traffic was polluting prod PostHog analytics**.

## how

Gate `posthog.init` on the existing canonical E2E signal (`NEXT_PUBLIC_SCREENPIPE_E2E === "true"`, already used by `lib/app-entitlement.ts`) alongside the debug guard:

```ts
const isDebug = process.env.TAURI_ENV_DEBUG === "true";
const isE2E = process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
if (isDebug || isE2E) return;
```

One spot suppresses the whole flag-driven-UI class (announcements + any future flag UI) in tests.

## scope / safety

- Real users (prod, non-debug, non-E2E) are unaffected — PostHog + the use-case survey announcement still work.
- No E2E spec references posthog or announcements (grepped `e2e/`), so nothing depends on it being on.
- `bun tauri dev` already skipped posthog via `TAURI_ENV_DEBUG`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)