### PR TITLE
fix(screen): drain SCK window enumeration autorelease objects

### DIFF
--- a/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
+++ b/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
@@ -311,6 +311,7 @@ impl WindowFilters {
 }
 
 /// Intermediate structure for window data extracted from platform-specific Window types
+#[cfg_attr(target_os = "macos", derive(Clone))]
 struct WindowData {
     app_name: String,
     title: String,
@@ -634,11 +635,16 @@ fn get_all_windows() -> Result<Vec<WindowData>, Box<dyn Error>> {
 
 #[cfg(target_os = "macos")]
 fn get_all_windows_sck() -> Result<Vec<WindowData>, Box<dyn Error>> {
-    let windows = SckWindow::all()?;
-    Ok(windows
-        .into_iter()
-        .filter_map(extract_window_data_sck)
-        .collect())
+    let result: Result<Vec<WindowData>, String> = cidre::objc::ar_pool(|| {
+        let windows = SckWindow::all().map_err(|e| e.to_string())?;
+        Ok(windows
+            .into_iter()
+            .filter_map(extract_window_data_sck)
+            .collect())
+    });
+
+    result
+        .map_err(|e| Box::new(std::io::Error::new(std::io::ErrorKind::Other, e)) as Box<dyn Error>)
 }
 
 #[cfg(target_os = "macos")]
@@ -913,8 +919,28 @@ pub fn get_excluded_sck_window_ids(window_filters: &WindowFilters) -> Vec<u32> {
         return Vec::new();
     }
 
-    let windows = match SckWindow::all() {
-        Ok(w) => w,
+    let excluded = match cidre::objc::ar_pool(|| -> Result<Vec<u32>, String> {
+        let windows = SckWindow::all().map_err(|e| e.to_string())?;
+        let mut excluded = Vec::new();
+
+        for w in &windows {
+            let app_name = w.app_name().unwrap_or_default();
+            let title = w.title().unwrap_or_default();
+
+            if app_name.is_empty() {
+                continue;
+            }
+
+            if !window_filters.is_valid(&app_name, &title) {
+                if let Ok(id) = w.id() {
+                    excluded.push(id);
+                }
+            }
+        }
+
+        Ok(excluded)
+    }) {
+        Ok(ids) => ids,
         Err(e) => {
             debug!(
                 "get_excluded_sck_window_ids: failed to enumerate windows: {}",
@@ -923,22 +949,6 @@ pub fn get_excluded_sck_window_ids(window_filters: &WindowFilters) -> Vec<u32> {
             return Vec::new();
         }
     };
-
-    let mut excluded = Vec::new();
-    for w in &windows {
-        let app_name = w.app_name().unwrap_or_default();
-        let title = w.title().unwrap_or_default();
-
-        if app_name.is_empty() {
-            continue;
-        }
-
-        if !window_filters.is_valid(&app_name, &title) {
-            if let Ok(id) = w.id() {
-                excluded.push(id);
-            }
-        }
-    }
 
     if !excluded.is_empty() {
         debug!(


### PR DESCRIPTION
## Summary
- wrap ScreenCaptureKit window enumeration in a macOS autorelease pool
- cover both all-window listing and filtered SCK excluded-window-id resolution
- return owned Rust data from the pool before continuing capture work

## Evidence
- installed app version monitored: 2.5.88
- monitor dir: /Users/louisbeaumont/.screenpipe/diagnostics/release-monitor/20260702-130827-app-2.5.88
- main screenpipe-app PID 26402 grew from 6392 MB to >7400 MB during the run while helper memory moved independently
- vmmap at the jump: IOAccelerator graphics stayed around 2.4 GB, while DefaultMallocZone rose to ~4.5 GB resident / ~2.3 GB allocated
- heap after the jump showed ~113k NSRunningApplication and ~113k NSLock objects, matching the autorelease leak signature
- CPU samples hit SCK window enumeration / LaunchServices / NSRunningApplication during capture

## Verification
- cargo check -p screenpipe-screen