### PR TITLE
fix(app): point clean script's cargo clean at the app crate, not the root workspace

### DIFF
--- a/apps/screenpipe-app-tauri/package.json
+++ b/apps/screenpipe-app-tauri/package.json
@@ -36,7 +36,7 @@
     "prebuild": "bun scripts/gen-skill-content.js && bun scripts/pre_build.js",
     "tauri": "tauri",
     "tauri:build": "scripts/build_macos.sh",
-    "clean": "rm -rf out && cargo clean && rm -rf src-tauri/{screenpipe-*,tesseract-*,ffmpeg*,openblas*,bun*,ollama*,ui_monitor*} node_modules"
+    "clean": "rm -rf out && cargo clean --manifest-path src-tauri/Cargo.toml && rm -rf src-tauri/{screenpipe-*,tesseract-*,ffmpeg*,openblas*,bun*,ollama*,ui_monitor*} node_modules"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## description

the app's `clean` script (`apps/screenpipe-app-tauri/package.json`) runs a bare `cargo clean` with cwd = `apps/screenpipe-app-tauri`, which has no `Cargo.toml`. cargo walks up to the repo-root workspace manifest — and since the app crate is in that workspace's `exclude` list, the result is exactly backwards:

- it deletes the **shared root `target/`** (the workspace build for every engine crate — easily 100+ GB on a dev machine, and shared across parallel worktrees), and
- it leaves the **app's own `src-tauri/target`** — the thing `clean` was meant to reset — completely untouched.

this has been broken since the script was introduced (jul 2024): the app crate was already workspace-excluded back then, so the bare `cargo clean` never once cleaned the app build. every other step in the script is app-local (`out/`, sidecar binaries under `src-tauri/`, `node_modules`), so the intent is unambiguous. nothing in CI, docs, or other scripts calls `clean` — it's a local dev convenience — so no behavior anyone depends on changes.

fix: `cargo clean --manifest-path src-tauri/Cargo.toml`.

## before

no UI surface — dev-only script change, so no recording. resolution before the fix (verified with `cargo metadata`, non-destructively):

```
$ cd apps/screenpipe-app-tauri
$ cargo locate-project
{"root":"<repo>/Cargo.toml"}                  # root workspace!
$ cargo metadata ... | jq .target_directory
"<repo>/target"                                # bun run clean nukes ~100+ GB of engine builds
                                               # ...and src-tauri/target survives untouched
```

## after

```
$ cd apps/screenpipe-app-tauri
$ cargo metadata --manifest-path src-tauri/Cargo.toml ... | jq .target_directory
"<repo>/apps/screenpipe-app-tauri/src-tauri/target"   # the app build, as intended
```

## how to test

non-destructive — don't run the actual clean against a warm root target :)

1. `cd apps/screenpipe-app-tauri`
2. `cargo clean --dry-run` → note it resolves to the repo-root workspace (old behavior)
3. `cargo clean --manifest-path src-tauri/Cargo.toml --dry-run` → resolves to `src-tauri/target` (new behavior)
4. optionally `cargo metadata --no-deps --manifest-path src-tauri/Cargo.toml --format-version 1 | jq -r .target_directory` to confirm the target dir

## desktop app checklist (if applicable)

N/A — package.json script change only; no `#[tauri::command]` handlers or exported Rust types touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
