### PR TITLE
fix(search): don't drop whole frame batch when one frame fails

### DIFF
--- a/crates/screenpipe-engine/src/routes/search.rs
+++ b/crates/screenpipe-engine/src/routes/search.rs
@@ -48,7 +48,7 @@ impl oasgen::OaParameter for OptionalPipePerms {}
 use chrono::{DateTime, Utc};
 use screenpipe_db::{ContentType, DatabaseManager, Order, SearchResult};
 
-use futures::future::{try_join, try_join_all};
+use futures::future::{join_all, try_join};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
 use std::{
@@ -751,17 +751,25 @@ pub(crate) async fn search(
             })
             .collect();
 
-        let frames = match try_join_all(frame_futures).await {
-            Ok(f) => f,
-            Err(e) => {
-                tracing::warn!("failed to extract some frames: {}", e);
-                vec![]
-            }
-        };
+        // join_all (not try_join_all): one frame that can't be extracted — e.g. an
+        // offset in the still-being-recorded chunk, or a corrupt file — must not
+        // discard the frames for the whole batch. A missing frame here is expected,
+        // so log it at debug rather than spamming warnings.
+        let frames = join_all(frame_futures).await;
 
-        for (item, frame) in content_items.iter_mut().zip(frames.into_iter()) {
+        let mut frames = frames.into_iter();
+        for item in content_items.iter_mut() {
             if let ContentItem::OCR(ref mut ocr_content) = item {
-                ocr_content.frame = Some(frame);
+                match frames.next() {
+                    Some(Ok(frame)) => ocr_content.frame = Some(frame),
+                    Some(Err(e)) => {
+                        debug!(
+                            "skipping frame for {} at offset {}: {}",
+                            ocr_content.file_path, ocr_content.offset_index, e
+                        )
+                    }
+                    None => {}
+                }
             }
         }
     }

--- a/crates/screenpipe-engine/src/video_utils.rs
+++ b/crates/screenpipe-engine/src/video_utils.rs
@@ -104,16 +104,33 @@ pub async fn extract_frame(file_path: &str, offset_index: i64) -> Result<String>
     let offset_seconds = offset_index as f64 / 1000.0;
     let offset_str = format!("{:.3}", offset_seconds);
 
+    // Frames may be stored either as video chunks (seek by offset) or as
+    // individual still images. Input-seeking (`-ss` before `-i`) on a still
+    // image produces zero output ("nothing was encoded"), so only seek when we
+    // have a real, non-zero offset into a non-image source.
+    let is_image = std::path::Path::new(file_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| {
+            matches!(
+                e.to_ascii_lowercase().as_str(),
+                "jpg" | "jpeg" | "png" | "webp" | "bmp" | "gif" | "tiff"
+            )
+        })
+        .unwrap_or(false);
+    let seek = !is_image && offset_seconds > 0.0;
+
     debug!(
-        "extracting frame from {} at offset {}",
-        file_path, offset_str
+        "extracting frame from {} at offset {} (seek={})",
+        file_path, offset_str, seek
     );
 
     let mut command = ffmpeg_cmd_async(ffmpeg_path);
+    if seek {
+        command.args(["-ss", &offset_str]);
+    }
     command
         .args([
-            "-ss",
-            &offset_str,
             "-i",
             file_path,
             "-vf",


### PR DESCRIPTION
### Description:

Fixes #4698 

- before:

<img width="709" height="130" alt="image" src="https://github.com/user-attachments/assets/ed0736d4-29f6-423c-92e7-92a65ad6b622" />


- after:

<img width="666" height="135" alt="image" src="https://github.com/user-attachments/assets/bfca656d-b1dd-4fd4-a2cb-1e31adaac45b" />


- **Root cause:** frames stored as individual still images (`.jpg`/`.png`) instead of video chunks fail to extract. `extract_frame` always input-seeked with `-ss` before `-i`, which yields zero output on a still image (ffmpeg: "Output file is empty, nothing was encoded") — so every frame came back empty and the timeline showed none.
- **Fix (`video_utils.rs`):** skip input-seeking for image sources and for a zero offset, decoding the image directly; video chunks still seek by offset as before. Verified against real data — same ffmpeg command returns 0 bytes with `-ss`, ~90KB without.
- **Resilience (`search.rs`):** timeline search used `try_join_all` (fail-fast), so one unextractable frame discarded every frame in the batch and logged `failed to extract some frames` as a WARN every couple of seconds. Switched to `join_all`, handling each frame's `Result` independently so extractable frames still attach.
- **Latent bug:** frame futures were built from OCR items only but zipped against all content types, mispairing/dropping frames when non-OCR items were interleaved; now both sides consume OCR items in the same order.
- Downgraded the expected "frame not available yet" case from WARN to `debug`. No API/response-shape change, no config change; users get more frames and quieter logs. `cargo check -p screenpipe-engine` passes.