### PR TITLE
ci(sync-skills): make best-effort PR step non-blocking (PAT expired, #4676)

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -55,6 +55,12 @@ jobs:
       # PAT pattern adds maintenance pain (PATs expire). A PR is robust
       # forever; merge is one click.
       - name: Open PR if skills changed
+        # Non-blocking: the repo PAT (created 2025-01-28) is expired, so the push
+        # currently fails with "could not read Username". This is a best-effort
+        # mirror that has never gated anything — don't red the workflow on it.
+        # Once secrets.PAT is rotated the PR opens for real; until then a human
+        # can run the rsync above by hand. Tracked in #4676.
+        continue-on-error: true
         uses: peter-evans/create-pull-request@v6
         with:
           # GITHUB_TOKEN can't open PRs here — the enterprise policy disables


### PR DESCRIPTION
The repo `secrets.PAT` (created 2025-01-28) is expired → the auto-PR push fails with `could not read Username` (exit 128). sync-skills is a best-effort mirror that has never gated anything, so mark the PR step `continue-on-error` instead of reddening main. Rotate the PAT (#4676) to restore the real auto-PR + drop this flag.