### PR TITLE
[codex] align serial_test workspace version

### DIFF
--- a/crates/screenpipe-secrets/Cargo.toml
+++ b/crates/screenpipe-secrets/Cargo.toml
@@ -25,4 +25,4 @@ keyring = { workspace = true, features = ["linux-native-sync-persistent"] }
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
-serial_test = "3"
+serial_test = "3.2.0"


### PR DESCRIPTION
## Summary
- align `crates/screenpipe-secrets` to `serial_test = "3.2.0"`
- remove the workspace dependency-version drift that tripped the consolidation gate
- keep the change scoped to the single crate that was still on the looser `"3"` spec

## Root Cause
The dependency consolidation check was failing because workspace crates were resolving two different `serial_test` version specs:
- `crates/screenpipe-events/Cargo.toml` used `3.2.0`
- `crates/screenpipe-secrets/Cargo.toml` used `3`

That mismatch showed up in CI as:

`serial_test | 3, 3.2.0 | screenpipe-events, screenpipe-secrets | suggested 3.2.0`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p screenpipe-secrets`
- `cargo consolidate`
- `cargo consolidate --path ee/sdk`

## Notes
- This is intentionally small and separate from the AppImage/Pi env work that originally surfaced the failure.
- I did not change runtime code or behavior.
