### PR TITLE
fix(app): don't mark all notifications read just by opening the bell

### DIFF
--- a/apps/screenpipe-app-tauri/components/notification-bell.tsx
+++ b/apps/screenpipe-app-tauri/components/notification-bell.tsx
@@ -175,12 +175,24 @@ export function NotificationBell() {
 
   const unreadCount = history.filter((n) => !n.read).length;
 
-  const markAllRead = async () => {
-    setHistory((prev) => prev.map((n) => ({ ...n, read: true })));
+  // Mark a single notification read once the user actually engages with it
+  // (expands it). Opening the bell no longer blanket-marks everything read —
+  // glancing at the bell shouldn't clear unread state you never looked at.
+  const markRead = useCallback(async (id: string) => {
+    let wasUnread = false;
+    setHistory((prev) =>
+      prev.map((n) => {
+        if (n.id === id && !n.read) wasUnread = true;
+        return n.id === id ? { ...n, read: true } : n;
+      }),
+    );
+    if (!wasUnread) return;
     try {
-      await notificationFetch("/notifications", { method: "POST" });
+      await notificationFetch(`/notifications/${encodeURIComponent(id)}/read`, {
+        method: "POST",
+      });
     } catch {}
-  };
+  }, []);
 
   const clearAll = async () => {
     posthog.capture("notification_bell_clear_all", { count: history.length });
@@ -275,7 +287,6 @@ export function NotificationBell() {
             unread_count: unreadCount,
             total_count: history.length,
           });
-          markAllRead();
         }
       }}
     >
@@ -355,6 +366,7 @@ export function NotificationBell() {
                       const willExpand = !isExpanded;
                       setExpandedId(willExpand ? entry.id : null);
                       if (willExpand) {
+                        markRead(entry.id);
                         posthog.capture("notification_bell_expand", {
                           notification_type: entry.type,
                           pipe_name: entry.pipe_name,
@@ -367,6 +379,7 @@ export function NotificationBell() {
                       e.preventDefault();
                       const willExpand = !isExpanded;
                       setExpandedId(willExpand ? entry.id : null);
+                      if (willExpand) markRead(entry.id);
                     }}
                   >
                     <div className="flex items-start justify-between gap-2">

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -741,7 +741,7 @@ describe("Windows user journey", function () {
       // inner div and *toggles* expand/collapse, so the click must never fire on
       // an already-open row. The earlier version split the "is it expanded?"
       // check and the click across two WebDriver round-trips; the 5s history
-      // poll + mark-all-read pass re-render the list between those two calls, so
+      // poll re-renders the list between those two calls, so
       // the unconditional toggle-click could land on a row that had just
       // expanded and collapse it again — livelocking until the 30s timeout (it
       // failed on both the initial attempt and the retry in CI). Do the check

--- a/apps/screenpipe-app-tauri/src-tauri/src/notifications/routes.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/notifications/routes.rs
@@ -442,6 +442,30 @@ pub async fn clear() -> Json<ApiResponse> {
     })
 }
 
+/// `POST /notifications/:id/read` — mark a single notification as read.
+///
+/// Opening the bell no longer marks everything read; a notification is read
+/// only once the user actually expands it. This per-id endpoint persists that.
+pub async fn mark_one_read(Path(id): Path<String>) -> (StatusCode, Json<ApiResponse>) {
+    if store::mark_read_by_id(&id) {
+        (
+            StatusCode::OK,
+            Json(ApiResponse {
+                success: true,
+                message: "notification marked as read".to_string(),
+            }),
+        )
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ApiResponse {
+                success: false,
+                message: "notification not found".to_string(),
+            }),
+        )
+    }
+}
+
 /// `DELETE /notifications/:id` — dismiss a single notification.
 pub async fn dismiss(Path(id): Path<String>) -> (StatusCode, Json<ApiResponse>) {
     if store::remove_by_id(&id) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/notifications/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/notifications/store.rs
@@ -68,6 +68,21 @@ pub fn mark_all_read() {
     write_all(&history);
 }
 
+pub fn mark_read_by_id(id: &str) -> bool {
+    let mut history = read_all();
+    let mut changed = false;
+    for entry in &mut history {
+        if entry.id == id && !entry.read {
+            entry.read = true;
+            changed = true;
+        }
+    }
+    if changed {
+        write_all(&history);
+    }
+    changed
+}
+
 pub fn remove_by_id(id: &str) -> bool {
     let mut history = read_all();
     let before = history.len();

--- a/apps/screenpipe-app-tauri/src-tauri/src/server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server.rs
@@ -253,6 +253,10 @@ pub async fn run_server(app_handle: tauri::AppHandle, port: u16) {
             "/notifications/:id",
             axum::routing::delete(crate::notifications::routes::dismiss),
         )
+        .route(
+            "/notifications/:id/read",
+            axum::routing::post(crate::notifications::routes::mark_one_read),
+        )
         .route("/inbox", axum::routing::post(send_inbox_message))
         .route("/log", axum::routing::post(log_message))
         .route("/auth", axum::routing::post(handle_auth))


### PR DESCRIPTION
## the bug

Opening the notification bell marked **every** notification as read — `onOpenChange` fired `markAllRead()` on each open. So just clicking the bell to peek (or it briefly opening) wiped the unread state of items you never actually looked at, and the unread dot vanished for the whole list.

## the fix

A notification is now marked read **only when the user expands it** (clicks/keys into the row), the same moment the body is revealed. Glancing at the bell no longer clears anything.

```
before                                         after
──────                                         ─────
open bell  -> POST /notifications (mark ALL)    open bell  -> nothing marked
                                                expand row -> POST /notifications/:id/read
                                                              (that one item only)
```

## changes

- **`store.rs`** — `mark_read_by_id(id)` (mirrors `remove_by_id`), persists a single item's read flag.
- **`routes.rs`** — `POST /notifications/:id/read` handler (mirrors `dismiss`).
- **`server.rs`** — registers the `/notifications/:id/read` route.
- **`notification-bell.tsx`** — drop the `markAllRead()` call on open; add `markRead(id)` (optimistic local update + per-id POST) wired into the row expand handlers (click + keyboard).
- The blanket `POST /notifications` mark-all endpoint stays for API users — it's just no longer fired automatically.

Read state still persists across the 5s history poll because each expand writes through to disk.

## testing

- `tsc --noEmit` clean for `notification-bell.tsx`.
- Rust changes mirror existing `remove_by_id`/`dismiss` patterns exactly. (Local `cargo check` is blocked by an unrelated build-script bun-resource download in this sandbox.)
- The Windows e2e journey still expands a bell row and asserts the body — behavior preserved; updated a stale comment that referenced the removed mark-all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)