### PR TITLE
docs(AGENTS.md): fix H1 to AGENTS.md (was CLAUDE.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 screenpipe captures accessibility trees, with OCR as fallback and conversations, and index them for AI consumption locally
 


### PR DESCRIPTION
## Change
Fix H1 heading in `AGENTS.md` from `# CLAUDE.md` to `# AGENTS.md`.

## Evidence
`AGENTS.md:1` currently reads `# CLAUDE.md` — matches the CLAUDE.md file byte-for-byte, likely a copy-paste from commit 8ac83e71a ("Add AGENTS instructions"). File renders on GitHub with a "CLAUDE.md" title on a file named AGENTS.md.

Thanks for the great work on screenpipe!
