### PR TITLE
fix(engine): de-flake sleep_monitor wake/lock flag tests (global-state pollution)

### DIFF
--- a/crates/screenpipe-engine/src/sleep_monitor.rs
+++ b/crates/screenpipe-engine/src/sleep_monitor.rs
@@ -698,8 +698,26 @@ pub fn start_sleep_monitor() {
 mod tests {
     use super::*;
 
+    /// `RECENTLY_WOKE` / `RECENTLY_WOKE_SEQ` are process-global, and
+    /// `mark_recently_woke` arms them with a 30s-delayed clear thread. Tests
+    /// that touch them must hold this lock so they can't interleave under the
+    /// parallel test runner.
+    static RECENTLY_WOKE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Neutralize any pending delayed clear (by bumping the seq) and reset the
+    /// flag, giving the caller a clean baseline regardless of what earlier
+    /// tests left behind.
+    fn reset_recently_woke() {
+        RECENTLY_WOKE_SEQ.fetch_add(1, Ordering::SeqCst);
+        RECENTLY_WOKE.store(false, Ordering::SeqCst);
+    }
+
     #[test]
     fn test_recently_woke_flag() {
+        let _guard = RECENTLY_WOKE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset_recently_woke();
         assert!(!recently_woke_from_sleep());
         RECENTLY_WOKE.store(true, Ordering::SeqCst);
         assert!(recently_woke_from_sleep());
@@ -709,6 +727,12 @@ mod tests {
 
     #[test]
     fn test_screen_is_locked_flag() {
+        // SCREEN_IS_LOCKED is process-global and the capture path mirrors the
+        // REAL machine lock state into it (event_driven_capture stores true
+        // when it resolves loginwindow as the frontmost app). Running the
+        // suite while the screen is actually locked leaves it armed — reset
+        // for a hermetic baseline.
+        SCREEN_IS_LOCKED.store(false, Ordering::SeqCst);
         assert!(!screen_is_locked());
         SCREEN_IS_LOCKED.store(true, Ordering::SeqCst);
         assert!(screen_is_locked());
@@ -812,10 +836,13 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[tokio::test]
     async fn test_on_did_wake_sets_audio_invalidation() {
+        let _guard = RECENTLY_WOKE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         // Clear stale flags
         let _ = screenpipe_audio::stream_invalidation::take();
         let _ = screenpipe_screen::stream_invalidation::take();
-        RECENTLY_WOKE.store(false, Ordering::SeqCst);
+        reset_recently_woke();
 
         let handle = tokio::runtime::Handle::current();
         on_did_wake(&handle);
@@ -837,6 +864,10 @@ mod tests {
             !screenpipe_audio::stream_invalidation::take(),
             "Audio flag should be cleared after take()"
         );
+
+        // Don't leak the armed flag (and its pending 30s clear thread) to
+        // whatever test runs next.
+        reset_recently_woke();
     }
 
     /// A screen-unlock transition must arm the permission-monitor wake grace,


### PR DESCRIPTION
## description

`sleep_monitor::tests::test_recently_woke_flag` failed on roughly every full-suite run (and every `--test-threads=1` module run), while passing in isolation. root cause: `test_on_did_wake_sets_audio_invalidation` runs first in libtest's alphabetical order, calls `on_did_wake()`, and leaves the process-global `RECENTLY_WOKE` armed — the clear happens on a detached thread 30 seconds later (seq-guarded), so the flag test's very first `assert!(!recently_woke_from_sleep())` reads stale state and panics.

changes (test module only, zero production code):

- add `RECENTLY_WOKE_TEST_LOCK`, a module-local mutex both wake-flag tests hold, so they can't interleave under the parallel test runner
- add `reset_recently_woke()`: bumps `RECENTLY_WOKE_SEQ` (neutralizing any pending 30s delayed-clear thread — the same seq guard production uses) and stores `false`
- `test_recently_woke_flag`: lock + reset before the first assertion instead of assuming a pristine global
- `test_on_did_wake_sets_audio_invalidation`: lock, reset via the helper in its preamble, and reset again at the end so it no longer leaks an armed flag (with a live 30s clear thread) to whatever test runs next
- `test_screen_is_locked_flag`: same disease through a different door — the capture path (`event_driven_capture.rs`) mirrors the REAL machine lock state into `SCREEN_IS_LOCKED` (loginwindow frontmost → `set_screen_locked(true)`, and nothing stores `false` while the screen stays locked). running the suite while the machine is actually locked failed this test 4/4; CI never sees it because headless runners are never locked. reset the baseline at the start.

## before

test-only change, no UI surface — before/after is the cargo output.

```
test sleep_monitor::tests::test_on_did_wake_sets_audio_invalidation ... ok
test sleep_monitor::tests::test_recently_woke_flag ... FAILED

---- sleep_monitor::tests::test_recently_woke_flag stdout ----
thread 'sleep_monitor::tests::test_recently_woke_flag' panicked at crates/screenpipe-engine/src/sleep_monitor.rs:703:9:
assertion failed: !recently_woke_from_sleep()
```

## after

```
test result: ok. 8 passed; 0 failed; 1 ignored   (sleep_monitor module, --test-threads=1, 5/5 runs)
test result: ok. 959 passed; 0 failed; 7 ignored (full cargo test -p screenpipe-engine, 5/5 runs)
```

the 5 green full-suite runs were executed while the machine's screen was genuinely locked — the harshest condition for the `SCREEN_IS_LOCKED` mirroring, which failed 4/4 before the fix.

## how to test

1. `cargo test -p screenpipe-engine --lib -- --test-threads=1 sleep_monitor` — deterministic failure before this change, green after.
2. `cargo test -p screenpipe-engine` — repeat a few times; green every run (also with the screen locked).
3. optional red-check: revert the test-module hunks and rerun step 1 — `test_recently_woke_flag` fails on its first assertion every time.

## desktop app checklist (if applicable)

N/A — no `#[tauri::command]` handlers or exported Rust types touched; the diff is confined to the `crates/screenpipe-engine` test module.
