### PR TITLE
[codex] move E2E app data under temp scope

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/helpers/app-launcher.ts
+++ b/apps/screenpipe-app-tauri/e2e/helpers/app-launcher.ts
@@ -4,6 +4,7 @@
 
 import { spawn, execSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 
@@ -50,7 +51,9 @@ function killPort(port: number): void {
 
 // e2e/helpers/ → ../.. = app root (Bun runs from source, no dist)
 const APP_ROOT = resolve(__dirname, '../..');
-export const E2E_DATA_DIR = resolve(APP_ROOT, '.e2e');
+// Keep E2E data outside the repo checkout so Tauri's fs scope (which already
+// allows $TEMP/**) can read/write chats and fixtures on Windows CI.
+export const E2E_DATA_DIR = resolve(tmpdir(), 'screenpipe-app-tauri.e2e');
 const APP_PID_FILE = resolve(E2E_DATA_DIR, 'app.pid');
 
 // `onboarding` marks the onboarding store complete so the app drops straight

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-system-integration.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-system-integration.spec.ts
@@ -12,6 +12,7 @@
 
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { E2E_DATA_DIR, getAppPath, getAppPid, WEBDRIVER_PORT } from "../helpers/app-launcher.js";
 import { authHeaders, fetchJson, getLocalApiConfig, waitForLocalApi } from "../helpers/api-utils.js";
@@ -197,6 +198,7 @@ Add-Type -AssemblyName System.Windows.Forms
     if (!isWindows || !api) this.skip();
 
     expect(E2E_DATA_DIR.toLowerCase()).toContain(".e2e");
+    expect(E2E_DATA_DIR.toLowerCase()).toContain(tmpdir().toLowerCase());
     expect(E2E_DATA_DIR.toLowerCase()).not.toContain("\\appdata\\roaming\\.screenpipe");
     expect(existsSync(E2E_DATA_DIR)).toBe(true);
     expect(statSync(E2E_DATA_DIR).isDirectory()).toBe(true);


### PR DESCRIPTION
## Summary
- move the WebDriver E2E `SCREENPIPE_DATA_DIR` from the repo checkout into a stable OS temp path that still includes a `.e2e` marker
- keep the existing Windows isolation assertion but strengthen it to require the E2E data dir to live under `tmpdir()`

## Evidence
- PR #4724 is currently failing `Windows E2E Tests` with `forbidden path: D:\a\screenpipe\screenpipe\apps\screenpipe-app-tauri\.e2e\chats, maybe it is not allowed on the scope for allow-exists permission in your capability file`
- the Tauri capability already allows `$TEMP/**`, but the prior harness path lived under the repo checkout, outside the allowed fs scope
- follow-on WDIO timeouts happen after that denial, so fixing the path is the smallest scoped change to unblock the lane

## Tests
- `bunx tsx -e "import { E2E_DATA_DIR } from './e2e/helpers/app-launcher.ts'; console.log(E2E_DATA_DIR);"`
- `bunx tsx -e "(async () => { globalThis.describe = () => {}; globalThis.it = () => {}; globalThis.before = () => {}; globalThis.after = () => {}; globalThis.beforeEach = () => {}; globalThis.afterEach = () => {}; await import('./e2e/specs/windows-system-integration.spec.ts'); console.log('parsed windows-system-integration.spec.ts'); })().catch((err) => { console.error(err); process.exit(1); });"`

## Notes
- `bun run typecheck` is not currently usable in this local environment: the invoked TypeScript toolchain rejects the repo's `moduleResolution: bundler` config before reaching app code.
- no screen recording is applicable here because this is an E2E harness / CI-path fix rather than a user-visible UI change.
