### PR TITLE
[codex] harden style workflow around cargo-consolidate install flakes

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install cargo tools
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-audit,cargo-deny,cargo-consolidate
+          tool: cargo-audit,cargo-deny
 
       - name: Security audit
         continue-on-error: true
@@ -68,12 +68,20 @@ jobs:
         continue-on-error: true
         run: cargo deny check bans
 
+      - name: Install cargo-consolidate
+        id: install-consolidate
+        continue-on-error: true
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-consolidate
+
       - name: Check workspace dependency consolidation
         # Informational, like the sibling Security audit / cargo-deny steps:
         # cargo-consolidate flags unavoidable transitive version duplicates
         # (thiserror 1.x+2.x, the windows-* family) that can't be reconciled
         # at the workspace level, so it was failing Code Quality on every
         # commit. Don't block the gate on it.
+        if: ${{ steps.install-consolidate.outcome == 'success' }}
         continue-on-error: true
         run: |
           cargo consolidate


### PR DESCRIPTION
## Summary
- stop the shared cargo-tool install step from hard-failing `Code Quality & Optimization` when `cargo-consolidate` flakes
- install `cargo-consolidate` in its own best-effort step and only run the consolidation check when that install succeeds
- keep `cargo-audit` and `cargo-deny` in the required install path

## Evidence
- PR #4757 hit a red `Dependency & Performance Checks` gate even though the only failure was fetching `cargo-consolidate` from crates.io via `taiki-e/install-action`
- failure signature: `could not GET https://static.crates.io/crates/cargo-consolidate/0.1.0/download: HTTP status server error (500 Internal Server Error)`
- the consolidation check is already documented as informational / non-blocking, so its installer should not be able to fail the whole job first

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/style.yml")'`
- `git diff --check`

## Residual risk
- if `cargo-consolidate` downloads cleanly, the informational step still runs exactly as before
- if crates.io or the installer flakes again, the consolidation check is skipped instead of reddening unrelated PRs
