### PR TITLE
a11y(rewind-search): label thumbnail loading + error states

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -299,12 +299,24 @@ const FrameThumbnail = ({ frameId, alt }: { frameId: number; alt: string }) => {
   return (
     <div className="aspect-video bg-muted relative overflow-hidden">
       {isLoading && (
-        <div className="absolute inset-0 flex items-center justify-center">
-          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          role="status"
+          aria-live="polite"
+        >
+          <Loader2
+            className="h-4 w-4 animate-spin text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="sr-only">loading frame</span>
         </div>
       )}
       {hasError ? (
-        <div className="absolute inset-0 flex items-center justify-center bg-muted">
+        <div
+          className="absolute inset-0 flex items-center justify-center bg-muted"
+          role="img"
+          aria-label={`${alt} unavailable`}
+        >
           <span className="text-xs text-muted-foreground">unavailable</span>
         </div>
       ) : (


### PR DESCRIPTION
## Problem
`components/rewind/search-modal.tsx` `FrameThumbnail` has two accessibility gaps:

- L301-304: `<Loader2 />` spinner during frame load has no accessible name. Screen readers announce nothing while thumbnails load.
- L306-309: When retry-3-then-give-up fires, the fallback is a `<span>` with `unavailable` — no `role`, no label, and the surrounding `<img>` is never rendered (so its `alt` prop is dropped on the floor).

## Fix
- Wrap spinner in `role="status" aria-live="polite"` + `sr-only "loading frame"` text.
- Wrap error fallback in `role="img" aria-label={\`${alt} unavailable\`}` — reuses the `alt` prop the component already accepts.

## Verification
Diff: 15 add / 3 remove, single file. Zero behavior change — retry logic, `src` state, `hasError` all untouched.

Thanks for the great work on screenpipe!
