### PR TITLE
refactor(app): replace ref-mirror effects with render assignment (useEffect cleanup phase 1)

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -417,8 +417,10 @@ function HomeContent() {
   // Net effect: the sidebar slammed shut every time the user tried to
   // open it during a meeting.
   const sidebarPrevCollapsedRef = useRef<boolean | null>(null);
+  // Assigned during render (not in an effect): read only from the meeting
+  // focus-mode handler below, never during render.
   const sidebarCollapsedRef = useRef(sidebarCollapsed);
-  useEffect(() => { sidebarCollapsedRef.current = sidebarCollapsed; }, [sidebarCollapsed]);
+  sidebarCollapsedRef.current = sidebarCollapsed;
   const handleMeetingFocusModeChange = useCallback(
     (focused: boolean) => {
       if (focused) {

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-session-runtime.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-session-runtime.ts
@@ -145,17 +145,13 @@ export function useChatSessionRuntime({
     if (storeChatIsLoading === false) setIsLoading(false);
   }, [storeChatIsStreaming, storeChatIsLoading, setIsLoading, setIsStreaming]);
 
-  useEffect(() => {
-    isStreamingRef.current = isStreaming;
-  }, [isStreaming, isStreamingRef]);
-
-  useEffect(() => {
-    isLoadingRef.current = isLoading;
-  }, [isLoading, isLoadingRef]);
-
-  useEffect(() => {
-    messagesRef.current = messages;
-  }, [messages, messagesRef]);
+  // Mirror the latest render values into their refs. These refs are read only
+  // from event-bus callbacks and the unmount snapshot below (never during
+  // render), so assigning during render — instead of in an effect — is the
+  // simpler, correct form and matches the pattern used in use-settings.tsx.
+  isStreamingRef.current = isStreaming;
+  isLoadingRef.current = isLoading;
+  messagesRef.current = messages;
 
   useEffect(() => {
     return () => {

--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -344,10 +344,10 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 	// position. We CANNOT read this from inside the setCurrentIndex updater
 	// because React defers functional updaters until render — a value captured
 	// there is not yet set when the subscriber needs it.
+	// Assigned during render (not in an effect): the ref is read only from the
+	// store subscriber callback below, never during this component's render.
 	const currentIndexRef = useRef(currentIndex);
-	useEffect(() => {
-		currentIndexRef.current = currentIndex;
-	}, [currentIndex]);
+	currentIndexRef.current = currentIndex;
 
 	useEffect(() => {
 		let prevTs = 0;


### PR DESCRIPTION
### Description:

Phase 1 of the useEffect cleanup (#4791, follow-up to #4790). Just the **ref-mirror → render assignment** checkbox.

- Removes 3 effects whose only job was mirroring a render value into a ref:
  - `use-chat-session-runtime.ts` — `isStreamingRef` / `isLoadingRef` / `messagesRef`
  - `rewind/timeline.tsx` — `currentIndexRef`
  - `app/home/page.tsx` — `sidebarCollapsedRef`
- Each ref is read only from event-bus/store-subscriber callbacks and unmount cleanup — never during render — so assigning during render is behavior-identical and matches the existing pattern at `use-settings.tsx:1178`.
- Net: −4 `useEffect` calls, no behavior change, no UI change (nothing to screenshot).

Verification:
- `bun run typecheck` → 0 errors
- `bun run lint:effects` → 0 errors (warning count unchanged)
- vitest (chat standalone hooks + rewind) → 15/15 pass
