### PR TITLE
feat(onboarding): show skip link earlier when engine spawn stalls

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -650,6 +650,27 @@ if the input is sparse, just describe what little you have warmly. don't apologi
     return () => clearTimeout(timer);
   }, [state]);
 
+  // Escape hatch for users whose engine never reaches live-feed. The 15s
+  // live-feed timer above only arms once /health polling succeeds; in
+  // corp-VDI / DLP-intercepted WebView2 → localhost / firewalled-3030
+  // environments the poll never resolves and the user is stuck on the
+  // starting screen with no way out. Arm a 10s fallback in any non-terminal
+  // state so a manual skip is always reachable. On the happy path the state
+  // transitions to running well before 10s and this effect's cleanup cancels
+  // the timer before it fires.
+  useEffect(() => {
+    if (state === "running" || state === "live-feed") return;
+    const timer = setTimeout(() => setShowSkip(true), 10000);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  // If we already know spawn failed (permission denied, engine crash, etc.)
+  // reveal skip immediately — there's no reason to gate the escape hatch on
+  // a timer once the failure is confirmed.
+  useEffect(() => {
+    if (state === "stuck") setShowSkip(true);
+  }, [state]);
+
   // Timers for taking-longer and stuck.
   //
   // The stuck timer used to fire unconditionally after 15s. That was wrong
@@ -1079,6 +1100,23 @@ if the input is sparse, just describe what little you have warmly. don't apologi
                 {bootPhase?.message ?? "starting engine..."}
               </motion.p>
             )}
+        </AnimatePresence>
+
+        {/* Escape hatch during prolonged starting — see the setShowSkip
+            effects above. Corp-VDI / DLP-filtered WebView → localhost users
+            never reach live-feed, so the skip must be reachable here too. */}
+        <AnimatePresence>
+          {state === "starting" && showSkip && (
+            <motion.button
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={handleSkip}
+              className="font-mono text-[11px] text-muted-foreground/40 hover:text-muted-foreground transition-colors lowercase mt-4 underline underline-offset-4"
+            >
+              skip — continue without recording
+            </motion.button>
+          )}
         </AnimatePresence>
 
         {/* Stuck UI */}


### PR DESCRIPTION
## Problem
Onboarding shows the skip link only after 15s **in `live-feed` state** (engine-startup.tsx:649). Users whose `/health` poll never succeeds — corp-VDI, DLP-intercepted WebView2→localhost, or firewall on 3030 — stay in `starting` state indefinitely with no escape hatch.

Repro'd on Windows 11 corp laptop with screenpipe engine confirmed running at `localhost:3030` via curl — but Tauri webview cannot reach it, likely CPIT DLP interception.

## Fix
Two additional `useEffect` triggers that flip `setShowSkip(true)`:
1. After 10s in any non-live-feed state (10s < 15s live-feed timer, so it acts as a lower-bound safety net without overriding normal flow)
2. Immediately when `state === "stuck"` (spawn errors — TCC denial, engine crash)

Plus a JSX skip button rendered during `state === "starting"` when `showSkip` is true — currently the skip is only rendered in the live-feed branch, so the state flip alone wouldn't be visible.

## Impact
- No change to the happy path — engine spawns fast → `state` transitions to `running` before 10s → the 10s effect's cleanup cancels the timer before it fires
- Users in stuck/racing scenarios can now bail after 10s instead of never

Thanks for the great work on screenpipe!
