### PR TITLE
fix(app): recall the first chat message with ArrowUp (#4400)

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
@@ -143,6 +143,31 @@ export function useChatComposerShellActions({
   // Index from the newest message. `null` means the user is editing normally.
   const historyIndexRef = useRef<number | null>(null);
 
+  // Recall source for the arrow-key history. `messageHistory` is derived from
+  // the `messages` state, which lags a send: on the first message of a session
+  // `sendMessage` awaits session/preset init before committing the user
+  // message, so the just-sent text isn't in `messageHistory` yet and recall
+  // silently does nothing until a second message exists (#4400). We append to
+  // this ref synchronously at send time so the message is recallable
+  // immediately, and resync it from `messageHistory` whenever a different
+  // conversation loads.
+  const recallHistoryRef = useRef<string[]>(messageHistory);
+
+  useEffect(() => {
+    const recall = recallHistoryRef.current;
+    // Keep the locally-tracked list only while it is `messageHistory` plus
+    // freshly-sent messages not yet reflected in `messages` (the send lag).
+    // That requires `messageHistory` to be a non-empty prefix of `recall`.
+    const recallExtendsHistory =
+      messageHistory.length > 0 &&
+      messageHistory.length <= recall.length &&
+      messageHistory.every((message, index) => message === recall[index]);
+    if (!recallExtendsHistory) {
+      // A different (or new/empty) conversation loaded — adopt its history.
+      recallHistoryRef.current = messageHistory;
+    }
+  }, [messageHistory]);
+
   const sendComposerMessage = useCallback(() => {
     if (pendingDocsRef.current.length > 0) return;
     if (!input.trim() && pastedImages.length === 0 && attachedDocsRef.current.length === 0) return;
@@ -150,8 +175,14 @@ export function useChatComposerShellActions({
     historyIndexRef.current = null;
     const chip = connectionChip;
     setConnectionChip(null);
+    const outgoing = chip ? buildChipModelContent(chip, input.trim()) : input.trim();
+    if (outgoing) {
+      // Mirror what `messageHistory` stores (message.content) so the resync
+      // prefix check above matches once the message commits.
+      recallHistoryRef.current = [...recallHistoryRef.current, outgoing];
+    }
     void sendMessage(
-      chip ? buildChipModelContent(chip, input.trim()) : input.trim(),
+      outgoing,
       chip ? buildChipDisplayContent(chip, input.trim()) : undefined,
     );
   }, [
@@ -263,17 +294,18 @@ export function useChatComposerShellActions({
     }
 
     const isPlainArrow = !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey;
+    const recallHistory = recallHistoryRef.current;
     if (
       !mentions.isOpen &&
       isPlainArrow &&
       event.key === "ArrowUp" &&
       (input === "" || historyIndexRef.current !== null)
     ) {
-      const nextIndex = Math.min((historyIndexRef.current ?? -1) + 1, messageHistory.length - 1);
+      const nextIndex = Math.min((historyIndexRef.current ?? -1) + 1, recallHistory.length - 1);
       if (nextIndex >= 0) {
         event.preventDefault();
         historyIndexRef.current = nextIndex;
-        setInput(messageHistory[messageHistory.length - 1 - nextIndex]);
+        setInput(recallHistory[recallHistory.length - 1 - nextIndex]);
       }
       return;
     }
@@ -287,7 +319,7 @@ export function useChatComposerShellActions({
       event.preventDefault();
       const nextIndex = historyIndexRef.current - 1;
       historyIndexRef.current = nextIndex >= 0 ? nextIndex : null;
-      setInput(nextIndex >= 0 ? messageHistory[messageHistory.length - 1 - nextIndex] : "");
+      setInput(nextIndex >= 0 ? recallHistory[recallHistory.length - 1 - nextIndex] : "");
       return;
     }
 
@@ -324,7 +356,6 @@ export function useChatComposerShellActions({
     isComposing,
     isMac,
     input,
-    messageHistory,
     mentionActions,
     mentions,
     sendComposerMessage,


### PR DESCRIPTION
## what

Fixes a bug in the ArrowUp chat-history recall shipped in #4400: **recall does nothing for the very first message of a session.**

Repro:
1. Open a fresh chat, send `hi`
2. Press ↑ → nothing happens
3. Send a second message → ↑ now works (and recalls both)

```
BEFORE                                  AFTER
─────────────────────────────────      ─────────────────────────────────
send "hi"                               send "hi"
press ↑   →  (empty, nothing)           press ↑   →  "hi"   ✓
send "yo"                               send "yo"
press ↑   →  "yo"  (now works)          press ↑   →  "yo"   ✓
press ↑   →  "hi"                       press ↑   →  "hi"   ✓
```

## why

`messageHistory` is derived from the `messages` state. On the **first** send, `sendMessage` `await`s session/preset init **before** it commits the user message via `setMessages`. During that window `messageHistory` is still empty, so when the user presses ↑ the recall computes `Math.min(0, length - 1) === -1` and silently no-ops. Once a second message exists the array is non-empty and it works — which is exactly the reported symptom.

## fix

Track sent messages in a ref (`recallHistoryRef`) appended **synchronously at send time**, and use that ref as the recall source so the just-sent message is recallable immediately. The ref resyncs from `messageHistory` whenever a different / new / empty conversation loads (it only keeps the local list while `messageHistory` is a non-empty prefix of it, i.e. during the commit lag), so switching conversations and opening existing chats behave correctly.

Stored values mirror `message.content` (including chip model-content) so the resync prefix check matches once the message commits.

## test plan

- [x] `bunx tsc --noEmit` clean
- [ ] fresh chat → send one message → ↑ recalls it
- [ ] ↑/↓ still cycle correctly with multiple messages
- [ ] switching to another conversation recalls that conversation's messages, not the previous one
- [ ] opening a new empty chat → ↑ does nothing (no stale recall from prior chat)
- [ ] ↑ does not clobber a half-typed draft (only triggers when input is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
