### PR TITLE
ci(e2e): make macOS E2E advisory so its 90-min timeout can't cancel the run

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -729,7 +729,9 @@ jobs:
     # Swift 6 package, while the current latest image advertises an Xcode 26.5
     # toolchain path but is missing clang_rt.osx.
     runs-on: macos-15
-    timeout-minutes: 90
+    # Backstop above the 70-min advisory step timeout on "Run E2E Tests" so the
+    # post-test steps (coverage, artifact upload) finish inside the job budget.
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v4
 
@@ -807,6 +809,16 @@ jobs:
         tauriScript: bunx tauri -v
 
     - name: Run E2E Tests
+      # ADVISORY (non-blocking): the full serial suite (maxInstances:1) with
+      # specFileRetries:3 on the slow macos-15 image exceeds the job budget and
+      # was killed at the 90-min job timeout every run -> "cancelled" reddened
+      # the whole workflow even though Linux passed. Step-level continue-on-error
+      # + a step timeout BELOW the job timeout lets macOS run for signal but never
+      # cancel the run (job-level continue-on-error does NOT cover a timeout
+      # cancellation). Linux remains the hard E2E gate. Make-it-gate-again
+      # (parallelize maxInstances, cache the build, cut retries) tracked in #4688.
+      continue-on-error: true
+      timeout-minutes: 70
       shell: bash
       working-directory: ./apps/screenpipe-app-tauri
       env:


### PR DESCRIPTION
**Root cause:** the macOS E2E job runs the full WebdriverIO suite **serially** (`maxInstances:1`) with `specFileRetries:3` on the required `macos-15` image, and the retry flood exceeds the **90-min job timeout every run** → the job is `cancelled`, reddening the whole workflow even though Linux passes. (macos-15 is required: macos-14 too old for permission-flow Swift 6, macos-latest lacks clang_rt.osx — so pinning the image isn't an option.)

**Fix:** `continue-on-error: true` + `timeout-minutes: 70` on the **`Run E2E Tests` step** (below the job's new 120-min backstop). The step is cut before the job timeout fires → the job succeeds → the run is green. macOS runs for signal but never cancels the run. **Linux + Linux Wayland stay hard gates**; Windows was already advisory. Perf work to restore macOS gating tracked in #4688.

Validated: YAML parses, Linux job unchanged (still gating).