### PR TITLE
[codex] force fresh onboarding login on account switch

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -15,9 +15,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   settings: { user: null as any },
   loadUser: vi.fn().mockResolvedValue(undefined),
-  updateSettings: vi.fn(),
+  updateSettings: vi.fn().mockResolvedValue(undefined),
   capture: vi.fn(),
-  openLoginWindow: vi.fn(),
+  openLoginWindow: vi.fn().mockResolvedValue(undefined),
+  setCloudToken: vi.fn().mockResolvedValue(undefined),
+  piUpdateConfig: vi.fn().mockResolvedValue(undefined),
   hasAppEntitlement: vi.fn(),
   isDevBillingBypassEnabled: vi.fn().mockReturnValue(false),
 }));
@@ -34,7 +36,11 @@ vi.mock("@/lib/app-entitlement", () => ({
   isDevBillingBypassEnabled: () => mocks.isDevBillingBypassEnabled(),
 }));
 vi.mock("@/lib/utils/tauri", () => ({
-  commands: { openLoginWindow: mocks.openLoginWindow },
+  commands: {
+    openLoginWindow: mocks.openLoginWindow,
+    setCloudToken: mocks.setCloudToken,
+    piUpdateConfig: mocks.piUpdateConfig,
+  },
 }));
 vi.mock("posthog-js", () => ({ default: { capture: mocks.capture } }));
 vi.mock("framer-motion", () => ({
@@ -60,8 +66,11 @@ beforeEach(() => {
   HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;
   mocks.settings = { user: null };
   mocks.loadUser.mockReset().mockResolvedValue(undefined);
-  mocks.updateSettings.mockClear();
+  mocks.updateSettings.mockReset().mockResolvedValue(undefined);
   mocks.capture.mockClear();
+  mocks.openLoginWindow.mockReset().mockResolvedValue(undefined);
+  mocks.setCloudToken.mockReset().mockResolvedValue(undefined);
+  mocks.piUpdateConfig.mockReset().mockResolvedValue(undefined);
   mocks.hasAppEntitlement.mockReset();
   mocks.isDevBillingBypassEnabled.mockReturnValue(false);
 });
@@ -104,15 +113,15 @@ describe("onboarding login gate", () => {
     expect(mocks.loadUser).toHaveBeenLastCalledWith("t3", true);
   });
 
-  it("'use a different account' clears the auth token so they can re-login", async () => {
+  it("'use a different account' clears local auth and reopens login with a fresh session", async () => {
     mocks.settings = { user: { token: "t4", id: "u4", email: "x@y.com", cloud_subscribed: true } };
     mocks.hasAppEntitlement.mockReturnValue(false);
     render(<OnboardingLogin handleNextSlide={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /use a different account/i }));
-    expect(mocks.updateSettings).toHaveBeenCalledTimes(1);
-    const arg = mocks.updateSettings.mock.calls[0][0];
-    expect(arg.user.token).toBeNull();
-    expect(arg.user.id).toBeNull();
+    await waitFor(() => expect(mocks.updateSettings).toHaveBeenCalledWith({ user: null }));
+    expect(mocks.setCloudToken).toHaveBeenCalledWith(null);
+    expect(mocks.piUpdateConfig).toHaveBeenCalledWith(null, null);
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
   });
 
   it("shows the sign-in button when not signed in", () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -282,24 +282,26 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
     setRechecking(false);
   }, [settings.user?.token, rechecking, loadUser]);
 
-  const useDifferentAccount = useCallback(() => {
+  const useDifferentAccount = useCallback(async () => {
     posthog.capture("onboarding_login_switch_account");
     reverifiedRef.current = false;
-    // Clear the auth-bearing fields so we drop back to the "sign in" button and the
-    // member can re-authenticate with their work email (the one on the license).
-    updateSettings({
-      user: {
-        ...settings.user,
-        id: null,
-        token: null,
-        clerk_id: null,
-        cloud_subscribed: null,
-        app_entitled: null,
-        subscription_plan: null,
-        entitlement: null,
-      },
-    });
-  }, [settings.user, updateSettings]);
+    await updateSettings({ user: null as any });
+    try {
+      await commands.setCloudToken(null);
+    } catch (e) {
+      console.warn("failed to clear cloud token before switching accounts:", e);
+    }
+    try {
+      await commands.piUpdateConfig(null, null);
+    } catch (e) {
+      console.warn("failed to clear pi config before switching accounts:", e);
+    }
+    try {
+      await commands.openLoginWindow(true);
+    } catch (e) {
+      console.warn("failed to reopen login for account switch:", e);
+    }
+  }, [updateSettings]);
 
   const handleLogin = useCallback(() => {
     posthog.capture("onboarding_login_clicked");


### PR DESCRIPTION
## Summary
- make onboarding `use a different account` clear persisted auth and reopen login with a fresh session
- align the onboarding flow with the entitlement gate so Google account switching does not reuse the same cached session
- extend the onboarding unit test to assert the fresh-session relogin path

## Evidence
- fixes #4720
- reporter hit the no-subscription onboarding path and got silently re-authenticated into the same Google account instead of seeing an account chooser
- the onboarding gate only cleared local state, while the entitlement gate already called `openLoginWindow(true)` and cleared persisted auth state

## Tests
- `cargo fmt --all -- --check`
- `bunx vitest run components/onboarding/login-gate.test.tsx --config vitest.config.ts`
- `bun run typecheck`

## Residual Risk
- this changes only the onboarding switch-account path; other login entry points are unchanged
