### PR TITLE
ci(rust): pin test-macos to macos-14 (macos-latest Xcode 26.5 lacks clang_rt.osx)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,13 @@ jobs:
       # pipes_test removed — pipe manager system deleted in #2212
 
   test-macos:
-    runs-on: macos-latest
+    # Pinned off `macos-latest`: that label rolled to the Xcode 26.5 image whose
+    # clang toolchain is missing `clang_rt.osx`, so `cargo test`'s debug link
+    # fails with `ld: library 'clang_rt.osx' not found` (green on the 3 prior
+    # commits, then red on the next 2 with no related code change). macos-14
+    # (Sonoma) has a complete toolchain and is proven here — e2e-macos.yml builds
+    # screenpipe-screen on it and passes. Revisit when macos-latest is fixed.
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4


### PR DESCRIPTION
Rust CI's macOS job went red with `ld: library 'clang_rt.osx' not found` — **green on the 3 prior commits, red on the next 2 with no related code change**. Infra root cause: `macos-latest` rolled to the **Xcode 26.5** runner image whose clang toolchain is missing the compiler-rt darwin lib that `cargo test`'s debug link needs. `test-ubuntu` + `test-windows` unaffected.

Fix: pin `test-macos` to **`macos-14`** (Sonoma) — complete toolchain, and **proven in this repo**: `e2e-macos.yml` runs on macos-14 and builds `screenpipe-screen` + the full app (green on the last 3 runs). Revert once GitHub fixes the `macos-latest` image.