### PR TITLE
a11y(engine-startup): announce streaming prose to screen readers

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -914,7 +914,12 @@ if the input is sparse, just describe what little you have warmly. don't apologi
           </h2>
 
           {/* Streaming prose — sans-serif body, soft and readable */}
-          <div className="w-full min-h-[140px] flex items-start">
+          <div
+            className="w-full min-h-[140px] flex items-start"
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+          >
             {noActivityYet ? (
               <motion.p
                 className="font-sans text-sm text-muted-foreground/70 leading-relaxed text-center w-full"


### PR DESCRIPTION
## Problem
`components/onboarding/engine-startup.tsx` L917-948 is a live-updating status region — its content flips between `settling in…` (pulsing), `no activity yet` (static copy), and the streaming LLM summary as engine state advances. The container is a plain `<div>` with no ARIA — screen readers hear the first snapshot only, and every subsequent update is silent.

This matters most in the corp-restricted-env onboarding path (see #4850) where the region can sit on "settling in…" for a long time before flipping to a real message.

## Fix
Add `role="status" aria-live="polite" aria-atomic="true"` to the wrapper `<div>`. Live-region best practice: `aria-atomic` on a container that swaps its whole content forces the reader to speak the new state as one coherent message instead of diffing character-by-character.

## Verification
Diff: 6 add / 1 remove, single file. No JS logic touched. Pulse animation, motion transitions, and text content preserved verbatim.

Thanks for the great work on screenpipe!
