### PR TITLE
fix(app): heal wipe-primed empty settings store in place on L5 refusal

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -297,6 +297,9 @@ jemalloc = ["tikv-jemallocator"]
 tempfile = "3"
 wiremock = "0.6"
 serial_test = "3"
+# MockRuntime for store.rs recovery tests that must exercise the real
+# tauri-plugin-store registry (state + resources table).
+tauri = { version = "=2.11.2", features = ["test"] }
 
 
 [package.metadata.cargo-machete]

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -82,10 +82,11 @@ const APP_ENTITLEMENT_CLOCK_SKEW_MINUTES: i64 = 5;
 //       leave it in place.
 //   L5: after the plugin builds, if the disk file has a `settings` key but
 //       the loaded store doesn't, the load silently failed — refuse to hand
-//       out the wipe-primed handle AND eject it from the plugin registry
-//       (the plugin registers stores before we can inspect them, and serves
-//       registry hits without re-reading disk), so retries and the webview
-//       rebuild from the file instead of re-serving the empty instance.
+//       out the wipe-primed handle AND heal the registered instance in
+//       place via reload() (the plugin registers stores before we can
+//       inspect them and serves registry hits without re-reading disk, so
+//       an unhealed instance would be re-served to retries, the webview,
+//       and the exit-time save-all).
 // ---------------------------------------------------------------------------
 
 /// Suffix for the most-recent known-healthy snapshot.
@@ -626,15 +627,37 @@ fn build_store_at<R: tauri::Runtime>(
                         store_path.display(),
                         attempt + 1
                     );
-                    // The plugin registered this instance (resources table +
-                    // path map) before we could inspect it, and `.build()`
-                    // serves registry hits without re-reading disk — so a
-                    // bare `continue` would hand every retry, the webview's
-                    // Store.load, and the plugin's exit-time save-all this
-                    // same empty store, and the first save would flush
-                    // defaults over the user's data. Eject it so the next
-                    // build re-reads the file.
-                    s.close_resource();
+                    // The plugin registered this instance before we could
+                    // inspect it and serves it from the registry on every
+                    // later build — ours AND the webview's — without ever
+                    // re-reading disk, so a bare `continue` would retry into
+                    // the same empty store and the first save would flush
+                    // defaults over the user's data. Heal it in place:
+                    // reload() re-reads the file with errors VISIBLE (build
+                    // swallows them), and fixing the shared instance fixes
+                    // every handle already pointing at it. Deliberately no
+                    // registry ejection — close_resource() takes the
+                    // resources-table and stores-map locks in the opposite
+                    // order to build_inner (ABBA deadlock risk) and would
+                    // invalidate resource ids held by live webview handles.
+                    match s.reload() {
+                        Ok(()) if s.get("settings").is_some() => {
+                            tracing::warn!(
+                                "store healed in place from {} after a \
+                                 silently-swallowed load failure",
+                                store_path.display()
+                            );
+                            encrypt_store_file(&store_path);
+                            return Ok(s);
+                        }
+                        Ok(()) => tracing::error!(
+                            "store reload succeeded but settings key still \
+                             missing — retrying"
+                        ),
+                        Err(e) => {
+                            tracing::error!("store reload from disk failed: {} — retrying", e)
+                        }
+                    }
                     last_err = None;
                     std::thread::sleep(std::time::Duration::from_millis(
                         100 * (attempt as u64 + 1),
@@ -2504,15 +2527,18 @@ mod tests {
     }
 
     #[test]
-    fn l5_refusal_ejects_wipe_primed_store_from_plugin_registry() {
+    fn l5_refusal_heals_wipe_primed_store_in_place() {
         // The plugin's build_inner registers a freshly-built store in its
         // registry BEFORE build_store can refuse it, and `.build()` serves
         // registry hits without re-reading disk. If the L5 refusal only
         // dropped its local Arc, every retry — and the webview's Store.load,
         // and the plugin's exit-time save-all — would keep getting the same
         // wipe-primed EMPTY instance, so the first save would flush defaults
-        // over the user's real store.bin. The refusal must eject the instance
-        // from the registry so the next build re-reads the disk file.
+        // over the user's real store.bin. The refusal must reload the SHARED
+        // instance from disk in place: healing it heals every handle already
+        // pointing at it (a webview's included), keeps its resource id valid,
+        // and needs no registry surgery (whose lock order inverts the
+        // plugin's and risks deadlock).
         use tauri_plugin_store::StoreExt;
 
         let tmp = tempfile::tempdir().unwrap();
@@ -2524,7 +2550,8 @@ mod tests {
             .expect("failed to build mock app");
 
         // Poison the registry the way a transient read failure does: the
-        // plugin swallows the load error and registers an EMPTY store.
+        // plugin swallows the load error and registers an EMPTY store. This
+        // handle also stands in for one a webview grabbed before recovery.
         std::fs::write(&store_path, b"transient garbage").unwrap();
         let poisoned = StoreBuilder::new(app.handle(), store_path.clone())
             .build()
@@ -2541,18 +2568,22 @@ mod tests {
         );
 
         let store = build_store_at(app.handle(), store_path.clone())
-            .expect("must eject the poisoned instance and load the disk state");
+            .expect("must heal the poisoned instance from the disk state");
         assert!(
             store.get("settings").is_some(),
             "must hand out the on-disk settings, not the wipe-primed empty store"
         );
         assert!(
-            !Arc::ptr_eq(&poisoned, &store),
-            "must not re-serve the ejected instance"
+            Arc::ptr_eq(&poisoned, &store),
+            "must heal the shared registered instance, not swap in a new one"
+        );
+        assert!(
+            poisoned.get("settings").is_some(),
+            "handles obtained before recovery must see the healed state"
         );
 
         // The registry — what the webview's Store.load and the plugin's
-        // exit-time save-all read — must also serve the healthy instance now.
+        // exit-time save-all read — must also serve the healthy instance.
         let registered = app
             .get_store(&store_path)
             .expect("healthy store must be registered");

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -82,7 +82,10 @@ const APP_ENTITLEMENT_CLOCK_SKEW_MINUTES: i64 = 5;
 //       leave it in place.
 //   L5: after the plugin builds, if the disk file has a `settings` key but
 //       the loaded store doesn't, the load silently failed — refuse to hand
-//       out the wipe-primed handle.
+//       out the wipe-primed handle AND eject it from the plugin registry
+//       (the plugin registers stores before we can inspect them, and serves
+//       registry hits without re-reading disk), so retries and the webview
+//       rebuild from the file instead of re-serving the empty instance.
 // ---------------------------------------------------------------------------
 
 /// Suffix for the most-recent known-healthy snapshot.
@@ -538,8 +541,18 @@ static STORE_CACHE: Mutex<Option<Arc<tauri_plugin_store::Store<tauri::Wry>>>> = 
 /// Build (or rebuild) the store, retrying on TOCTOU races and stale resource IDs.
 fn build_store(app: &AppHandle) -> anyhow::Result<Arc<tauri_plugin_store::Store<tauri::Wry>>> {
     let base_dir = get_base_dir(app, None)?;
-    let store_path = base_dir.join("store.bin");
+    build_store_at(app, base_dir.join("store.bin"))
+}
 
+/// Runtime-generic core of [`build_store`]: decrypt, snapshot recovery and
+/// the guarded build-retry loop over an already-resolved store path. Split
+/// out so the recovery layers can be tested against `tauri::test::MockRuntime`
+/// — the registry the L5 guard must clean up lives in tauri-managed state,
+/// unreachable from pure path-based tests.
+fn build_store_at<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    store_path: std::path::PathBuf,
+) -> anyhow::Result<Arc<tauri_plugin_store::Store<R>>> {
     // Decrypt store.bin before the plugin reads it (no-op if plain JSON or keychain unavailable)
     if store_path.exists() && decrypt_store_file(&store_path) == DecryptOutcome::Locked {
         // L2b — the encrypted blob is unreadable (key denied/missing or
@@ -613,6 +626,15 @@ fn build_store(app: &AppHandle) -> anyhow::Result<Arc<tauri_plugin_store::Store<
                         store_path.display(),
                         attempt + 1
                     );
+                    // The plugin registered this instance (resources table +
+                    // path map) before we could inspect it, and `.build()`
+                    // serves registry hits without re-reading disk — so a
+                    // bare `continue` would hand every retry, the webview's
+                    // Store.load, and the plugin's exit-time save-all this
+                    // same empty store, and the first save would flush
+                    // defaults over the user's data. Eject it so the next
+                    // build re-reads the file.
+                    s.close_resource();
                     last_err = None;
                     std::thread::sleep(std::time::Duration::from_millis(
                         100 * (attempt as u64 + 1),
@@ -2479,6 +2501,62 @@ mod tests {
             blob,
             "file must be untouched when there is nothing to restore from"
         );
+    }
+
+    #[test]
+    fn l5_refusal_ejects_wipe_primed_store_from_plugin_registry() {
+        // The plugin's build_inner registers a freshly-built store in its
+        // registry BEFORE build_store can refuse it, and `.build()` serves
+        // registry hits without re-reading disk. If the L5 refusal only
+        // dropped its local Arc, every retry — and the webview's Store.load,
+        // and the plugin's exit-time save-all — would keep getting the same
+        // wipe-primed EMPTY instance, so the first save would flush defaults
+        // over the user's real store.bin. The refusal must eject the instance
+        // from the registry so the next build re-reads the disk file.
+        use tauri_plugin_store::StoreExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store_path = tmp.path().join("store.bin");
+
+        let app = tauri::test::mock_builder()
+            .plugin(tauri_plugin_store::Builder::default().build())
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("failed to build mock app");
+
+        // Poison the registry the way a transient read failure does: the
+        // plugin swallows the load error and registers an EMPTY store.
+        std::fs::write(&store_path, b"transient garbage").unwrap();
+        let poisoned = StoreBuilder::new(app.handle(), store_path.clone())
+            .build()
+            .expect("plugin builds an empty store from an unreadable file");
+        assert!(
+            poisoned.get("settings").is_none(),
+            "precondition: the registered store is empty"
+        );
+
+        // The disk heals underneath it — the user's data was there all along.
+        write_store(
+            tmp.path(),
+            &json!({"settings": {"aiPresets": presets_n(2)}}),
+        );
+
+        let store = build_store_at(app.handle(), store_path.clone())
+            .expect("must eject the poisoned instance and load the disk state");
+        assert!(
+            store.get("settings").is_some(),
+            "must hand out the on-disk settings, not the wipe-primed empty store"
+        );
+        assert!(
+            !Arc::ptr_eq(&poisoned, &store),
+            "must not re-serve the ejected instance"
+        );
+
+        // The registry — what the webview's Store.load and the plugin's
+        // exit-time save-all read — must also serve the healthy instance now.
+        let registered = app
+            .get_store(&store_path)
+            .expect("healthy store must be registered");
+        assert!(Arc::ptr_eq(&registered, &store));
     }
 
     // ---- Existing tests ----


### PR DESCRIPTION
## description

closes a hole in the L5 settings-wipe guard in `apps/screenpipe-app-tauri/src-tauri/src/store.rs` (surfaced while reviewing #4779; pre-existing and independent of it).

tauri-plugin-store 2.4.2's `build_inner` registers a freshly-built store in the plugin registry **before** our L5 check can inspect it, and swallows load errors (`let _ = store_inner.load()`) into a successfully-built empty store. when L5 refused such a store (parses empty while disk still holds a `settings` key — transient read failure or a cross-process file swap), the refusal only dropped its local `Arc`; the poisoned empty instance stayed registered. every retry then registry-hit the same instance (deterministic exhaustion), and the webview's `Store.load` got it too — so the first frontend settings save flushed defaults over the user's real `store.bin`, and `snapshot_last_good` then froze those defaults into `.last-good`, destroying the recovery source. the plugin's exit-time save-all had the same wipe path.

the fix is refuse-and-heal, not registry surgery: on L5 refusal we call the plugin's `Store::reload()`, which re-reads the file **with errors visible** and heals the registered instance in place. because every holder shares the same `Arc`, handles a webview already grabbed heal too, and their resource ids stay valid. we deliberately do **not** eject via `close_resource()` — it takes the resources-table → stores-map locks in the opposite order to `build_inner` (ABBA deadlock risk on the boot path) and would orphan live webview resource ids.

also in this pr:

- `build_store`'s core split into a runtime-generic `build_store_at` so the recovery layers are testable against `tauri::test::MockRuntime` (the registry lives in tauri-managed state, unreachable from pure path-based tests); tauri's `test` feature added as a dev-dependency.
- regression test `l5_refusal_heals_wipe_primed_store_in_place`: poisons the registry the way a transient read failure does, heals the disk, and asserts the same shared instance is healed in place (`Arc::ptr_eq`), pre-recovery handles see the healed state, and the registry serves the healthy instance.

## before

no UI surface — boot-path recovery logic only. failure flow this fixes:

```
disk: {"settings": {...}}          registry
        │                             │
  transient read failure             │
        ▼                             ▼
  plugin builds EMPTY store ──► registered (rid N)
        │
  L5 refuses, Arc dropped ──► empty store STAYS registered
        │
  retries ──► registry hit (rid N, still empty) ×3 ──► exhausted
  webview Store.load ──► same empty store
  first save ──► defaults overwrite user's store.bin
  snapshot_last_good ──► defaults frozen into .last-good  💀
```

## after

```
  L5 refuses ──► s.reload()  (errors visible, leaf lock only)
        │
  disk healed? ──► SAME registered instance now holds real settings
        │             webview handles heal too, rids stay valid
        ▼
  return healthy store — no wipe, no registry surgery, no lock inversion
```

## how to test

1. `mkdir -p apps/screenpipe-app-tauri/out` if you've never built the frontend (empty dir satisfies `generate_context!` for test builds).
2. `cd apps/screenpipe-app-tauri/src-tauri && cargo test --bin screenpipe-app store::tests` — 34 tests, including `l5_refusal_heals_wipe_primed_store_in_place`.
3. to see the bug the test guards against: revert the `match s.reload()` block in `build_store_at` to a bare `continue` and re-run — the test fails with "store loaded empty while … has a settings key — refused the wipe-primed store" (retry exhaustion against the poisoned registry entry).

## desktop app checklist (if applicable)

N/A — no `#[tauri::command]` handlers or frontend-exported types changed; internal function split, a dev-dependency, and unit tests only.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
