### PR TITLE
ci(sdk): add concurrency group to cancel superseded PR runs

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -19,6 +19,13 @@ on:
       - ".github/workflows/sdk.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  # Same rule as ci.yml / style.yml / test-frontend.yml — cancel superseded
+  # PR runs (saves minutes on rapid re-pushes); main pushes use per-commit
+  # groups so they don't queue behind stale commits.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   DEBUG: napi:*
   MACOSX_DEPLOYMENT_TARGET: "11.0"


### PR DESCRIPTION
## Problem
`sdk.yml` has no `concurrency:` block, so every push to a PR spawns fresh parallel runs of the whole matrix (4 build targets + macOS/Windows integration + Swift). Rapid re-pushes on the same PR waste runner minutes queueing stale runs.

## Fix
Add a `concurrency:` block that matches the existing pattern used in `ci.yml`, `style.yml`, and `test-frontend.yml`:
- Cancel superseded runs on PR branches.
- Group by SHA on `main` pushes so main pushes never cancel each other.

## Verification
YAML shape matches the three neighbouring workflows verbatim (only the workflow name differs). No job/matrix/step changes.

Thanks for the great work on screenpipe!
