### PR TITLE
chore(tauri): enable noFallthroughCasesInSwitch in tsconfig

### DIFF
--- a/apps/screenpipe-app-tauri/tsconfig.json
+++ b/apps/screenpipe-app-tauri/tsconfig.json
@@ -9,6 +9,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noFallthroughCasesInSwitch": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Change
Enable `noFallthroughCasesInSwitch` in `apps/screenpipe-app-tauri/tsconfig.json`.

## Rationale
The codebase has ~40 `switch` statements across `lib/`, `components/`, and `app/`. This flag catches accidental missing-`break` bugs at type-check time. The codebase is already clean under this flag — zero code changes needed. Complements the existing `strict: true`.

## Verification
```
cd apps/screenpipe-app-tauri && bunx tsc --noEmit
```
Passes cleanly with the flag added.

Thanks for the great work on screenpipe!