### PR TITLE
[codex] fix stale Windows E2E settings assertions

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -450,7 +450,7 @@ describe("Windows user journey", function () {
       await waitForBodyText(
         (bodyText) =>
           bodyText.includes("auto-select audio devices") &&
-          bodyText.includes("microphone echo cancellation") &&
+          bodyText.includes("echo cancellation") &&
           bodyText.includes("windows wasapi aec"),
         "Windows audio troubleshooting controls did not appear after enabling audio recording",
       );
@@ -716,7 +716,7 @@ describe("Windows user journey", function () {
     const notificationId = `windows-e2e-bell-${Date.now()}`;
     const notificationTitle = "Windows UX notification";
     const notificationBody = "Notification body visible from the bell history.";
-    const displayChangesSelector = '[data-testid="notification-pref-display-changes"]';
+    const displayChangesSelector = '[data-testid="notification-pref-displayChanges"]';
     let initialDisplayChanges: boolean | null = null;
 
     try {


### PR DESCRIPTION
## Summary
- update the Windows recording-settings E2E assertion to match the current `Echo cancellation` heading
- update the notification settings selector to the current registry-driven `displayChanges` test id

## Evidence
- shared Windows E2E failures from job `84644978809` on run `28550087353`
- failure 1: `Windows audio troubleshooting controls did not appear after enabling audio recording`
- failure 2: `[data-testid="notification-pref-display-changes"] still not existing after 30000ms`
- current app code renders `Echo cancellation` in `recording-settings.tsx` and `data-testid="notification-pref-displayChanges"` in `notifications-settings.tsx`

## Validation
- `cd apps/screenpipe-app-tauri && bun run typecheck`
- `git diff --check`

## Notes
- full local WDIO execution in a fresh scratch worktree still requires the Tauri debug app binary at `src-tauri/target/debug/screenpipe-app`
- I verified the exact code path and selector drift locally; the WDIO runner got past dependency resolution but could not start without that built binary
