### PR TITLE
fix(app): prevent timeline scroll from hijacking sidebar and other windows

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/hooks/use-scroll-zoom.ts
+++ b/apps/screenpipe-app-tauri/components/rewind/hooks/use-scroll-zoom.ts
@@ -286,16 +286,26 @@ export function useScrollZoom(opts: {
 		}>("native-scroll", (event) => {
 			const { deltaX, deltaY, ctrlKey, metaKey } = event.payload;
 
+			// Ignore native-scroll from other windows — the Rust side emits
+			// app-wide so scrolling in the chat window would otherwise
+			// navigate the timeline.
+			if (!document.hasFocus()) return;
+
 			// Don't intercept scroll when a modal/panel is open
 			if (showSearchModal) return;
 
-			// Check if cursor is over a panel/dialog — let those scroll natively
+			// Check if cursor is over a panel/dialog/sidebar — let those scroll natively
 			const target = document.elementFromPoint(lastMouseX.current, lastMouseY.current);
 			if (target) {
+				// If cursor is outside the timeline container, don't hijack scroll
+				if (containerRef.current && !containerRef.current.contains(target)) return;
+
 				const isOverExcluded =
 					document.querySelector(".audio-transcript-panel")?.contains(target) ||
 					document.querySelector(".ai-panel")?.contains(target) ||
-					document.querySelector('[role="dialog"]')?.contains(target);
+					document.querySelector('[role="dialog"]')?.contains(target) ||
+					document.querySelector('[data-settings-dialog]')?.contains(target) ||
+					document.querySelector('[data-search-modal]')?.contains(target);
 				if (isOverExcluded) return;
 			}
 


### PR DESCRIPTION
This PR fixes scrolling on the sidebar and on search ui also scrolling the timeline, and scrolling in the chat window navigating the timeline because native-scroll events broadcast app-wide via app.emit()

It added a container bounds check so the scroll handler only activates when cursor is within the timeline, and a document.hasFocus() guard to ignore events from other windows.

Before -

https://github.com/user-attachments/assets/96288c55-4250-4522-ac11-886aa50951b0



After -


https://github.com/user-attachments/assets/0ab0a174-127b-4448-9bd5-1d12fa85a425

