### PR TITLE
fix(chat): don't mark the previous answer as live during the pre-token gap

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-message-list.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-message-list.tsx
@@ -102,9 +102,22 @@ export function ChatMessageList({
           const renderItems = buildCollapsedSteerRenderItems(visibleMessages, {
             canCollapseSteerWork: !isLoading && !isStreaming && !activeSourceFooterMessageId,
           });
+          // Fall back to the newest visible assistant message — but only when
+          // it is also the newest assistant message overall. Right after a
+          // send, the fresh assistant row is still the invisible
+          // "Processing..." placeholder (filtered above), so the newest
+          // *visible* assistant is the previous turn's completed answer;
+          // marking that one live would hide its action bar and tick a bogus
+          // "Working for …" header on it until the first token arrives.
+          const lastVisibleAssistantId = [...visibleMessages]
+            .reverse()
+            .find((candidate) => candidate.role === "assistant")?.id;
+          const lastAssistantId = [...messages]
+            .reverse()
+            .find((candidate) => candidate.role === "assistant")?.id;
           const activeAssistantMessageId =
             activeSourceFooterMessageId ??
-            [...visibleMessages].reverse().find((candidate) => candidate.role === "assistant")?.id;
+            (lastVisibleAssistantId === lastAssistantId ? lastVisibleAssistantId : undefined);
 
           return renderItems.map((item) => {
             if (item.type === "collapsed-steer-work") {


### PR DESCRIPTION
Follow-up to #4703 (see [review comment](https://github.com/screenpipe/screenpipe/pull/4703#issuecomment-4869303113)).

## Bug

The `activeAssistantMessageId` fallback in `chat-message-list.tsx` picked the newest **visible** assistant message:

```ts
const activeAssistantMessageId =
  activeSourceFooterMessageId ??
  [...visibleMessages].reverse().find((c) => c.role === "assistant")?.id;
```

Right after a send, the fresh assistant row is still the `"Processing..."` placeholder, which the visibility filter drops — so the fallback landed on the **previous turn's completed answer**. That message got `isActiveStreamingAssistantMessage = true`: its action bar disappeared and `isGenerating` flowed into its `ToolCallGroup`, starting a ticking "Working for …" header computed from the *old* message's timestamp (so it could instantly read "Working for 12 min" on a finished answer). It self-corrected at the first token, but flickered on every send.

## Fix

Only use the fallback when the newest visible assistant is also the newest assistant in the raw `messages` array:

- **pre-token gap**: raw-newest = the filtered placeholder ≠ visible-newest (old answer) → nothing marked, the send loader shows as before
- **streaming with content**: both = the live message → picked as before
- **steer mid-stream** (trailing user steer message): raw-newest assistant = the streaming one → still resolved correctly

## Test plan
- `bunx tsc --noEmit` clean
- `vitest lib/chat/__tests__/message-rendering.test.ts` — 6/6 pass
- manual: send a message in a chat whose previous answer used tools → previous answer no longer flashes a "Working for …" header / doesn't lose its action bar during the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)