### PR TITLE
[codex] add Zendesk OAuth fallback guidance

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/integration-icon-keys.test.ts
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/integration-icon-keys.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from "vitest";
 import {
   INTEGRATION_ICON_KEYS,
   TRY_IN_CHAT_PROMPTS,
+  getOAuthFallbackMessage,
   isMcpOAuthProviderTileConnected,
 } from "../connections-section";
 import { connectionNameToId } from "../../../lib/utils/connection-chip";
@@ -45,5 +46,18 @@ describe("isMcpOAuthProviderTileConnected", () => {
 
   it("does not apply MCP provider state to unrelated connections", () => {
     expect(isMcpOAuthProviderTileConnected("github", false, { github: true })).toBe(false);
+  });
+});
+
+describe("getOAuthFallbackMessage", () => {
+  it("surfaces a Zendesk token fallback when the OAuth app is unavailable", () => {
+    expect(getOAuthFallbackMessage("zendesk", "failed", "No such client")).toContain(
+      "connect with a token"
+    );
+  });
+
+  it("shows the Zendesk pending-flow hint only for Zendesk", () => {
+    expect(getOAuthFallbackMessage("zendesk", "pending")).toContain("No such client");
+    expect(getOAuthFallbackMessage("slack", "pending")).toBeNull();
   });
 });

--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -2345,6 +2345,27 @@ const OAUTH_SCOPE_VARIANTS: Record<
   ],
 };
 
+export function getOAuthFallbackMessage(
+  integrationId: string,
+  phase: "pending" | "failed",
+  error?: unknown
+): string | null {
+  if (integrationId !== "zendesk") return null;
+  if (phase === "pending") {
+    return "If Zendesk shows Invalid Authorization Request / No such client, use advanced: connect with a token instead.";
+  }
+  const reason = error instanceof Error ? error.message : String(error ?? "");
+  if (
+    reason.includes("timed out") ||
+    reason.includes("channel closed") ||
+    reason.includes("No such client") ||
+    reason.includes("Invalid Authorization Request")
+  ) {
+    return "Zendesk OAuth is not available for this subdomain yet. Use advanced: connect with a token instead.";
+  }
+  return "Zendesk OAuth failed. Use advanced: connect with a token instead.";
+}
+
 function OAuthPanel({
   integrationId,
   integrationName,
@@ -2365,8 +2386,10 @@ function OAuthPanel({
   const [status, setStatus] = useState<"idle" | "loading">("idle");
   const [accounts, setAccounts] = useState<OAuthAccount[]>([]);
   const [disconnecting, setDisconnecting] = useState<string | null>(null);
+  const [oauthMessage, setOauthMessage] = useState<string | null>(null);
   // Ref guard so a cancelled or timed-out connect attempt doesn't update state after cancel.
   const connectingRef = useRef(false);
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Zendesk (and any future per-account provider) authorizes against the
   // customer's own subdomain, so collect it up front and pass it as the OAuth
   // instance. The token is then stored under oauth:zendesk:{subdomain}.
@@ -2380,6 +2403,15 @@ function OAuthPanel({
     ? initialScopeVariant!
     : scopeVariants?.[0]?.id ?? null;
   const [scopeVariant, setScopeVariant] = useState(defaultScopeVariant);
+
+  const clearFallbackTimer = useCallback(() => {
+    if (fallbackTimerRef.current) {
+      clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearFallbackTimer(), [clearFallbackTimer]);
 
   useEffect(() => {
     if (!scopeVariants?.some((v) => v.id === initialScopeVariant)) return;
@@ -2418,19 +2450,37 @@ function OAuthPanel({
     const instanceArg = isSubdomainProvider ? subdomain.trim() : null;
     if (isSubdomainProvider && !instanceArg) return;
     setStatus("loading");
+    setOauthMessage(null);
     connectingRef.current = true;
+    clearFallbackTimer();
+    const pendingMessage = getOAuthFallbackMessage(integrationId, "pending");
+    if (pendingMessage) {
+      fallbackTimerRef.current = setTimeout(() => {
+        if (connectingRef.current) setOauthMessage(pendingMessage);
+      }, 8000);
+    }
     try {
       const res = await commands.oauthConnect(integrationId, instanceArg, scopeVariant);
       if (!connectingRef.current) return; // cancelled — handleCancel owns the UI
       if (res.status === "ok" && res.data.connected) {
+        clearFallbackTimer();
+        setOauthMessage(null);
         await fetchStatus();
         notifyConnectionsUpdated();
         onConnected?.();
       } else {
+        clearFallbackTimer();
+        setOauthMessage(
+          getOAuthFallbackMessage(integrationId, "failed", res.status === "error" ? res.error : null)
+        );
         setStatus("idle");
       }
-    } catch {
-      if (connectingRef.current) setStatus("idle");
+    } catch (error) {
+      clearFallbackTimer();
+      if (connectingRef.current) {
+        setOauthMessage(getOAuthFallbackMessage(integrationId, "failed", error));
+        setStatus("idle");
+      }
     } finally {
       connectingRef.current = false;
       setStatus("idle");
@@ -2439,6 +2489,7 @@ function OAuthPanel({
 
   const handleCancel = async () => {
     connectingRef.current = false;
+    clearFallbackTimer();
     // Stay in "loading" (cancel button visible, connect button hidden) until the
     // backend has actually dropped the pending sender. Otherwise a quick
     // cancel→connect sequence can race: a late-arriving oauth_cancel would
@@ -2566,6 +2617,12 @@ function OAuthPanel({
           </Button>
         )}
       </div>
+      {oauthMessage && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-2 text-[11px] text-muted-foreground">
+          <AlertCircle className="mt-0.5 h-3 w-3 shrink-0 text-amber-600" />
+          <span>{oauthMessage}</span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a Zendesk-specific OAuth fallback message in the connections settings panel
- show the hint while the external browser OAuth flow is still pending, so users who see Zendesk's raw `Invalid Authorization Request / No such client` page are pointed to the token fallback instead of staring at `connecting...`
- preserve the existing manual `advanced: connect with a token instead` path and keep other OAuth providers unaffected

## Root Cause
Zendesk rejects the global OAuth client in the browser before it redirects back to the desktop app, so the app cannot receive the exact `No such client` error through the OAuth callback. The UI previously waited for the generic OAuth timeout/cancel path with no actionable guidance.

Fixes #4668.

## Validation
- `bunx vitest run --config vitest.config.ts components/settings/__tests__/integration-icon-keys.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`

## Notes
No backend OAuth secret/config change is included here. The real OAuth fix still requires the Zendesk global client/proxy env setup described in #4668.
