### PR TITLE
fix(app): resolve store.bin via backend base dir (honors SCREENPIPE_DATA_DIR)

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -721,12 +721,30 @@ let _store: Promise<Store> | undefined;
 
 export const getStore = async () => {
 	if (!_store) {
-		// Use homeDir to match Rust backend's get_base_dir which uses $HOME/.screenpipe
-		const dir = await homeDir();
-		_store = Store.load(`${dir}/.screenpipe/store.bin`, {
-			autoSave: false,
-			defaults: {},
-		});
+		_store = (async () => {
+			// Resolve the base dir via the backend so the webview opens the same
+			// store.bin as Rust (get_base_dir honors SCREENPIPE_DATA_DIR); a
+			// hardcoded ~/.screenpipe here splits the settings store in two
+			// whenever that override is set.
+			let baseDir: string | null = null;
+			try {
+				const res = await commands.getScreenpipeBaseDir();
+				if (res.status === "ok") {
+					baseDir = res.data;
+				} else {
+					console.warn("get_screenpipe_base_dir failed, using ~/.screenpipe:", res.error);
+				}
+			} catch (e) {
+				console.warn("get_screenpipe_base_dir unavailable, using ~/.screenpipe:", e);
+			}
+			if (!baseDir) {
+				baseDir = `${await homeDir()}/.screenpipe`;
+			}
+			return Store.load(`${baseDir}/store.bin`, {
+				autoSave: false,
+				defaults: {},
+			});
+		})();
 	}
 	return _store;
 };

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -553,6 +553,18 @@ async getCachedSuggestions() : Promise<Result<CachedSuggestions, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Resolve the chat-conversations directory under the *active* screenpipe data
+ * dir (honors `SCREENPIPE_DATA_DIR` / a relocated data dir), creating it if
+ * needed. The frontend previously hardcoded `~/.screenpipe/chats` via
+ * `homeDir()`, which (a) ignored a relocated data dir and (b) leaked the
+ * developer's real chats into isolated e2e runs.
+ *
+ * One-time migration: for a relocated data dir whose `chats/` is still empty,
+ * copy conversations from the legacy `~/.screenpipe/chats` so history isn't
+ * orphaned. Skipped under e2e (`SCREENPIPE_E2E_SEED` set) so isolated runs
+ * stay empty.
+ */
 async getChatsDir() : Promise<Result<string, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_chats_dir") };
@@ -698,6 +710,20 @@ async getOnboardingStatus() : Promise<Result<OnboardingStore, string>> {
 async getPendingUpdate() : Promise<Result<PendingUpdateSnapshot | null, null>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_pending_update") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Tauri command: absolute path of the screenpipe base dir (where store.bin
+ * lives). Honors SCREENPIPE_DATA_DIR; the webview must use this instead of
+ * hardcoding ~/.screenpipe, or it reads/writes a different settings file
+ * than the Rust side whenever the override is set.
+ */
+async getScreenpipeBaseDir() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_screenpipe_base_dir") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -2668,7 +2694,7 @@ macosInputVpioEnabled?: boolean;
  */
 screenpipeAecEnabled?: boolean;
 /**
- * Durable AEC engine choice. Missing legacy values intentionally migrate to Screenpipe AEC.
+ * Durable AEC engine choice. Missing values default to off so AEC remains opt-in.
  */
 aecMode?: AecMode;
 /**

--- a/apps/screenpipe-app-tauri/src-tauri/src/config.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/config.rs
@@ -24,6 +24,18 @@ pub fn get_base_dir(
     Ok(local_data_dir)
 }
 
+/// Tauri command: absolute path of the screenpipe base dir (where store.bin
+/// lives). Honors SCREENPIPE_DATA_DIR; the webview must use this instead of
+/// hardcoding ~/.screenpipe, or it reads/writes a different settings file
+/// than the Rust side whenever the override is set.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_screenpipe_base_dir(app: tauri::AppHandle) -> Result<String, String> {
+    get_base_dir(&app, None)
+        .map(|p| p.to_string_lossy().into_owned())
+        .map_err(|e| e.to_string())
+}
+
 /// Resolve the recording data directory from the store's `data_dir` setting.
 ///
 /// Returns `(resolved_path, fell_back)` where `fell_back` is true when the


### PR DESCRIPTION
## description

when `SCREENPIPE_DATA_DIR` is set, the rust side resolves the settings store via `get_base_dir` → `default_screenpipe_data_dir()` (honors the override), but the webview hardcoded `~/.screenpipe/store.bin`. the two sides read/write **different files** — a split-brain settings store where each side sees different settings, and the recovery machinery (`.last-good` snapshots, encryption, durable flush in `store.rs`) only guards the rust-side file. this also leaked the developer's real `~/.screenpipe/store.bin` into "isolated" e2e runs — the e2e launcher sets `SCREENPIPE_DATA_DIR` exactly for that isolation.

fix:
- new `get_screenpipe_base_dir` tauri command in `config.rs` — a thin wrapper over the exact `get_base_dir(app, None)` call the rust store uses (`store.rs` joins `store.bin` onto it), so path identity between the two sides is guaranteed
- `getStore()` in `use-settings.tsx` resolves the dir through that command, falling back to `~/.screenpipe` if it fails (same pattern as `getChatsDir()` in `chat-storage.ts`)
- `use-settings.tsx` has the only `Store.load` call site in the frontend; every other store consumer (`use-team`, the shortcut-reminder window, chat migration) goes through `getStore()`, so this one change covers them all

```
with SCREENPIPE_DATA_DIR=/custom      before                          after

rust  (store.rs build_store)          /custom/store.bin               /custom/store.bin
webview (getStore)                    ~/.screenpipe/store.bin  ✗      /custom/store.bin  ✓
```

## before

no ui surface change — with `SCREENPIPE_DATA_DIR` set, settings changed in the ui land in `~/.screenpipe/store.bin` while the backend reads/writes `$SCREENPIPE_DATA_DIR/store.bin`, so the two sides silently diverge.

## after

both sides read and write `$SCREENPIPE_DATA_DIR/store.bin`. default setups (no override) are unchanged: the command resolves to `~/.screenpipe` exactly as before.

## how to test

1. from `apps/screenpipe-app-tauri/`: `SCREENPIPE_DATA_DIR=/tmp/sp-test bun tauri dev`
2. change any setting in the ui (e.g. toggle a shortcut)
3. `ls -la /tmp/sp-test/store.bin` — freshly written; `~/.screenpipe/store.bin` mtime unchanged
4. relaunch without the env var — settings load from `~/.screenpipe/store.bin` as before

## desktop app checklist (if applicable)

- [x] `bun run bindings:generate` (if bindings changed)
- [x] `bun run bindings:check`
- [x] `bun run typecheck`
