### PR TITLE
fix(cli): retention auto-enable now authenticates its localhost self-call (fixes #4804)

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1816,44 +1816,67 @@ async fn main() -> anyhow::Result<()> {
 
     // Auto-enable local data retention for CLI users.
     // The Tauri app does this via auto_start_retention(); for CLI we hit the
-    // same HTTP endpoint after a short delay to let the server bind.
+    // same HTTP endpoint after the server binds. The self-call must present
+    // the local API key: with --api-auth (default on) the auth middleware
+    // rejects even localhost requests, and /retention/configure is not an
+    // exempt path — without the token the call 403s and retention silently
+    // never starts while the DB grows unbounded (#4804).
     {
         let port = config.port;
         let retention_days = record_args.retention_days;
         let retention_mode = record_args.retention_mode;
         let retention_enabled = retention_days > 0;
+        let api_auth_key = config
+            .api_auth
+            .then(|| config.api_auth_key.clone())
+            .flatten();
         tokio::spawn(async move {
             if !retention_enabled {
                 tracing::info!("local retention disabled (--retention-days 0)");
                 return;
             }
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            let client = reqwest::Client::new();
-            let url = format!("http://localhost:{}/retention/configure", port);
-            match client
-                .post(&url)
-                .json(&serde_json::json!({
-                    "enabled": true,
-                    "retention_days": retention_days,
-                    "mode": retention_mode,
-                }))
-                .send()
+            // Retry with backoff: on a large DB the server can take far longer
+            // than a fixed sleep to bind, and a one-shot failure would leave
+            // retention disabled for the entire run.
+            let delays_secs = [5u64, 10, 20, 40, 60];
+            let attempts = delays_secs.len();
+            let mut last_error = String::new();
+            for (i, delay) in delays_secs.into_iter().enumerate() {
+                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+                match screenpipe_engine::retention::configure_retention_via_local_api(
+                    port,
+                    retention_days,
+                    retention_mode,
+                    api_auth_key.as_deref(),
+                )
                 .await
-            {
-                Ok(r) if r.status().is_success() => {
-                    tracing::info!(
-                        "local retention auto-enabled ({} days, mode={:?})",
-                        retention_days,
-                        retention_mode
-                    );
-                }
-                Ok(r) => {
-                    tracing::debug!("retention configure returned {}", r.status());
-                }
-                Err(e) => {
-                    tracing::debug!("retention configure failed: {}", e);
+                {
+                    Ok(()) => {
+                        tracing::info!(
+                            "local retention auto-enabled ({} days, mode={:?})",
+                            retention_days,
+                            retention_mode
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        last_error = e;
+                        tracing::warn!(
+                            "retention configure attempt {}/{} failed: {}",
+                            i + 1,
+                            attempts,
+                            last_error
+                        );
+                    }
                 }
             }
+            tracing::error!(
+                "local retention could NOT be enabled after {} attempts (last error: {}); \
+                 --retention-days {} will have no effect and the database will keep growing",
+                attempts,
+                last_error,
+                retention_days
+            );
         });
     }
 

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -713,9 +713,10 @@ pub struct RecordArgs {
     #[arg(long, default_value_t = false)]
     pub disable_click_capture: bool,
 
-    /// Require authentication for remote API access. When enabled, non-localhost
-    /// requests must include Authorization: Bearer <SCREENPIPE_API_KEY>.
-    /// Localhost requests are always allowed.
+    /// Require authentication for API access. When enabled, all requests —
+    /// including from localhost — must include Authorization: Bearer
+    /// <SCREENPIPE_API_KEY> (get the key with `screenpipe auth token`). Only
+    /// a small exempt list (/health, OAuth callbacks, pipe store) skips auth.
     #[arg(long, default_value_t = true)]
     pub api_auth: bool,
 

--- a/crates/screenpipe-engine/src/retention.rs
+++ b/crates/screenpipe-engine/src/retention.rs
@@ -241,6 +241,35 @@ pub async fn retention_configure(
     }
 }
 
+/// Configure retention by calling the engine's own HTTP endpoint, presenting
+/// the local API bearer token. Used by the CLI (`screenpipe-engine record`) to
+/// auto-enable retention after the server binds: with `--api-auth` (default
+/// on) the auth middleware rejects even localhost requests without the token,
+/// and `/retention/configure` is not an exempt path — an unauthenticated
+/// self-call gets a 403 and retention silently never starts (#4804).
+pub async fn configure_retention_via_local_api(
+    port: u16,
+    retention_days: u32,
+    mode: RetentionMode,
+    api_auth_key: Option<&str>,
+) -> Result<(), String> {
+    let client = reqwest::Client::new();
+    let url = format!("http://localhost:{}/retention/configure", port);
+    let mut request = client.post(&url).json(&json!({
+        "enabled": true,
+        "retention_days": retention_days,
+        "mode": mode,
+    }));
+    if let Some(key) = api_auth_key {
+        request = request.header(reqwest::header::AUTHORIZATION, format!("Bearer {key}"));
+    }
+    match request.send().await {
+        Ok(r) if r.status().is_success() => Ok(()),
+        Ok(r) => Err(format!("HTTP {}", r.status())),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 /// GET /retention/status — return current retention state.
 #[oasgen]
 pub async fn retention_status(
@@ -612,5 +641,49 @@ mod tests {
         // `now - Duration::days(..)` panicked here; the guard must yield None so
         // the retention loop skips the cycle instead of crashing.
         assert_eq!(retention_cutoff(u32::MAX, now), None);
+    }
+
+    #[tokio::test]
+    async fn configure_via_local_api_sends_bearer_token() {
+        use axum::routing::post;
+        use std::sync::Mutex;
+
+        // Stub /retention/configure that records the Authorization header of
+        // each request — the regression in #4804 was the CLI self-call
+        // omitting it and being 403'd by the auth middleware.
+        let seen: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_handler = seen.clone();
+        let app = axum::Router::new().route(
+            "/retention/configure",
+            post(move |headers: axum::http::HeaderMap| {
+                let seen = seen_handler.clone();
+                async move {
+                    seen.lock().unwrap().push(
+                        headers
+                            .get(axum::http::header::AUTHORIZATION)
+                            .and_then(|v| v.to_str().ok())
+                            .map(|s| s.to_string()),
+                    );
+                    JsonResponse(json!({"success": true}))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        configure_retention_via_local_api(port, 7, RetentionMode::All, Some("test-key"))
+            .await
+            .expect("authorized configure succeeds");
+        configure_retention_via_local_api(port, 7, RetentionMode::All, None)
+            .await
+            .expect("configure without key still succeeds against stub");
+
+        let calls = seen.lock().unwrap().clone();
+        assert_eq!(
+            calls,
+            vec![Some("Bearer test-key".to_string()), None],
+            "self-call must carry the bearer token exactly when a key is provided"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4804 — CLI `--retention-days`/`--retention-mode` silently never prunes and the DB grows unbounded (reporter: 41 GB over 25 days under a 14-day window, zero retention log lines).

**Root cause**: the CLI auto-enables retention by POSTing to its own `http://localhost:{port}/retention/configure` — **without an Authorization header**. But `--api-auth` defaults to **on** for every CLI run, the auth middleware enforces the bearer token on **all** requests including localhost, and `/retention/configure` is not on the exempt-path list. So the self-call gets a 403, and both failure branches logged only at `tracing::debug!` — invisible at the default `info` filter. Retention never starts, and nothing says so. (The desktop app is unaffected: `auto_start_retention()` in `sync.rs` injects the bearer token.)

## Changes

- **`crates/screenpipe-engine/src/retention.rs`**: new `configure_retention_via_local_api(port, days, mode, api_auth_key)` helper that attaches `Authorization: Bearer <key>` when a key is provided; unit test with a stub server asserting the header is sent exactly when a key is present.
- **`crates/screenpipe-engine/src/bin/screenpipe-engine.rs`**: the auto-enable block now (1) passes the already-resolved `config.api_auth_key` through the helper, (2) retries 5× with backoff (5s→60s) instead of a single shot 5s after spawn — on a large DB the server can take far longer than 5s to bind, and a one-shot failure permanently disabled retention, (3) logs failures at `warn!` per attempt and a final `error!` naming the flag, instead of swallowing everything at `debug!`.
- **`crates/screenpipe-engine/src/cli/mod.rs`**: the `--api-auth` help text claimed "Localhost requests are always allowed" — false since the middleware enforces on localhost too; rewritten to describe actual behavior and point at `screenpipe auth token`.

## Before / after (log behavior)

Before — `screenpipe record --retention-days 7 --retention-mode all`, default log filter:

```
(no retention lines at all — the 403 is swallowed at debug level;
 retention loop never spawns; DB grows forever)
```

After — same command:

```
INFO  local retention auto-enabled (7 days, mode=All)
```

After — if the configure call genuinely cannot succeed:

```
WARN  retention configure attempt 1/5 failed: HTTP 403 Forbidden
...
ERROR local retention could NOT be enabled after 5 attempts (last error: HTTP 403 Forbidden); --retention-days 7 will have no effect and the database will keep growing
```

## Tests

- `cargo test -p screenpipe-engine --lib retention` — includes the new `configure_via_local_api_sends_bearer_token` stub-server test (asserts `Bearer <key>` header present exactly when a key is provided) plus the existing cutoff tests.

## Verification of the root cause

- `crates/screenpipe-engine/src/server.rs` middleware comment: "when api_auth is enabled, ALL requests (including localhost) must include a valid bearer token"; `is_api_auth_exempt_path` covers only `/health`, OAuth callbacks, and pipe-store paths — not `/retention/configure`.
- `--api-auth` default: `default_value_t = true` (`cli/mod.rs`).
- The key is already resolved before the spawn site via `resolve_api_auth_key` → `config.api_auth_key`, so the fix is a pass-through, no new key plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
