### PR TITLE
Fix stale subscription entitlement bypass

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -171,6 +171,20 @@ describe("AppEntitlementGate", () => {
     await waitFor(() => expect(mocks.stopScreenpipe).toHaveBeenCalled());
   });
 
+  it("does not trust cloud_subscribed when app entitlement is explicitly denied", async () => {
+    mocks.state.user = baseUser({
+      cloud_subscribed: true,
+      app_entitled: false,
+      subscription_plan: "none",
+      entitlement: null,
+    });
+    render(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
+
+    expect(screen.getByText(/subscription required/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("protected-app")).not.toBeInTheDocument();
+    await waitFor(() => expect(mocks.stopScreenpipe).toHaveBeenCalled());
+  });
+
   it("renders the app for a fresh entitled account without stopping capture", () => {
     mocks.state.user = baseUser({
       app_entitled: true,

--- a/apps/screenpipe-app-tauri/e2e/specs/zz-app-entitlement-gate.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-app-entitlement-gate.spec.ts
@@ -22,6 +22,8 @@ import { invoke } from '../helpers/tauri.js';
 import { getLocalApiConfig, waitForLocalApi } from '../helpers/api-utils.js';
 
 const FORCE_KEY = 'screenpipe_e2e_force_billing_gate';
+const FAKE_DENIED_TOKEN = 'e2e-fake-token-cloud-sub-app-denied';
+const FAKE_DENIED_EMAIL = 'e2e-cloud-sub-app-denied@screenpipe.test';
 
 /** Forcing the gate on drives the entitlement gate to stop the engine
  *  (components/app-entitlement-gate.tsx calls stopScreenpipe for an unentitled
@@ -77,6 +79,71 @@ async function setForceGate(on: boolean): Promise<void> {
   }
 }
 
+/** Emit a deep-link to the HOME window only. The login handler calls loadUser in
+ *  the receiving window, so targeting "home" keeps this deterministic. */
+async function emitDeepLink(url: string): Promise<void> {
+  const emitErr = (await browser.executeAsync(
+    (payload: string, done: (v?: unknown) => void) => {
+      const g = globalThis as unknown as {
+        __TAURI__?: {
+          event?: { emitTo?: (target: string, n: string, p: unknown) => Promise<unknown> };
+        };
+      };
+      const emitTo = g.__TAURI__?.event?.emitTo;
+      if (!emitTo) {
+        done('global __TAURI__.event.emitTo unavailable');
+        return;
+      }
+      void emitTo('home', 'deep-link-received', payload)
+        .then(() => done(null))
+        .catch((e: unknown) => done(String(e)));
+    },
+    url,
+  )) as string | null;
+  expect(emitErr).toBeNull();
+}
+
+async function patchFetchForCloudSubscribedAppDeniedUser(): Promise<void> {
+  await browser.execute((mockEmail: string) => {
+    const w = window as unknown as Record<string, unknown>;
+    w.__E2E_APP_DENIED_EMAIL = mockEmail;
+    if (w.__E2E_APP_DENIED_PATCHED) return;
+    const orig = window.fetch.bind(window);
+    w.__E2E_APP_DENIED_ORIG_FETCH = orig;
+    window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string' ? input : (input as Request)?.url ?? String(input);
+      if (url.includes('/api/user')) {
+        const body = JSON.stringify({
+          user: {
+            id: 'e2e-cloud-sub-app-denied-user',
+            email: w.__E2E_APP_DENIED_EMAIL,
+            cloud_subscribed: true,
+            app_entitled: false,
+            subscription_plan: 'none',
+          },
+        });
+        return Promise.resolve(
+          new Response(body, { status: 200, headers: { 'Content-Type': 'application/json' } }),
+        );
+      }
+      return orig(input, init);
+    };
+    w.__E2E_APP_DENIED_PATCHED = true;
+  }, FAKE_DENIED_EMAIL);
+}
+
+async function restoreFetch(): Promise<void> {
+  await browser.execute(() => {
+    const w = window as unknown as Record<string, unknown>;
+    if (w.__E2E_APP_DENIED_ORIG_FETCH) {
+      window.fetch = w.__E2E_APP_DENIED_ORIG_FETCH as typeof window.fetch;
+      delete w.__E2E_APP_DENIED_ORIG_FETCH;
+    }
+    w.__E2E_APP_DENIED_PATCHED = false;
+  });
+}
+
 describe('App entitlement gate', () => {
   before(async () => {
     await waitForAppReady();
@@ -84,6 +151,8 @@ describe('App entitlement gate', () => {
   });
 
   after(async () => {
+    await restoreFetch().catch(() => {});
+
     // Never leave the gate forced on for a trailing spec.
     await browser.execute((key: string) => {
       try {
@@ -115,5 +184,19 @@ describe('App entitlement gate', () => {
     await navHome.waitForExist({ timeout: t(15000) });
     expect(await navHome.isExisting()).toBe(true);
     expect(await (await $('button*=choose plan')).isExisting()).toBe(false);
+  });
+
+  it('blocks a cloud_subscribed account when the server denies app entitlement', async () => {
+    await setForceGate(true);
+    await patchFetchForCloudSubscribedAppDeniedUser();
+    await emitDeepLink(`screenpipe://login?api_key=${FAKE_DENIED_TOKEN}`);
+
+    const title = await $('h1=subscription required');
+    await title.waitForExist({ timeout: t(15000) });
+    expect(await title.isExisting()).toBe(true);
+    expect(await (await $('[data-testid="nav-home"]')).isExisting()).toBe(false);
+
+    await restoreFetch();
+    await setForceGate(false);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/__tests__/upsell-gating.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/upsell-gating.test.ts
@@ -21,12 +21,12 @@ describe("shouldShowModelUpsell (fail-open gate for the upsell UI)", () => {
     expect(
       shouldShowModelUpsell(user({ cloud_subscribed: false, app_entitled: false }), true),
     ).toBe(true);
+    expect(shouldShowModelUpsell(user({ cloud_subscribed: true }), true)).toBe(true);
   });
 
   it("fails OPEN — never shows to anyone carrying persisted paid evidence", () => {
     // This is the guard against the past incident: a transient tier flicker on
     // a paying customer must NOT surface a paywall.
-    expect(shouldShowModelUpsell(user({ cloud_subscribed: true }), true)).toBe(false);
     expect(shouldShowModelUpsell(user({ app_entitled: true }), true)).toBe(false);
     expect(
       shouldShowModelUpsell(user({ entitlement: { features: { app: true } } } as Partial<AppUser>), true),

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -21,7 +21,7 @@ function user(overrides: Record<string, any>) {
   return {
     token: "token",
     cloud_subscribed: false,
-    app_entitled: false,
+    app_entitled: null,
     subscription_plan: "standard",
     ...overrides,
   } as any;
@@ -84,8 +84,11 @@ describe("app entitlement", () => {
     ).toBe(true);
   });
 
-  it("keeps legacy cloud subscribers working during rollout", () => {
-    expect(hasAppEntitlement(user({ cloud_subscribed: true, entitlement: null }))).toBe(true);
+  it("does not trust a stale legacy cloud_subscribed flag by itself", () => {
+    expect(hasAppEntitlement(user({ cloud_subscribed: true, entitlement: null }))).toBe(false);
+    expect(
+      needsAppEntitlementRefresh(user({ cloud_subscribed: true, entitlement: null })),
+    ).toBe(false);
   });
 
   it("separates consumer subscriptions from enterprise-only app grants", () => {
@@ -129,6 +132,7 @@ describe("app entitlement", () => {
   });
 
   it("does not unlock new cloud features from stale entitlement data", () => {
+    expect(hasCloudEntitlement(user({ cloud_subscribed: true, entitlement: null }))).toBe(false);
     expect(
       hasCloudEntitlement(
         user({
@@ -159,6 +163,58 @@ describe("app entitlement", () => {
       features: { app: true, cloud: false },
     });
     expect(hasAppEntitlement(normalized)).toBe(true);
+  });
+
+  it("normalizes fresh legacy cloud subscribers into checked app entitlements", () => {
+    const normalized = normalizeAppUser(
+      {
+        subscription_plan: "pro",
+        cloud_subscribed: true,
+      },
+      "token",
+    );
+
+    expect(normalized.app_entitled).toBe(true);
+    expect(normalized.entitlement).toMatchObject({
+      active: true,
+      checked_at: NOW.toISOString(),
+      features: { app: true, cloud: true },
+    });
+    expect(hasAppEntitlement(normalized)).toBe(true);
+    expect(hasCloudEntitlement(normalized)).toBe(true);
+  });
+
+  it("does not let cloud_subscribed override explicit server app denial", () => {
+    const normalized = normalizeAppUser(
+      {
+        app_entitled: false,
+        subscription_plan: "none",
+        cloud_subscribed: true,
+      },
+      "token",
+    );
+
+    expect(normalized.app_entitled).toBe(false);
+    expect(normalized.entitlement).toMatchObject({
+      active: false,
+      checked_at: NOW.toISOString(),
+      features: { app: false, cloud: true },
+    });
+    expect(hasAppEntitlement(normalized)).toBe(false);
+
+    expect(
+      hasAppEntitlement(
+        user({
+          cloud_subscribed: true,
+          app_entitled: false,
+          entitlement: {
+            active: true,
+            checked_at: NOW.toISOString(),
+            features: { app: true, cloud: true },
+          },
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("keeps lifetime grants working offline even when the cache is stale", () => {
@@ -246,7 +302,6 @@ describe("isTokenHydrationPending", () => {
 
 describe("hasPersistedEntitlementEvidence", () => {
   it("trusts store.bin signals that survive a token-hydration failure", () => {
-    expect(hasPersistedEntitlementEvidence(user({ cloud_subscribed: true }))).toBe(true);
     expect(hasPersistedEntitlementEvidence(user({ app_entitled: true }))).toBe(true);
     expect(
       hasPersistedEntitlementEvidence(user({ entitlement: { features: { app: true } } })),
@@ -255,6 +310,7 @@ describe("hasPersistedEntitlementEvidence", () => {
   });
 
   it("is false for an account with no entitlement evidence", () => {
+    expect(hasPersistedEntitlementEvidence(user({ cloud_subscribed: true }))).toBe(false);
     expect(
       hasPersistedEntitlementEvidence(
         user({ cloud_subscribed: false, app_entitled: false, entitlement: null }),

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -163,7 +163,19 @@ function hasEntitlementFeature(user: AppUser | null | undefined, feature: keyof 
 }
 
 export function hasLegacyPaidAccess(user: AppUser | null | undefined) {
-  return user?.cloud_subscribed === true;
+  if (user?.cloud_subscribed !== true) return false;
+
+  const entitlement = asEntitlement(user.entitlement);
+  if (!entitlement) return false;
+
+  const hasAppFeature =
+    user.app_entitled !== false &&
+    (user.app_entitled === true || entitlement.features?.app === true);
+  if (!hasAppFeature) return false;
+
+  if (isLifetimeEntitlement(entitlement) || hasFutureGrace(entitlement)) return true;
+
+  return isEntitlementFresh(entitlement) && entitlement.active === true;
 }
 
 export function hasAppEntitlement(user: AppUser | null | undefined) {
@@ -174,7 +186,9 @@ export function hasAppEntitlement(user: AppUser | null | undefined) {
   const entitlement = asEntitlement(user.entitlement);
   if (!entitlement) return false;
 
-  const hasAppFeature = user.app_entitled === true || entitlement.features?.app === true;
+  const hasAppFeature =
+    user.app_entitled !== false &&
+    (user.app_entitled === true || entitlement.features?.app === true);
   if (!hasAppFeature) return false;
 
   // Perpetual (lifetime) grants and server-issued offline grace windows stay
@@ -199,15 +213,17 @@ export function hasConsumerAppSubscription(user: AppUser | null | undefined) {
     return hasAppEntitlement(user);
   }
 
-  // Legacy users may only have cloud_subscribed/app_entitled persisted locally.
-  // If the account also carries an enterprise-app requirement, that boolean may
+  // Legacy users may arrive from /api/user with cloud_subscribed but no
+  // entitlement object; normalizeAppUser turns that fresh server response into
+  // a checked entitlement. Never let the old persisted boolean alone count.
+  // If the account also carries an enterprise-app requirement, the app grant may
   // be the enterprise org grant, so do not treat it as a separate consumer sub.
   const enterpriseAccount = getEnterpriseAccount(user);
   return hasLegacyPaidAccess(user) && enterpriseAccount?.requires_enterprise_app !== true;
 }
 
 export function hasCloudEntitlement(user: AppUser | null | undefined) {
-  return user?.cloud_subscribed === true || hasEntitlementFeature(user, "cloud");
+  return hasEntitlementFeature(user, "cloud");
 }
 
 // Whether the account UI should treat this user as a *signed-in* cloud subscriber
@@ -238,20 +254,18 @@ export function isTokenHydrationPending(user: AppUser | null | undefined): boole
   return !!user && !!user.id && !user.token;
 }
 
-// store.bin keeps these entitlement signals even when the token doesn't hydrate,
-// so they're evidence the (now tokenless) account was a paying user — used to
-// fail the recording gate OPEN on a transient token loss instead of walling a
-// subscriber out mid-session.
+// store.bin keeps these entitlement signals even when the token doesn't hydrate.
+// They are evidence the (now tokenless) account was a paying user — unlike the
+// old cloud_subscribed boolean, which can linger after a refund/cancel.
 export function hasPersistedEntitlementEvidence(user: AppUser | null | undefined): boolean {
   if (!user) return false;
-  if (user.cloud_subscribed === true) return true;
   if (user.app_entitled === true) return true;
   const entitlement = asEntitlement(user.entitlement);
   return entitlement?.features?.app === true || entitlement?.active === true;
 }
 
 export function needsAppEntitlementRefresh(user: AppUser | null | undefined) {
-  if (!user?.token || hasLegacyPaidAccess(user)) return false;
+  if (!user?.token) return false;
 
   const entitlement = asEntitlement(user.entitlement);
   // Lifetime grants and active grace windows are already honored offline, so
@@ -299,17 +313,20 @@ export function planDisplayName(
 export function normalizeAppUser(rawUser: any, token: string): AppUser {
   const checkedAt = new Date().toISOString();
   const rawEntitlement = asEntitlement(rawUser?.entitlement);
+  const cloudSubscribed = rawUser?.cloud_subscribed === true;
   const appEntitled =
     typeof rawUser?.app_entitled === "boolean"
       ? rawUser.app_entitled
-      : hasLegacyPaidAccess(rawUser);
+      : rawEntitlement
+        ? rawEntitlement.features?.app === true
+        : cloudSubscribed;
   const subscriptionPlan =
     rawUser?.subscription_plan ??
-    (rawUser?.cloud_subscribed === true ? "pro" : appEntitled ? "standard" : null);
+    (cloudSubscribed ? "pro" : appEntitled ? "standard" : null);
   const entitlement =
     rawEntitlement
       ? { ...rawEntitlement, checked_at: rawEntitlement.checked_at ?? checkedAt }
-      : typeof rawUser?.app_entitled === "boolean"
+      : typeof rawUser?.app_entitled === "boolean" || cloudSubscribed
         ? {
             active: appEntitled,
             plan: subscriptionPlan,
@@ -317,7 +334,7 @@ export function normalizeAppUser(rawUser: any, token: string): AppUser {
             checked_at: checkedAt,
             features: {
               app: appEntitled,
-              cloud: rawUser?.cloud_subscribed === true,
+              cloud: cloudSubscribed,
             },
           }
         : null;

--- a/apps/screenpipe-app-tauri/lib/upsell-gating.ts
+++ b/apps/screenpipe-app-tauri/lib/upsell-gating.ts
@@ -25,7 +25,7 @@ export const MODEL_UPSELL_FLAG = "model_gating_upsell";
  * Fails OPEN on two axes so we never nag a paying customer:
  *   1. Off entirely unless the PostHog flag is on.
  *   2. Never shown to a user carrying persisted evidence of a paid plan
- *      (cloud_subscribed / app_entitled), so a transient tier flicker — the
+ *      (app_entitled / entitlement), so a transient tier flicker — the
  *      exact failure mode behind past "gate fired on payers" complaints —
  *      can't false-lock them even if the live signal momentarily says free.
  */

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1531,54 +1531,29 @@ impl SettingsStore {
             return true;
         }
 
-        // Legacy cloud subscribers keep working during rollout.
-        if self.user.cloud_subscribed == Some(true) {
-            return true;
-        }
+        self.has_current_app_entitlement()
+    }
 
+    fn has_current_app_entitlement(&self) -> bool {
         let Some(entitlement) = self.user.entitlement.as_ref() else {
             return false;
         };
 
-        let has_app_feature =
-            self.user.app_entitled == Some(true) || entitlement_feature(entitlement, "app");
+        let has_app_feature = self.user.app_entitled != Some(false)
+            && (self.user.app_entitled == Some(true) || entitlement_feature(entitlement, "app"));
         if !has_app_feature {
             return false;
         }
 
-        // Perpetual (lifetime) grants and server-issued offline grace windows stay
-        // valid even when the cached entitlement is stale. A local-first app must
-        // not stop recording just because it could not reach the server for a few
-        // days.
         if entitlement_is_lifetime(entitlement) || entitlement_has_future_grace(entitlement) {
             return true;
         }
 
-        // Otherwise require a recent check confirming the plan is still active.
         entitlement_checked_recently(entitlement) && entitlement_active(entitlement)
     }
 
     fn cloud_transcription_entitled(&self) -> bool {
-        // Legacy cloud subscribers keep working during the paid-plan rollout.
-        if self.user.cloud_subscribed == Some(true) {
-            return true;
-        }
-
-        let Some(entitlement) = self.user.entitlement.as_ref() else {
-            return false;
-        };
-
-        let has_app_feature =
-            self.user.app_entitled == Some(true) || entitlement_feature(entitlement, "app");
-        if !has_app_feature {
-            return false;
-        }
-
-        if entitlement_is_lifetime(entitlement) || entitlement_has_future_grace(entitlement) {
-            return true;
-        }
-
-        entitlement_checked_recently(entitlement) && entitlement_active(entitlement)
+        self.has_current_app_entitlement()
     }
 
     pub fn audio_engine_resolution(&self) -> AudioEngineResolution {
@@ -1962,6 +1937,50 @@ mod tests {
     }
 
     #[test]
+    fn stale_legacy_cloud_subscribed_does_not_count_as_app_entitled() {
+        let mut store = SettingsStore::default();
+        store.user.token = Some("token".to_string());
+        store.user.cloud_subscribed = Some(true);
+        store.user.entitlement = None;
+
+        assert!(!store.has_current_app_entitlement());
+    }
+
+    #[test]
+    fn fresh_app_entitlement_counts_as_app_entitled() {
+        let mut store = SettingsStore::default();
+        store.user.token = Some("token".to_string());
+        store.user.cloud_subscribed = Some(false);
+        store.user.app_entitled = Some(true);
+        store.user.entitlement = Some(json!({
+            "active": true,
+            "plan": "standard",
+            "source": "subscription",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "features": { "app": true, "cloud": false }
+        }));
+
+        assert!(store.has_current_app_entitlement());
+    }
+
+    #[test]
+    fn explicit_app_entitlement_denial_overrides_cached_entitlement_blob() {
+        let mut store = SettingsStore::default();
+        store.user.token = Some("token".to_string());
+        store.user.cloud_subscribed = Some(true);
+        store.user.app_entitled = Some(false);
+        store.user.entitlement = Some(json!({
+            "active": true,
+            "plan": "pro",
+            "source": "subscription",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "features": { "app": true, "cloud": true }
+        }));
+
+        assert!(!store.has_current_app_entitlement());
+    }
+
+    #[test]
     fn screenpipe_cloud_falls_back_when_not_logged_in() {
         let mut store = SettingsStore::default();
         store.recording.audio_transcription_engine = "screenpipe-cloud".to_string();
@@ -2018,7 +2037,7 @@ mod tests {
     }
 
     #[test]
-    fn screenpipe_cloud_stays_active_for_subscribed_users() {
+    fn screenpipe_cloud_falls_back_for_stale_legacy_cloud_subscribed_without_entitlement() {
         let mut store = SettingsStore::default();
         store.recording.audio_transcription_engine = "screenpipe-cloud".to_string();
         store.user.token = Some("token".to_string());
@@ -2026,8 +2045,11 @@ mod tests {
 
         let resolution = store.audio_engine_resolution();
 
-        assert_eq!(resolution.active, "screenpipe-cloud");
-        assert_eq!(resolution.fallback_reason, None);
+        assert_eq!(resolution.active, FALLBACK_ENGINE);
+        assert_eq!(
+            resolution.fallback_reason,
+            Some(AudioEngineFallbackReason::NotSubscribed)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- stop treating persisted `cloud_subscribed: true` as app/cloud access by itself
- normalize fresh legacy `/api/user` cloud subscribers into checked entitlements, while letting explicit `app_entitled: false` win
- apply the same current-entitlement check to native recording/cloud transcription paths
- add unit and e2e coverage for cloud-subscribed accounts that are explicitly denied app access

## Verification
- `bunx vitest run --config vitest.config.ts lib/app-entitlement.test.ts lib/__tests__/upsell-gating.test.ts components/app-entitlement-gate.test.tsx` ✅ 48 tests
- `rustfmt --check src-tauri/src/store.rs` ✅
- `git diff --check` ✅

## E2E note
- Added `e2e/specs/zz-app-entitlement-gate.spec.ts` coverage for `cloud_subscribed: true` + `app_entitled: false`.
- Local WDIO execution was blocked before the spec ran because this clean worktree did not have the required debug app binary. After preparing bundled sidecars, native build/test still hit baseline build blockers unrelated to this patch: missing `../out` frontend export and an existing `src/pi.rs` compile error (`bun_command` not in scope).