### PR TITLE
[codex] force fresh session when switching onboarding accounts

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -17,7 +17,9 @@ const mocks = vi.hoisted(() => ({
   loadUser: vi.fn().mockResolvedValue(undefined),
   updateSettings: vi.fn(),
   capture: vi.fn(),
-  openLoginWindow: vi.fn(),
+  openLoginWindow: vi.fn().mockResolvedValue(undefined),
+  setCloudToken: vi.fn().mockResolvedValue(undefined),
+  piUpdateConfig: vi.fn().mockResolvedValue(undefined),
   hasAppEntitlement: vi.fn(),
   isDevBillingBypassEnabled: vi.fn().mockReturnValue(false),
 }));
@@ -34,7 +36,11 @@ vi.mock("@/lib/app-entitlement", () => ({
   isDevBillingBypassEnabled: () => mocks.isDevBillingBypassEnabled(),
 }));
 vi.mock("@/lib/utils/tauri", () => ({
-  commands: { openLoginWindow: mocks.openLoginWindow },
+  commands: {
+    openLoginWindow: mocks.openLoginWindow,
+    setCloudToken: mocks.setCloudToken,
+    piUpdateConfig: mocks.piUpdateConfig,
+  },
 }));
 vi.mock("posthog-js", () => ({ default: { capture: mocks.capture } }));
 vi.mock("framer-motion", () => ({
@@ -62,6 +68,9 @@ beforeEach(() => {
   mocks.loadUser.mockReset().mockResolvedValue(undefined);
   mocks.updateSettings.mockClear();
   mocks.capture.mockClear();
+  mocks.openLoginWindow.mockClear();
+  mocks.setCloudToken.mockClear();
+  mocks.piUpdateConfig.mockClear();
   mocks.hasAppEntitlement.mockReset();
   mocks.isDevBillingBypassEnabled.mockReturnValue(false);
 });
@@ -104,15 +113,15 @@ describe("onboarding login gate", () => {
     expect(mocks.loadUser).toHaveBeenLastCalledWith("t3", true);
   });
 
-  it("'use a different account' clears the auth token so they can re-login", async () => {
+  it("'use a different account' clears auth and forces a fresh login session", async () => {
     mocks.settings = { user: { token: "t4", id: "u4", email: "x@y.com", cloud_subscribed: true } };
     mocks.hasAppEntitlement.mockReturnValue(false);
     render(<OnboardingLogin handleNextSlide={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /use a different account/i }));
-    expect(mocks.updateSettings).toHaveBeenCalledTimes(1);
-    const arg = mocks.updateSettings.mock.calls[0][0];
-    expect(arg.user.token).toBeNull();
-    expect(arg.user.id).toBeNull();
+    await waitFor(() => expect(mocks.updateSettings).toHaveBeenCalledWith({ user: null }));
+    expect(mocks.setCloudToken).toHaveBeenCalledWith(null);
+    expect(mocks.piUpdateConfig).toHaveBeenCalledWith(null, null);
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
   });
 
   it("shows the sign-in button when not signed in", () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -124,6 +124,19 @@ describe("onboarding login gate", () => {
     expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
   });
 
+  it("manual sign-in after switching accounts stays fresh-session", async () => {
+    mocks.settings = { user: { token: "t5", id: "u5", email: "x@y.com", cloud_subscribed: true } };
+    mocks.hasAppEntitlement.mockReturnValue(false);
+    const { rerender } = render(<OnboardingLogin handleNextSlide={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: /use a different account/i }));
+    await waitFor(() => expect(mocks.openLoginWindow).toHaveBeenCalledWith(true));
+    // user cancelled the auto-opened window; settings now hold the cleared user
+    mocks.settings = { user: null };
+    rerender(<OnboardingLogin handleNextSlide={vi.fn()} />);
+    fireEvent.click(screen.getByText(/^sign in$/i));
+    expect(mocks.openLoginWindow).toHaveBeenLastCalledWith(true);
+  });
+
   it("shows the sign-in button when not signed in", () => {
     mocks.settings = { user: null };
     mocks.hasAppEntitlement.mockReturnValue(false);

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -282,24 +282,25 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
     setRechecking(false);
   }, [settings.user?.token, rechecking, loadUser]);
 
-  const useDifferentAccount = useCallback(() => {
+  const useDifferentAccount = useCallback(async () => {
     posthog.capture("onboarding_login_switch_account");
     reverifiedRef.current = false;
-    // Clear the auth-bearing fields so we drop back to the "sign in" button and the
-    // member can re-authenticate with their work email (the one on the license).
-    updateSettings({
-      user: {
-        ...settings.user,
-        id: null,
-        token: null,
-        clerk_id: null,
-        cloud_subscribed: null,
-        app_entitled: null,
-        subscription_plan: null,
-        entitlement: null,
-      },
-    });
-  }, [settings.user, updateSettings]);
+    // Match the entitlement gate's switch-account flow: clear local auth state,
+    // then open a fresh browser session so Google shows the account chooser
+    // instead of silently reusing the previous session.
+    await updateSettings({ user: null as any });
+    try {
+      await commands.setCloudToken(null);
+    } catch (e) {
+      console.warn("failed to clear cloud token before switching accounts:", e);
+    }
+    try {
+      await commands.piUpdateConfig(null, null);
+    } catch (e) {
+      console.warn("failed to clear pi config before switching accounts:", e);
+    }
+    await commands.openLoginWindow(true);
+  }, [updateSettings]);
 
   const handleLogin = useCallback(() => {
     posthog.capture("onboarding_login_clicked");

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -229,6 +229,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
   const { settings, loadUser, updateSettings } = useSettings();
   const hasAdvanced = useRef(false);
   const reverifiedRef = useRef(false);
+  const freshSessionLoginRef = useRef(false);
   const [showSkip, setShowSkip] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [rechecking, setRechecking] = useState(false);
@@ -285,6 +286,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
   const useDifferentAccount = useCallback(async () => {
     posthog.capture("onboarding_login_switch_account");
     reverifiedRef.current = false;
+    freshSessionLoginRef.current = true;
     // Match the entitlement gate's switch-account flow: clear local auth state,
     // then open a fresh browser session so Google shows the account chooser
     // instead of silently reusing the previous session.
@@ -305,8 +307,11 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
   const handleLogin = useCallback(() => {
     posthog.capture("onboarding_login_clicked");
     // Open login in an in-app WebView instead of Safari so we can intercept
-    // the screenpipe:// deep-link redirect (Safari blocks custom-scheme redirects)
-    commands.openLoginWindow(null);
+    // the screenpipe:// deep-link redirect (Safari blocks custom-scheme redirects).
+    // If the user asked to switch accounts and then cancelled the auto-opened
+    // window, the manual sign-in must also be fresh-session — otherwise Google
+    // silently reuses the previous session and re-logs the same account.
+    commands.openLoginWindow(freshSessionLoginRef.current ? true : null);
   }, []);
 
   const handleSkip = useCallback(() => {


### PR DESCRIPTION
## Summary
- fix the onboarding "use a different account" path so it opens a fresh login session instead of reusing the existing Google session
- clear the local cloud token and Pi auth config before re-opening login
- add a regression test for the switch-account flow

## Root cause
The onboarding login gate only cleared a few local auth fields and then relied on the normal sign-in button flow. That reused the shared login session, so Google could silently re-authenticate the same account instead of showing an account chooser. The entitlement gate already had the stronger fresh-session flow; onboarding had drifted from it.

## Evidence
- fixes #4720
- no overlapping open PR was found for the onboarding account-switch path
- recent Sentry cleanup workflow logs were inspected as a proxy because `SENTRY_AUTH_TOKEN` is not available locally in this run

## Validation
- `bun run test:vitest -- components/onboarding/login-gate.test.tsx`
- `./node_modules/.bin/eslint components/onboarding/login-gate.tsx components/onboarding/login-gate.test.tsx`
- `bun run typecheck`

## Residual risk
- this is scoped to the onboarding entitlement dead-end path only; other login entry points still use their existing behavior unless they already opt into `freshSession`
