### PR TITLE
[codex] harden enterprise activation edge cases

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/enterprise-license-prompt.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/enterprise-license-prompt.test.tsx
@@ -42,4 +42,29 @@ describe("EnterpriseLicensePrompt", () => {
     await waitFor(() => expect(screen.getByText("failed to validate license key")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /activate/i })).not.toBeDisabled();
   });
+
+  it("normalizes lowercase and surrounding spaces before submit", async () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }));
+    render(<EnterpriseLicensePrompt onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText("ENT-XXXX-XXXX-XXXX-XXXX"), {
+      target: { value: "  ent-gwxx-rnub-lw9f-3ya6  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /activate/i }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith("ENT-GWXX-RNUB-LW9F-3YA6"));
+  });
+
+  it("rejects malformed license keys locally", async () => {
+    const onSubmit = vi.fn(async () => ({ ok: true }));
+    render(<EnterpriseLicensePrompt onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText("ENT-XXXX-XXXX-XXXX-XXXX"), {
+      target: { value: "not-a-license" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /activate/i }));
+
+    expect(await screen.findByText("enter a license key like ENT-XXXX-XXXX-XXXX-XXXX")).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/apps/screenpipe-app-tauri/components/enterprise-license-prompt.tsx
+++ b/apps/screenpipe-app-tauri/components/enterprise-license-prompt.tsx
@@ -11,6 +11,13 @@ interface EnterpriseLicensePromptProps {
   onSubmit: (key: string) => Promise<{ ok: boolean; error?: string }>;
 }
 
+const LICENSE_KEY_PATTERN = /^ENT-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+const LICENSE_KEY_FORMAT_ERROR = "enter a license key like ENT-XXXX-XXXX-XXXX-XXXX";
+
+function normalizeLicenseKey(value: string): string {
+  return value.trim().toUpperCase();
+}
+
 export function EnterpriseLicensePrompt({ onSubmit }: EnterpriseLicensePromptProps) {
   const [key, setKey] = useState("");
   const [loading, setLoading] = useState(false);
@@ -18,14 +25,18 @@ export function EnterpriseLicensePrompt({ onSubmit }: EnterpriseLicensePromptPro
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const trimmed = key.trim();
-    if (!trimmed) return;
+    const normalized = normalizeLicenseKey(key);
+    if (!normalized) return;
+    if (!LICENSE_KEY_PATTERN.test(normalized)) {
+      setError(LICENSE_KEY_FORMAT_ERROR);
+      return;
+    }
 
     setLoading(true);
     setError(null);
 
     try {
-      const result = await onSubmit(trimmed);
+      const result = await onSubmit(normalized);
       if (!result.ok) {
         setError(result.error || "failed to validate license key");
       }
@@ -49,7 +60,10 @@ export function EnterpriseLicensePrompt({ onSubmit }: EnterpriseLicensePromptPro
           <input
             type="text"
             value={key}
-            onChange={(e) => setKey(e.target.value)}
+            onChange={(e) => {
+              setKey(e.target.value.toUpperCase());
+              if (error) setError(null);
+            }}
             placeholder="ENT-XXXX-XXXX-XXXX-XXXX"
             className="w-full px-3 py-2 text-sm border border-border rounded bg-background font-mono focus:outline-none focus:ring-2 focus:ring-ring"
             autoFocus
@@ -64,7 +78,7 @@ export function EnterpriseLicensePrompt({ onSubmit }: EnterpriseLicensePromptPro
 
           <button
             type="submit"
-            disabled={loading || !key.trim()}
+            disabled={loading || !normalizeLicenseKey(key)}
             className="w-full px-4 py-2 text-sm font-medium bg-foreground text-background rounded hover:opacity-90 disabled:opacity-50 flex items-center justify-center gap-2"
           >
             {loading ? (

--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-enterprise-policy.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-enterprise-policy.test.tsx
@@ -167,6 +167,22 @@ describe("useEnterprisePolicy manual activation", () => {
     expect(mocks.commands.saveEnterpriseLicenseKey).not.toHaveBeenCalled();
   });
 
+  it("surfaces policy fetch failures with retryable copy", async () => {
+    mockEnterpriseApi({ policyStatus: 500 });
+    const { result } = await renderEnterprisePolicy();
+
+    let activation!: Awaited<ReturnType<typeof result.current.submitLicenseKey>>;
+    await act(async () => {
+      activation = await result.current.submitLicenseKey(KEY);
+    });
+
+    expect(activation).toEqual({
+      ok: false,
+      error: "could not validate license - check your connection and try again",
+    });
+    expect(mocks.commands.saveEnterpriseLicenseKey).not.toHaveBeenCalled();
+  });
+
   it("saves a valid key and closes the prompt before applying local policy", async () => {
     mockEnterpriseApi({ policy: { lockedSettings: { disableKeyboardCapture: "false" } } });
     const { result } = await renderEnterprisePolicy();

--- a/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
@@ -808,7 +808,7 @@ export function useEnterprisePolicy() {
         ok: false,
         error: result.reason === "invalid_key"
           ? "invalid or expired license key"
-          : "could not reach server — check your internet connection",
+          : "could not validate license - check your connection and try again",
       };
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/notifications/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/notifications/store.rs
@@ -70,17 +70,26 @@ pub fn mark_all_read() {
 
 pub fn mark_read_by_id(id: &str) -> bool {
     let mut history = read_all();
+    let (found, changed) = mark_read_by_id_in(&mut history, id);
+    if changed {
+        write_all(&history);
+    }
+    found
+}
+
+fn mark_read_by_id_in(entries: &mut [NotificationHistoryEntry], id: &str) -> (bool, bool) {
+    let mut found = false;
     let mut changed = false;
-    for entry in &mut history {
+    for entry in entries {
+        if entry.id == id {
+            found = true;
+        }
         if entry.id == id && !entry.read {
             entry.read = true;
             changed = true;
         }
     }
-    if changed {
-        write_all(&history);
-    }
-    changed
+    (found, changed)
 }
 
 pub fn remove_by_id(id: &str) -> bool {
@@ -97,4 +106,38 @@ pub fn remove_by_id(id: &str) -> bool {
 
 pub fn clear() {
     write_all(&[]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, read: bool) -> NotificationHistoryEntry {
+        NotificationHistoryEntry {
+            id: id.to_string(),
+            notification_type: "pipe".to_string(),
+            title: "title".to_string(),
+            body: "body".to_string(),
+            pipe_name: None,
+            source_session_id: None,
+            source_message_id: None,
+            source_url: None,
+            timestamp: "2026-07-01T00:00:00Z".to_string(),
+            read,
+            actions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn mark_read_by_id_is_idempotent_for_existing_entries() {
+        let mut entries = vec![entry("one", false), entry("two", true)];
+
+        assert_eq!(mark_read_by_id_in(&mut entries, "one"), (true, true));
+        assert!(entries[0].read);
+
+        assert_eq!(mark_read_by_id_in(&mut entries, "two"), (true, false));
+        assert!(entries[1].read);
+
+        assert_eq!(mark_read_by_id_in(&mut entries, "missing"), (false, false));
+    }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -955,8 +955,13 @@ pub async fn spawn_screenpipe(
                         return Ok(());
                     }
                     drop(capture_guard);
-                    // Start capture on existing server
-                    return start_capture_internal(&state, &app).await;
+                    // Start capture on existing server. If this fails before
+                    // start_capture_internal reaches its success cleanup, clear
+                    // startup flags so the next retry is not wedged.
+                    let result = start_capture_internal(&state, &app).await;
+                    state.is_starting.store(false, Ordering::SeqCst);
+                    state.is_starting_capture.store(false, Ordering::SeqCst);
+                    return result;
                 }
                 _ => {
                     warn!("Server exists but not responding, will do full restart");


### PR DESCRIPTION
## Summary
- normalize and validate enterprise license keys before activation so lowercase/padded input submits as the canonical key and malformed input fails locally
- surface policy validation/network failures with retryable copy instead of a generic reachability message
- make notification mark-read idempotent for already-read entries
- clear startup flags when capture restart on an existing healthy server fails, so recording retries are not wedged

## Verification
- `npx vitest run --config vitest.config.ts components/__tests__/enterprise-license-prompt.test.tsx lib/hooks/__tests__/use-enterprise-policy.test.tsx`
- `npx tsc --noEmit`
- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml notifications -- --nocapture`
- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml recording -- --nocapture`

## Notes
- Based on manual CU verification of version 84 enterprise flows against the version 82/84 diff.
- Draft PR because this hardens newly found edge cases after the publish-safety pass.