### PR TITLE
fix: extend windows ffmpeg download timeout

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -756,7 +756,7 @@ if (platform == 'windows') {
 			const arm64Url = asset.browser_download_url
 			const arm64Filename = asset.name
 			console.log(`ffmpeg ARM64: ${arm64Url}`)
-			await downloadFile(arm64Url, arm64Filename, { retries: 10, timeoutMs: 120000 })
+			await downloadFile(arm64Url, arm64Filename, { retries: 10, timeoutMs: 900000 })
 			await $`${sevenZ} x ${arm64Filename}`
 			// tordona 7z extracts to a single folder; move its contents to ffmpeg (or rename if single top-level dir)
 			const entries = await fs.readdir(cwd, { withFileTypes: true })
@@ -772,7 +772,7 @@ if (platform == 'windows') {
 			}
 			await fs.rm(path.join(cwd, arm64Filename), { force: true }).catch(() => {})
 		} else {
-			await downloadFile(config.windows.ffmpegUrl, `${config.windows.ffmpegName}.7z`, { retries: 10, timeoutMs: 120000 })
+			await downloadFile(config.windows.ffmpegUrl, `${config.windows.ffmpegName}.7z`, { retries: 10, timeoutMs: 900000 })
 			await $`${sevenZ} x ${config.windows.ffmpegName}.7z`
 			await $`mv ${config.windows.ffmpegName} ${config.ffmpegRealname}`
 			await $`rm -rf ${config.windows.ffmpegName}.7z`


### PR DESCRIPTION
﻿## description

Increase the Windows FFmpeg download timeout in `apps/screenpipe-app-tauri/scripts/pre_build.js` from 120 seconds to 900 seconds for both Windows x64 and Windows ARM64 builds.

Root cause: the Windows x64 FFmpeg archive currently reports `Content-Length: 55372118` bytes, and slow downloads can take longer than the previous two-minute `curl --max-time` limit. When that happened, `bun tauri build` could fail before FFmpeg was available for extraction.

This only changes the Windows FFmpeg download calls. macOS and Linux pre-build paths are unchanged.

related issue: #

No screenshots or recordings; build-script-only change.

## before

Windows builds could fail while downloading FFmpeg on slower connections because the download had a 120-second total timeout.

## after

Windows builds allow up to 15 minutes for the FFmpeg archive download before failing. macOS and Linux behavior is unchanged.

## how to test

1. From the repo root, run `node --check apps/screenpipe-app-tauri/scripts/pre_build.js`.
2. From the repo root, run `git diff --check -- apps/screenpipe-app-tauri/scripts/pre_build.js`.
3. On Windows, remove `apps/screenpipe-app-tauri/src-tauri/ffmpeg` and run `bun scripts/pre_build.js` from `apps/screenpipe-app-tauri/`; confirm FFmpeg downloads and extracts.

## desktop app checklist (if applicable)

Not applicable; this only changes a build-time JavaScript timeout and does not add or change Tauri commands, Rust types, frontend bindings, or app TypeScript.
