### PR TITLE
ci(cache): dedupe Rust caches, release-dev profile for Windows tests, sccache for e2e-windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,23 +37,33 @@ jobs:
       RUSTFLAGS: "-C link-arg=-Wl,--allow-multiple-definition"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           override: true
-          cache: true
+          # The explicit rust-cache step below is the single cache layer.
+          # cache: true ran Swatinem/rust-cache a second time next to the
+          # plain actions/cache this replaced — two ~1 GB saves of the same
+          # artifacts per run, which fed the repo-wide cache eviction
+          # (>20 GB active vs GitHub's 10 GB limit) that kept every Rust CI
+          # restore cold.
+          cache: false
           rustflags: ""
+
+      - name: Rust cache
+        # Replaces actions/cache keyed exactly on hashFiles(Cargo.lock) with
+        # no restore-keys — any lockfile bump meant a fully cold 20+ min
+        # build. rust-cache falls back to the closest previous cache on a
+        # prefix match, so only changed deps rebuild. Restore/save is an
+        # optimization only; a transient GHA cache service error must never
+        # fail the job (same rationale as e2e-test.yml).
+        continue-on-error: true
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-test-ubuntu
+          cache-bin: false
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -78,12 +88,6 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~\AppData\Local\cargo\
-            target\
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -100,8 +104,22 @@ jobs:
         with:
           toolchain: stable
           override: true
-          cache: true
+          # See test-ubuntu: the explicit rust-cache step below is the
+          # single cache layer; cache: true would save a duplicate.
+          # The removed actions/cache here was doubly broken — its
+          # ~\AppData\Local\cargo\ path isn't CARGO_HOME on GitHub
+          # runners (that's ~\.cargo), so the registry half cached junk.
+          cache: false
           rustflags: ""
+
+      - name: Rust cache
+        # See test-ubuntu — prefix-fallback restore, single cache layer,
+        # never fail the job on a cache service error.
+        continue-on-error: true
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-test-windows
+          cache-bin: false
 
       - name: setup Bun
         uses: oven-sh/setup-bun@v2
@@ -171,14 +189,15 @@ jobs:
       # exits with STATUS_DLL_NOT_FOUND (0xc0000135) on the first
       # ort::api() call — which is exactly what test_process_ocr_task_windows
       # hits inside accuracy_test. Stage them before any cargo test that
-      # touches ort. Run this once for both --release/--target builds —
-      # cargo test --release --target x86_64-pc-windows-msvc puts test
-      # binaries under target/x86_64-pc-windows-msvc/release/deps/.
+      # touches ort. Run this once for all --profile release-dev/--target
+      # builds — cargo test --profile release-dev --target
+      # x86_64-pc-windows-msvc puts test binaries under
+      # target/x86_64-pc-windows-msvc/release-dev/deps/.
       - name: Stage ONNX Runtime DLLs next to test binary
         shell: pwsh
         run: |
           $src = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.24.2/lib"
-          $dst = "${{ github.workspace }}/target/x86_64-pc-windows-msvc/release/deps"
+          $dst = "${{ github.workspace }}/target/x86_64-pc-windows-msvc/release-dev/deps"
           if (-not (Test-Path $dst)) {
             New-Item -ItemType Directory -Path $dst -Force | Out-Null
           }
@@ -252,7 +271,11 @@ jobs:
           # above still provides the runtime DLL.
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
-        run: cargo test -p screenpipe-screen test_process_ocr_task_windows --release --target x86_64-pc-windows-msvc
+        # --profile release-dev, not --release: the release profile is the
+        # shipping profile (fat LTO, codegen-units=1) — pointlessly slow
+        # codegen for tests. release-dev (thin LTO, 16 codegen units, same
+        # opt-level) exists exactly for this; see root Cargo.toml.
+        run: cargo test -p screenpipe-screen test_process_ocr_task_windows --profile release-dev --target x86_64-pc-windows-msvc
 
       - name: Run PII removal tests
         env:
@@ -265,7 +288,8 @@ jobs:
           # above still provides the runtime DLL.
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
-        run: cargo test -p screenpipe-core pii_removal --release --target x86_64-pc-windows-msvc
+        # release-dev, not release — see the OCR test step above.
+        run: cargo test -p screenpipe-core pii_removal --profile release-dev --target x86_64-pc-windows-msvc
 
       - name: Run PII redaction tests
         env:
@@ -278,7 +302,8 @@ jobs:
           # above still provides the runtime DLL.
           # Use prebuilt NASM objects on Windows: https://aws.github.io/aws-lc-rs/requirements/windows.html#prebuilt-nasm-objects
           AWS_LC_SYS_PREBUILT_NASM: "1"
-        run: cargo test -p screenpipe-engine --lib pii_redaction_tests --release --target x86_64-pc-windows-msvc
+        # release-dev, not release — see the OCR test step above.
+        run: cargo test -p screenpipe-engine --lib pii_redaction_tests --profile release-dev --target x86_64-pc-windows-msvc
 
       # pipes_test removed — pipe manager system deleted in #2212
 
@@ -292,23 +317,28 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
           override: true
-          cache: true
+          # See test-ubuntu: the explicit rust-cache step below is the
+          # single cache layer; cache: true would save a duplicate.
+          cache: false
           rustflags: ""
+
+      - name: Rust cache
+        # See test-ubuntu — prefix-fallback restore, single cache layer,
+        # never fail the job on a cache service error. cache-bin: false
+        # also stops restoring a stale ~/.cargo/bin over the toolchain,
+        # the failure mode the "Verify Rust toolchain" step below guards
+        # against.
+        continue-on-error: true
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-test-macos
+          cache-bin: false
 
       - name: Verify Rust toolchain
         shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -106,6 +106,19 @@ jobs:
         target: x86_64-pc-windows-msvc
         cache-bin: false
 
+    # sccache, same as the Linux/macOS e2e jobs. This Build step is the
+    # slowest in all of CI (~45 min cold) and was the only e2e build
+    # without compiler-level caching. CARGO_INCREMENTAL=0 (set in the job
+    # env above) is required for sccache to cache rustc invocations.
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Configure sccache
+      shell: pwsh
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> $env:GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $env:GITHUB_ENV
+
     - name: Rust cache
       # cache restore/save is an optimization only; a transient GHA cache
       # service error must never fail the job (skipped build+tests, red CI)


### PR DESCRIPTION
## description

Rust CI is slow because its caches barely survive between runs. Two concrete problems, plus one profile fix and one missing sccache:

**1. Every Rust CI job saved two ~1 GB duplicate caches per run.** `ci.yml` had a plain `actions/cache` keyed *exactly* on `hashFiles('**/Cargo.lock')` with no `restore-keys`, **and** `setup-rust-toolchain` with `cache: true`, which runs Swatinem/rust-cache a second time over the same `~/.cargo` + `target/`. The repo sits at **~21 GB of active caches against GitHub's 10 GB eviction threshold** (2,233 entries), so entries get LRU-evicted within hours. Measured on run [28621168402](https://github.com/screenpipe/screenpipe/actions/runs/28621168402): test-ubuntu restored nothing ("Cache not found" + rust-cache "No cache found."), ran `cargo test --workspace` cold for 21.6 min, saved 2.3 GB of caches at 21:21 UTC — and by 22:20 UTC the `Linux-cargo-*` key was already evicted (cache API returns 0 results). Fix: **one** explicit `Swatinem/rust-cache@v2` layer per job (prefix-fallback restore, `continue-on-error`, `cache-bin: false`), `cache: false` on the toolchain action. This halves what these jobs feed into the eviction pool, which also helps every other workflow's caches survive. Bonus: the Windows job's plain cache path `~\AppData\Local\cargo\` wasn't even `CARGO_HOME` (that's `~\.cargo`), so its registry half cached junk.

**2. Windows tests built with the shipping profile.** The three `cargo test ... --release` invocations used `[profile.release]` from the root Cargo.toml — fat LTO + `codegen-units = 1`, sized for shipped binaries, pointless codegen cost for tests. They now use the existing `release-dev` profile (thin LTO, 16 codegen units, same opt-level). The ONNX DLL staging path moved with it (`release/deps` → `release-dev/deps`).

**3. e2e-windows had no sccache.** Its Build step is the single slowest step in all of CI (~45 min cold); the Linux and macOS e2e jobs both have sccache, Windows didn't. Added the same `mozilla-actions/sccache-action` + env setup (the job already sets `CARGO_INCREMENTAL: "0"`, which sccache requires).

**Not changed — style.yml (Code Quality):** it was suspected of running clippy with no Rust cache, but run logs show `setup-rust-toolchain`'s embedded rust-cache is already active there by default and hitting (`Cache hit for: v0-rust-lint-Linux-x64-...`, "Restored from cache ... full match: true", 3.4 min warm job on run [28624806834](https://github.com/screenpipe/screenpipe/actions/runs/28624806834)). Adding an explicit Swatinem step would recreate exactly the duplication this PR removes. Its occasional slow runs are the same eviction pressure, which this PR reduces at the source.

Verified with `actionlint` 1.7.12 — clean on both files.

## before

CI-only change, no app/CLI surface — timings are the visual (before = measured on recent `main` runs; after = expected once caches persist):

| job / step | before (measured) | after (expected) |
|---|---|---|
| Rust CI · test-ubuntu | 23 min (21.6 min `cargo test` fully cold; cache evicted within ~1 h of saving) | ~8–12 min warm; lockfile bumps rebuild only changed deps via prefix fallback |
| Rust CI · test-windows | 15.3 min, tests under fat-LTO `--release` | thin-LTO `release-dev` codegen + working dep cache |
| Rust CI cache footprint | ~2 GB duplicate saves per job per run → feeds 21 GB/10 GB eviction spiral | half the footprint; caches actually survive between runs |
| E2E · windows Build | ~45 min, zero compiler caching (slowest step in CI) | sccache-warm rebuilds like the Linux/macOS e2e jobs |
| Code Quality · clippy | 3.4 min warm (cache already works — left untouched) | unchanged, survives eviction more often |

## after

Same table above — "after" numbers firm up after a couple of `main` runs repopulate the caches. First run on this PR is expectedly cold (new cache keys).

## how to test

1. Watch the Rust CI run on this PR: each job should show one `Rust cache` step restoring/saving (and no `actions/cache` step); `test-windows` test steps compile with `--profile release-dev` and still pass, with DLL staging into `release-dev/deps`.
2. In the E2E `windows-e2e-test` job, the Build step log should show `RUSTC_WRAPPER=sccache` taking effect (sccache stats printed by the action's post step); second run on the same branch should be markedly faster.
3. After merge, re-run a `main` push twice and compare test-ubuntu wall time (cold vs warm) — warm should drop well under 23 min. `gh api repos/screenpipe/screenpipe/actions/cache/usage` should trend down from ~21 GB.

## desktop app checklist (if applicable)

N/A — CI workflow YAML only; no `#[tauri::command]` or exported Rust type changes.
