### PR TITLE
[codex] force fresh onboarding login when switching accounts

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -60,8 +60,9 @@ beforeEach(() => {
   HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;
   mocks.settings = { user: null };
   mocks.loadUser.mockReset().mockResolvedValue(undefined);
-  mocks.updateSettings.mockClear();
+  mocks.updateSettings.mockReset().mockResolvedValue(undefined);
   mocks.capture.mockClear();
+  mocks.openLoginWindow.mockReset().mockResolvedValue(undefined);
   mocks.hasAppEntitlement.mockReset();
   mocks.isDevBillingBypassEnabled.mockReturnValue(false);
 });
@@ -104,15 +105,16 @@ describe("onboarding login gate", () => {
     expect(mocks.loadUser).toHaveBeenLastCalledWith("t3", true);
   });
 
-  it("'use a different account' clears the auth token so they can re-login", async () => {
+  it("'use a different account' clears the auth token and reopens login with a fresh session", async () => {
     mocks.settings = { user: { token: "t4", id: "u4", email: "x@y.com", cloud_subscribed: true } };
     mocks.hasAppEntitlement.mockReturnValue(false);
     render(<OnboardingLogin handleNextSlide={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /use a different account/i }));
-    expect(mocks.updateSettings).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.updateSettings).toHaveBeenCalledTimes(1));
     const arg = mocks.updateSettings.mock.calls[0][0];
     expect(arg.user.token).toBeNull();
     expect(arg.user.id).toBeNull();
+    await waitFor(() => expect(mocks.openLoginWindow).toHaveBeenCalledWith(true));
   });
 
   it("shows the sign-in button when not signed in", () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -282,12 +282,12 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
     setRechecking(false);
   }, [settings.user?.token, rechecking, loadUser]);
 
-  const useDifferentAccount = useCallback(() => {
+  const useDifferentAccount = useCallback(async () => {
     posthog.capture("onboarding_login_switch_account");
     reverifiedRef.current = false;
     // Clear the auth-bearing fields so we drop back to the "sign in" button and the
     // member can re-authenticate with their work email (the one on the license).
-    updateSettings({
+    await updateSettings({
       user: {
         ...settings.user,
         id: null,
@@ -299,6 +299,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
         entitlement: null,
       },
     });
+    await commands.openLoginWindow(true);
   }, [settings.user, updateSettings]);
 
   const handleLogin = useCallback(() => {


### PR DESCRIPTION
## Summary
- fix the onboarding "use a different account" path to reopen login with `freshSession=true`
- keep clearing the stale auth snapshot first so the UI drops out of the signed-in/no-plan state cleanly
- tighten the onboarding regression test to assert the fresh-session login window call

## Why
Fixes #4720.

On the onboarding no-subscription screen, clicking "use a different account" cleared local state but fell back to the normal login flow, which reused the existing Google session and silently re-authenticated the same account. The app entitlement gate already used a fresh session for the same action; onboarding was the inconsistent path.

## Validation
- `bunx vitest run --config vitest.config.ts components/onboarding/login-gate.test.tsx`
- `bun run typecheck`
- `cargo fmt --all -- --check`

## Residual Risk
- This covers the onboarding entry point reported in #4720.
- Other account-switch entry points were inspected; the app entitlement gate already uses `openLoginWindow(true)`.
