### PR TITLE
fix(meetings): probe browsers for active-tab URL, start on live evidence

### DIFF
--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/macos.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/macos.rs
@@ -8,6 +8,68 @@ use super::*;
 use crate::meeting_watcher::shared::ignore::{is_browser_app, meeting_app_is_ignored_with_terms};
 use crate::meeting_watcher::shared::profiles::MeetingDetectionProfile;
 
+/// Ask each mic-holding browser directly for its active-tab URL and match it
+/// against the meeting profiles.
+///
+/// Uses the same per-browser detector as the vision pipeline
+/// (`browser_utils::create_url_detector`): AppleScript for Arc, AXDocument /
+/// AX address-bar walk for the rest. AppleScript reads the URL even when the
+/// browser shows no URL bar at all, so this resolves e.g. Arc + Google Meet
+/// within one poll of the mic being taken instead of waiting for the vision
+/// pipeline to happen to capture a frame.
+///
+/// Only called while a browser candidate is still unresolved (same gating as
+/// `ax_resolved_candidates`), so the ~100ms osascript round-trip runs at most
+/// once per poll during that window. The whole probe is capped by a timeout so
+/// a hung browser can't stall the detection loop.
+pub(crate) async fn active_tab_url_candidates(
+    browser_apps: &[String],
+    profiles: &[MeetingDetectionProfile],
+    ignored_terms: &[String],
+) -> Vec<AxResolvedCandidate> {
+    let browser_apps = browser_apps.to_vec();
+    let profiles = profiles.to_vec();
+    let ignored_terms = ignored_terms.to_vec();
+    let probe = tokio::task::spawn_blocking(move || {
+        let detector = screenpipe_screen::browser_utils::create_url_detector();
+        browser_apps
+            .iter()
+            .filter_map(|app| {
+                let pid = crate::meeting_watcher::ui_scan::resolve_browser_pid(app);
+                if pid <= 0 {
+                    return None;
+                }
+                let url = match detector.get_active_url(app, pid, "") {
+                    Ok(Some(url)) => url,
+                    Ok(None) => return None,
+                    Err(e) => {
+                        debug!(
+                            "audio-process meeting detector: active-tab URL probe failed for {}: {}",
+                            app, e
+                        );
+                        return None;
+                    }
+                };
+                let candidate = resolve_active_tab_url_candidate(app, &url, &profiles)?;
+                let profile = profiles.get(candidate.profile_index)?;
+                let platform = platform_name_for_profile(profile, true);
+                if meeting_app_is_ignored_with_terms(&platform, profile, &ignored_terms) {
+                    return None;
+                }
+                debug!(
+                    "audio-process meeting detector: active-tab URL probe resolved {} to {}",
+                    app, platform
+                );
+                Some(candidate)
+            })
+            .collect()
+    });
+    match tokio::time::timeout(Duration::from_secs(3), probe).await {
+        Ok(Ok(candidates)) => candidates,
+        _ => Vec::new(),
+    }
+}
+
 pub(crate) async fn ax_resolved_candidates(
     profiles: &[MeetingDetectionProfile],
     ignored_terms: &[String],

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/mod.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/mod.rs
@@ -39,18 +39,32 @@ mod null;
 mod windows;
 
 #[cfg(target_os = "macos")]
-use macos::ax_resolved_candidates;
+use macos::{active_tab_url_candidates, ax_resolved_candidates};
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-use null::ax_resolved_candidates;
+use null::{active_tab_url_candidates, ax_resolved_candidates};
 #[cfg(target_os = "windows")]
-use windows::ax_resolved_candidates;
+use windows::{active_tab_url_candidates, ax_resolved_candidates};
 
 const STICKY_PROCESS_WINDOW: Duration = Duration::from_secs(4);
-const CANDIDATE_CONFIRM_WINDOW: Duration = Duration::from_secs(3);
+/// How long a session resolved from STORED evidence (DB frames, up to 10s
+/// stale) must persist before a meeting starts — two consecutive sightings at
+/// the 1s active poll, so one stale frame alone can't mint a meeting. Live
+/// evidence (active-tab probe, AX window sweep, native app identity) bypasses
+/// this entirely and starts on the first sighting. This window does NOT
+/// filter voice notes on messaging platforms (real voice notes run 5–60s and
+/// outlast any sane value) — that is #4776's call-signal gate, not this
+/// constant.
+const CANDIDATE_CONFIRM_WINDOW: Duration = Duration::from_secs(1);
 const ENDING_GRACE: Duration = Duration::from_secs(20);
 const ACTIVE_POLL_INTERVAL: Duration = Duration::from_secs(1);
 const IDLE_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const UNKNOWN_BROWSER_PLATFORM: &str = "Unknown";
+/// Log (at INFO, so it lands in the shipped log file) once a mic-holding
+/// browser has stayed unattributed this long — the "my call was never
+/// detected" failure mode is otherwise completely silent.
+const UNRESOLVED_BROWSER_LOG_AFTER: Duration = Duration::from_secs(15);
+/// Rate limit for the unresolved-browser log line.
+const UNRESOLVED_BROWSER_LOG_EVERY: Duration = Duration::from_secs(60);
 
 mod model;
 pub(crate) use model::*;
@@ -89,6 +103,7 @@ pub async fn run_audio_process_meeting_detection_loop(
     let mut last_explicit_stop_id: Option<i64> = None;
     let mut suppressed_sessions: Vec<SuppressedSession> = Vec::new();
     let mut flap_count = 0u32;
+    let mut last_unresolved_browser_log: Option<Instant> = None;
 
     if close_orphaned_meetings_on_start {
         match db.close_orphaned_meetings().await {
@@ -229,6 +244,34 @@ pub async fn run_audio_process_meeting_detection_loop(
             flap_count = flap_count.saturating_add(1);
         }
         state = new_state;
+
+        // A browser holding the mic that we can't attribute to a platform is
+        // the silent failure mode behind "my call was never detected": every
+        // resolution attempt happens at debug level. Surface it at INFO once
+        // it has been pending a while, rate-limited.
+        if let AudioProcessMeetingState::CandidateUnresolvedBrowser {
+            browser_app,
+            first_seen_at,
+            ..
+        } = &state
+        {
+            let pending_for = now.duration_since(*first_seen_at);
+            if pending_for >= UNRESOLVED_BROWSER_LOG_AFTER
+                && last_unresolved_browser_log
+                    .is_none_or(|at| now.duration_since(at) >= UNRESOLVED_BROWSER_LOG_EVERY)
+            {
+                info!(
+                    "audio-process meeting detector: {} has held the mic for {}s without \
+                     resolving to a meeting platform (no fresh URL/title evidence and the \
+                     active-tab probe found no meeting URL; still retrying every poll)",
+                    browser_app,
+                    pending_for.as_secs()
+                );
+                last_unresolved_browser_log = Some(now);
+            }
+        } else {
+            last_unresolved_browser_log = None;
+        }
 
         if let Some(action) = action {
             apply_state_action(

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/model.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/model.rs
@@ -129,6 +129,12 @@ pub(crate) enum ResolvedMeetingCandidate {
         session_key: ProcessKey,
         first_seen_at: Instant,
         process: AudioInputProcess,
+        /// True when the platform was observed live on this poll (active-tab
+        /// URL probe or AX window sweep) rather than replayed from stored
+        /// frame evidence, which can be up to 10s stale. Live evidence starts
+        /// a meeting on a single sighting; stored evidence waits out the
+        /// confirm window.
+        live_evidence: bool,
     },
     UnresolvedBrowser {
         browser_app: String,
@@ -154,12 +160,16 @@ impl ResolvedMeetingCandidate {
                 meeting_url: None,
                 first_seen_at: *first_seen_at,
                 is_browser: false,
+                // A native app holding the mic is by definition a live
+                // observation of the current snapshot.
+                live_evidence: true,
             }),
             Self::Browser {
                 platform,
                 meeting_url,
                 session_key,
                 first_seen_at,
+                live_evidence,
                 ..
             } => Some(ResolvedSession {
                 platform: platform.clone(),
@@ -167,6 +177,7 @@ impl ResolvedMeetingCandidate {
                 meeting_url: Some(meeting_url.clone()),
                 first_seen_at: *first_seen_at,
                 is_browser: true,
+                live_evidence: *live_evidence,
             }),
             _ => None,
         }
@@ -199,6 +210,9 @@ pub(crate) struct ResolvedSession {
     pub(crate) meeting_url: Option<String>,
     pub(crate) first_seen_at: Instant,
     pub(crate) is_browser: bool,
+    /// See [`ResolvedMeetingCandidate::Browser::live_evidence`]. Always true
+    /// for native candidates.
+    pub(crate) live_evidence: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/null.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/null.rs
@@ -13,3 +13,11 @@ pub(crate) async fn ax_resolved_candidates(
 ) -> Vec<AxResolvedCandidate> {
     Vec::new()
 }
+
+pub(crate) async fn active_tab_url_candidates(
+    _browser_apps: &[String],
+    _profiles: &[MeetingDetectionProfile],
+    _ignored_terms: &[String],
+) -> Vec<AxResolvedCandidate> {
+    Vec::new()
+}

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -56,14 +56,70 @@ pub(crate) async fn should_use_ax_fallback(
     profiles: &[MeetingDetectionProfile],
     ignored_terms: &[String],
 ) -> Vec<AxResolvedCandidate> {
-    let has_browser = tracked
+    let mut browser_apps: Vec<String> = tracked
         .iter()
-        .any(|(_, tracked)| browser_app_name(&tracked.raw).is_some());
-    if !has_browser {
+        .filter_map(|(_, tracked)| browser_app_name(&tracked.raw))
+        .collect();
+    browser_apps.sort();
+    browser_apps.dedup();
+    if browser_apps.is_empty() {
         return Vec::new();
     }
 
-    ax_resolved_candidates(profiles, ignored_terms).await
+    let mut candidates = ax_resolved_candidates(profiles, ignored_terms).await;
+
+    // The AX window sweep is blind on browsers that expose neither AXDocument
+    // nor a URL in the window title (Arc titles its in-call window with just
+    // the meeting code). For mic-holding browsers it could not attribute, ask
+    // the browser directly for its active-tab URL — this works with the URL
+    // bar hidden and does not depend on the vision pipeline having recently
+    // captured a frame (event-driven capture produces none on a static call
+    // screen, which starved `db_find_browser_evidence` exactly when a call
+    // just started).
+    let unattributed: Vec<String> = browser_apps
+        .into_iter()
+        .filter(|app| {
+            !candidates
+                .iter()
+                .any(|candidate| browser_names_match(app, &candidate.browser_app))
+        })
+        .collect();
+    if !unattributed.is_empty() {
+        candidates.extend(active_tab_url_candidates(&unattributed, profiles, ignored_terms).await);
+    }
+    candidates
+}
+
+/// Match a browser's live active-tab URL against the meeting profiles.
+///
+/// URL-only matching (titles are never consulted here), with query/fragment
+/// ignored by `browser_window_matches_meeting` so a meeting link carried as a
+/// parameter on an unrelated page can't resolve (#4246). The stored
+/// `meeting_url` keeps the browser-reported form for parity with the DB
+/// evidence path.
+pub(crate) fn resolve_active_tab_url_candidate(
+    browser_app: &str,
+    active_tab_url: &str,
+    profiles: &[MeetingDetectionProfile],
+) -> Option<AxResolvedCandidate> {
+    let url = active_tab_url.trim();
+    if url.is_empty() {
+        return None;
+    }
+    profiles.iter().enumerate().find_map(|(idx, profile)| {
+        if profile.app_identifiers.browser_url_patterns.is_empty() {
+            return None;
+        }
+        if browser_window_matches_meeting(Some(url), None, profile) {
+            Some(AxResolvedCandidate {
+                browser_app: browser_app.to_string(),
+                profile_index: idx,
+                meeting_url: Some(url.to_string()),
+            })
+        } else {
+            None
+        }
+    })
 }
 
 pub(crate) async fn db_find_browser_evidence(
@@ -101,6 +157,48 @@ pub(crate) fn resolve_process_candidate(
     ignored_terms: &[String],
 ) -> ResolvedMeetingCandidate {
     if let Some(browser_app) = browser_app_name(process) {
+        // Live observation first (active-tab URL probe / AX window sweep):
+        // it reflects the browser RIGHT NOW, while DB frame evidence can be
+        // up to 10s stale — a stale frame must never outrank a live answer.
+        // Live evidence is also what entitles the state machine to start a
+        // meeting on a single sighting.
+        if let Some(ax) = resolve_ax_browser_candidate(&browser_app, profiles, ax_candidates) {
+            let profile = &profiles[ax.profile_index];
+            let platform = platform_name_for_profile(profile, true);
+            // The AX window sweep resolves without a URL; borrow the URL from
+            // frame evidence when it agrees on the profile so meeting_url
+            // quality doesn't regress (e.g. Safari: AXDocument match while a
+            // fresh frame carries the real URL).
+            let meeting_url = ax
+                .meeting_url
+                .or_else(|| {
+                    resolve_browser_evidence(&browser_app, profiles, evidence)
+                        .filter(|(idx, _)| *idx == ax.profile_index)
+                        .map(|(_, url)| url)
+                })
+                .unwrap_or_else(|| platform.clone());
+            if candidate_is_ignored(
+                &platform,
+                Some(profile),
+                process,
+                ignored_terms,
+                Some(&browser_app),
+                Some(&meeting_url),
+                None,
+            ) {
+                return ResolvedMeetingCandidate::Ignored;
+            }
+            return ResolvedMeetingCandidate::Browser {
+                platform,
+                meeting_url,
+                browser_app,
+                session_key,
+                first_seen_at,
+                process: process.clone(),
+                live_evidence: true,
+            };
+        }
+
         if let Some((profile_index, meeting_url)) =
             resolve_browser_evidence(&browser_app, profiles, evidence)
         {
@@ -124,31 +222,7 @@ pub(crate) fn resolve_process_candidate(
                 session_key,
                 first_seen_at,
                 process: process.clone(),
-            };
-        }
-
-        if let Some(ax) = resolve_ax_browser_candidate(&browser_app, profiles, ax_candidates) {
-            let profile = &profiles[ax.profile_index];
-            let platform = platform_name_for_profile(profile, true);
-            let meeting_url = ax.meeting_url.unwrap_or_else(|| platform.clone());
-            if candidate_is_ignored(
-                &platform,
-                Some(profile),
-                process,
-                ignored_terms,
-                Some(&browser_app),
-                Some(&meeting_url),
-                None,
-            ) {
-                return ResolvedMeetingCandidate::Ignored;
-            }
-            return ResolvedMeetingCandidate::Browser {
-                platform,
-                meeting_url,
-                browser_app,
-                session_key,
-                first_seen_at,
-                process: process.clone(),
+                live_evidence: false,
             };
         }
 

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/state.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/state.rs
@@ -72,6 +72,41 @@ pub(crate) fn advance_audio_process_state(
         .iter()
         .find_map(ResolvedMeetingCandidate::unresolved_browser_session);
 
+    // Live evidence — a native app identity, the active-tab URL probe, or the
+    // AX window sweep, all observed on THIS poll — starts a meeting from any
+    // pre-start state on a single sighting. The confirm window exists so that
+    // stored frame evidence (up to 10s stale) has to prove itself across two
+    // polls; a live observation has nothing to prove by waiting, and every
+    // poll spent waiting is time a competing notes app owns the user's
+    // attention.
+    let pre_start = matches!(
+        state,
+        AudioProcessMeetingState::Idle
+            | AudioProcessMeetingState::Candidate { .. }
+            | AudioProcessMeetingState::CandidateUnresolvedBrowser { .. }
+    );
+    if pre_start && resolved.as_ref().is_some_and(|s| s.live_evidence) {
+        let session = resolved.expect("checked is_some above");
+        return (
+            AudioProcessMeetingState::Active {
+                meeting_id: -1,
+                platform: session.platform.clone(),
+                session_key: session.session_key.clone(),
+                meeting_url: session.meeting_url.clone(),
+                first_seen_at: session.first_seen_at,
+                last_seen_at: now,
+                is_browser: session.is_browser,
+            },
+            Some(AudioProcessStateAction::StartMeeting {
+                platform: session.platform,
+                session_key: session.session_key,
+                meeting_url: session.meeting_url,
+                first_seen_at: session.first_seen_at,
+                is_browser: session.is_browser,
+            }),
+        );
+    }
+
     match state {
         AudioProcessMeetingState::Idle => advance_from_idle(resolved, unresolved, now),
         AudioProcessMeetingState::Candidate {

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -317,6 +317,66 @@ fn ax_fallback_can_resolve_browser_platform() {
 }
 
 #[test]
+fn active_tab_meet_url_resolves_candidate() {
+    // Arc exposes no AXDocument and titles its in-call window with just the
+    // meeting code ("phv-jdrc-vxw"), so the AX sweep can never attribute it.
+    // The live active-tab URL probe must resolve it directly.
+    let profiles = load_detection_profiles();
+    let candidate =
+        resolve_active_tab_url_candidate("Arc", "https://meet.google.com/abc-defg-hij", &profiles)
+            .expect("meet url should resolve to a candidate");
+    assert_eq!(candidate.browser_app, "Arc");
+    assert_eq!(
+        platform_name_for_profile(&profiles[candidate.profile_index], true),
+        "Google Meet"
+    );
+    assert_eq!(
+        candidate.meeting_url.as_deref(),
+        Some("https://meet.google.com/abc-defg-hij")
+    );
+}
+
+#[test]
+fn active_tab_join_url_with_query_params_resolves_candidate() {
+    // Green-room join URLs carry query params (?ijlm=…&adhoc=1). Matching
+    // strips them, but the stored meeting_url keeps the browser-reported form.
+    let profiles = load_detection_profiles();
+    let url = "https://meet.google.com/abc-defg-hij?ijlm=1783008102488&hs=187&adhoc=1";
+    let candidate = resolve_active_tab_url_candidate("Arc", url, &profiles)
+        .expect("join url should resolve to a candidate");
+    assert_eq!(
+        platform_name_for_profile(&profiles[candidate.profile_index], true),
+        "Google Meet"
+    );
+    assert_eq!(candidate.meeting_url.as_deref(), Some(url));
+}
+
+#[test]
+fn active_tab_unrelated_url_does_not_resolve() {
+    let profiles = load_detection_profiles();
+    assert!(resolve_active_tab_url_candidate(
+        "Arc",
+        "https://github.com/screenpipe/screenpipe/pull/4772",
+        &profiles
+    )
+    .is_none());
+    assert!(resolve_active_tab_url_candidate("Arc", "", &profiles).is_none());
+}
+
+#[test]
+fn active_tab_meeting_link_in_query_does_not_resolve() {
+    // A meeting URL carried as a query param on an unrelated page is not the
+    // page you're on (#4246): the query/fragment must be ignored for matching.
+    let profiles = load_detection_profiles();
+    assert!(resolve_active_tab_url_candidate(
+        "Arc",
+        "https://example.com/redirect?to=https://meet.google.com/abc-defg-hij",
+        &profiles
+    )
+    .is_none());
+}
+
+#[test]
 fn unresolved_browser_does_not_start_after_confirmation() {
     let process = chrome_process();
     let key = ProcessKey::from_process(&process).unwrap();
@@ -443,6 +503,8 @@ fn sticky_process_absent_from_live_snapshot_cannot_start() {
     let process = chrome_process();
     let key = ProcessKey::from_process(&process).unwrap();
     let start = Instant::now();
+    // live_evidence: true on purpose — even live evidence must not start a
+    // meeting for a process that is absent from the live snapshot.
     let sticky_only = vec![ResolvedMeetingCandidate::Browser {
         platform: "Google Meet".to_string(),
         meeting_url: "https://meet.google.com/abc-defg-hij".to_string(),
@@ -450,6 +512,7 @@ fn sticky_process_absent_from_live_snapshot_cannot_start() {
         session_key: key,
         first_seen_at: start,
         process,
+        live_evidence: true,
     }];
 
     let (state, action) = advance_audio_process_state(
@@ -466,7 +529,9 @@ fn sticky_process_absent_from_live_snapshot_cannot_start() {
 }
 
 #[test]
-fn unresolved_browser_resolution_gets_fresh_confirm_window() {
+fn stored_evidence_resolution_gets_fresh_confirm_window() {
+    // Resolution via stored frame evidence (live_evidence: false) still has to
+    // survive the confirm window, measured from the moment it resolved.
     let process = chrome_process();
     let key = ProcessKey::from_process(&process).unwrap();
     let start = Instant::now();
@@ -492,6 +557,7 @@ fn unresolved_browser_resolution_gets_fresh_confirm_window() {
         session_key: key,
         first_seen_at: start,
         process,
+        live_evidence: false,
     };
     let resolved_at = start + Duration::from_secs(10);
     let (state, action) = advance_audio_process_state(
@@ -520,6 +586,124 @@ fn unresolved_browser_resolution_gets_fresh_confirm_window() {
         action,
         Some(AudioProcessStateAction::StartMeeting { first_seen_at, .. }) if first_seen_at == resolved_at
     ));
+}
+
+#[test]
+fn live_resolution_starts_meeting_on_first_sighting() {
+    // Evidence observed live on this poll (active-tab probe / AX sweep /
+    // native identity) starts the meeting immediately — no confirm window,
+    // even a generous one.
+    let process = arc_process();
+    let key = ProcessKey::from_process(&process).unwrap();
+    let start = Instant::now();
+    let resolved = ResolvedMeetingCandidate::Browser {
+        platform: "Google Meet".to_string(),
+        meeting_url: "https://meet.google.com/abc-defg-hij".to_string(),
+        browser_app: "Arc".to_string(),
+        session_key: key,
+        first_seen_at: start,
+        process,
+        live_evidence: true,
+    };
+    let (state, action) = advance_audio_process_state(
+        AudioProcessMeetingState::Idle,
+        std::slice::from_ref(&resolved),
+        std::slice::from_ref(&resolved),
+        start,
+        Duration::from_secs(30),
+        Duration::from_secs(20),
+    );
+    assert!(matches!(state, AudioProcessMeetingState::Active { .. }));
+    assert!(matches!(
+        action,
+        Some(AudioProcessStateAction::StartMeeting { platform, .. }) if platform == "Google Meet"
+    ));
+}
+
+#[test]
+fn live_resolution_starts_immediately_from_unresolved_browser() {
+    // An unresolved browser that resolves via live evidence does not wait out
+    // a fresh confirm window — that wait exists for stored evidence only.
+    let process = arc_process();
+    let key = ProcessKey::from_process(&process).unwrap();
+    let start = Instant::now();
+    let state = AudioProcessMeetingState::CandidateUnresolvedBrowser {
+        browser_app: "Arc".to_string(),
+        session_key: key.clone(),
+        first_seen_at: start,
+        last_resolution_attempt: start,
+    };
+    let resolved = ResolvedMeetingCandidate::Browser {
+        platform: "Google Meet".to_string(),
+        meeting_url: "https://meet.google.com/abc-defg-hij".to_string(),
+        browser_app: "Arc".to_string(),
+        session_key: key,
+        first_seen_at: start,
+        process,
+        live_evidence: true,
+    };
+    let (state, action) = advance_audio_process_state(
+        state,
+        std::slice::from_ref(&resolved),
+        std::slice::from_ref(&resolved),
+        start + Duration::from_secs(5),
+        Duration::from_secs(3),
+        Duration::from_secs(20),
+    );
+    assert!(matches!(state, AudioProcessMeetingState::Active { .. }));
+    assert!(action.is_some());
+}
+
+#[test]
+fn live_ax_candidate_outranks_stored_frame_evidence() {
+    // A live observation wins over stored frame evidence (which can be up to
+    // 10s stale), and an urlless AX-sweep candidate borrows the stored URL
+    // when both agree on the profile.
+    let profiles = load_detection_profiles();
+    let process = arc_process();
+    let meet_profile = profiles
+        .iter()
+        .position(|p| {
+            p.app_identifiers
+                .browser_url_patterns
+                .contains(&"meet.google.com")
+        })
+        .unwrap();
+    let evidence = vec![BrowserPageEvidence {
+        browser_app: Some("Arc".to_string()),
+        url: Some("https://meet.google.com/abc-defg-hij".to_string()),
+        title: Some("abc-defg-hij".to_string()),
+    }];
+    let ax = vec![AxResolvedCandidate {
+        browser_app: "Arc".to_string(),
+        profile_index: meet_profile,
+        meeting_url: None,
+    }];
+    let candidate = resolve_process_candidate(
+        ProcessKey::from_process(&process).unwrap(),
+        Instant::now(),
+        &process,
+        &profiles,
+        &evidence,
+        &ax,
+        &[],
+    );
+    match candidate {
+        ResolvedMeetingCandidate::Browser {
+            platform,
+            meeting_url,
+            live_evidence,
+            ..
+        } => {
+            assert_eq!(platform, "Google Meet");
+            assert!(live_evidence, "ax-resolved candidate must be live");
+            assert_eq!(
+                meeting_url, "https://meet.google.com/abc-defg-hij",
+                "urlless AX candidate should borrow the stored URL for the same profile"
+            );
+        }
+        other => panic!("expected Browser candidate, got {other:?}"),
+    }
 }
 
 #[test]
@@ -640,6 +824,7 @@ fn auto_end_suppresses_same_session_restart_until_audio_session_disappears() {
         session_key: key.clone(),
         first_seen_at: start + Duration::from_secs(22),
         process: process.clone(),
+        live_evidence: true,
     }];
     filter_suppressed_candidates(&mut candidates, &suppressed);
     assert!(
@@ -672,6 +857,7 @@ fn explicit_stop_suppresses_current_session_until_process_disappears() {
         session_key: key.clone(),
         first_seen_at: start,
         process: process.clone(),
+        live_evidence: true,
     }];
 
     filter_suppressed_candidates(&mut candidates, &suppressed);
@@ -708,6 +894,7 @@ fn explicit_stop_does_not_suppress_new_browser_meeting_url() {
         session_key: key,
         first_seen_at: start,
         process,
+        live_evidence: true,
     }];
 
     filter_suppressed_candidates(&mut candidates, &suppressed);
@@ -739,6 +926,7 @@ fn explicit_stop_does_not_suppress_new_audio_session_same_browser_pid() {
         session_key: new_key,
         first_seen_at: start,
         process: new_process,
+        live_evidence: true,
     }];
 
     filter_suppressed_candidates(&mut candidates, &suppressed);

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/windows.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/windows.rs
@@ -8,6 +8,18 @@ use super::*;
 use crate::meeting_watcher::shared::ignore::{is_browser_app, meeting_app_is_ignored_with_terms};
 use crate::meeting_watcher::shared::profiles::MeetingDetectionProfile;
 
+/// Windows: no live active-tab URL probe yet. The UIA sweep in
+/// `ax_resolved_candidates` reads browser window titles/URLs already; wiring
+/// `browser_utils`' UIA URL detector here is possible but unverified, so keep
+/// this a no-op until it's tested on a real Windows browser matrix.
+pub(crate) async fn active_tab_url_candidates(
+    _browser_apps: &[String],
+    _profiles: &[MeetingDetectionProfile],
+    _ignored_terms: &[String],
+) -> Vec<AxResolvedCandidate> {
+    Vec::new()
+}
+
 pub(crate) async fn ax_resolved_candidates(
     profiles: &[MeetingDetectionProfile],
     ignored_terms: &[String],


### PR DESCRIPTION
## description

Browser meetings — Arc + Google Meet worst of all — were detected 30–90s late, or never. A browser holding the mic must resolve to a platform URL before a meeting starts, and both resolution paths were broken for Arc: the AX fallback is structurally blind (Arc exposes no `AXDocument`, and its in-call window title is just the meeting code, e.g. `phv-jdrc-vxw` — no domain to match), so the only working source was `frames.browser_url` queried with a 10s freshness window. Frame capture is event-driven (`window_focus`/`key_press`/`visual_change`), so a static call screen produces **zero** frames and resolution starves until the user happens to interact. Verified against real calls with coreaudiod/TCC unified-log forensics: mic held from 16:01:43.8, fresh URL evidence in the DB, meeting row only at 16:02:22 — seconds after the *next* captured frame landed.

This PR:

- **Active-tab URL probe** — while a mic-holding browser is unresolved, ask the browser directly for its front-window active-tab URL every poll, reusing the vision pipeline's `browser_utils` detector (AppleScript for Arc, which works with the URL bar hidden; `AXDocument`/AX address-bar walk for the rest). Runs only in pre-start states, on a blocking thread, capped by a timeout so a hung browser can't stall the loop. Same TCC automation permission the vision pipeline already uses — no new prompt surface.
- **Start on live evidence, first sighting** — candidates resolved from live observations (the probe, the AX window sweep, a native app identity) start the meeting immediately. Stored frame evidence (up to 10s stale) keeps a confirm window, reduced 3s → 1s: the window only ever debounced blips — it never filtered voice notes, which run 5–60s (that gap is tracked in #4776).
- **Live outranks stored** — resolution precedence flipped so a stale frame can't override a live probe answer; urlless AX-sweep candidates borrow the stored URL when both agree on the profile.
- **Observability** — rate-limited INFO log when a mic-holding browser stays unresolved >15s; this "my call was never detected" mode was previously debug-only, i.e. silent.

related issue: #4776

## before

Backend-only change (meeting-watcher engine) — no UI surface, so measured timelines instead of recordings. From this machine's production DB + unified log, Arc + Meet, URL bar hidden:

```
16:01:43.8  Arc opens the mic (coreaudiod)          16:01:43-45  frames with meet URL captured
16:01:45.6  last frame before screen goes static
     ...    31s of static call screen → zero frames → zero evidence → no detection
16:02:16.6  user opens Arc side panel → visual_change frame → evidence lands
16:02:22.1  meeting row created                      = 39s after the mic engaged
```

(Second call, same day: 85s. A call with no interaction at all is never detected.)

## after

```
mic grab → next 1s poll: probe reads Arc's active tab (AppleScript, no URL bar needed)
         → resolves meet.google.com/... → live evidence → meeting starts on that poll
≈ 1–2s from mic grab, independent of frames, OCR, screen activity, or URL-bar visibility
```

## how to test

1. macOS, Arc with the toolbar/URL bar hidden: run the app (`bun tauri dev` from `apps/screenpipe-app-tauri/`), then start an ad-hoc meeting at `meet.new` and **don't touch anything** after joining (the old failure repro). Expect the "meeting detected: Google Meet" notification ~1–2s after the mic indicator appears (previously: only after clicking around, or never).
2. Repeat with the meeting joined and Arc immediately backgrounded behind another app — still detects (probe reads Arc's front window regardless of app focus).
3. `cargo test -p screenpipe-engine --lib meeting_watcher::audio_process` — 30/30, including the new `live_resolution_*` / `active_tab_*` / precedence tests.
4. Windows smoke (semantics are cross-platform even though the probe is a stub there): a native Teams/Zoom call should detect ~1–2s after the mic engages; launching Zoom/Teams *without* joining must not fire a phantom notification.

## desktop app checklist (if applicable)

N/A — touches `crates/screenpipe-engine` only; no `#[tauri::command]` handlers or frontend-exported types changed.
