### PR TITLE
fix(tauri-conf): enable Hardened Runtime for beta + enterprise macOS builds

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
@@ -43,7 +43,8 @@
       "PermissionFlow_PermissionFlow.bundle"
     ],
     "macOS": {
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "hardenedRuntime": true
     }
   },
   "plugins": {

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
@@ -44,7 +44,8 @@
       "PermissionFlow_PermissionFlow.bundle"
     ],
     "macOS": {
-      "entitlements": "entitlements.plist"
+      "entitlements": "entitlements.plist",
+      "hardenedRuntime": true
     },
     "windows": {
       "signCommand": "powershell -ExecutionPolicy Bypass -File sign-ssl.ps1 %1",


### PR DESCRIPTION
## Problem

`tauri.conf.json` and `tauri.prod.conf.json` set:

```json
"macOS": {
  "entitlements": "entitlements.plist",
  "hardenedRuntime": true
}
```

`tauri.beta.conf.json` and `tauri.enterprise.conf.json` are missing the `hardenedRuntime` flag. macOS builds without Hardened Runtime lose:

- Library validation (unsigned dylib injection prevention)
- `DYLD_INSERT_LIBRARIES` protection
- Executable-memory (W^X) enforcement
- Debug attach prevention
- Are **ineligible for Apple notarization** ([developer.apple.com — Notarizing macOS Software](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution))

For a screen-recording app that captures everything the user sees, the beta and enterprise channels warrant the same posture as prod.

## Fix

Two-line JSON edit — add `"hardenedRuntime": true` to `bundle.macOS` in the two configs.

## Files changed
- `apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json` (+2 -1)
- `apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json` (+2 -1)

Zero behavior change on Windows/Linux. If the beta channel's ad-hoc signing flow needs adjustment, happy to iterate.

Thanks for the great work on screenpipe!