### PR TITLE
[codex] fix AppImage bun env for Pi install

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -875,9 +875,9 @@ fn apply_no_window(_cmd: &mut Command) {
 
 fn bun_command(bun: &str) -> Command {
     let mut cmd = Command::new(bun);
-    // Single source of truth in screenpipe-core: only strips LD_LIBRARY_PATH
-    // when running inside an AppImage (APPDIR set), so bun doesn't load the
-    // bundle's glibc/libstdc++ and crash.
+    // Single source of truth in screenpipe-core: on Linux, bun subprocesses
+    // must not inherit the app's LD_LIBRARY_PATH, or bundled runtimes like
+    // AppImage can make bun crash before it prints diagnostics.
     screenpipe_core::agents::pi::scrub_bun_runtime_env(&mut cmd);
     cmd
 }

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -3534,7 +3534,7 @@ mod tests {
 
         let env_value = cmd
             .get_envs()
-            .find(|(key, _)| key == OsStr::new("LD_LIBRARY_PATH"))
+            .find(|(key, _)| *key == OsStr::new("LD_LIBRARY_PATH"))
             .map(|(_, value)| value);
         assert_eq!(
             env_value,

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -2247,12 +2247,14 @@ pub fn bun_version_string(bun: &str) -> String {
     }
 }
 
-/// Inside an AppImage, AppRun exports `LD_LIBRARY_PATH` pointing at the bundle's
-/// libs. bun is a self-contained baseline binary and must not inherit it, or it
-/// loads the bundled glibc/libstdc++ and crashes (SIGSEGV/SIGILL). Only scrub it
-/// in that environment so a normal Linux install keeps any user-set value.
+/// On Linux, bun is a self-contained baseline binary and should not inherit the
+/// parent process' `LD_LIBRARY_PATH`. In AppImage launches that path points at
+/// the bundle's glibc/libstdc++ and bun can crash before it prints anything
+/// (observed as SIGSEGV/SIGILL during AppImage smoke). Scrubbing unconditionally
+/// on Linux avoids relying on AppImage-specific env markers that may not survive
+/// every launcher path.
 fn should_scrub_bun_runtime_env() -> bool {
-    cfg!(target_os = "linux") && std::env::var_os("APPDIR").is_some()
+    cfg!(target_os = "linux")
 }
 
 /// Strip the AppImage runtime library path from a bun command (see
@@ -3518,5 +3520,26 @@ mod tests {
         let tail = output_tail(unicode.as_bytes(), 101);
         assert!(tail.starts_with("..."));
         assert!(tail.ends_with('é'));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn scrub_bun_runtime_env_always_removes_ld_library_path_on_linux() {
+        use std::ffi::OsStr;
+
+        let mut cmd = std::process::Command::new("sh");
+        cmd.env("LD_LIBRARY_PATH", "/tmp/appimage/usr/lib");
+
+        scrub_bun_runtime_env(&mut cmd);
+
+        let env_value = cmd
+            .get_envs()
+            .find(|(key, _)| key == OsStr::new("LD_LIBRARY_PATH"))
+            .map(|(_, value)| value);
+        assert_eq!(
+            env_value,
+            Some(None),
+            "bun subprocesses on Linux must clear inherited LD_LIBRARY_PATH"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- always scrub `LD_LIBRARY_PATH` from bun subprocesses on Linux instead of relying only on AppImage env markers
- keep the Tauri-side bun wrapper comment aligned with the shared helper behavior
- add a regression test for Linux that asserts bun subprocesses clear inherited `LD_LIBRARY_PATH`

## Evidence
- repeated PR failures in `Linux AppImage Smoke` were hitting `Pi background install failed: bun install failed (killed by signal 11 (SIGSEGV))`
- the failing smoke step also logged `bun version: unknown (killed by signal 11 (SIGSEGV))`, which indicates the bundled bun process was crashing before it could print diagnostics
- the same smoke failure showed up across unrelated PRs, so this looked like a shared runtime/env issue rather than a patch-specific regression

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p screenpipe-core install_failure_message_is_never_empty`
- `git diff --check`
- attempted: `cargo test -p screenpipe-core --target x86_64-unknown-linux-gnu scrub_bun_runtime_env_always_removes_ld_library_path_on_linux --no-run`
  - blocked locally because this macOS host does not have `x86_64-linux-gnu-gcc`

## Residual risk
- this changes Linux bun subprocess env handling globally, not just AppImage launches; bun should be self-contained, but if any user depends on a custom `LD_LIBRARY_PATH` for bun itself that path will no longer be inherited
