### PR TITLE
[codex] mitigate Linux bundled Bun startup segfaults

### DIFF
--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -250,7 +250,7 @@ jobs:
               squashfs-root/usr/bin/ffmpeg -version
               squashfs-root/usr/bin/ffprobe -version
               squashfs-root/usr/bin/tesseract --version
-              env -u LD_LIBRARY_PATH squashfs-root/usr/bin/bun --version
+              env -u LD_LIBRARY_PATH BUN_JSC_useJIT=0 squashfs-root/usr/bin/bun --version
 
               check_ldd() {
                 local target="$1"

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -2289,6 +2289,7 @@ fn tokio_bun_command(bun: &str) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new(bun);
     if should_scrub_bun_runtime_env() {
         cmd.env_remove("LD_LIBRARY_PATH");
+        cmd.env("BUN_JSC_useJIT", "0");
     }
     cmd
 }
@@ -3581,6 +3582,46 @@ mod tests {
                 cmd.get_envs()
                     .all(|(key, _)| key != OsStr::new("BUN_JSC_useJIT")),
                 "non-linux bun subprocesses should not inject Linux-only Bun flags"
+            );
+        }
+    }
+
+    #[test]
+    fn tokio_bun_command_sets_platform_expected_env() {
+        use std::ffi::OsStr;
+
+        let cmd = tokio_bun_command("bun");
+
+        let env_value = cmd
+            .as_std()
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new("LD_LIBRARY_PATH"))
+            .map(|(_, value)| value);
+        if cfg!(target_os = "linux") {
+            assert_eq!(
+                env_value,
+                Some(None),
+                "async bun subprocesses on Linux must clear inherited LD_LIBRARY_PATH"
+            );
+
+            let jit_value = cmd
+                .as_std()
+                .get_envs()
+                .find(|(key, _)| *key == OsStr::new("BUN_JSC_useJIT"))
+                .and_then(|(_, value)| value)
+                .map(|value| value.to_os_string());
+            assert_eq!(
+                jit_value,
+                Some(std::ffi::OsString::from("0")),
+                "async bun subprocesses should disable JSC JIT to avoid startup segfaults"
+            );
+        } else {
+            assert_eq!(env_value, None);
+            assert!(
+                cmd.as_std()
+                    .get_envs()
+                    .all(|(key, _)| key != OsStr::new("BUN_JSC_useJIT")),
+                "non-linux async bun subprocesses should not inject Linux-only Bun flags"
             );
         }
     }

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -2267,9 +2267,15 @@ fn should_scrub_bun_runtime_env() -> bool {
 
 /// Strip the AppImage runtime library path from a bun command (see
 /// [`should_scrub_bun_runtime_env`]). Shared with the Tauri app crate.
+///
+/// On Linux we also force Bun's JSC JIT off for spawned subprocesses. Bun has
+/// a documented `BUN_JSC_useJIT=0` workaround for startup segfault classes on
+/// hardened / newer Linux hosts; this matches the Debian 13 AppImage smoke
+/// failure where the bundled baseline bun crashed before printing `--version`.
 pub fn scrub_bun_runtime_env(cmd: &mut std::process::Command) {
     if should_scrub_bun_runtime_env() {
         cmd.env_remove("LD_LIBRARY_PATH");
+        cmd.env("BUN_JSC_useJIT", "0");
     }
 }
 
@@ -3535,9 +3541,8 @@ mod tests {
         assert!(tail.ends_with('é'));
     }
 
-    #[cfg(target_os = "linux")]
     #[test]
-    fn scrub_bun_runtime_env_always_removes_ld_library_path_on_linux() {
+    fn scrub_bun_runtime_env_sets_platform_expected_env() {
         use std::ffi::OsStr;
 
         let mut cmd = std::process::Command::new("sh");
@@ -3549,10 +3554,34 @@ mod tests {
             .get_envs()
             .find(|(key, _)| *key == OsStr::new("LD_LIBRARY_PATH"))
             .map(|(_, value)| value);
-        assert_eq!(
-            env_value,
-            Some(None),
-            "bun subprocesses on Linux must clear inherited LD_LIBRARY_PATH"
-        );
+        if cfg!(target_os = "linux") {
+            assert_eq!(
+                env_value,
+                Some(None),
+                "bun subprocesses on Linux must clear inherited LD_LIBRARY_PATH"
+            );
+
+            let jit_value = cmd
+                .get_envs()
+                .find(|(key, _)| *key == OsStr::new("BUN_JSC_useJIT"))
+                .and_then(|(_, value)| value)
+                .map(|value| value.to_os_string());
+            assert_eq!(
+                jit_value,
+                Some(std::ffi::OsString::from("0")),
+                "linux bun subprocesses should disable JSC JIT to avoid startup segfaults"
+            );
+        } else {
+            assert_eq!(
+                env_value,
+                Some(Some(OsStr::new("/tmp/appimage/usr/lib"))),
+                "non-linux bun subprocesses should not rewrite LD_LIBRARY_PATH"
+            );
+            assert!(
+                cmd.get_envs()
+                    .all(|(key, _)| key != OsStr::new("BUN_JSC_useJIT")),
+                "non-linux bun subprocesses should not inject Linux-only Bun flags"
+            );
+        }
     }
 }

--- a/packages/screenpipe-mcp/src/index.ts
+++ b/packages/screenpipe-mcp/src/index.ts
@@ -52,6 +52,14 @@ const SCREENPIPE_API = (
   `http://${host}:${port}`
 ).replace(/\/+$/, "");
 
+function bundledBunEnv(): NodeJS.ProcessEnv {
+  if (process.platform !== "linux") return process.env;
+  return {
+    ...process.env,
+    BUN_JSC_useJIT: process.env.BUN_JSC_useJIT ?? "0",
+  };
+}
+
 // Discover the local API key, in priority order:
 //
 //   1. env vars set by the launcher (Claude Desktop config, terminal, etc.)
@@ -123,6 +131,7 @@ function discoverApiKey(): string {
         timeout: 30000, // first run downloads the package; subsequent runs are cached
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        env: bundledBunEnv(),
       }).trim();
       if (token && token.startsWith("sp-")) return token;
     } catch {


### PR DESCRIPTION
## Summary
- disable Bun JSC JIT for Linux Bun subprocesses in the shared Rust helper used by the desktop app
- apply the same Linux Bun env workaround when `screenpipe-mcp` shells out through the bundled desktop Bun
- update `Linux AppImage Smoke` to probe the bundled Bun with the same mitigation

## Evidence
- `Linux AppImage Smoke` was failing across otherwise-valid PRs in `Smoke AppImage on Debian 13`
- failure signature: `env -u LD_LIBRARY_PATH squashfs-root/usr/bin/bun --version` -> `Segmentation fault (core dumped)` / exit `139`
- `SENTRY_AUTH_TOKEN` was not present in this run, so Sentry cleanup workflow logs were only a proxy source

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p screenpipe-core scrub_bun_runtime_env_sets_platform_expected_env`

## Validation Notes
- `bunx tsc --noEmit -p packages/screenpipe-mcp/tsconfig.json` is currently not usable in this checkout because the package lacks its ambient Node/MCP/vitest deps in the local toolchain; the resulting errors are pre-existing and not introduced by this patch

## Residual Risk
- This mitigates the known Linux bundled-Bun startup crash class but does not prove the underlying Bun binary issue is fixed upstream
