### PR TITLE
[codex] fix macOS app icon memory spike

### DIFF
--- a/apps/screenpipe-app-tauri/components/ui/multi-select.tsx
+++ b/apps/screenpipe-app-tauri/components/ui/multi-select.tsx
@@ -48,6 +48,8 @@ function OptionIcon({
         src={iconUrl}
         alt=""
         className={cn("rounded-sm object-contain", className)}
+        loading="lazy"
+        decoding="async"
         onLoad={(e) => {
           const img = e.target as HTMLImageElement;
           if (img.naturalWidth <= 2) setImgFailed(true);

--- a/apps/screenpipe-app-tauri/src-tauri/src/audio_exclusions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/audio_exclusions.rs
@@ -161,7 +161,7 @@ fn bundle_name_from_plist(plist: &plist::Value, app_path: &Path) -> String {
 #[cfg(target_os = "macos")]
 fn icon_data_url_for_app(app_path: &str) -> Option<String> {
     use cocoa::base::{id, nil};
-    use cocoa::foundation::{NSAutoreleasePool, NSData, NSSize, NSString};
+    use cocoa::foundation::{NSAutoreleasePool, NSString};
     use objc::{class, msg_send, sel, sel_impl};
 
     unsafe {
@@ -174,27 +174,9 @@ fn icon_data_url_for_app(app_path: &str) -> Option<String> {
             return None;
         }
 
-        let size = NSSize::new(32.0, 32.0);
-        let _: () = msg_send![icon, setSize: size];
-
-        let tiff_data: id = msg_send![icon, TIFFRepresentation];
-        if tiff_data == nil {
-            return None;
-        }
-        let image_rep: id = msg_send![class!(NSBitmapImageRep), imageRepWithData: tiff_data];
-        if image_rep == nil {
-            return None;
-        }
-        // NSBitmapImageFileTypePNG = 0
-        let png_data: id = msg_send![image_rep, representationUsingType: 0 properties: nil];
-        if png_data == nil {
-            return None;
-        }
-
-        let length = NSData::length(png_data);
-        let bytes = NSData::bytes(png_data);
-        let data = std::slice::from_raw_parts(bytes as *const u8, length as usize);
-        Some(format!("data:image/png;base64,{}", BASE64.encode(data)))
+        let data = crate::icons::encode_nsimage_as_small_png(icon)?;
+        let encoded = BASE64.encode(&data);
+        Some(format!("data:image/png;base64,{}", encoded))
     }
 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/icons.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/icons.rs
@@ -7,12 +7,71 @@ pub struct AppIcon {
 }
 
 #[cfg(target_os = "macos")]
+pub(crate) fn encode_nsimage_as_small_png(icon: cocoa::base::id) -> Option<Vec<u8>> {
+    use cocoa::base::{id, nil};
+    use cocoa::foundation::{NSData, NSPoint, NSRect, NSSize};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    unsafe {
+        if icon == nil {
+            return None;
+        }
+
+        let target_size = NSSize::new(32.0, 32.0);
+        let target_rect = NSRect::new(NSPoint::new(0.0, 0.0), target_size);
+        let zero_rect = NSRect::new(NSPoint::new(0.0, 0.0), NSSize::new(0.0, 0.0));
+        let resized: id = msg_send![class!(NSImage), alloc];
+        let resized: id = msg_send![resized, initWithSize: target_size];
+        if resized == nil {
+            return None;
+        }
+
+        let _: () = msg_send![resized, lockFocus];
+        // NSCompositingOperationSourceOver = 2.
+        let _: () = msg_send![
+            icon,
+            drawInRect: target_rect
+            fromRect: zero_rect
+            operation: 2usize
+            fraction: 1.0f64
+        ];
+        let _: () = msg_send![resized, unlockFocus];
+
+        let tiff_data: id = msg_send![resized, TIFFRepresentation];
+        if tiff_data == nil {
+            let _: () = msg_send![resized, release];
+            return None;
+        }
+
+        let image_rep: id = msg_send![class!(NSBitmapImageRep), imageRepWithData: tiff_data];
+        if image_rep == nil {
+            let _: () = msg_send![resized, release];
+            return None;
+        }
+
+        // NSBitmapImageFileTypePNG = 4.
+        let png_data: id = msg_send![image_rep, representationUsingType: 4usize properties:nil];
+        if png_data == nil {
+            let _: () = msg_send![resized, release];
+            return None;
+        }
+
+        let length = NSData::length(png_data);
+        let bytes = NSData::bytes(png_data);
+        let data = std::slice::from_raw_parts(bytes as *const u8, length as usize).to_vec();
+        let _: () = msg_send![resized, release];
+
+        Some(data)
+    }
+}
+
+#[cfg(target_os = "macos")]
 pub async fn get_app_icon(
     app_name: &str,
     app_path: Option<String>,
 ) -> Result<Option<AppIcon>, String> {
     use cocoa::base::{id, nil};
-    use cocoa::foundation::{NSAutoreleasePool, NSData, NSString};
+    use cocoa::foundation::{NSAutoreleasePool, NSString};
     use objc::{class, msg_send, sel, sel_impl};
 
     unsafe {
@@ -45,13 +104,9 @@ pub async fn get_app_icon(
                 return Ok(None);
             }
 
-            let tiff_data: id = msg_send![icon, TIFFRepresentation];
-            let image_rep: id = msg_send![class!(NSBitmapImageRep), imageRepWithData: tiff_data];
-            let png_data: id = msg_send![image_rep, representationUsingType:0 properties:nil]; // Type 0 is PNG (supports transparency)
-
-            let length = NSData::length(png_data);
-            let bytes = NSData::bytes(png_data);
-            let data = std::slice::from_raw_parts(bytes as *const u8, length as usize).to_vec();
+            let Some(data) = encode_nsimage_as_small_png(icon) else {
+                return Ok(None);
+            };
 
             Ok(Some(AppIcon {
                 data,
@@ -751,6 +806,55 @@ pub fn list_installed_apps() -> Vec<String> {
     }
 
     names.into_iter().collect()
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod macos_tests {
+    use super::encode_nsimage_as_small_png;
+    use cocoa::base::{id, nil};
+    use cocoa::foundation::{NSAutoreleasePool, NSString};
+    use objc::{class, msg_send, sel, sel_impl};
+
+    fn first_available_system_icon() -> Option<id> {
+        unsafe {
+            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            for app_name in ["Safari", "TextEdit", "Finder"] {
+                let ns_app_name = NSString::alloc(nil).init_str(app_name);
+                let path: id = msg_send![workspace, fullPathForApplication: ns_app_name];
+                let _: () = msg_send![ns_app_name, release];
+                if path == nil {
+                    continue;
+                }
+
+                let icon: id = msg_send![workspace, iconForFile: path];
+                if icon != nil {
+                    return Some(icon);
+                }
+            }
+            None
+        }
+    }
+
+    #[test]
+    fn macos_icon_encoder_returns_small_png() {
+        unsafe {
+            let pool = NSAutoreleasePool::new(nil);
+            let icon = first_available_system_icon().expect("expected a system app icon on macOS");
+            let data = encode_nsimage_as_small_png(icon).expect("expected encoded app icon");
+            let _: () = msg_send![pool, drain];
+
+            assert!(
+                data.starts_with(b"\x89PNG\r\n\x1a\n"),
+                "app icon should be encoded as PNG, got first bytes: {:02x?}",
+                &data[..data.len().min(8)]
+            );
+            assert!(
+                data.len() < 128 * 1024,
+                "downsampled app icon should stay small, got {} bytes",
+                data.len()
+            );
+        }
+    }
 }
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary
- Fix macOS app icon responses to downsample icons to 32pt before encoding.
- Use the correct AppKit bitmap file type for PNG (`NSBitmapImageFileTypePNG = 4`) instead of returning TIFF-style bytes from the icon route.
- Share the tested native encoder between `/app-icon` and the audio-exclusion app metadata path.
- Add lazy/async decoding for option icons in the multi-select UI so privacy/audio app icon lists do less eager image work.
- Add a macOS unit regression test that asserts the native encoder returns PNG bytes and keeps app icon payloads below 128 KB.

## Why
The `/app-icon` endpoint was returning very large icon payloads on macOS. In the live installed app, `VLC` returned an 8.0 MB `TIFF image data` payload while the response was treated as `image/png`. Opening icon-heavy settings surfaces can request dozens of these icons and push large image payloads through the Tauri/WebKit boundary.

## Before / after proof
Live old endpoint evidence before the fix:
- `curl --get --data-urlencode 'name=VLC' http://localhost:11435/app-icon` produced an 8.0 MB response.
- `file` reported `TIFF image data, big-endian`.
- A loop over installed apps transferred ~1.0 GB of icon bytes per pass; two passes increased the old running app RSS by roughly 380 MB.

Local AppKit comparison of old vs fixed encoding path, without touching the currently running old app again:
- apps compared: 121
- old total bytes: 1,011,296,246
- fixed total bytes: 1,366,557
- reduction: 740.0x
- largest old icon payload: Alacritty, 8,392,486 bytes
- largest fixed icon payload: Image Playground, 19,515 bytes
- spot checks: VLC fixed 32pt PNG = 5,955 bytes; Safari fixed 32pt PNG = 16,036 bytes

## Validation
- `rustfmt --edition 2021 apps/screenpipe-app-tauri/src-tauri/src/icons.rs apps/screenpipe-app-tauri/src-tauri/src/audio_exclusions.rs`
- `git diff --check -- apps/screenpipe-app-tauri/src-tauri/src/icons.rs apps/screenpipe-app-tauri/src-tauri/src/audio_exclusions.rs apps/screenpipe-app-tauri/components/ui/multi-select.tsx`
- Native Swift/AppKit before/after payload probe above.
- Added unit test: `macos_icon_encoder_returns_small_png`.

Blocked locally:
- Fresh clean-worktree `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --features e2e` first hit local disk exhaustion while rebuilding dependencies.
- Retried with the warm target cache; it progressed through dependencies but failed in the app build script before compiling the app crate because `resource path bun-aarch64-apple-darwin doesn't exist` in this local environment.
- Added a temporary local `bun-aarch64-apple-darwin` stub and tried `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml macos_icon_encoder_returns_small_png -- --nocapture`; that progressed further but hit local disk exhaustion while compiling native deps (`aws-lc-sys`/AppKit crates), before the test binary ran.
