### PR TITLE
fix(app): pass freshSession arg to openLoginWindow() — unbreak tsc

### DIFF
--- a/apps/screenpipe-app-tauri/app/settings/page.tsx
+++ b/apps/screenpipe-app-tauri/app/settings/page.tsx
@@ -191,7 +191,7 @@ function ReferralSection() {
           <div className="border border-border p-4 bg-card">
             <p className="text-sm text-muted-foreground mb-3">sign in to get your referral link</p>
             <button
-              onClick={() => commands.openLoginWindow()}
+              onClick={() => commands.openLoginWindow(null)}
               className="px-4 py-2 text-xs font-medium border border-border bg-background hover:bg-foreground hover:text-background transition-colors duration-150"
             >
               SIGN IN

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -258,7 +258,7 @@ export function AppEntitlementGate({ children }: { children: React.ReactNode }) 
 
   const openLogin = useCallback(() => {
     posthog.capture("app_entitlement_login_clicked");
-    commands.openLoginWindow();
+    commands.openLoginWindow(null);
   }, []);
 
   const refreshUser = useCallback(async () => {

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
@@ -48,7 +48,7 @@ export function UpgradeQuotaBanner() {
     setBusy(true);
     try {
       if (!signedIn) {
-        await commands.openLoginWindow();
+        await commands.openLoginWindow(null);
         return;
       }
       const res = await fetch("https://screenpipe.com/api/cloud-sync/checkout", {

--- a/apps/screenpipe-app-tauri/components/login-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/login-dialog.tsx
@@ -26,7 +26,7 @@ export function LoginDialog() {
           <Button
             variant="default"
             onClick={() => {
-              commands.openLoginWindow();
+              commands.openLoginWindow(null);
               setIsOpen(false);
             }}
           >

--- a/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
@@ -607,7 +607,7 @@ export default function ConnectApps({ handleNextSlide }: ConnectAppsProps) {
 
   const handleUpgradeToPro = useCallback(async () => {
     if (!settings.user?.id || !settings.user?.token) {
-      await commands.openLoginWindow();
+      await commands.openLoginWindow(null);
       return;
     }
 

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -305,7 +305,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
     posthog.capture("onboarding_login_clicked");
     // Open login in an in-app WebView instead of Safari so we can intercept
     // the screenpipe:// deep-link redirect (Safari blocks custom-scheme redirects)
-    commands.openLoginWindow();
+    commands.openLoginWindow(null);
   }, []);
 
   const handleSkip = useCallback(() => {

--- a/apps/screenpipe-app-tauri/components/pipe-advisory-watcher.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-advisory-watcher.tsx
@@ -59,7 +59,7 @@ export function PipeAdvisoryWatcher() {
     const startUpgrade = async () => {
       try {
         if (!token) {
-          await commands.openLoginWindow();
+          await commands.openLoginWindow(null);
           return;
         }
         const res = await fetch("https://screenpipe.com/api/cloud-sync/checkout", {

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -124,7 +124,7 @@ export function AccountSection() {
 
   const handleCheckout = async () => {
     if (!settings.user?.id) {
-      await commands.openLoginWindow();
+      await commands.openLoginWindow(null);
       return;
     }
     if (!settings.user?.cloud_subscribed) {
@@ -275,7 +275,7 @@ export function AccountSection() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => commands.openLoginWindow()}
+              onClick={() => commands.openLoginWindow(null)}
             >
               login <ExternalLinkIcon className="w-3.5 h-3.5 ml-1.5" />
             </Button>
@@ -522,7 +522,7 @@ export function AccountSection() {
             <Button
               className="w-full max-w-xs bg-foreground text-background hover:bg-background hover:text-foreground transition-colors duration-150"
               size="lg"
-              onClick={() => commands.openLoginWindow()}
+              onClick={() => commands.openLoginWindow(null)}
             >
               Log in
               <ExternalLinkIcon className="w-4 h-4 ml-2" />
@@ -603,7 +603,7 @@ export function AccountSection() {
               <div className="flex items-center gap-2">
                 <Switch disabled checked={false} />
                 <button
-                  onClick={() => commands.openLoginWindow()}
+                  onClick={() => commands.openLoginWindow(null)}
                   className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full font-medium flex items-center gap-1 hover:bg-primary/20 transition-colors cursor-pointer"
                 >
                   <Lock className="h-3 w-3" />

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -1527,7 +1527,7 @@ const AISection = ({
                               // checkout (or sign-in first) instead of selecting it.
                               if (locked) {
                                 if (!settings.user?.token) {
-                                  await commands.openLoginWindow();
+                                  await commands.openLoginWindow(null);
                                 } else {
                                   try {
                                     const res = await fetch("https://screenpipe.com/api/cloud-sync/checkout", {

--- a/apps/screenpipe-app-tauri/components/settings/archive-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/archive-settings.tsx
@@ -296,7 +296,7 @@ export function ArchiveSettings() {
 
   const handleCheckout = async () => {
     if (!settings.user?.id) {
-      await commands.openLoginWindow();
+      await commands.openLoginWindow(null);
       return;
     }
     try {

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -441,7 +441,7 @@ export function StandaloneChat({
     });
 
     try {
-      await commands.openLoginWindow();
+      await commands.openLoginWindow(null);
     } catch (e) {
       console.warn("failed to open login after Pi auth error:", e);
     }
@@ -1139,7 +1139,7 @@ export function StandaloneChat({
         hasValidModel={hasValidModel}
         needsLogin={needsLogin}
         onOpenLogin={async () => {
-          await commands.openLoginWindow();
+          await commands.openLoginWindow(null);
         }}
         onOpenSettings={async () => {
           await commands.showWindow({ Home: { page: null } });


### PR DESCRIPTION
Frontend Tests `Type-check (tsc --noEmit)` was failing with **15× `TS2554: Expected 1 arguments, but got 0`** (the only tsc errors). The Rust `open_login_window` command gained `fresh_session: Option<bool>`, so the binding is now `openLoginWindow(freshSession: boolean | null)`, but 15 call sites still passed 0 args.

Fix: pass `null` everywhere — `None` → `unwrap_or(false)` server-side = exact prior behavior. Mechanical, 15/15 lines, zero collateral changes.