### PR TITLE
[codex] fix onboarding account switch auth picker

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -104,15 +104,16 @@ describe("onboarding login gate", () => {
     expect(mocks.loadUser).toHaveBeenLastCalledWith("t3", true);
   });
 
-  it("'use a different account' clears the auth token so they can re-login", async () => {
+  it("'use a different account' clears the auth token and opens a fresh login session", async () => {
     mocks.settings = { user: { token: "t4", id: "u4", email: "x@y.com", cloud_subscribed: true } };
     mocks.hasAppEntitlement.mockReturnValue(false);
     render(<OnboardingLogin handleNextSlide={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /use a different account/i }));
-    expect(mocks.updateSettings).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.updateSettings).toHaveBeenCalledTimes(1));
     const arg = mocks.updateSettings.mock.calls[0][0];
     expect(arg.user.token).toBeNull();
     expect(arg.user.id).toBeNull();
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
   });
 
   it("shows the sign-in button when not signed in", () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -229,6 +229,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
   const { settings, loadUser, updateSettings } = useSettings();
   const hasAdvanced = useRef(false);
   const reverifiedRef = useRef(false);
+  const freshSessionLoginRef = useRef(false);
   const [showSkip, setShowSkip] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [rechecking, setRechecking] = useState(false);
@@ -282,12 +283,13 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
     setRechecking(false);
   }, [settings.user?.token, rechecking, loadUser]);
 
-  const useDifferentAccount = useCallback(() => {
+  const useDifferentAccount = useCallback(async () => {
     posthog.capture("onboarding_login_switch_account");
     reverifiedRef.current = false;
+    freshSessionLoginRef.current = true;
     // Clear the auth-bearing fields so we drop back to the "sign in" button and the
     // member can re-authenticate with their work email (the one on the license).
-    updateSettings({
+    await updateSettings({
       user: {
         ...settings.user,
         id: null,
@@ -299,13 +301,14 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({ handleNextSlide }) =>
         entitlement: null,
       },
     });
+    await commands.openLoginWindow(true);
   }, [settings.user, updateSettings]);
 
   const handleLogin = useCallback(() => {
     posthog.capture("onboarding_login_clicked");
     // Open login in an in-app WebView instead of Safari so we can intercept
     // the screenpipe:// deep-link redirect (Safari blocks custom-scheme redirects)
-    commands.openLoginWindow(null);
+    commands.openLoginWindow(freshSessionLoginRef.current ? true : null);
   }, []);
 
   const handleSkip = useCallback(() => {


### PR DESCRIPTION
## Summary
- make onboarding's `use a different account` path immediately open a fresh login session
- preserve that fresh-session intent for the fallback sign-in button after an account switch
- add a regression test covering the fresh-session login handoff

## Root cause
The onboarding login gate cleared the saved auth token, but it sent the user back through the default login flow. On Google, that reused the existing browser session, so the "use a different account" recovery path could silently re-authenticate the same account instead of surfacing the account picker.

## User impact
Users stuck on the no-plan/no-subscription onboarding recovery screen can now actually switch to the invited work Google account instead of looping back into the same personal account.

## Validation
- `bunx vitest run components/onboarding/login-gate.test.tsx --config vitest.config.ts`
- `bun run typecheck`
- `bunx eslint components/onboarding/login-gate.tsx components/onboarding/login-gate.test.tsx`

## Issue
- Closes #4720
