### PR TITLE
fix(analytics): honor opt-out for attribution fetch + email alias

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -515,6 +515,14 @@ pub fn start_analytics(
     tokio::spawn({
         let analytics_manager = analytics_manager.clone();
         async move {
+            // Respect the user's telemetry opt-out for network beacons too. The
+            // `send_event` path already gates on `enabled`, but `fetch_attribution`
+            // and `send_alias` used to fire an outbound request to
+            // screenpipe.com regardless — so an opt-out user still leaked their
+            // IP + install-launch timing to the website every boot.
+            if !should_enable_analytics {
+                return;
+            }
             // Try to fetch UTM attribution from website (IP-matched, 2hr window)
             // This must happen before app_started so the first event carries attribution
             analytics_manager.fetch_attribution().await;


### PR DESCRIPTION
## Problem

`AnalyticsManager` gates event capture on `analytics_enabled`, but the boot spawn in `start_analytics` calls `fetch_attribution()` and `send_alias()` BEFORE any such gate. Both issue outbound requests to `screenpipe.com`.

Consequence: an opted-out user still beacons their IP + install-launch timing on every app start.

## Fix

`apps/screenpipe-app-tauri/src-tauri/src/analytics.rs` — return early from the boot task when `should_enable_analytics == false`. Skips attribution fetch, email alias, and the initial `app_started` event. Periodic `app_still_running` already gates correctly inside `send_event` and is unchanged.

## Files changed
- `apps/screenpipe-app-tauri/src-tauri/src/analytics.rs` (+8 lines)

No behavior change for opted-in users.

Thanks for the great work on screenpipe!