### PR TITLE
refactor(engine): move crossbeam to dev-dependencies

### DIFF
--- a/crates/screenpipe-engine/Cargo.toml
+++ b/crates/screenpipe-engine/Cargo.toml
@@ -87,9 +87,6 @@ reqwest = { workspace = true }
 # Upstream tinfoilsh/tinfoil-rs main, post-#21 (the ring-backend fix).
 tinfoil = { workspace = true }
 
-# Concurrency
-crossbeam = { workspace = true }
-
 # base64
 base64 = { workspace = true }
 
@@ -139,6 +136,11 @@ env_logger = { workspace = true }
 tempfile = { workspace = true }
 tokio-tungstenite = { workspace = true }
 tower = { version = "0.4", features = ["util"] }
+
+# Lock-free queue used by tests/consumer_sleep_test.rs to reproduce the
+# OCR frame-drop bug (see the test's docstring). Not needed by the crate
+# itself — src/, benches/, and examples/ don't import crossbeam.
+crossbeam = { workspace = true }
 
 # Benches
 criterion = { workspace = true }


### PR DESCRIPTION
## Change
Move `crossbeam` from `[dependencies]` to `[dev-dependencies]` in `crates/screenpipe-engine/Cargo.toml`.

## Rationale
`crossbeam` is only imported by `crates/screenpipe-engine/tests/consumer_sleep_test.rs:12` (the OCR frame-drop regression test). No `src/`, `benches/`, `examples/`, or `build.rs` file in `screenpipe-engine` references `crossbeam` or `crossbeam::`. Keeping it in `[dependencies]` links it into every release build unnecessarily.

## Verification
```
$ grep -rn "crossbeam" crates/screenpipe-engine/{src,benches,examples,build.rs}
(no matches)
$ grep -rn "crossbeam" crates/screenpipe-engine/tests
crates/screenpipe-engine/tests/consumer_sleep_test.rs:12:use crossbeam::queue::ArrayQueue;
```

Also confirmed no `pub use crossbeam` re-export in the crate. Cargo not available in the environment, so no `cargo check` run.

Thanks for the great work on screenpipe!
