### PR TITLE
fix(ci): use pwsh (PowerShell 7) for all Windows build steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Ensure 7-Zip is available
-        shell: powershell
+        shell: pwsh
         run: |
           # GitHub-hosted windows runners ship 7-Zip pre-installed, so this is
           # normally a no-op. Only download when it's genuinely missing, and

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,7 +41,7 @@ jobs:
         bun-version: 1.3.10
 
     - name: Install Scream on Windows
-      shell: powershell
+      shell: pwsh
       run: |
         $ErrorActionPreference = "Stop"
         $screamUrl = "https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip"
@@ -63,7 +63,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Sign and Install Scream Driver on Windows
-      shell: powershell
+      shell: pwsh
       run: |
         signtool sign /v /fd SHA256 /f ScreamCertificate.pfx Scream\Install\driver\x64\Scream.cat
         Import-Certificate -FilePath ScreamCertificate.cer -CertStoreLocation Cert:\LocalMachine\root
@@ -72,7 +72,7 @@ jobs:
       timeout-minutes: 5
 
     - name: Start Windows Audio Service
-      shell: powershell
+      shell: pwsh
       run: |
         $service = Get-Service -Name audiosrv
         if ($service.Status -ne 'Running') {

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -202,7 +202,7 @@ jobs:
     steps:
       - name: Enable Git long paths on Windows
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         run: |
           Write-Host "Enabling git core.longpaths..."
           # Use --global instead of --system to avoid permission issues on self-hosted runners
@@ -224,7 +224,7 @@ jobs:
 
       - name: Shorten target dir to avoid MAX_PATH (Windows)
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         run: |
           # vulkan-shaders-gen ExternalProject creates deeply nested paths
           # that exceed the 260-char Windows MAX_PATH limit when built under
@@ -272,21 +272,21 @@ jobs:
 
       - name: Install Rust (Windows x64)
         if: matrix.os_type == 'windows' && matrix.target == 'x86_64-pc-windows-msvc'
-        shell: powershell
+        shell: pwsh
         run: |
           Invoke-WebRequest https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe -OutFile rustup-init.exe
           .\rustup-init.exe -y
 
       - name: Install Rust (Windows ARM64 native)
         if: matrix.os_type == 'windows' && matrix.target == 'aarch64-pc-windows-msvc'
-        shell: powershell
+        shell: pwsh
         run: |
           Invoke-WebRequest https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe -OutFile rustup-init.exe
           .\rustup-init.exe -y
 
       - name: setup rust path
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         run: |
           $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
           echo "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -499,7 +499,7 @@ jobs:
 
       - name: Install Ninja (ARM64)
         if: matrix.os_type == 'windows' && matrix.target == 'aarch64-pc-windows-msvc'
-        shell: powershell
+        shell: pwsh
         run: |
           # The windows-11-arm runner image pre-installs Ninja at C:\Tools\Ninja
           # but winget is NOT on PATH by default - so blindly calling
@@ -534,7 +534,7 @@ jobs:
 
       - name: Verify Windows download support
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         env:
           SKIP_SCREENPIPE_SETUP: true
         run: |
@@ -807,7 +807,7 @@ jobs:
 
       - name: Install CodeSignTool for SSL.com EV signing (Windows)
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         run: |
           # 1. CodeSignTool: signs the inner binaries + final NSIS installer
           #    via SSL.com eSigner (called by Tauri's signCommand wrapper).
@@ -846,7 +846,7 @@ jobs:
       - name: Build (Windows)
         if: matrix.os_type == 'windows'
         working-directory: apps/screenpipe-app-tauri
-        shell: powershell
+        shell: pwsh
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
@@ -903,7 +903,7 @@ jobs:
         # transient SSL.com CSC API failures (HTML-instead-of-JSON,
         # "Unexpected character (<) at position 0").
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         env:
           ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
           ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
@@ -1554,7 +1554,7 @@ jobs:
 
       - name: Upload to Cloudflare R2 (Windows)
         if: matrix.os_type == 'windows'
-        shell: powershell
+        shell: pwsh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -1641,7 +1641,7 @@ jobs:
       - name: Upload debug symbols to Sentry (Windows)
         if: matrix.os_type == 'windows'
         continue-on-error: true
-        shell: powershell
+        shell: pwsh
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: mediar

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -259,7 +259,7 @@ jobs:
           .\rustup-init.exe -y
 
       - name: Install 7zip
-        shell: powershell
+        shell: pwsh
         run: |
           $7zipUrl = "https://7-zip.org/a/7z2301-x64.exe"
           $7zipInstaller = "7z-installer.exe"
@@ -308,7 +308,7 @@ jobs:
           Get-ChildItem "$extractDir/lib" | ForEach-Object { Write-Host $_.Name }
 
       - name: Install wget (Windows)
-        shell: powershell
+        shell: pwsh
         run: |
           $wgetDir = "C:\wget"
           if (-not (Test-Path "$wgetDir\wget.exe")) {
@@ -329,7 +329,7 @@ jobs:
           "OPENBLAS_PATH=${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/openblas" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Shorten target dir to avoid MAX_PATH
-        shell: powershell
+        shell: pwsh
         run: |
           $targetDir = "target"
           $shortDir = "C:\t"
@@ -370,7 +370,7 @@ jobs:
           cargo build --release -p screenpipe-engine --bin screenpipe --features directml,redact-onnx-directml --target x86_64-pc-windows-msvc
 
       - name: Upload debug symbols to Sentry
-        shell: powershell
+        shell: pwsh
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: mediar
@@ -379,7 +379,7 @@ jobs:
           .\sentry-cli.exe debug-files upload --org $env:SENTRY_ORG --project screenpipe-cli target/x86_64-pc-windows-msvc/release/
 
       - name: Install CodeSignTool for SSL.com EV signing (Windows)
-        shell: powershell
+        shell: pwsh
         run: |
           # Same SSL.com eSigner cert + tool the desktop app uses (release-app.yml).
           $cstDest = "$env:RUNNER_TEMP\CodeSignTool"
@@ -390,7 +390,7 @@ jobs:
           Write-Host "CodeSignTool installed at $cstDest"
 
       - name: Sign screenpipe.exe with SSL.com EV (Windows)
-        shell: powershell
+        shell: pwsh
         env:
           ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
           ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -25,13 +25,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Enable Git long paths on Windows
-        shell: powershell
+        shell: pwsh
         run: |
           git config --global core.longpaths true
           if ((git config --global --get core.longpaths) -ne "true") { throw "Failed to enable git long paths" }
 
       - name: Shorten target dir to avoid MAX_PATH
-        shell: powershell
+        shell: pwsh
         run: |
           $targetDir = "apps\screenpipe-app-tauri\src-tauri\target"
           $shortDir = "C:\t"
@@ -67,7 +67,7 @@ jobs:
           .\rustup-init.exe -y
 
       - name: Setup Rust path and MSVC target
-        shell: powershell
+        shell: pwsh
         run: |
           $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
           echo "$env:USERPROFILE\.cargo\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -114,7 +114,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Install 7zip
-        shell: powershell
+        shell: pwsh
         run: |
           if (-not (Test-Path "C:\Program Files\7-Zip\7z.exe")) {
             Invoke-WebRequest -Uri "https://7-zip.org/a/7z2301-x64.exe" -OutFile "7z-installer.exe"
@@ -124,7 +124,7 @@ jobs:
           echo "C:\Program Files\7-Zip" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Install wget (Windows)
-        shell: powershell
+        shell: pwsh
         run: |
           $wgetDir = "C:\wget"
           if (-not (Test-Path "$wgetDir\wget.exe")) {
@@ -179,7 +179,7 @@ jobs:
         run: cp apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
 
       - name: Install CodeSignTool for binary signing
-        shell: powershell
+        shell: pwsh
         run: |
           $cstDest = "$env:RUNNER_TEMP\CodeSignTool"
           Write-Host "Downloading CodeSignTool..."
@@ -225,7 +225,7 @@ jobs:
         # backoff logic against transient SSL.com / CSC API failures
         # (the "Unexpected character (<) at position 0" HTML-instead-of-JSON
         # symptom that took out enterprise build 25196389570 on 2026-05-01).
-        shell: powershell
+        shell: pwsh
         env:
           ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
           ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
@@ -261,7 +261,7 @@ jobs:
           }
 
       - name: Create .intunewin and upload to R2
-        shell: powershell
+        shell: pwsh
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-signing.yml
+++ b/.github/workflows/test-signing.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Create dummy exe
-        shell: powershell
+        shell: pwsh
         run: |
           # Create a minimal valid PE exe to test signing
           $exePath = "$env:RUNNER_TEMP\test-signing.exe"
@@ -23,7 +23,7 @@ jobs:
           Write-Host "Test exe: $exePath"
 
       - name: Sign with SSL.com EV certificate
-        shell: powershell
+        shell: pwsh
         env:
           ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
           ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}

--- a/.github/workflows/windows-integration-test.yml
+++ b/.github/workflows/windows-integration-test.yml
@@ -58,7 +58,7 @@ jobs:
         echo "C:\ProgramData\chocolatey\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install Scream on Windows
-      shell: powershell
+      shell: pwsh
       run: |
         Invoke-WebRequest https://github.com/duncanthrax/scream/releases/download/4.0/Scream4.0.zip -OutFile Scream4.0.zip
         Expand-Archive -Path Scream4.0.zip -DestinationPath Scream
@@ -69,7 +69,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     - name: Sign and Install Scream Driver on Windows
-      shell: powershell
+      shell: pwsh
       run: |
         signtool sign /v /fd SHA256 /f ScreamCertificate.pfx Scream\Install\driver\x64\Scream.cat
         Import-Certificate -FilePath ScreamCertificate.cer -CertStoreLocation Cert:\LocalMachine\root
@@ -78,7 +78,7 @@ jobs:
       timeout-minutes: 5
 
     - name: Start Windows Audio Service
-      shell: powershell
+      shell: pwsh
       run: |
         $service = Get-Service -Name audiosrv
         if ($service.Status -ne 'Running') {
@@ -88,7 +88,7 @@ jobs:
         }
 
     - name: Ensure 7-Zip is available
-      shell: powershell
+      shell: pwsh
       run: |
         # GitHub-hosted windows runners ship 7-Zip pre-installed, so this is
         # normally a no-op. Only download when it's genuinely missing, and


### PR DESCRIPTION
All 7 Windows CI workflows used `shell: powershell` (PS 5.1) which lacks the `?.` null-conditional operator and other PS 7 syntax, causing Windows jobs to fail.

## Changes

Replace `shell: powershell` with `shell: pwsh` across all affected workflows:
- `.github/workflows/ci.yml`
- `.github/workflows/e2e-test.yml`
- `.github/workflows/release-app.yml`
- `.github/workflows/release-cli.yml`
- `.github/workflows/release-enterprise.yml`
- `.github/workflows/test-signing.yml`
- `.github/workflows/windows-integration-test.yml`

`pwsh` (PowerShell 7) is pre-installed on all `windows-latest` GitHub-hosted runners. No runner config changes needed.

Thanks for the great work on screenpipe!