### PR TITLE
chore(build): clear stale frontend export so a failed build can't ship a stale UI

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -23,6 +23,16 @@ const winArch = platform === 'windows' ? (process.arch === 'arm64' ? 'arm64' : '
 const cwd = process.cwd()
 console.log('cwd', cwd)
 
+// Remove any stale static export before the frontend rebuilds. `next build`
+// (output: 'export') only writes ../out on success; if it fails (e.g. a type
+// error), a previously-built out/ stays on disk and tauri embeds that OLD
+// bundle — so the app "builds" but silently ships a stale UI. Clearing it here
+// (prebuild runs before `next build`) means a failed build leaves no out/ and
+// tauri fails loudly on the missing frontendDist instead. See #4645 post-mortem.
+const staleExportDir = path.join(cwd, '..', 'out')
+await fs.rm(staleExportDir, { recursive: true, force: true })
+console.log('cleared stale frontend export:', staleExportDir)
+
 
 const config = {
 	ffmpegRealname: 'ffmpeg',


### PR DESCRIPTION
## Problem

`next build` (output: `export`) only writes `../out` on a **successful** build. When it fails — e.g. a TypeScript error, or a stale/auto-regenerated `tauri.ts` binding mismatch — a previously-built `out/` stays on disk, and `tauri build` happily embeds that **old** bundle. Result: the app "builds" green but silently ships a **stale UI**.

This cost a long debugging session on #4645: frontend fixes appeared to have no effect because every failed `next build` left the old `out/` for tauri to re-embed, so the running app never reflected the source.

## Fix

`prebuild` runs `pre_build.js` before `next build`. Clear `../out` there:

```js
const staleExportDir = path.join(cwd, '..', 'out')
await fs.rm(staleExportDir, { recursive: true, force: true })
```

Now a failed build leaves **no** `out/`, so `tauri build` fails loudly on the missing `frontendDist` instead of silently embedding stale assets. Uses `fs.rm` (not `rm -rf`) so it's cross-platform — the Windows e2e build runs this same path.

Verified locally: a planted `out/marker.txt` is removed on `bun scripts/pre_build.js`, no errors.

## Scope note

The *trigger* in that session was separate: regenerating `lib/utils/tauri.ts` locally (after adding a Tauri command) produced an `openLoginWindow` whose `Option<bool>` param became **required** (`x: T | null`) rather than optional, which broke ~16 zero-arg call sites and failed `next build`. That points at a specta-typescript ergonomics/version question for `Option<T>` command params — repo-wide and out of scope here, and I couldn't cleanly verify the committed-vs-generated bindings state from my churned worktree, so I'm not making a claim about CI's `bindings:check` status. This PR is the orthogonal, high-leverage fix: it turns that whole class of "build succeeded but UI is stale" failure into a loud, immediate one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
