### PR TITLE
[codex] Add Hyprland Wayland attribution fallback

### DIFF
--- a/crates/screenpipe-a11y/src/platform/linux.rs
+++ b/crates/screenpipe-a11y/src/platform/linux.rs
@@ -31,10 +31,11 @@ use crossbeam_channel::{bounded, Receiver, Sender};
 use parking_lot::Mutex;
 use screenpipe_core::pii_removal::remove_pii;
 use std::path::Path;
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
 /// Permission status for UI capture on Linux.
@@ -991,25 +992,45 @@ fn run_window_observer(
 /// Get active window info: (app_name, window_title, pid).
 /// Uses Hyprland IPC on Hyprland/Wayland, then falls back to xdotool for X11.
 pub fn get_active_window_info() -> Option<(String, String, i32)> {
+    const ACTIVE_WINDOW_CACHE_TTL: Duration = Duration::from_secs(1);
+    static CACHE: OnceLock<Mutex<Option<(Option<(String, String, i32)>, Instant)>>> =
+        OnceLock::new();
+
+    let cache = CACHE.get_or_init(|| Mutex::new(None));
+    let now = Instant::now();
+    {
+        let cached = cache.lock();
+        if let Some((value, captured_at)) = &*cached {
+            if now.duration_since(*captured_at) < ACTIVE_WINDOW_CACHE_TTL {
+                return value.clone();
+            }
+        }
+    }
+
+    let fresh = get_active_window_info_uncached();
+    *cache.lock() = Some((fresh.clone(), Instant::now()));
+    fresh
+}
+
+fn get_active_window_info_uncached() -> Option<(String, String, i32)> {
     get_hyprland_active_window_info().or_else(get_x11_active_window_info)
 }
 
 fn get_hyprland_active_window_info() -> Option<(String, String, i32)> {
     if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_none()
-        && std::env::var_os("XDG_CURRENT_DESKTOP")
-            .and_then(|v| v.into_string().ok())
-            .map_or(true, |desktop| {
-                !desktop.to_ascii_lowercase().contains("hyprland")
-            })
+        && std::env::var("XDG_CURRENT_DESKTOP").map_or(true, |desktop| {
+            !desktop.to_ascii_lowercase().contains("hyprland")
+        })
     {
         return None;
     }
 
-    let output = std::process::Command::new("hyprctl")
-        .args(["-j", "activewindow"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
+    let output = command_output_with_timeout(
+        "hyprctl",
+        &["-j", "activewindow"],
+        Duration::from_millis(200),
+    )
+    .filter(|o| o.status.success())?;
 
     parse_hyprland_active_window_json(&output.stdout)
 }
@@ -1044,10 +1065,10 @@ fn parse_hyprland_active_window_json(raw: &[u8]) -> Option<(String, String, i32)
 fn clean_hyprland_title(title: &str) -> String {
     title
         .chars()
-        .filter(|c| {
+        .filter(|&c| {
             !matches!(
-                *c as u32,
-                0x200e | 0x200f | 0x202a..=0x202e | 0x2066..=0x2069
+                c,
+                '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'
             )
         })
         .collect::<String>()
@@ -1057,11 +1078,9 @@ fn clean_hyprland_title(title: &str) -> String {
 
 fn get_x11_active_window_info() -> Option<(String, String, i32)> {
     // Try xdotool (works on X11 and XWayland)
-    let wid_output = std::process::Command::new("xdotool")
-        .arg("getactivewindow")
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
+    let wid_output =
+        command_output_with_timeout("xdotool", &["getactivewindow"], Duration::from_millis(300))
+            .filter(|o| o.status.success())?;
 
     let wid = String::from_utf8_lossy(&wid_output.stdout)
         .trim()
@@ -1071,21 +1090,23 @@ fn get_x11_active_window_info() -> Option<(String, String, i32)> {
     }
 
     // Get window name
-    let name_output = std::process::Command::new("xdotool")
-        .args(["getwindowname", &wid])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
+    let name_output = command_output_with_timeout(
+        "xdotool",
+        &["getwindowname", &wid],
+        Duration::from_millis(300),
+    )
+    .filter(|o| o.status.success())?;
     let title = String::from_utf8_lossy(&name_output.stdout)
         .trim()
         .to_string();
 
     // Get PID
-    let pid_output = std::process::Command::new("xdotool")
-        .args(["getwindowpid", &wid])
-        .output()
-        .ok()
-        .filter(|o| o.status.success());
+    let pid_output = command_output_with_timeout(
+        "xdotool",
+        &["getwindowpid", &wid],
+        Duration::from_millis(300),
+    )
+    .filter(|o| o.status.success());
 
     let pid: i32 = pid_output
         .map(|o| {
@@ -1104,6 +1125,28 @@ fn get_x11_active_window_info() -> Option<(String, String, i32)> {
     };
 
     Some((app_name, title, pid))
+}
+
+fn command_output_with_timeout(command: &str, args: &[&str], timeout: Duration) -> Option<Output> {
+    let mut child = Command::new(command)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+    let start = Instant::now();
+
+    loop {
+        if child.try_wait().ok()?.is_some() {
+            return child.wait_with_output().ok();
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 /// Get process name from PID by reading /proc/<pid>/comm.
@@ -1464,7 +1507,7 @@ mod tests {
     fn test_parse_hyprland_active_window_json() {
         let raw = br#"{
             "class": "org.telegram.desktop",
-            "title": "\u200e\u2068Lucern Clinic\u2069 \u2013 (106539)",
+            "title": "\u061c\u200e\u2068Lucern Clinic\u2069 \u2013 (106539)",
             "initialClass": "Telegram",
             "pid": 2800,
             "xwayland": false
@@ -1475,6 +1518,13 @@ mod tests {
         assert_eq!(app_name, "org.telegram.desktop");
         assert_eq!(window_title, "Lucern Clinic \u{2013} (106539)");
         assert_eq!(pid, 2800);
+    }
+
+    #[test]
+    fn test_clean_hyprland_title_strips_bidi_controls() {
+        let title = "\u{061c}\u{200e}\u{2068}Telegram\u{2069}\u{202e}";
+
+        assert_eq!(clean_hyprland_title(title), "Telegram");
     }
 
     #[test]

--- a/crates/screenpipe-a11y/src/platform/linux.rs
+++ b/crates/screenpipe-a11y/src/platform/linux.rs
@@ -1001,18 +1001,21 @@ pub fn get_active_window_info() -> Option<(String, String, i32)> {
     {
         let cached = cache.lock();
         if let Some((value, captured_at)) = &*cached {
-            if now.duration_since(*captured_at) < ACTIVE_WINDOW_CACHE_TTL {
+            if now.saturating_duration_since(*captured_at) < ACTIVE_WINDOW_CACHE_TTL {
                 return value.clone();
             }
         }
     }
 
-    let fresh = get_active_window_info_uncached();
+    let fresh = get_active_window_info_fresh();
     *cache.lock() = Some((fresh.clone(), Instant::now()));
     fresh
 }
 
-fn get_active_window_info_uncached() -> Option<(String, String, i32)> {
+/// Get active window info without using the shared observer cache.
+///
+/// Use this when stale focused-window metadata would affect privacy gates.
+pub fn get_active_window_info_fresh() -> Option<(String, String, i32)> {
     get_hyprland_active_window_info().or_else(get_x11_active_window_info)
 }
 
@@ -1137,8 +1140,14 @@ fn command_output_with_timeout(command: &str, args: &[&str], timeout: Duration) 
     let start = Instant::now();
 
     loop {
-        if child.try_wait().ok()?.is_some() {
-            return child.wait_with_output().ok();
+        match child.try_wait() {
+            Ok(Some(_)) => return child.wait_with_output().ok(),
+            Ok(None) => {}
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
         }
         if start.elapsed() >= timeout {
             let _ = child.kill();

--- a/crates/screenpipe-a11y/src/platform/linux.rs
+++ b/crates/screenpipe-a11y/src/platform/linux.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Window Tracking
 //!
-//! Uses `xdotool` (X11) or D-Bus (Wayland) to track the active window.
+//! Uses Hyprland IPC (Wayland) or `xdotool` (X11) to track the active window.
 //!
 //! ## Clipboard
 //!
@@ -202,7 +202,7 @@ impl UiRecorder {
             );
         }
 
-        // Thread 2: App/window observer (always runs — uses xdotool, no evdev needed)
+        // Thread 2: App/window observer (always runs — uses compositor/X11 metadata, no evdev needed)
         let tx2 = tx.clone();
         let stop2 = stop.clone();
         let config2 = self.config.clone();
@@ -989,8 +989,73 @@ fn run_window_observer(
 }
 
 /// Get active window info: (app_name, window_title, pid).
-/// Tries xdotool (X11) first, falls back to D-Bus.
-fn get_active_window_info() -> Option<(String, String, i32)> {
+/// Uses Hyprland IPC on Hyprland/Wayland, then falls back to xdotool for X11.
+pub fn get_active_window_info() -> Option<(String, String, i32)> {
+    get_hyprland_active_window_info().or_else(get_x11_active_window_info)
+}
+
+fn get_hyprland_active_window_info() -> Option<(String, String, i32)> {
+    if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_none()
+        && std::env::var_os("XDG_CURRENT_DESKTOP")
+            .and_then(|v| v.into_string().ok())
+            .map_or(true, |desktop| {
+                !desktop.to_ascii_lowercase().contains("hyprland")
+            })
+    {
+        return None;
+    }
+
+    let output = std::process::Command::new("hyprctl")
+        .args(["-j", "activewindow"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+
+    parse_hyprland_active_window_json(&output.stdout)
+}
+
+fn parse_hyprland_active_window_json(raw: &[u8]) -> Option<(String, String, i32)> {
+    let value: serde_json::Value = serde_json::from_slice(raw).ok()?;
+    let app_name = value
+        .get("class")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            value
+                .get("initialClass")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+        })?
+        .to_string();
+
+    let window_title = value
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(clean_hyprland_title)
+        .unwrap_or_default();
+
+    let pid = value.get("pid").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+
+    Some((app_name, window_title, pid))
+}
+
+fn clean_hyprland_title(title: &str) -> String {
+    title
+        .chars()
+        .filter(|c| {
+            !matches!(
+                *c as u32,
+                0x200e | 0x200f | 0x202a..=0x202e | 0x2066..=0x2069
+            )
+        })
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+fn get_x11_active_window_info() -> Option<(String, String, i32)> {
     // Try xdotool (works on X11 and XWayland)
     let wid_output = std::process::Command::new("xdotool")
         .arg("getactivewindow")
@@ -1393,6 +1458,39 @@ mod tests {
     fn test_truncate() {
         assert_eq!(truncate("hello", 10), "hello");
         assert_eq!(truncate("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn test_parse_hyprland_active_window_json() {
+        let raw = br#"{
+            "class": "org.telegram.desktop",
+            "title": "\u200e\u2068Lucern Clinic\u2069 \u2013 (106539)",
+            "initialClass": "Telegram",
+            "pid": 2800,
+            "xwayland": false
+        }"#;
+
+        let (app_name, window_title, pid) = parse_hyprland_active_window_json(raw).unwrap();
+
+        assert_eq!(app_name, "org.telegram.desktop");
+        assert_eq!(window_title, "Lucern Clinic \u{2013} (106539)");
+        assert_eq!(pid, 2800);
+    }
+
+    #[test]
+    fn test_parse_hyprland_active_window_json_falls_back_to_initial_class() {
+        let raw = br#"{
+            "class": "",
+            "title": "Terminal",
+            "initialClass": "Alacritty",
+            "pid": 123
+        }"#;
+
+        let (app_name, window_title, pid) = parse_hyprland_active_window_json(raw).unwrap();
+
+        assert_eq!(app_name, "Alacritty");
+        assert_eq!(window_title, "Terminal");
+        assert_eq!(pid, 123);
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2881,12 +2881,8 @@ mod tests {
             window_name: Some(" Telegram ".into()),
         };
 
-        let (app_name, window_name, _, _) = resolve_capture_metadata_with_policy(
-            Some(&snapshot),
-            &CaptureTrigger::Idle,
-            Some(&metadata),
-            true,
-        );
+        let (app_name, window_name, _, _) =
+            resolve_capture_metadata(Some(&snapshot), &CaptureTrigger::Idle, Some(&metadata));
 
         assert_eq!(app_name.as_deref(), Some("org.telegram.desktop"));
         assert_eq!(window_name.as_deref(), Some("Telegram"));
@@ -2915,8 +2911,12 @@ mod tests {
             window_name: Some("screenpipe-wayland-fix".into()),
         };
 
-        let (app_name, window_name, _, _) =
-            resolve_capture_metadata(Some(&snapshot), &CaptureTrigger::Idle, Some(&metadata));
+        let (app_name, window_name, _, _) = resolve_capture_metadata_with_policy(
+            Some(&snapshot),
+            &CaptureTrigger::Idle,
+            Some(&metadata),
+            true,
+        );
 
         assert_eq!(app_name.as_deref(), Some("Alacritty"));
         assert_eq!(window_name.as_deref(), Some("screenpipe-wayland-fix"));

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1744,6 +1744,10 @@ struct LightweightFocusedMetadata {
     window_name: Option<String>,
 }
 
+fn metadata_value_is_blank(value: &Option<String>) -> bool {
+    value.as_deref().map(str::trim).unwrap_or("").is_empty()
+}
+
 fn resolve_capture_metadata(
     tree_snapshot: Option<&screenpipe_a11y::tree::TreeSnapshot>,
     trigger: &CaptureTrigger,
@@ -1770,15 +1774,17 @@ fn resolve_capture_metadata(
     // Without this, captures triggered by click/visual_change/idle would be
     // stored with null app/window metadata even though the compositor or OS
     // knows the focused target.
-    if app_name.is_none() {
+    if metadata_value_is_blank(&app_name) {
         if let Some(name) = lightweight_metadata.and_then(|m| m.app_name.as_deref()) {
+            let name = name.trim();
             if !name.is_empty() {
                 app_name = Some(name.to_string());
             }
         }
     }
-    if window_name.is_none() {
+    if metadata_value_is_blank(&window_name) {
         if let Some(name) = lightweight_metadata.and_then(|m| m.window_name.as_deref()) {
+            let name = name.trim();
             if !name.is_empty() {
                 window_name = Some(name.to_string());
             }
@@ -2815,6 +2821,36 @@ mod tests {
         assert_eq!(window_name.as_deref(), Some("Lucern Clinic"));
         assert_eq!(browser_url, None);
         assert_eq!(document_path, None);
+    }
+
+    #[test]
+    fn resolve_capture_metadata_uses_lightweight_metadata_when_tree_values_are_blank() {
+        let snapshot = screenpipe_a11y::tree::TreeSnapshot {
+            app_name: "  ".into(),
+            window_name: "".into(),
+            text_content: "visible text".into(),
+            nodes: Vec::new(),
+            browser_url: None,
+            document_path: None,
+            timestamp: Utc::now(),
+            node_count: 0,
+            walk_duration: Duration::from_millis(1),
+            content_hash: 0,
+            simhash: 0,
+            truncated: false,
+            truncation_reason: screenpipe_a11y::tree::TruncationReason::None,
+            max_depth_reached: 0,
+        };
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some(" org.telegram.desktop ".into()),
+            window_name: Some(" Telegram ".into()),
+        };
+
+        let (app_name, window_name, _, _) =
+            resolve_capture_metadata(Some(&snapshot), &CaptureTrigger::Idle, Some(&metadata));
+
+        assert_eq!(app_name.as_deref(), Some("org.telegram.desktop"));
+        assert_eq!(window_name.as_deref(), Some("Telegram"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1744,8 +1744,11 @@ struct LightweightFocusedMetadata {
     window_name: Option<String>,
 }
 
-fn metadata_value_is_blank(value: &Option<String>) -> bool {
-    value.as_deref().map(str::trim).unwrap_or("").is_empty()
+fn normalize_metadata_value(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn resolve_capture_metadata(
@@ -1768,26 +1771,18 @@ fn resolve_capture_metadata(
         None => (None, None, None, None),
     };
 
-    // Fallback to lightweight focused-window metadata when the tree walk returned
-    // nothing (focused_window AX query failed, e.g. Zoom during meetings, or
-    // native Wayland apps where AT-SPI did not identify the frontmost window).
-    // Without this, captures triggered by click/visual_change/idle would be
-    // stored with null app/window metadata even though the compositor or OS
-    // knows the focused target.
-    if metadata_value_is_blank(&app_name) {
-        if let Some(name) = lightweight_metadata.and_then(|m| m.app_name.as_deref()) {
-            let name = name.trim();
-            if !name.is_empty() {
-                app_name = Some(name.to_string());
-            }
+    app_name = normalize_metadata_value(app_name.as_deref());
+    window_name = normalize_metadata_value(window_name.as_deref());
+
+    // Prefer lightweight focused-window metadata when available. On Linux
+    // Wayland, AT-SPI can return stale or generic app names (for example
+    // "electron") while Hyprland knows the actual focused app/window.
+    if let Some(metadata) = lightweight_metadata {
+        if let Some(name) = normalize_metadata_value(metadata.app_name.as_deref()) {
+            app_name = Some(name);
         }
-    }
-    if metadata_value_is_blank(&window_name) {
-        if let Some(name) = lightweight_metadata.and_then(|m| m.window_name.as_deref()) {
-            let name = name.trim();
-            if !name.is_empty() {
-                window_name = Some(name.to_string());
-            }
+        if let Some(name) = normalize_metadata_value(metadata.window_name.as_deref()) {
+            window_name = Some(name);
         }
     }
 
@@ -2129,7 +2124,22 @@ async fn do_capture(
     // to ALL captures, not just app switches.
     let lightweight_focused_metadata = match trigger {
         CaptureTrigger::AppSwitch { .. } => None,
-        _ => get_focused_metadata_lightweight(),
+        _ => match tokio::time::timeout(
+            Duration::from_secs(1),
+            tokio::task::spawn_blocking(get_focused_metadata_lightweight),
+        )
+        .await
+        {
+            Ok(Ok(metadata)) => metadata,
+            Ok(Err(err)) => {
+                debug!("focused metadata lookup task failed: {}", err);
+                None
+            }
+            Err(_) => {
+                debug!("focused metadata lookup timed out");
+                None
+            }
+        },
     };
     let trigger_app = match trigger {
         CaptureTrigger::AppSwitch { app_name, .. } => Some(app_name.clone()),
@@ -2522,7 +2532,8 @@ fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
 
 #[cfg(target_os = "linux")]
 fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
-    let (app_name, window_name, _) = screenpipe_a11y::platform::linux::get_active_window_info()?;
+    let (app_name, window_name, _) =
+        screenpipe_a11y::platform::linux::get_active_window_info_fresh()?;
     Some(LightweightFocusedMetadata {
         app_name: if app_name.is_empty() {
             None
@@ -2851,6 +2862,62 @@ mod tests {
 
         assert_eq!(app_name.as_deref(), Some("org.telegram.desktop"));
         assert_eq!(window_name.as_deref(), Some("Telegram"));
+    }
+
+    #[test]
+    fn resolve_capture_metadata_prefers_lightweight_metadata_over_stale_tree_values() {
+        let snapshot = screenpipe_a11y::tree::TreeSnapshot {
+            app_name: "electron".into(),
+            window_name: "stale browser title".into(),
+            text_content: "visible text".into(),
+            nodes: Vec::new(),
+            browser_url: None,
+            document_path: None,
+            timestamp: Utc::now(),
+            node_count: 0,
+            walk_duration: Duration::from_millis(1),
+            content_hash: 0,
+            simhash: 0,
+            truncated: false,
+            truncation_reason: screenpipe_a11y::tree::TruncationReason::None,
+            max_depth_reached: 0,
+        };
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("Alacritty".into()),
+            window_name: Some("screenpipe-wayland-fix".into()),
+        };
+
+        let (app_name, window_name, _, _) =
+            resolve_capture_metadata(Some(&snapshot), &CaptureTrigger::Idle, Some(&metadata));
+
+        assert_eq!(app_name.as_deref(), Some("Alacritty"));
+        assert_eq!(window_name.as_deref(), Some("screenpipe-wayland-fix"));
+    }
+
+    #[test]
+    fn resolve_capture_metadata_normalizes_blank_tree_values_without_lightweight_metadata() {
+        let snapshot = screenpipe_a11y::tree::TreeSnapshot {
+            app_name: "  ".into(),
+            window_name: "".into(),
+            text_content: "visible text".into(),
+            nodes: Vec::new(),
+            browser_url: None,
+            document_path: None,
+            timestamp: Utc::now(),
+            node_count: 0,
+            walk_duration: Duration::from_millis(1),
+            content_hash: 0,
+            simhash: 0,
+            truncated: false,
+            truncation_reason: screenpipe_a11y::tree::TruncationReason::None,
+            max_depth_reached: 0,
+        };
+
+        let (app_name, window_name, _, _) =
+            resolve_capture_metadata(Some(&snapshot), &CaptureTrigger::Idle, None);
+
+        assert_eq!(app_name, None);
+        assert_eq!(window_name, None);
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1738,10 +1738,16 @@ struct CaptureOutput {
     corrupt: Option<CorruptKind>,
 }
 
+#[derive(Debug, Clone)]
+struct LightweightFocusedMetadata {
+    app_name: Option<String>,
+    window_name: Option<String>,
+}
+
 fn resolve_capture_metadata(
     tree_snapshot: Option<&screenpipe_a11y::tree::TreeSnapshot>,
     trigger: &CaptureTrigger,
-    lightweight_app_name: Option<&str>,
+    lightweight_metadata: Option<&LightweightFocusedMetadata>,
 ) -> (
     Option<String>,
     Option<String>,
@@ -1758,14 +1764,23 @@ fn resolve_capture_metadata(
         None => (None, None, None, None),
     };
 
-    // Fallback to the lightweight focused-app query when the tree walk returned
-    // nothing (focused_window AX query failed, e.g. Zoom during meetings).
+    // Fallback to lightweight focused-window metadata when the tree walk returned
+    // nothing (focused_window AX query failed, e.g. Zoom during meetings, or
+    // native Wayland apps where AT-SPI did not identify the frontmost window).
     // Without this, captures triggered by click/visual_change/idle would be
-    // stored with null app_name even though we know the focused app.
+    // stored with null app/window metadata even though the compositor or OS
+    // knows the focused target.
     if app_name.is_none() {
-        if let Some(name) = lightweight_app_name {
+        if let Some(name) = lightweight_metadata.and_then(|m| m.app_name.as_deref()) {
             if !name.is_empty() {
                 app_name = Some(name.to_string());
+            }
+        }
+    }
+    if window_name.is_none() {
+        if let Some(name) = lightweight_metadata.and_then(|m| m.window_name.as_deref()) {
+            if !name.is_empty() {
+                window_name = Some(name.to_string());
             }
         }
     }
@@ -2102,22 +2117,19 @@ async fn do_capture(
     // reduced max_nodes and timeout to avoid blocking their UI thread.
     let mut config = params.tree_walker_config.clone();
 
-    // Get the focused app name for budget decisions. AppSwitch triggers carry
+    // Get focused metadata for budget decisions. AppSwitch triggers carry
     // the name directly; for all other triggers (visual change, idle, manual)
-    // we do a lightweight AX query to get the focused app. This ensures the
-    // walk budget applies to ALL captures, not just app switches.
+    // we do a lightweight platform query. This ensures the walk budget applies
+    // to ALL captures, not just app switches.
+    let lightweight_focused_metadata = match trigger {
+        CaptureTrigger::AppSwitch { .. } => None,
+        _ => get_focused_metadata_lightweight(),
+    };
     let trigger_app = match trigger {
         CaptureTrigger::AppSwitch { app_name, .. } => Some(app_name.clone()),
-        _ => {
-            #[cfg(target_os = "macos")]
-            {
-                get_focused_app_name_lightweight()
-            }
-            #[cfg(not(target_os = "macos"))]
-            {
-                None
-            }
-        }
+        _ => lightweight_focused_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.app_name.clone()),
     };
 
     // Terminal OCR rate-limit: wezterm/alacritty/kitty/hyper/warp all bypass AX
@@ -2333,7 +2345,11 @@ async fn do_capture(
     // Use tree metadata by default, but for focus-change triggers prefer the
     // event payload when the tree lags or reports the wrong frontmost target.
     let (app_name_owned, window_name_owned, browser_url_owned, document_path_owned) =
-        resolve_capture_metadata(tree_snapshot.as_ref(), trigger, trigger_app.as_deref());
+        resolve_capture_metadata(
+            tree_snapshot.as_ref(),
+            trigger,
+            lightweight_focused_metadata.as_ref(),
+        );
 
     // Skip lock screen / screensaver — these waste disk and pollute timeline.
     // Also update the global SCREEN_IS_LOCKED flag so subsequent loop iterations
@@ -2449,7 +2465,7 @@ async fn do_capture(
     })
 }
 
-/// Cheaply get the focused app name. Used to tag captures and to apply
+/// Cheaply get focused app/window metadata. Used to tag captures and to apply
 /// per-app throttles (walk budget, terminal OCR, Obsidian OCR).
 ///
 /// Tries NSWorkspace first: filters `running_apps()` to the one with
@@ -2467,7 +2483,7 @@ async fn do_capture(
 /// TTL keeps staleness bounded to something no human perceives while
 /// collapsing the common case to a single atomic load.
 #[cfg(target_os = "macos")]
-fn get_focused_app_name_lightweight() -> Option<String> {
+fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
     use arc_swap::ArcSwap;
     use std::sync::OnceLock;
     use std::time::{Duration, Instant};
@@ -2476,7 +2492,8 @@ fn get_focused_app_name_lightweight() -> Option<String> {
 
     // (name, captured_at). ArcSwap gives lock-free reads; in the common
     // case the whole function is one atomic load + a clock read + clone.
-    static CACHE: OnceLock<ArcSwap<(Option<String>, Instant)>> = OnceLock::new();
+    static CACHE: OnceLock<ArcSwap<(Option<LightweightFocusedMetadata>, Instant)>> =
+        OnceLock::new();
     let cache = CACHE.get_or_init(|| {
         ArcSwap::from_pointee((None, Instant::now() - CACHE_TTL - Duration::from_secs(1)))
     });
@@ -2489,9 +2506,34 @@ fn get_focused_app_name_lightweight() -> Option<String> {
         }
     }
 
-    let fresh = query_frontmost_app_name_uncached();
+    let fresh = query_frontmost_app_name_uncached().map(|app_name| LightweightFocusedMetadata {
+        app_name: Some(app_name),
+        window_name: None,
+    });
     cache.store(std::sync::Arc::new((fresh.clone(), now)));
     fresh
+}
+
+#[cfg(target_os = "linux")]
+fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
+    let (app_name, window_name, _) = screenpipe_a11y::platform::linux::get_active_window_info()?;
+    Some(LightweightFocusedMetadata {
+        app_name: if app_name.is_empty() {
+            None
+        } else {
+            Some(app_name)
+        },
+        window_name: if window_name.is_empty() {
+            None
+        } else {
+            Some(window_name)
+        },
+    })
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
+    None
 }
 
 #[cfg(target_os = "macos")]
@@ -2757,6 +2799,42 @@ mod tests {
         assert_eq!(CaptureTrigger::VisualChange.as_str(), "visual_change");
         assert_eq!(CaptureTrigger::Idle.as_str(), "idle");
         assert_eq!(CaptureTrigger::Manual.as_str(), "manual");
+    }
+
+    #[test]
+    fn resolve_capture_metadata_uses_lightweight_app_and_window_without_tree() {
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("Telegram".into()),
+            window_name: Some("Lucern Clinic".into()),
+        };
+
+        let (app_name, window_name, browser_url, document_path) =
+            resolve_capture_metadata(None, &CaptureTrigger::Idle, Some(&metadata));
+
+        assert_eq!(app_name.as_deref(), Some("Telegram"));
+        assert_eq!(window_name.as_deref(), Some("Lucern Clinic"));
+        assert_eq!(browser_url, None);
+        assert_eq!(document_path, None);
+    }
+
+    #[test]
+    fn resolve_capture_metadata_prefers_window_focus_trigger_title() {
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("Telegram".into()),
+            window_name: Some("Stale Title".into()),
+        };
+
+        let (app_name, window_name, _, _) = resolve_capture_metadata(
+            None,
+            &CaptureTrigger::WindowFocus {
+                window_name: "Fresh Title".into(),
+                target: None,
+            },
+            Some(&metadata),
+        );
+
+        assert_eq!(app_name.as_deref(), Some("Telegram"));
+        assert_eq!(window_name.as_deref(), Some("Fresh Title"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2881,8 +2881,12 @@ mod tests {
             window_name: Some(" Telegram ".into()),
         };
 
-        let (app_name, window_name, _, _) =
-            resolve_capture_metadata(Some(&snapshot), &CaptureTrigger::Idle, Some(&metadata));
+        let (app_name, window_name, _, _) = resolve_capture_metadata_with_policy(
+            Some(&snapshot),
+            &CaptureTrigger::Idle,
+            Some(&metadata),
+            true,
+        );
 
         assert_eq!(app_name.as_deref(), Some("org.telegram.desktop"));
         assert_eq!(window_name.as_deref(), Some("Telegram"));

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1761,6 +1761,25 @@ fn resolve_capture_metadata(
     Option<String>,
     Option<String>,
 ) {
+    resolve_capture_metadata_with_policy(
+        tree_snapshot,
+        trigger,
+        lightweight_metadata,
+        cfg!(target_os = "linux"),
+    )
+}
+
+fn resolve_capture_metadata_with_policy(
+    tree_snapshot: Option<&screenpipe_a11y::tree::TreeSnapshot>,
+    trigger: &CaptureTrigger,
+    lightweight_metadata: Option<&LightweightFocusedMetadata>,
+    prefer_lightweight_metadata: bool,
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
     let (mut app_name, mut window_name, browser_url, document_path) = match tree_snapshot {
         Some(snap) => (
             Some(snap.app_name.clone()),
@@ -1774,15 +1793,20 @@ fn resolve_capture_metadata(
     app_name = normalize_metadata_value(app_name.as_deref());
     window_name = normalize_metadata_value(window_name.as_deref());
 
-    // Prefer lightweight focused-window metadata when available. On Linux
-    // Wayland, AT-SPI can return stale or generic app names (for example
-    // "electron") while Hyprland knows the actual focused app/window.
+    // Prefer focused-window metadata on Linux Wayland, where AT-SPI can return
+    // stale or generic app names (for example "electron") while Hyprland knows
+    // the actual focused app/window. Other platforms keep the older fallback
+    // behavior because their lightweight source may itself be cached.
     if let Some(metadata) = lightweight_metadata {
         if let Some(name) = normalize_metadata_value(metadata.app_name.as_deref()) {
-            app_name = Some(name);
+            if prefer_lightweight_metadata || app_name.is_none() {
+                app_name = Some(name);
+            }
         }
         if let Some(name) = normalize_metadata_value(metadata.window_name.as_deref()) {
-            window_name = Some(name);
+            if prefer_lightweight_metadata || window_name.is_none() {
+                window_name = Some(name);
+            }
         }
     }
 
@@ -2892,6 +2916,40 @@ mod tests {
 
         assert_eq!(app_name.as_deref(), Some("Alacritty"));
         assert_eq!(window_name.as_deref(), Some("screenpipe-wayland-fix"));
+    }
+
+    #[test]
+    fn resolve_capture_metadata_keeps_tree_values_when_lightweight_is_fallback_only() {
+        let snapshot = screenpipe_a11y::tree::TreeSnapshot {
+            app_name: "Safari".into(),
+            window_name: "Current Page".into(),
+            text_content: "visible text".into(),
+            nodes: Vec::new(),
+            browser_url: None,
+            document_path: None,
+            timestamp: Utc::now(),
+            node_count: 0,
+            walk_duration: Duration::from_millis(1),
+            content_hash: 0,
+            simhash: 0,
+            truncated: false,
+            truncation_reason: screenpipe_a11y::tree::TruncationReason::None,
+            max_depth_reached: 0,
+        };
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("Terminal".into()),
+            window_name: Some("Stale Terminal".into()),
+        };
+
+        let (app_name, window_name, _, _) = resolve_capture_metadata_with_policy(
+            Some(&snapshot),
+            &CaptureTrigger::Idle,
+            Some(&metadata),
+            false,
+        );
+
+        assert_eq!(app_name.as_deref(), Some("Safari"));
+        assert_eq!(window_name.as_deref(), Some("Current Page"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a Linux Hyprland/Wayland focused-window fallback for Screenpipe frame attribution.

- Uses `hyprctl -j activewindow` on Hyprland sessions before falling back to the existing X11 `xdotool` path.
- Parses Hyprland `class`, `title`, and `pid`, including Telegram titles with hidden directionality marks.
- Reuses the Linux active-window provider from the event-driven capture path so idle/visual/manual OCR captures can fill missing `app_name` and `window_name` when the accessibility tree is unavailable.
- Adds unit coverage for Hyprland JSON parsing and engine metadata resolution.

## Why

On Omarchy/Hyprland Wayland, native Wayland windows are invisible to the current X11-only `xdotool` active-window lookup. Screenpipe still captures OCR text, but many `frames` rows are stored with blank `app_name` and `window_name`, so searches like `screenpipe search --app telegram ...` cannot find Telegram Desktop OCR content.

Hyprland already has the focused-window metadata Screenpipe needs. This patch uses that compositor source for Hyprland sessions while preserving the existing X11 fallback.

## Local Verification

- Live DB proof on Omarchy/Hyprland:
  - Telegram Desktop rows were attributed as `Telegram` / `Lucern Clinic`.
  - `screenpipe search --app telegram --start "10m ago"` returned the newly attributed Telegram OCR frames.
  - Alacritty rows were attributed as `Alacritty` / `lucerneclinic.test`.
  - `screenpipe search --app Alacritty --start "10m ago"` returned the newly attributed terminal OCR frame.
- `cargo fmt --package screenpipe-a11y --package screenpipe-engine`
- `git diff --check`
- `cargo test -p screenpipe-a11y`
- `CFLAGS=-D_GNU_SOURCE cargo check -p screenpipe-engine`
- `CFLAGS=-D_GNU_SOURCE cargo test -p screenpipe-engine resolve_capture_metadata --lib`

Note: the `CFLAGS=-D_GNU_SOURCE` environment variable was needed locally because an unrelated `antirez-asr-sys` C dependency uses `strdup` while compiling with `-std=c11`.

## Review Update

Follow-up commit `0d56dbb` addresses the bot review feedback:

- Caches Linux active-window lookup for 1 second so the 200ms observer loop and event capture path do not repeatedly shell out to `hyprctl`/`xdotool`.
- Adds short command timeouts around `hyprctl -j activewindow` and `xdotool` so capture cannot hang indefinitely on active-window attribution.
- Treats blank tree-snapshot app/window values as missing, allowing focused-window metadata to fill OCR rows for non-window-focus captures.
- Cleans Hyprland titles with direct `char` matching and strips `U+061C` Arabic Letter Mark as well as the existing bidi controls.
- Example apps covered in local evidence: Telegram Desktop (`org.telegram.desktop` / `Telegram`) and Alacritty (`Alacritty` / `lucerneclinic.test`).

I also generated a before/after demo video locally with `shot-scraper`. If maintainers would rather not take this PR as-is, I can open a GitHub issue with the Hyprland/Wayland attribution repro, DB evidence, and the Telegram/Alacritty examples so the project can implement it in its preferred shape.

## Second Review Update

Follow-up commit `70fec17` addresses the latest review pass and the local runtime finding:

- Runs Linux focused-window lookup from the async capture path via `tokio::task::spawn_blocking` with a 1s timeout.
- Keeps the window-observer cache, but uses a fresh active-window read for capture metadata so ignored-window/privacy gates do not use stale focus data.
- Handles `try_wait()` errors by killing and reaping the child process.
- Uses `saturating_duration_since` for cache age checks.
- Normalizes blank tree metadata to `None`.
- Prefers focused-window metadata over stale/generic AT-SPI tree values. This fixed the local case where Alacritty frames were initially stored as `electron`.

Local runtime verification on Omarchy/Hyprland after installing the rebuilt binary:

- Frame `33439`: `app_name=Alacritty`, `window_name=screenpipe-wayland-fix`.
- Frame `33455`: `app_name=org.telegram.desktop`, `window_name=Telegram (106674)`.
- `screenpipe search --app telegram --start "5m ago"` returned frame `33455`.
- `grim` capture is working again and Screenpipe is writing new frames under the fixed binary.

## Third Review Update

Follow-up commit `e06e6a2` addresses Codex review on `70fec17`:

- Keeps the focused-window override policy Linux-only, where the Hyprland query is fresh and authoritative.
- Preserves fallback-only behavior for macOS/other platforms so cached lightweight app metadata cannot overwrite fresh tree metadata.
- Adds a regression test for the fallback-only policy, emulating the macOS stale-cache case.

Validation after this change:

- `cargo fmt --package screenpipe-a11y --package screenpipe-engine`
- `git diff --check`
- `cargo test -p screenpipe-a11y hyprland --lib`
- `CFLAGS=-D_GNU_SOURCE cargo test -p screenpipe-engine resolve_capture_metadata --lib`
- `CFLAGS=-D_GNU_SOURCE cargo build -p screenpipe-engine --bin screenpipe --release`
- Installed rebuilt binary locally and confirmed `screenpipe.service` starts and writes frames after restart.

## Fourth Review Update

Follow-up commit `92b1886` addresses Codex review on `e06e6a2`:

- Makes the Linux override regression test platform-independent by calling the explicit resolver policy helper with `prefer_lightweight_metadata=true`.
- Keeps the fallback-only test for macOS/other-platform behavior.

Validation:

- `cargo fmt --package screenpipe-engine`
- `git diff --check`
- `CFLAGS=-D_GNU_SOURCE cargo test -p screenpipe-engine resolve_capture_metadata --lib`

## Fifth Review Update

Follow-up commit `e3b06ad` addresses Codex review on `92b1886`:

- The blank-tree fallback test now uses the normal resolver wrapper.
- The stale-tree Linux override test now calls the explicit resolver policy helper with `prefer_lightweight_metadata=true`, making the test expectation platform-independent.

Validation:

- `cargo fmt --package screenpipe-engine`
- `git diff --check`
- `CFLAGS=-D_GNU_SOURCE cargo test -p screenpipe-engine resolve_capture_metadata --lib`