### PR TITLE
[codex] avoid phantom chat ids during save fallback

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -480,12 +480,18 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     //
     // Fall back to the ref only when `conversationId` is briefly null
     // during startNewConversation (setConversationId(null) → … →
-    // setConversationId(newSid)); without the fallback the save would mint
-    // a fresh uuid and duplicate the conversation.
-    const convId = conversationId || piSessionIdRef.current || crypto.randomUUID();
+    // setConversationId(newSid)). If the ref is also empty, prefer the
+    // store's current id; if all three are absent, skip this save instead
+    // of minting a phantom conversation file under a brand-new uuid.
+    const { useChatStore } = await import("@/lib/stores/chat-store");
+    const storeCurrentId = useChatStore.getState().currentId;
+    const convId = conversationId || piSessionIdRef.current || storeCurrentId;
+    if (!convId) {
+      console.warn("[chat] skipping saveConversation without a stable conversation id");
+      return;
+    }
 
     // Try to load existing conversation to preserve createdAt + title + kind.
-    const { loadConversationFile } = await import("@/lib/chat-storage");
     const existing = await loadConversationFile(convId);
     const browserState = resolveNewestBrowserState(
       existing?.browserState,

--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-switch-save-race.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-switch-save-race.test.ts
@@ -25,7 +25,7 @@
  * content.
  *
  * PR #3600's fix flips the order:
- *     const convId = conversationId || piSessionIdRef.current || crypto.randomUUID();
+ *     const convId = conversationId || piSessionIdRef.current || store.currentId || null;
  *
  * which keeps convId in lockstep with the `messages` argument (both
  * captured by the same render).
@@ -40,8 +40,12 @@ function pickConvIdBuggy(piRef: string | null, conversationId: string | null): s
   return piRef || conversationId || "fallback-uuid";
 }
 
-function pickConvIdFixed(piRef: string | null, conversationId: string | null): string {
-  return conversationId || piRef || "fallback-uuid";
+function pickConvIdFixed(
+  piRef: string | null,
+  conversationId: string | null,
+  storeCurrentId: string | null,
+): string | null {
+  return conversationId || piRef || storeCurrentId || null;
 }
 
 describe("chat-switch save race (issue #3636 candidate, PR #3600)", () => {
@@ -73,7 +77,7 @@ describe("chat-switch save race (issue #3636 candidate, PR #3600)", () => {
     const conversationIdState = "A";
     const messagesBeingSaved = ["A's messages"];
 
-    const convId = pickConvIdFixed(piSessionIdRefCurrent, conversationIdState);
+    const convId = pickConvIdFixed(piSessionIdRefCurrent, conversationIdState, null);
 
     // Now the save targets A (matches the messages payload).
     expect(convId).toBe("A");
@@ -91,14 +95,19 @@ describe("chat-switch save race (issue #3636 candidate, PR #3600)", () => {
     const piSessionIdRefCurrent = "C";
     const conversationIdState = null;
 
-    const convId = pickConvIdFixed(piSessionIdRefCurrent, conversationIdState);
+    const convId = pickConvIdFixed(piSessionIdRefCurrent, conversationIdState, null);
 
     expect(convId).toBe("C");
-    expect(convId).not.toBe("fallback-uuid");
+    expect(convId).not.toBeNull();
   });
 
-  it("FIX: mints a fresh uuid only when both are null (first send before any state)", () => {
-    const convId = pickConvIdFixed(null, null);
-    expect(convId).toBe("fallback-uuid");
+  it("FIX: uses store.currentId when state/ref are both transiently empty", () => {
+    const convId = pickConvIdFixed(null, null, "D");
+    expect(convId).toBe("D");
+  });
+
+  it("FIX: returns null when no stable id exists instead of minting a phantom uuid", () => {
+    const convId = pickConvIdFixed(null, null, null);
+    expect(convId).toBeNull();
   });
 });

--- a/apps/screenpipe-app-tauri/lib/__tests__/save-conversation-race.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/__tests__/save-conversation-race.test.tsx
@@ -219,6 +219,49 @@ describe("saveConversation race (PR #3600 / issue #3636 candidate)", () => {
     expect(saveCalls[0].id).toBe("fresh-sid");
   });
 
+  it("uses store.currentId before inventing a stray conversation id", async () => {
+    const messages = [{ id: "u1", role: "user" as const, content: "hello", timestamp: 1 }];
+    useChatStore.setState({ sessions: {}, currentId: "store-sid", panelSessionId: null });
+
+    const { result } = renderHook(() =>
+      useHarness({
+        initialMessages: messages,
+        initialConversationId: null,
+        initialPiSessionId: "",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.hook.saveConversation(messages);
+    });
+
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].id).toBe("store-sid");
+  });
+
+  it("skips the save when no stable conversation id exists", async () => {
+    const messages = [{ id: "u1", role: "user" as const, content: "hello", timestamp: 1 }];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useHarness({
+        initialMessages: messages,
+        initialConversationId: null,
+        initialPiSessionId: "",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.hook.saveConversation(messages);
+    });
+
+    expect(saveCalls).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[chat] skipping saveConversation without a stable conversation id",
+    );
+    warnSpy.mockRestore();
+  });
+
   it("preserves browserState from the shadow cache when the disk file does not exist yet", async () => {
     const messages = [{ id: "u1", role: "user" as const, content: "hello", timestamp: 1 }];
     setCachedBrowserState("fresh-sid", {


### PR DESCRIPTION
## Summary
- stop `saveConversation` from minting a brand-new chat UUID when the panel is between session ids
- fall back to `store.currentId` when `conversationId` and `piSessionIdRef.current` are both transiently empty
- skip the save entirely when no stable conversation id exists, instead of persisting a phantom twin file

## Why
Issue #4719 documents a remaining follow-up after PR #4706: the save path could still invent a second conversation id during the null-id window and surface duplicate or mis-titled chats through the cross-window save race.

This change keeps the existing `conversationId`-first race fix, but removes the last UUID minting fallback from the save path.

## Validation
- `bunx vitest run lib/__tests__/save-conversation-race.test.tsx lib/__tests__/chat-switch-save-race.test.ts --config vitest.config.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`

## Notes
- Follow-up to #4706, but scoped only to the stable-id fallback in `saveConversation`
- No direct Sentry query was available in this run because `SENTRY_AUTH_TOKEN` was not present; triage used GitHub issue evidence and repo code paths
