### PR TITLE
refactor(app): drop reset-on-prop effects, rely on key remount (useEffect cleanup phase 1)

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -361,25 +361,13 @@ export function NoteView({
     [meeting.id],
   );
 
-  // Reset draft when meeting changes
-  useEffect(() => {
-    setTitle(meeting.title ?? "");
-    setAttendees(meeting.attendees ?? "");
-    setNote(meeting.note ?? "");
-    setSaveState({ kind: "idle" });
-    setMeetingCtx(null);
-    setTranscriptOpenState(
-      initialTranscriptOpen || readTranscriptOpenPreference(meeting.id),
-    );
-    setTranscriptRefreshKey(0);
-    setInactivityPrompt(false);
-    setDismissedJoinUrl(null);
-    lastSavedRef.current = {
-      title: meeting.title ?? "",
-      attendees: meeting.attendees ?? "",
-      note: meeting.note ?? "",
-    };
-  }, [meeting.id, initialTranscriptOpen]);
+  // Draft state resets when the meeting changes because the parent already
+  // remounts this component per meeting: `<NoteView key={selected.id} ... />`
+  // in components/meeting-notes/index.tsx (selected === the `meeting` prop).
+  // A fresh mount re-runs the useState initializers and lastSavedRef above,
+  // which reproduce exactly what a reset effect would set — so no reset effect
+  // is needed. (A dedicated effect below opens the transcript when
+  // initialTranscriptOpen is requested.)
 
   useEffect(() => {
     posthog.capture("meeting_note_opened", {

--- a/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/search-modal.tsx
@@ -289,12 +289,9 @@ const FrameThumbnail = ({ frameId, alt }: { frameId: number; alt: string }) => {
   const [src, setSrc] = useState(appendAuthToken(`${getApiBaseUrl()}/frames/${frameId}`));
   const retryCount = useRef(0);
 
-  useEffect(() => {
-    setSrc(appendAuthToken(`${getApiBaseUrl()}/frames/${frameId}`));
-    setIsLoading(true);
-    setHasError(false);
-    retryCount.current = 0;
-  }, [frameId]);
+  // State resets on a new frameId via `key={frameId}` at each render site —
+  // the initializers above already produce the correct fresh values, so no
+  // reset effect is needed.
 
   return (
     <div className="aspect-video bg-muted relative overflow-hidden">
@@ -1485,6 +1482,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                   >
                     {frameId ? (
                       <FrameThumbnail
+                        key={frameId}
                         frameId={frameId}
                         alt={t.transcription || t.speaker_name}
                       />
@@ -1609,6 +1607,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                   className="cursor-pointer rounded overflow-hidden border border-border hover:border-foreground/50 transition-all duration-150"
                 >
                   <FrameThumbnail
+                    key={frame.frame_id}
                     frameId={frame.frame_id}
                     alt={frame.tag_names.join(", ")}
                   />
@@ -2047,6 +2046,7 @@ export function SearchModal({ isOpen, onClose, onNavigateToTimestamp, embedded =
                     >
                       <div className="relative">
                         <FrameThumbnail
+                          key={result.frame_id}
                           frameId={result.frame_id}
                           alt={`${result.app_name} - ${result.window_name}`}
                         />


### PR DESCRIPTION
### Description:

Phase 1 of the useEffect cleanup (#4791). The **reset-on-prop → key remount** checkbox.

- `note-view.tsx`: removes the "reset draft when meeting changes" effect (8 `setState` + a `lastSavedRef` reset). It was redundant — `NoteView` already has `key={selected.id}` at the parent (`meeting-notes/index.tsx`), so switching meetings already remounts with fresh state from the `useState`/`useRef` initializers. The effect's only *live* path was firing on an `initialTranscriptOpen` toggle for the same meeting, where it also wiped unsaved title/note/attendees — a latent edit-clobber. Transcript-open is already handled by a dedicated effect, so behavior is preserved and the clobber is gone.
- `search-modal.tsx`: `FrameThumbnail` reset its `src`/`isLoading`/`hasError`/`retryCount` on `frameId` change. Added `key={frameId}` at the three render sites and removed the reset effect; the initializers reproduce the same values on remount.

Net: −2 `useEffect`, no happy-path behavior change, no UI change.

Verification:
- `bun run typecheck` → 0 errors
- `bun run lint:effects` → 0 errors, `set-state-in-effect` warnings 304 → 292
- vitest (meeting-notes + rewind) → 32/32 pass
