### PR TITLE
[codex] backfill sidebar history after initial hydrate

### DIFF
--- a/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
@@ -26,11 +26,12 @@ vi.mock("@/lib/chat-storage", () => ({
   saveConversationFile: vi.fn(async () => undefined),
 }));
 
-import { saveConversationFile } from "@/lib/chat-storage";
+import { listConversations, saveConversationFile } from "@/lib/chat-storage";
 import {
   flushPendingSaves,
   handlePiEvent,
   handleTerminated,
+  hydrateRemainingConversationHistory,
 } from "../stores/pi-event-router";
 import { useChatStore, type SessionRecord } from "../stores/chat-store";
 import type { AgentEventEnvelope, AgentInnerEvent } from "../events/types";
@@ -162,6 +163,48 @@ describe("pi-event-router: status mirroring for backgrounded sessions", () => {
     const session = useChatStore.getState().sessions.A;
     expect(session.lastContentAt).toBeGreaterThan(100);
     expect(session.unread).toBe(true);
+  });
+});
+
+describe("pi-event-router: history hydration", () => {
+  beforeEach(reset);
+
+  it("hydrates older conversation pages after the initial sidebar batch", async () => {
+    const listConversationsMock = vi.mocked(listConversations);
+    listConversationsMock
+      .mockResolvedValueOnce([
+        {
+          id: "old-51",
+          title: "older run",
+          createdAt: 51,
+          updatedAt: 51,
+          messageCount: 1,
+          pinned: false,
+          hidden: false,
+          kind: "chat",
+        },
+      ] as any)
+      .mockResolvedValueOnce([]);
+
+    await hydrateRemainingConversationHistory(50, 50);
+
+    expect(listConversationsMock).toHaveBeenNthCalledWith(1, {
+      limit: 50,
+      offset: 50,
+      includeHidden: false,
+    });
+    expect(useChatStore.getState().sessions["old-51"]).toEqual(
+      expect.objectContaining({
+        id: "old-51",
+        title: "older run",
+        messageCount: 1,
+      }),
+    );
+    expect(listConversationsMock).toHaveBeenNthCalledWith(2, {
+      limit: 50,
+      offset: 100,
+      includeHidden: false,
+    });
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
@@ -83,6 +83,7 @@ import {
 let mounted = false;
 let mountPromise: Promise<() => void> | null = null;
 let unregistrations: Unregister[] = [];
+const CHAT_HISTORY_BACKGROUND_BATCH_SIZE = 200;
 
 // Local aliases to keep `applyEventToSessionContent` / `statusForEvent`
 // loosely typed against the inner event without having to thread
@@ -320,6 +321,26 @@ export function handleTerminated(payload: AgentTerminatedPayload) {
 
 /** Hydrate the store from on-disk chat history once at boot. The router
  *  keeps this in sync afterwards via incremental events. */
+export async function hydrateRemainingConversationHistory(
+  startOffset = CHAT_HISTORY_INITIAL_LIMIT,
+  batchSize = CHAT_HISTORY_BACKGROUND_BATCH_SIZE,
+) {
+  const pageSize = Math.max(1, Math.floor(batchSize));
+  let offset = Math.max(0, Math.floor(startOffset));
+
+  while (true) {
+    const metas = await listConversations({
+      limit: pageSize,
+      offset,
+      includeHidden: false,
+    });
+    if (metas.length === 0) break;
+    const records: SessionRecord[] = metas.map(sessionRecordFromMeta);
+    useChatStore.getState().actions.hydrateFromDisk(records);
+    offset += pageSize;
+  }
+}
+
 async function hydrate() {
   try {
     const metas = await listConversations({
@@ -328,6 +349,7 @@ async function hydrate() {
     });
     const records: SessionRecord[] = metas.map(sessionRecordFromMeta);
     useChatStore.getState().actions.hydrateFromDisk(records);
+    void hydrateRemainingConversationHistory();
   } catch {
     // Storage may not be ready yet on first launch — non-fatal.
     useChatStore.getState().actions.markDiskHydrated();


### PR DESCRIPTION
## Summary
- backfill older conversations and pipe runs into the chat store after the sidebar's fast first-page hydrate
- keep the initial 50-row boot hydrate for responsiveness, but continue loading the remaining history in background pages
- add a router test that covers the second-page hydration path so older runs cannot silently disappear again

## Evidence
- fixes #4362
- real code path: `mountPiEventRouter()` boot hydrate only loaded `CHAT_HISTORY_INITIAL_LIMIT` rows into the in-memory sidebar store, so anything older never appeared in the left sidebar even though it existed on disk
- no conflicting open PR covers the sidebar history hydration path; recent codex PRs around timeline/update/search target different issue families

## Tests
- `bunx vitest run lib/__tests__/pi-event-router.test.ts --config vitest.config.ts`
- `bun run typecheck`

## Notes
- direct Sentry auth was unavailable in this run, so Sentry cleanup logs were only a proxy triage signal
- residual risk: very large chat histories still hydrate incrementally; the fix restores completeness without regressing startup by blocking on every conversation file at boot
