### PR TITLE
ux(settings-search): add next-step hint to empty results state

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/settings-search.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/settings-search.tsx
@@ -496,7 +496,10 @@ export function SettingsSearchPopover<T extends SearchableNavItem>({
     >
       {results.length === 0 ? (
         <div className="px-3 py-3 text-xs text-muted-foreground text-center">
-          No settings found
+          <p>No settings found</p>
+          <p className="text-[10px] mt-1 opacity-70">
+            try different keywords
+          </p>
         </div>
       ) : (
         <div className="max-h-[60vh] overflow-y-auto py-1">


### PR DESCRIPTION
## Problem
`components/settings/settings-search.tsx` L497-500 renders `No settings found` as terminal copy with no next-step guidance:

```tsx
{results.length === 0 ? (
  <div className="px-3 py-3 text-xs text-muted-foreground text-center">
    No settings found
  </div>
) : (...)}
```

Given the fuzzy-match config already handles typos (`dispaly` → `display`), a genuine zero-result state usually means the query is too specific — but the user is left staring at a dead-end.

## Fix
Add one subtext line under the message: `try different keywords`. Copy-only, one small `<p>` addition wrapped in the existing container. No CTA button, no behavior change.

## Verification
Diff is 4 additions / 1 removal, single file.

Thanks for the great work on screenpipe!
