### PR TITLE
[codex] stop Linux Tauri builds from inheriting broken ASR defaults

### DIFF
--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -363,9 +363,10 @@ jobs:
               app_bin="$(find squashfs-root/usr/bin -maxdepth 1 -type f -executable -iname "*screenpipe*" -print -quit)"
               test -n "${app_bin}"
 
-              export LD_LIBRARY_PATH=/smoke/squashfs-root/usr/lib
+              app_ld_library_path=/smoke/squashfs-root/usr/lib
+              unset LD_LIBRARY_PATH
               set +e
-              su smoke-user -c "cd /smoke && export XDG_RUNTIME_DIR=/tmp/screenpipe-runtime && export SCREENPIPE_E2E_SEED=onboarding,no-recording && export LD_LIBRARY_PATH=/smoke/squashfs-root/usr/lib && timeout 20 dbus-run-session -- xvfb-run -a squashfs-root/AppRun --help" 2>&1 | tee /tmp/apprun-arch.log
+              su smoke-user -c "cd /smoke && export XDG_RUNTIME_DIR=/tmp/screenpipe-runtime && export SCREENPIPE_E2E_SEED=onboarding,no-recording && timeout 20 dbus-run-session -- xvfb-run -a env LD_LIBRARY_PATH=\"${app_ld_library_path}\" squashfs-root/AppRun --help" 2>&1 | tee /tmp/apprun-arch.log
               status="${PIPESTATUS[0]}"
               set -e
               # The exact failure we are guarding against.

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -169,8 +169,8 @@ jobs:
 
           bunx tauri build -v \
             --target x86_64-unknown-linux-gnu \
-            --no-default-features \
-            --features custom-protocol,enterprise-build,redact-onnx-cpu
+            --features custom-protocol,enterprise-build,redact-onnx-cpu \
+            -- --no-default-features
 
       - name: Repack AppImage with bundled runtime deps
         working-directory: apps/screenpipe-app-tauri

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -198,6 +198,11 @@ jobs:
                 squashfs-root/usr/lib/libsharpyuv.so* \
                 squashfs-root/usr/lib/libavif.so*
 
+          # linuxdeploy rewrites the bundled bun binary to prefer the AppImage
+          # lib dir. Restore the pristine sidecar so Debian 13 does not SIGSEGV
+          # before the app can scrub LD_LIBRARY_PATH at runtime.
+          install -m 0755 src-tauri/bun-x86_64-unknown-linux-gnu squashfs-root/usr/bin/bun
+
           # Guard the libavif/libsharpyuv fix: an orphan bundled libsharpyuv
           # shadows the host one and breaks Arch (libavif 1.4.2) with
           # "undefined symbol: SharpYuvConvertWithOptions". Fail if either

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -167,7 +167,10 @@ jobs:
           BUNDLE_DIR="src-tauri/target/x86_64-unknown-linux-gnu/release/bundle"
           rm -rf "${BUNDLE_DIR}" 2>/dev/null || true
 
-          bunx tauri build -v --target x86_64-unknown-linux-gnu --features enterprise-build,redact-onnx-cpu
+          bunx tauri build -v \
+            --target x86_64-unknown-linux-gnu \
+            --no-default-features \
+            --features custom-protocol,enterprise-build,redact-onnx-cpu
 
       - name: Repack AppImage with bundled runtime deps
         working-directory: apps/screenpipe-app-tauri

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -779,6 +779,7 @@ jobs:
                   squashfs-root/usr/lib/libpcre2-8.so* \
                   squashfs-root/usr/lib/libsharpyuv.so* \
                   squashfs-root/usr/lib/libavif.so*
+            install -m 0755 src-tauri/bun-x86_64-unknown-linux-gnu squashfs-root/usr/bin/bun
             echo "Removed bundled GLib libs, repacking AppImage..."
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -192,9 +192,9 @@ jobs:
             target: aarch64-pc-windows-msvc
             os_type: "windows"
           - platform: "ubuntu-24.04"
-            args: "--target x86_64-unknown-linux-gnu --no-default-features --features custom-protocol,redact-onnx-cpu"
+            args: "--target x86_64-unknown-linux-gnu --features custom-protocol,redact-onnx-cpu -- --no-default-features"
             target: x86_64-unknown-linux-gnu
-            tauri-args: "--target x86_64-unknown-linux-gnu --no-default-features --features custom-protocol,official-build,redact-onnx-cpu"
+            tauri-args: "--target x86_64-unknown-linux-gnu --features custom-protocol,official-build,redact-onnx-cpu -- --no-default-features"
             os_type: "linux"
 
     runs-on: ${{ matrix.platform == 'windows-desktop-test' && fromJSON('["self-hosted", "windows-desktop-test"]') || matrix.platform }}

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -192,9 +192,9 @@ jobs:
             target: aarch64-pc-windows-msvc
             os_type: "windows"
           - platform: "ubuntu-24.04"
-            args: "--target x86_64-unknown-linux-gnu --features redact-onnx-cpu"
+            args: "--target x86_64-unknown-linux-gnu --no-default-features --features custom-protocol,redact-onnx-cpu"
             target: x86_64-unknown-linux-gnu
-            tauri-args: "--target x86_64-unknown-linux-gnu --features official-build,redact-onnx-cpu"
+            tauri-args: "--target x86_64-unknown-linux-gnu --no-default-features --features custom-protocol,official-build,redact-onnx-cpu"
             os_type: "linux"
 
     runs-on: ${{ matrix.platform == 'windows-desktop-test' && fromJSON('["self-hosted", "windows-desktop-test"]') || matrix.platform }}

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -489,6 +489,7 @@ jobs:
                   squashfs-root/usr/lib/libpcre2-8.so* \
                   squashfs-root/usr/lib/libsharpyuv.so* \
                   squashfs-root/usr/lib/libavif.so*
+            install -m 0755 src-tauri/bun-x86_64-unknown-linux-gnu squashfs-root/usr/bin/bun
             echo "Removed bundled GLib libs, repacking AppImage..."
             ARCH=x86_64 /tmp/appimagetool squashfs-root "$APPIMAGE"
             rm -rf squashfs-root

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -462,8 +462,8 @@ jobs:
 
           bunx tauri build -v \
             --target x86_64-unknown-linux-gnu \
-            --no-default-features \
-            --features custom-protocol,enterprise-build,redact-onnx-cpu
+            --features custom-protocol,enterprise-build,redact-onnx-cpu \
+            -- --no-default-features
 
           # Strip bundled GLib/libmount/libblkid/libpcre2 (ABI mismatch on newer
           # distros) plus libavif/libsharpyuv: linuxdeploy bundles the old Ubuntu

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -460,7 +460,10 @@ jobs:
           echo "Cleaning stale bundle artifacts from ${BUNDLE_DIR}..."
           rm -rf "${BUNDLE_DIR}" 2>/dev/null || true
 
-          bunx tauri build -v --target x86_64-unknown-linux-gnu --features enterprise-build,redact-onnx-cpu
+          bunx tauri build -v \
+            --target x86_64-unknown-linux-gnu \
+            --no-default-features \
+            --features custom-protocol,enterprise-build,redact-onnx-cpu
 
           # Strip bundled GLib/libmount/libblkid/libpcre2 (ABI mismatch on newer
           # distros) plus libavif/libsharpyuv: linuxdeploy bundles the old Ubuntu


### PR DESCRIPTION
## Summary
- stop Linux AppImage and Linux release Tauri builds from inheriting the desktop app default `qwen3-asr` / `parakeet` features
- explicitly opt Linux packaging into only `custom-protocol` plus the existing release-specific flags

## Root cause
Clean Linux Tauri builds were pulling `apps/screenpipe-app-tauri` default features, which enable `qwen3-asr` and `parakeet`.

Those features transitively fetch `audiopipe`, whose pinned repo commit currently references a deleted `predict-woo/qwen3-asr.cpp` submodule revision (`f4df368778bb38bca1a0c1987c65d778cf791146`). That made unrelated PRs fail in `Linux AppImage Smoke` before the app bundle step could finish.

## Evidence
- repeated `Linux AppImage Smoke` failures across unrelated PRs including #4755, #4754, and #4752
- failing job signature: `failed to fetch submodule qwen3-asr-sys/qwen3-asr.cpp ... revision f4df368778bb38bca1a0c1987c65d778cf791146 not found`
- `git submodule status` on the pinned `audiopipe` rev `86aa0212d0b537496370ebbd65892ca70c6d2e24` still points at that missing submodule commit

## Validation
- `cargo fmt --all -- --check`
- Linux feature-graph probe for enterprise build args showed no `audiopipe` / `qwen3-asr` / `parakeet` after `--no-default-features` + explicit Linux features
- Linux feature-graph probe for consumer release args showed no `audiopipe` / `qwen3-asr` / `parakeet` after `--no-default-features` + explicit Linux features

## Residual risk
- Linux packages built through these workflows will not compile the local `qwen3-asr` / `parakeet` engines until the upstream `audiopipe` submodule pointer is repaired.
- I did not run a full Linux AppImage build locally from this macOS host; this change is scoped to workflow/build-arg resolution and should be verified in CI.
