### PR TITLE
[codex] fix monitor pause fallback

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -119,7 +119,7 @@ function HomeContent() {
   });
   const [connectionFocusRequest, setConnectionFocusRequest] = useState<ConnectionFocusRequest | null>(null);
 
-  const { settings } = useSettings();
+  const { settings, updateSettings } = useSettings();
   const { isTranslucent } = useSidebarContext();
   const teamState = useTeam();
   const { isSectionHidden, isSettingLocked, needsLicenseKey, submitLicenseKey } = useEnterprisePolicy();
@@ -478,6 +478,7 @@ function HomeContent() {
   }
   const [recordingDevices, setRecordingDevices] = useState<RecordingDevice[]>([]);
   const recordingDevicesSnapshotRef = useRef("");
+  const lastKnownMonitorDevicesRef = useRef<RecordingDevice[]>([]);
 
   const refreshRecordingDevices = useCallback(async () => {
     try {
@@ -502,7 +503,25 @@ function HomeContent() {
       // display can be paused/resumed individually) and reflects user pauses.
       // A display reads as "active" unless the user explicitly paused it, so a
       // transient capture stall at boot doesn't flicker the row to "paused".
-      if (Array.isArray(visionStatus) && visionStatus.length > 0) {
+      if (settings.disableVision) {
+        const lastKnownMonitors = lastKnownMonitorDevicesRef.current;
+        devices.push(
+          ...(lastKnownMonitors.length > 0
+            ? lastKnownMonitors.map((device) => ({
+                ...device,
+                active: false,
+                id: undefined,
+              }))
+            : [
+                {
+                  name: "Screen recording",
+                  fullName: "screen-recording",
+                  kind: "monitor" as const,
+                  active: false,
+                },
+              ])
+        );
+      } else if (Array.isArray(visionStatus) && visionStatus.length > 0) {
         for (const m of visionStatus) {
           devices.push({
             name: m.name,
@@ -531,6 +550,11 @@ function HomeContent() {
           }
           devices.push({ name, fullName: name, kind: "monitor", active: true });
         }
+      }
+
+      const monitorDevices = devices.filter((device) => device.kind === "monitor");
+      if (!settings.disableVision && monitorDevices.length > 0) {
+        lastKnownMonitorDevicesRef.current = monitorDevices;
       }
 
       const visibleAudioDevices = Array.isArray(audioStatus)
@@ -573,7 +597,7 @@ function HomeContent() {
     } catch {
       // Device status is advisory UI state; keep the last known snapshot.
     }
-  }, [settings.monitorIds, settings.useAllMonitors]);
+  }, [settings.disableVision, settings.monitorIds, settings.useAllMonitors]);
 
   useEffect(() => {
     void refreshRecordingDevices();
@@ -597,6 +621,25 @@ function HomeContent() {
       void refreshRecordingDevices();
     }, 500);
   }, [refreshRecordingDevices]);
+
+  const toggleScreenRecording = useCallback(async (active: boolean) => {
+    await updateSettings({ disableVision: !active });
+
+    const stopResult = await commands.stopCapture();
+    if (stopResult.status === "error") {
+      throw new Error(String(stopResult.error));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const startResult = await commands.startCapture();
+    if (startResult.status === "error") {
+      throw new Error(String(startResult.error));
+    }
+
+    window.setTimeout(() => {
+      void refreshRecordingDevices();
+    }, 1000);
+  }, [refreshRecordingDevices, updateSettings]);
 
   // Active meeting state — lights up the phone icon for ANY active meeting
   // (manual OR auto-detected: Teams, Zoom, etc.).
@@ -1037,6 +1080,7 @@ function HomeContent() {
               meetingLoading={meetingLoading}
               onToggleMeeting={() => void toggleMeeting()}
               onPauseRecording={pauseRecording}
+              onToggleScreenRecording={toggleScreenRecording}
               isTranslucent={isTranslucent}
               floatingOverMedia={sidebarCollapsed && activeSection === "timeline"}
             />

--- a/apps/screenpipe-app-tauri/components/recording-status.tsx
+++ b/apps/screenpipe-app-tauri/components/recording-status.tsx
@@ -39,6 +39,7 @@ interface RecordingStatusProps {
   meetingLoading: boolean;
   onToggleMeeting: () => void;
   onPauseRecording?: () => void | Promise<void>;
+  onToggleScreenRecording?: (active: boolean) => void | Promise<void>;
   isTranslucent?: boolean;
   /** buttons float over full-bleed video (timeline, sidebar collapsed) */
   floatingOverMedia?: boolean;
@@ -68,6 +69,7 @@ export function RecordingStatus({
   meetingLoading,
   onToggleMeeting,
   onPauseRecording,
+  onToggleScreenRecording,
   isTranslucent,
   floatingOverMedia,
 }: RecordingStatusProps) {
@@ -91,8 +93,26 @@ export function RecordingStatus({
   // and revert on failure so the popover feels instant.
   const toggleDevice = async (device: RecordingDevice) => {
     const isMonitor = device.kind === "monitor";
-    // Monitor control needs a numeric id; older sidecars don't report one.
-    if (isMonitor && device.id == null) return;
+    // Older sidecars don't report monitor ids. Fall back to the global screen
+    // recording setting so the display row still has a pause/resume affordance.
+    if (isMonitor && device.id == null) {
+      if (!onToggleScreenRecording) return;
+      onDevicesChange((prev) =>
+        prev.map((d) =>
+          d.kind === "monitor" ? { ...d, active: !device.active } : d
+        )
+      );
+      try {
+        await onToggleScreenRecording(!device.active);
+      } catch {
+        onDevicesChange((prev) =>
+          prev.map((d) =>
+            d.kind === "monitor" ? { ...d, active: device.active } : d
+          )
+        );
+      }
+      return;
+    }
 
     const endpoint = isMonitor
       ? device.active
@@ -258,16 +278,20 @@ export function RecordingStatus({
                 >
                   {device.name}
                 </span>
-                {/* Monitors are controllable only when the sidecar reports an
-                    id (/vision/device/status); audio rows always are. */}
-                {(device.kind !== "monitor" || device.id != null) && (
+                {(device.kind !== "monitor" ||
+                  device.id != null ||
+                  onToggleScreenRecording) && (
                   <button
                     onClick={() => void toggleDevice(device)}
                     title={
                       device.kind === "monitor"
                         ? device.active
-                          ? "pause screen recording for this display"
-                          : "resume screen recording for this display"
+                          ? device.id != null
+                            ? "pause screen recording for this display"
+                            : "pause screen recording"
+                          : device.id != null
+                            ? "resume screen recording for this display"
+                            : "resume screen recording"
                         : device.active
                           ? "pause recording for this device"
                           : "resume recording for this device"


### PR DESCRIPTION
## Summary
- always show a pause/resume control for display rows in the recording popover
- fall back to the global screen-recording setting when older/running sidecars do not expose per-monitor ids
- keep a paused screen row visible so users can resume screen capture from the same popover

## Root Cause
The popover only rendered monitor controls when `/vision/device/status` returned a numeric monitor id. In older or mixed frontend/sidecar builds, the UI falls back to `/health`, which only has monitor labels, so the display row became read-only even though screen capture could still be paused through the existing `disableVision` setting.

## Validation
- `bun run typecheck`
