### PR TITLE
fix(onboarding): detect 401 during live-feed polls, show actionable copy

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -286,6 +286,12 @@ export default function EngineStartup({
 
   // Live feed: poll search for recent activity + thumbnails
   const emptyPollCountRef = useRef(0);
+  // Auth-race: /search 401s when _apiKey in lib/api.ts hasn't propagated to
+  // the webview yet (ensureInitialized retries getLocalApiConfig up to 30×
+  // 500ms; on corp-VDI Windows 11 that init sometimes exhausts before the
+  // engine binds its key). Surface it explicitly instead of leaving the user
+  // staring at "no activity" for the full 15s.
+  const [authNotReady, setAuthNotReady] = useState(false);
 
   useEffect(() => {
     if (state !== "live-feed") return;
@@ -316,6 +322,16 @@ export default function EngineStartup({
               ).catch(() => null)
             : Promise.resolve(null),
         ]);
+
+        // Detect the auth-key propagation race: if lib/api.ts _apiKey hasn't
+        // landed yet, /search returns 401. Surface it so the copy tells the
+        // user this is an auth issue, not a data-flow issue.
+        if (mainRes?.status === 401 || audioRes?.status === 401) {
+          console.warn(
+            "onboarding live-feed: /search returned 401 — api key not yet propagated to webview"
+          );
+          setAuthNotReady(true);
+        }
 
         const items: ActivityItem[] = [];
         const seen = new Set<string>();
@@ -382,6 +398,8 @@ export default function EngineStartup({
         if (items.length > 0) {
           setActivityItems(items.slice(0, SUMMARY_MAX_ITEMS));
           emptyPollCountRef.current = 0;
+          // Real data flowing → auth clearly recovered. Clear the hint.
+          setAuthNotReady(false);
         } else {
           emptyPollCountRef.current++;
         }
@@ -923,6 +941,12 @@ if the input is sparse, just describe what little you have warmly. don't apologi
               >
                 screenpipe is up and watching. as you work, what you see and
                 say will start appearing here. you can continue now.
+                {authNotReady && (
+                  <span className="block text-xs text-muted-foreground/60 mt-2">
+                    auth still initializing — if this persists, quit and
+                    relaunch screenpipe
+                  </span>
+                )}
               </motion.p>
             ) : showWaiting ? (
               <motion.p
@@ -933,6 +957,12 @@ if the input is sparse, just describe what little you have warmly. don't apologi
                 <span className="inline-block animate-pulse">
                   settling in. give me a moment to notice what you&apos;re up to…
                 </span>
+                {authNotReady && (
+                  <span className="block text-xs text-muted-foreground/60 mt-2">
+                    auth still initializing — if this persists, quit and
+                    relaunch screenpipe
+                  </span>
+                )}
               </motion.p>
             ) : (
               <motion.p


### PR DESCRIPTION
## Motivation
Onboarding flow is a hard block in scenarios where it can't run — corp VDI, headless tests, Docker containers, restricted networks, sandboxed WebView2 with DLP blocking egress. Users must currently either finish onboarding or edit `store.bin` manually.

## Change
`SCREENPIPE_SKIP_ONBOARDING=1` env var marks onboarding complete at startup and lands at the main view directly. Mirrors the existing `SCREENPIPE_E2E_SEED=onboarding` pattern. Zero effect on happy-path installs (unset by default). Accepts `1`, `true`, `yes` case-insensitively.

## Repro
Corp SAP laptop, WebView2 sandboxed by DLP. `/health` at localhost:3030 works via curl but Tauri webview can't reach it. Onboarding stuck at "upgrading your memory" forever. Env-var workaround unblocks the user immediately.

## Impact
- Additive; no default behavior change
- E2E tests can set this to skip repetitive onboarding
- Enterprise deploys can preseed via MDM/Group Policy
- Reset available via existing `resetOnboarding` command

Thanks for the great work on screenpipe!
