### PR TITLE
[codex] relocate bundled bun before Linux AppImage execution

### DIFF
--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -251,8 +251,8 @@ jobs:
               squashfs-root/usr/bin/ffprobe -version
               squashfs-root/usr/bin/tesseract --version
               # The app relocates bundled bun out of the AppImage mount before
-              # executing it. In-place execution keeps bun's $ORIGIN/../lib
-              # RUNPATH pointed at the AppImage bundle and can SIGSEGV on newer
+              # executing it. In-place execution keeps the relative RUNPATH
+              # pointed at the AppImage bundle and can SIGSEGV on newer
               # hosts. Mirror the runtime path here instead of asserting the
               # extracted in-place binary is directly runnable.
               install -d /tmp/smoke-bun

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -195,6 +195,14 @@ jobs:
                 squashfs-root/usr/lib/libsharpyuv.so* \
                 squashfs-root/usr/lib/libavif.so*
 
+          # linuxdeploy rewrites the bundled bun sidecar with
+          # RUNPATH=$ORIGIN/../lib during AppImage assembly. That makes bun load
+          # the AppImage's bundled libc/libstdc++ set and SIGSEGV on newer hosts
+          # (Debian 13 Sentry/CI repro). Restore the pristine baseline bun that
+          # pre_build.js downloaded so screenpipe can continue scrubbing
+          # LD_LIBRARY_PATH and run bun against the host runtime.
+          install -m 0755 src-tauri/bun-x86_64-unknown-linux-gnu squashfs-root/usr/bin/bun
+
           # Guard the libavif/libsharpyuv fix: an orphan bundled libsharpyuv
           # shadows the host one and breaks Arch (libavif 1.4.2) with
           # "undefined symbol: SharpYuvConvertWithOptions". Fail if either
@@ -250,15 +258,7 @@ jobs:
               squashfs-root/usr/bin/ffmpeg -version
               squashfs-root/usr/bin/ffprobe -version
               squashfs-root/usr/bin/tesseract --version
-              # The app relocates bundled bun out of the AppImage mount before
-              # executing it. In-place execution keeps the relative RUNPATH
-              # pointed at the AppImage bundle and can SIGSEGV on newer
-              # hosts. Mirror the runtime path here instead of asserting the
-              # extracted in-place binary is directly runnable.
-              install -d /tmp/smoke-bun
-              cp squashfs-root/usr/bin/bun /tmp/smoke-bun/bun
-              chmod +x /tmp/smoke-bun/bun
-              env -u LD_LIBRARY_PATH /tmp/smoke-bun/bun --version
+              env -u LD_LIBRARY_PATH squashfs-root/usr/bin/bun --version
 
               check_ldd() {
                 local target="$1"

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -250,7 +250,15 @@ jobs:
               squashfs-root/usr/bin/ffmpeg -version
               squashfs-root/usr/bin/ffprobe -version
               squashfs-root/usr/bin/tesseract --version
-              env -u LD_LIBRARY_PATH squashfs-root/usr/bin/bun --version
+              # The app relocates bundled bun out of the AppImage mount before
+              # executing it. In-place execution keeps bun's $ORIGIN/../lib
+              # RUNPATH pointed at the AppImage bundle and can SIGSEGV on newer
+              # hosts. Mirror the runtime path here instead of asserting the
+              # extracted in-place binary is directly runnable.
+              install -d /tmp/smoke-bun
+              cp squashfs-root/usr/bin/bun /tmp/smoke-bun/bun
+              chmod +x /tmp/smoke-bun/bun
+              env -u LD_LIBRARY_PATH /tmp/smoke-bun/bun --version
 
               check_ldd() {
                 local target="$1"

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -363,9 +363,10 @@ jobs:
               app_bin="$(find squashfs-root/usr/bin -maxdepth 1 -type f -executable -iname "*screenpipe*" -print -quit)"
               test -n "${app_bin}"
 
-              export LD_LIBRARY_PATH=/smoke/squashfs-root/usr/lib
+              app_ld_library_path=/smoke/squashfs-root/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+              unset LD_LIBRARY_PATH
               set +e
-              su smoke-user -c "cd /smoke && export XDG_RUNTIME_DIR=/tmp/screenpipe-runtime && export SCREENPIPE_E2E_SEED=onboarding,no-recording && export LD_LIBRARY_PATH=/smoke/squashfs-root/usr/lib && timeout 20 dbus-run-session -- xvfb-run -a squashfs-root/AppRun --help" 2>&1 | tee /tmp/apprun-arch.log
+              su smoke-user -c "cd /smoke && export XDG_RUNTIME_DIR=/tmp/screenpipe-runtime && export SCREENPIPE_E2E_SEED=onboarding,no-recording && timeout 20 dbus-run-session -- xvfb-run -a env LD_LIBRARY_PATH=\"${app_ld_library_path}\" squashfs-root/AppRun --help" 2>&1 | tee /tmp/apprun-arch.log
               status="${PIPESTATUS[0]}"
               set -e
               # The exact failure we are guarding against.

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -779,6 +779,7 @@ jobs:
                   squashfs-root/usr/lib/libpcre2-8.so* \
                   squashfs-root/usr/lib/libsharpyuv.so* \
                   squashfs-root/usr/lib/libavif.so*
+            install -m 0755 src-tauri/bun-x86_64-unknown-linux-gnu squashfs-root/usr/bin/bun
             echo "Removed bundled GLib libs, repacking AppImage..."
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -486,6 +486,7 @@ jobs:
                   squashfs-root/usr/lib/libpcre2-8.so* \
                   squashfs-root/usr/lib/libsharpyuv.so* \
                   squashfs-root/usr/lib/libavif.so*
+            install -m 0755 src-tauri/bun-x86_64-unknown-linux-gnu squashfs-root/usr/bin/bun
             echo "Removed bundled GLib libs, repacking AppImage..."
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -864,42 +864,6 @@ fn clear_pi_install_artifacts(install_dir: &Path) {
     let _ = std::fs::remove_file(install_dir.join("package-lock.json"));
 }
 
-#[cfg(target_os = "linux")]
-fn should_relocate_linux_bundled_bun() -> bool {
-    std::env::var_os("APPIMAGE").is_some() || std::env::var_os("APPDIR").is_some()
-}
-
-#[cfg(target_os = "linux")]
-fn relocate_linux_bundled_bun(bundled: &Path, data_dir: &Path) -> std::io::Result<PathBuf> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let runtime_dir = data_dir.join("runtime");
-    std::fs::create_dir_all(&runtime_dir)?;
-
-    let relocated = runtime_dir.join("bun");
-    let needs_refresh = match std::fs::metadata(&relocated) {
-        Ok(existing) => {
-            let source = std::fs::metadata(bundled)?;
-            source.len() != existing.len()
-                || source.modified().ok() != existing.modified().ok()
-        }
-        Err(_) => true,
-    };
-
-    if needs_refresh {
-        let temp = runtime_dir.join("bun.tmp");
-        let _ = std::fs::remove_file(&temp);
-        let _ = std::fs::remove_file(&relocated);
-        std::fs::copy(bundled, &temp)?;
-        let mut perms = std::fs::metadata(&temp)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&temp, perms)?;
-        std::fs::rename(&temp, &relocated)?;
-    }
-
-    Ok(relocated)
-}
-
 fn apply_no_window(_cmd: &mut Command) {
     #[cfg(windows)]
     {
@@ -3045,25 +3009,6 @@ fn find_bun_executable() -> Option<String> {
             let bundled = exe_folder.join(if cfg!(windows) { "bun.exe" } else { "bun" });
             debug!("Checking bundled bun at: {}", bundled.display());
             if bundled.exists() {
-                #[cfg(target_os = "linux")]
-                if should_relocate_linux_bundled_bun() {
-                    let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
-                    match relocate_linux_bundled_bun(&bundled, &data_dir) {
-                        Ok(relocated) => {
-                            info!(
-                                "Using relocated bundled bun at: {} (source: {})",
-                                relocated.display(),
-                                bundled.display()
-                            );
-                            return Some(relocated.to_string_lossy().to_string());
-                        }
-                        Err(e) => warn!(
-                            "Failed to relocate bundled bun from {}: {}; falling back to in-place binary",
-                            bundled.display(),
-                            e
-                        ),
-                    }
-                }
                 info!("Found bundled bun at: {}", bundled.display());
                 return Some(bundled.to_string_lossy().to_string());
             }
@@ -3481,66 +3426,6 @@ mod tests {
         super::remove_screenpipe_auth_from_path(&auth_path).expect("missing auth is ok");
 
         assert!(!auth_path.exists());
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn relocate_linux_bundled_bun_copies_into_runtime_dir() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let bundled_dir = dir.path().join("squashfs-root/usr/bin");
-        let data_dir = dir.path().join("screenpipe-data");
-        std::fs::create_dir_all(&bundled_dir).expect("create bundled dir");
-
-        let bundled = bundled_dir.join("bun");
-        std::fs::write(&bundled, b"#!/bin/sh\necho bundled-bun\n").expect("write bun");
-        let mut perms = std::fs::metadata(&bundled).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&bundled, perms).expect("chmod");
-
-        let relocated =
-            super::relocate_linux_bundled_bun(&bundled, &data_dir).expect("relocate bun");
-        assert_eq!(relocated, data_dir.join("runtime").join("bun"));
-        assert_ne!(relocated, bundled);
-        assert_eq!(
-            std::fs::read(&relocated).expect("read relocated"),
-            b"#!/bin/sh\necho bundled-bun\n"
-        );
-        let relocated_mode = std::fs::metadata(&relocated)
-            .expect("relocated metadata")
-            .permissions()
-            .mode();
-        assert_ne!(relocated_mode & 0o111, 0, "relocated bun must stay executable");
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn relocate_linux_bundled_bun_refreshes_changed_source() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let bundled_dir = dir.path().join("squashfs-root/usr/bin");
-        let data_dir = dir.path().join("screenpipe-data");
-        std::fs::create_dir_all(&bundled_dir).expect("create bundled dir");
-
-        let bundled = bundled_dir.join("bun");
-        std::fs::write(&bundled, b"bun-v1").expect("write bun v1");
-        let mut perms = std::fs::metadata(&bundled).expect("metadata").permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&bundled, perms).expect("chmod");
-
-        let relocated =
-            super::relocate_linux_bundled_bun(&bundled, &data_dir).expect("initial relocate");
-        assert_eq!(std::fs::read(&relocated).expect("read relocated"), b"bun-v1");
-
-        std::fs::write(&bundled, b"bun-v2-with-new-bytes").expect("write bun v2");
-        let relocated =
-            super::relocate_linux_bundled_bun(&bundled, &data_dir).expect("refresh relocate");
-        assert_eq!(
-            std::fs::read(&relocated).expect("read refreshed relocated"),
-            b"bun-v2-with-new-bytes"
-        );
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -864,6 +864,42 @@ fn clear_pi_install_artifacts(install_dir: &Path) {
     let _ = std::fs::remove_file(install_dir.join("package-lock.json"));
 }
 
+#[cfg(target_os = "linux")]
+fn should_relocate_linux_bundled_bun() -> bool {
+    std::env::var_os("APPIMAGE").is_some() || std::env::var_os("APPDIR").is_some()
+}
+
+#[cfg(target_os = "linux")]
+fn relocate_linux_bundled_bun(bundled: &Path, data_dir: &Path) -> std::io::Result<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let runtime_dir = data_dir.join("runtime");
+    std::fs::create_dir_all(&runtime_dir)?;
+
+    let relocated = runtime_dir.join("bun");
+    let needs_refresh = match std::fs::metadata(&relocated) {
+        Ok(existing) => {
+            let source = std::fs::metadata(bundled)?;
+            source.len() != existing.len()
+                || source.modified().ok() != existing.modified().ok()
+        }
+        Err(_) => true,
+    };
+
+    if needs_refresh {
+        let temp = runtime_dir.join("bun.tmp");
+        let _ = std::fs::remove_file(&temp);
+        let _ = std::fs::remove_file(&relocated);
+        std::fs::copy(bundled, &temp)?;
+        let mut perms = std::fs::metadata(&temp)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&temp, perms)?;
+        std::fs::rename(&temp, &relocated)?;
+    }
+
+    Ok(relocated)
+}
+
 fn apply_no_window(_cmd: &mut Command) {
     #[cfg(windows)]
     {
@@ -3009,6 +3045,25 @@ fn find_bun_executable() -> Option<String> {
             let bundled = exe_folder.join(if cfg!(windows) { "bun.exe" } else { "bun" });
             debug!("Checking bundled bun at: {}", bundled.display());
             if bundled.exists() {
+                #[cfg(target_os = "linux")]
+                if should_relocate_linux_bundled_bun() {
+                    let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
+                    match relocate_linux_bundled_bun(&bundled, &data_dir) {
+                        Ok(relocated) => {
+                            info!(
+                                "Using relocated bundled bun at: {} (source: {})",
+                                relocated.display(),
+                                bundled.display()
+                            );
+                            return Some(relocated.to_string_lossy().to_string());
+                        }
+                        Err(e) => warn!(
+                            "Failed to relocate bundled bun from {}: {}; falling back to in-place binary",
+                            bundled.display(),
+                            e
+                        ),
+                    }
+                }
                 info!("Found bundled bun at: {}", bundled.display());
                 return Some(bundled.to_string_lossy().to_string());
             }
@@ -3222,7 +3277,7 @@ mod tests {
     #[cfg(windows)]
     use super::parse_where_output;
     #[cfg(not(windows))]
-    use super::{find_bun_executable, find_pi_executable};
+    use super::{bun_command, find_bun_executable, find_pi_executable};
     use serde_json::{json, Value};
     use std::io::{BufRead, BufReader, Write};
     use std::process::{Command, Stdio};
@@ -3426,6 +3481,66 @@ mod tests {
         super::remove_screenpipe_auth_from_path(&auth_path).expect("missing auth is ok");
 
         assert!(!auth_path.exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn relocate_linux_bundled_bun_copies_into_runtime_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundled_dir = dir.path().join("squashfs-root/usr/bin");
+        let data_dir = dir.path().join("screenpipe-data");
+        std::fs::create_dir_all(&bundled_dir).expect("create bundled dir");
+
+        let bundled = bundled_dir.join("bun");
+        std::fs::write(&bundled, b"#!/bin/sh\necho bundled-bun\n").expect("write bun");
+        let mut perms = std::fs::metadata(&bundled).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&bundled, perms).expect("chmod");
+
+        let relocated =
+            super::relocate_linux_bundled_bun(&bundled, &data_dir).expect("relocate bun");
+        assert_eq!(relocated, data_dir.join("runtime").join("bun"));
+        assert_ne!(relocated, bundled);
+        assert_eq!(
+            std::fs::read(&relocated).expect("read relocated"),
+            b"#!/bin/sh\necho bundled-bun\n"
+        );
+        let relocated_mode = std::fs::metadata(&relocated)
+            .expect("relocated metadata")
+            .permissions()
+            .mode();
+        assert_ne!(relocated_mode & 0o111, 0, "relocated bun must stay executable");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn relocate_linux_bundled_bun_refreshes_changed_source() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bundled_dir = dir.path().join("squashfs-root/usr/bin");
+        let data_dir = dir.path().join("screenpipe-data");
+        std::fs::create_dir_all(&bundled_dir).expect("create bundled dir");
+
+        let bundled = bundled_dir.join("bun");
+        std::fs::write(&bundled, b"bun-v1").expect("write bun v1");
+        let mut perms = std::fs::metadata(&bundled).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&bundled, perms).expect("chmod");
+
+        let relocated =
+            super::relocate_linux_bundled_bun(&bundled, &data_dir).expect("initial relocate");
+        assert_eq!(std::fs::read(&relocated).expect("read relocated"), b"bun-v1");
+
+        std::fs::write(&bundled, b"bun-v2-with-new-bytes").expect("write bun v2");
+        let relocated =
+            super::relocate_linux_bundled_bun(&bundled, &data_dir).expect("refresh relocate");
+        assert_eq!(
+            std::fs::read(&relocated).expect("read refreshed relocated"),
+            b"bun-v2-with-new-bytes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **root cause**: AppImage assembly (linuxdeploy) rewrites `usr/bin/bun` with `RUNPATH=$ORIGIN/../lib`, so the bundled bun loads the AppImage's library set and crashes with SIGSEGV on Debian 13 — even a byte-identical copy outside the mount still crashes, because the RUNPATH is baked into the binary itself
- **fix**: restore the pristine `src-tauri/bun-x86_64-unknown-linux-gnu` into the extracted AppImage before repacking, in `linux-appimage-smoke.yml`, `release-app.yml`, and `release-enterprise.yml`
- scope Arch AppImage `LD_LIBRARY_PATH` to AppRun in the smoke workflow
- the earlier in-app relocation attempt has been removed (`c1c0699fe`): it could not fix the crash (see root cause), its refresh cache never hit (`fs::copy` doesn't preserve mtime, so every `find_bun_executable` call re-copied the ~90MB binary), and concurrent callers raced on a shared `bun.tmp`

## Why
- `Linux AppImage Smoke` was failing on Debian 13 with `squashfs-root/usr/bin/bun` exiting with `SIGSEGV` — this check reds **every open PR branch**, so it blocks the whole backlog
- same failure family in the wild via Sentry proxy logs (`SCREENPIPE-APP-DX`): `Pi background install failed: bun install failed (killed by signal 11 (SIGSEGV))` — the next Linux release ships a working bundled bun via the same one-line fix in the release workflows

## Validation
- local repro used the exact failed AppImage artifact from Actions: bundled bun crashed on Debian 13; the same artifact succeeded immediately after swapping in the pristine baseline bun (`1.3.10`), with and without `LD_LIBRARY_PATH=/mnt/usr/lib`
- the green `Build AppImage and smoke on Debian 13` run on this PR vs. today's failures on every other branch is the before/after evidence
- `cargo check --lib` and `cargo check --tests` pass after removing the relocation code

## Residual risk
- none in-app (the app-side change is now a net-deletion); the workflow change only swaps the bun binary inside the AppImage back to the pristine one that `pre_build.js` downloaded
