### PR TITLE
[codex] disable GitHub-backed sccache in non-Windows E2E

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -467,13 +467,10 @@ jobs:
         target: x86_64-unknown-linux-gnu
         cache-bin: false
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
-
-    - name: Configure sccache
-      run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+    # sccache's GitHub cache backend has been intermittently failing DNS /
+    # cache-service startup on Actions, which kills the compiler wrapper
+    # before Linux E2E even reaches the build. Keep rust-cache below (best
+    # effort only) but do not put sccache on the critical build path here.
 
     - name: Rust cache
       # cache restore/save is an optimization only; a transient GHA cache
@@ -590,14 +587,10 @@ jobs:
         target: aarch64-apple-darwin
         cache-bin: false
 
-    - name: Setup sccache
-      uses: mozilla-actions/sccache-action@v0.0.9
-
-    - name: Configure sccache
-      shell: bash
-      run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+    # sccache's GitHub cache backend has been intermittently failing DNS /
+    # cache-service startup on Actions, which kills the compiler wrapper
+    # before macOS E2E reaches the build. Keep rust-cache below (best effort
+    # only) but do not put sccache on the critical build path here.
 
     - name: Rust cache
       # cache restore/save is an optimization only; a transient GHA cache


### PR DESCRIPTION
## Summary
- remove `mozilla-actions/sccache-action` from the Linux and macOS E2E jobs
- keep `rust-cache` in place as best-effort restore/save, but stop putting GitHub-backed `sccache` on the compiler path for those jobs
- align the non-Windows E2E workflows with the release workflows, which already disable `sccache` during GitHub cache instability

## Evidence
- PR #4732 failed in `Linux E2E Tests` before tests ran: the `Build` step died on `rustc -vV` because `sccache` could not start against GitHub's cache service
- failure signature from run `28547300715` / job `84635737560`:
  - `sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read => send http request`
  - `dns error: failed to lookup address information: Try again`
  - endpoint: `https://results-receiver.actions.githubusercontent.com/.../GetCacheEntryDownloadURL`
- this is CI infrastructure flakiness, not a code regression in #4732; disabling the wrapper prevents otherwise-valid PRs from going red before compile

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-test.yml"); puts "yaml-ok"'`

## Residual Risk
- Linux/macOS E2E builds may be slower without `sccache`
- this does not change Windows E2E, where the current flake signature was not observed in this run
