### PR TITLE
[codex] force fresh session when switching onboarding account

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -104,15 +104,16 @@ describe("onboarding login gate", () => {
     expect(mocks.loadUser).toHaveBeenLastCalledWith("t3", true);
   });
 
-  it("'use a different account' clears the auth token so they can re-login", async () => {
+  it("'use a different account' clears auth state and reopens login with a fresh session", async () => {
     mocks.settings = { user: { token: "t4", id: "u4", email: "x@y.com", cloud_subscribed: true } };
     mocks.hasAppEntitlement.mockReturnValue(false);
     render(<OnboardingLogin handleNextSlide={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /use a different account/i }));
-    expect(mocks.updateSettings).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.updateSettings).toHaveBeenCalledTimes(1));
     const arg = mocks.updateSettings.mock.calls[0][0];
     expect(arg.user.token).toBeNull();
     expect(arg.user.id).toBeNull();
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
   });
 
   it("shows the sign-in button when not signed in", () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -282,12 +282,12 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
     setRechecking(false);
   }, [settings.user?.token, rechecking, loadUser]);
 
-  const useDifferentAccount = useCallback(() => {
+  const useDifferentAccount = useCallback(async () => {
     posthog.capture("onboarding_login_switch_account");
     reverifiedRef.current = false;
     // Clear the auth-bearing fields so we drop back to the "sign in" button and the
     // member can re-authenticate with their work email (the one on the license).
-    updateSettings({
+    await updateSettings({
       user: {
         ...settings.user,
         id: null,
@@ -299,6 +299,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
         entitlement: null,
       },
     });
+    commands.openLoginWindow(true);
   }, [settings.user, updateSettings]);
 
   const handleLogin = useCallback(() => {


### PR DESCRIPTION
## Summary
- make the onboarding `use a different account` path reopen login with `freshSession=true`
- mirror the existing entitlement-gate behavior so Google does not silently reuse the previous signed-in account
- tighten the onboarding regression test to assert both auth-state clearing and the fresh-session reopen

## Evidence
- fixes #4720
- `apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx` previously cleared local auth state but left the follow-up sign-in on the default login session
- `apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx` already uses `commands.openLoginWindow(true)` for the same recovery flow, which exposed the mismatch

## Tests
- `bunx vitest run --config vitest.config.ts components/onboarding/login-gate.test.tsx`
- `bunx tsc --noEmit`
- `bunx @biomejs/biome check components/onboarding/login-gate.tsx components/onboarding/login-gate.test.tsx`

## Risk
- low: scoped to the onboarding account-switch recovery path; normal sign-in still uses the existing default-session flow
