### PR TITLE
ci(windows): parameterize ONNXRUNTIME_VERSION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ jobs:
     # image so we keep getting security patches and can pin a stable build
     # toolchain.
     runs-on: windows-2022
+    env:
+      # Single source of truth for the ONNX Runtime version. Referenced by
+      # the download URL, the extract dirname, the DLL staging src path, and
+      # the PATH-append step below. Bump this in one place instead of four.
+      ONNXRUNTIME_VERSION: "1.24.2"
     steps:
       - uses: actions/checkout@v4
 
@@ -164,9 +169,10 @@ jobs:
       - name: Download ONNX Runtime (CPU)
         shell: pwsh
         run: |
-          $url = "https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-win-x64-1.24.2.zip"
-          $zipFile = "onnxruntime-win-x64-1.24.2.zip"
-          $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.24.2"
+          $version = "${{ env.ONNXRUNTIME_VERSION }}"
+          $url = "https://github.com/microsoft/onnxruntime/releases/download/v$version/onnxruntime-win-x64-$version.zip"
+          $zipFile = "onnxruntime-win-x64-$version.zip"
+          $extractDir = "apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-$version"
           Invoke-WebRequest -Uri $url -OutFile $zipFile
           if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
           7z x $zipFile -o"apps/screenpipe-app-tauri/src-tauri/" -y
@@ -196,7 +202,7 @@ jobs:
       - name: Stage ONNX Runtime DLLs next to test binary
         shell: pwsh
         run: |
-          $src = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.24.2/lib"
+          $src = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-${{ env.ONNXRUNTIME_VERSION }}/lib"
           $dst = "${{ github.workspace }}/target/x86_64-pc-windows-msvc/release-dev/deps"
           if (-not (Test-Path $dst)) {
             New-Item -ItemType Directory -Path $dst -Force | Out-Null
@@ -256,7 +262,7 @@ jobs:
       - name: Add ONNX lib dir to PATH for cargo tests
         shell: pwsh
         run: |
-          $ortLib = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-1.24.2/lib"
+          $ortLib = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-${{ env.ONNXRUNTIME_VERSION }}/lib"
           echo $ortLib | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           Write-Host "PATH appended: $ortLib"
 


### PR DESCRIPTION
## Problem

The ONNX Runtime version (`1.24.2`) is hard-coded in 4 places inside `ci.yml`'s `test-windows` job:

- Download URL
- Zip filename
- Extract dirname
- DLL staging src path
- PATH-append step

A version bump today means editing four lines in this file alone, plus three more workflows (`e2e-test.yml`, `release-cli.yml`, `release-enterprise.yml`, `windows-integration-test.yml`) that follow the same pattern. Any miss leaves the extract dir mismatched with the bundle glob in `tauri.windows.conf.json` (`onnxruntime*\lib\onnxruntime.dll`) and the build silently produces an empty bundle, or tests fail at runtime with STATUS_DLL_NOT_FOUND.

## Fix

Extract the version to a single job-level env var `ONNXRUNTIME_VERSION` and reference it via `${{ env.ONNXRUNTIME_VERSION }}` everywhere. Same 1.24.2 pinned; same URL; same install path — pure refactor, no behavior change.

## Scope

Only `ci.yml` in this PR. If accepted, happy to open follow-ups for `e2e-test.yml`, `release-cli.yml`, `release-enterprise.yml`, and `windows-integration-test.yml` with the same pattern.

Thanks for maintaining screenpipe!