### PR TITLE
[codex] fix enterprise Windows updater fallback

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -64,6 +64,30 @@ interface UpdateBannerProps {
   variant?: "default" | "sidebar";
 }
 
+async function getWindowsUpdateOptions() {
+  const cpuArch = arch();
+  const isEnterprise = await commands.isEnterpriseBuildCmd().catch(() => false);
+  const channel = isEnterprise ? "enterprise" : "stable";
+  const headers: Record<string, string> = {};
+
+  if (isEnterprise) {
+    const licenseKey = await commands.getEnterpriseLicenseKey().catch(() => null);
+    if (licenseKey) {
+      headers["X-License-Key"] = licenseKey;
+    }
+  }
+
+  return {
+    checkOptions: {
+      endpoints: [
+        `https://screenpipe.com/api/app-update/${channel}/windows-${cpuArch}/{{current_version}}`,
+      ],
+      ...(Object.keys(headers).length > 0 ? { headers } : {}),
+    },
+    downloadOptions: Object.keys(headers).length > 0 ? { headers } : undefined,
+  };
+}
+
 export function UpdateBanner({ className, compact = false, variant = "default" }: UpdateBannerProps) {
   const { isVisible, updateInfo, isInstalling, setIsInstalling, pendingUpdate, authRequired, dismiss } = useUpdateBanner();
   const { toast } = useToast();
@@ -106,17 +130,15 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
 
         // Get or check for the update
         let update = pendingUpdate;
+        const { checkOptions, downloadOptions } = await getWindowsUpdateOptions();
         if (!update) {
-          const cpuArch = arch();
-          update = await check({ endpoints: [
-            `https://screenpipe.com/api/app-update/stable/windows-${cpuArch}/{{current_version}}`,
-          ] } as any);
+          update = await check(checkOptions as any);
         }
 
         if (update?.available) {
 
 
-          await update.downloadAndInstall();
+          await update.downloadAndInstall(undefined, downloadOptions);
 
           toast({
             title: "update complete",

--- a/docs/mintlify/docs-mintlify-mig-tmp/intune-deployment.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/intune-deployment.mdx
@@ -79,7 +79,7 @@ pick **Manually configure detection rules**. for first-time installs, a file-exi
 |---|---|
 | rule type | File |
 | path | `%ProgramFiles%\screenpipe` |
-| file or folder | `screenpipe.exe` |
+| file or folder | `screenpipe-app.exe` |
 | detection method | File or folder exists |
 | associated with a 32-bit app on 64-bit clients | No |
 
@@ -146,7 +146,7 @@ screenpipe needs the license key to enable enterprise mode (centralized telemetr
 ## verifying the deployment
 
 - in the Intune admin center: **Apps → screenpipe → Device install status** shows per-device install state
-- on the device: `C:\Program Files\screenpipe\screenpipe.exe` exists, screenpipe icon appears in the system tray after first user sign-in
+- on the device: `C:\Program Files\screenpipe\screenpipe-app.exe` exists, screenpipe icon appears in the system tray after first user sign-in
 - in the [enterprise dashboard](https://screenpi.pe/enterprise) → **devices** tab: each installed device starts heartbeating within minutes of launch, scoped to your license
 
 ## troubleshooting


### PR DESCRIPTION
## Summary
- route Windows update-banner fallback checks through the enterprise updater endpoint when running an enterprise build
- include the enterprise license key as `X-License-Key` for enterprise update checks/downloads
- correct the Intune deployment guide to detect `screenpipe-app.exe` instead of the old/wrong `screenpipe.exe` path

## Root cause
Enterprise Windows builds can show a restart/update banner while the frontend fallback path still re-checks the consumer stable updater endpoint. The banner store does not currently persist the Rust `Update` object, so the Windows click path usually performs that fallback check. For enterprise installs, that means the app may use the wrong channel and omit the required license header.

The deployment guide also pointed Intune file detection at `screenpipe.exe`, while the Windows desktop app binary is `screenpipe-app.exe`, which can make deployment diagnostics and upgrade detection misleading.

## Validation
- `bun run typecheck`
- `git diff --check`