### PR TITLE
fix(meetings): duplicate transcript lines with alternating speaker labels after meeting ends

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.test.ts
@@ -7,6 +7,8 @@ import type { MeetingRecord } from "./meeting-format";
 import {
   buildEnrichedSummarizePrompt,
   extractImageDataUrlsFromMarkdown,
+  mergeMeetingAudioChunks,
+  type MeetingAudioChunk,
   type MeetingContext,
 } from "./meeting-context";
 
@@ -48,5 +50,80 @@ describe("meeting-context image notes", () => {
     expect(prompt).not.toContain(PNG);
     expect(prompt).toContain("[attached image 1: diagram]");
     expect(prompt).toContain("1 image from the user's notes");
+  });
+});
+
+function chunk(overrides: Partial<MeetingAudioChunk>): MeetingAudioChunk {
+  return {
+    audioChunkId: 1,
+    audioFilePath: "/audio/a.mp4",
+    speakerId: null,
+    speakerName: "",
+    deviceType: "output",
+    isInput: false,
+    transcription: "hello world",
+    timestamp: "2026-06-04T15:00:00.000Z",
+    source: "background",
+    ...overrides,
+  };
+}
+
+describe("mergeMeetingAudioChunks", () => {
+  it("collapses the same utterance across sources even when speaker labels differ", () => {
+    // After a meeting ends, the live segment is mirrored into
+    // audio_transcriptions with speaker_id NULL. The routed endpoint returns
+    // the live copy labeled "speaker 1" (Deepgram diarization); /search
+    // returns the mirrored copy with an empty speaker name. Both describe the
+    // same utterance and must render once.
+    const live = chunk({
+      audioChunkId: -10,
+      speakerName: "speaker 1",
+      source: "live",
+    });
+    const mirrored = chunk({ audioChunkId: 7, speakerName: "" });
+
+    const merged = mergeMeetingAudioChunks([live], [mirrored], 100);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].speakerName).toBe("speaker 1");
+    expect(merged[0].source).toBe("live");
+  });
+
+  it("keeps the labeled live copy when /search returns first in time order", () => {
+    // sortAudioChunks ranks live before background on timestamp ties, so the
+    // labeled routed row survives regardless of input order.
+    const live = chunk({ speakerName: "speaker 2", source: "live" });
+    const mirrored = chunk({ speakerName: "speaker" });
+
+    const merged = mergeMeetingAudioChunks([live], [mirrored, chunk({ speakerName: "" })], 100);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].speakerName).toBe("speaker 2");
+  });
+
+  it("does not collapse the same text across devices (mic echo vs remote)", () => {
+    const remote = chunk({ speakerName: "speaker 1", source: "live" });
+    const mic = chunk({
+      deviceType: "Input",
+      isInput: true,
+      speakerName: "me",
+    });
+
+    const merged = mergeMeetingAudioChunks([remote], [mic], 100);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it("does not collapse distinct utterances in different seconds", () => {
+    const first = chunk({ source: "live", speakerName: "speaker 1" });
+    const second = chunk({
+      source: "live",
+      speakerName: "speaker 1",
+      timestamp: "2026-06-04T15:00:05.000Z",
+    });
+
+    const merged = mergeMeetingAudioChunks([first, second], [], 100);
+
+    expect(merged).toHaveLength(2);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
@@ -850,7 +850,7 @@ export async function fetchMeetingAudio(
   return mergeMeetingAudioChunks(routedRows, out, cap);
 }
 
-function mergeMeetingAudioChunks(
+export function mergeMeetingAudioChunks(
   liveRows: MeetingAudioChunk[],
   backgroundRows: MeetingAudioChunk[],
   cap: number,
@@ -863,10 +863,15 @@ function mergeMeetingAudioChunks(
     // /search returns DeviceType as "Input"/"Output" (PascalCase enum), while
     // /meetings/:id/transcript returns the raw DB column "input"/"output".
     // Lowercase both so the same chunk pulled from both endpoints collapses.
+    // Speaker label is deliberately NOT part of the key: the same utterance
+    // carries different labels across sources (Deepgram's live "speaker N" on
+    // the routed segment vs. NULL/global-speaker on the mirrored
+    // audio_transcriptions row /search returns), which used to double every
+    // line after a meeting ended. sortAudioChunks puts live rows first, so the
+    // labeled routed copy is the one that survives.
     const key = [
       Math.round(timestampMs(chunk.timestamp) / 1000),
       chunk.deviceType.toLowerCase(),
-      chunk.speakerName,
       chunk.transcription.replace(/\s+/g, " ").trim().toLowerCase(),
     ].join("|");
     if (seen.has(key)) continue;


### PR DESCRIPTION
## Summary

After a meeting stops (or completes), every transcript line in the meeting-notes panel is rendered **twice** — same text, same timestamp, but with alternating speaker labels like `speaker 1` / `speaker`. While the meeting is live, the transcript is clean.

The root cause is on the client: `fetchMeetingAudio` (in `apps/screenpipe-app-tauri/lib/utils/meeting-context.ts`) pulls the transcript from **two endpoints** and merges them, and its dedup key included the **speaker label** — which is exactly the field that legitimately differs between the two copies of the same utterance. This PR removes the speaker label from the merge key (1-line functional change) and adds regression tests.

## Before 

- After stopping a meeting, each utterance appears twice with alternating labels:


| Live | Completed |
|------|-----------|
| <img src="https://github.com/user-attachments/assets/d6ee57d3-a981-43df-a840-ea8d4733f088" alt="Live" width="100%"> | <img src="https://github.com/user-attachments/assets/516d8c90-21f0-470e-9342-bfd252cbb228" alt="Completed" width="100%"> |

## After

- each utterance appears once, keeping the diarized label from the live segment:

| Live | Completed |
|------|-----------|
| <img src="https://github.com/user-attachments/assets/0b2e3092-f124-4a95-a0b4-b3bbd79e547c" alt="Completed" width="100%"> | <img src="https://github.com/user-attachments/assets/aa48aed0-cdb7-47af-818b-8b7f039a160c" alt="Live" width="100%"> |



https://github.com/user-attachments/assets/73b8f49f-3027-4704-b894-2ca8cdf0d794



## Reproduction


1. Start a meeting with live transcription enabled (Deepgram cloud / `selected-engine`).
2. Play or speak audio where one remote speaker dominates (e.g. a YouTube video or Zoom output).
3. Open the meeting transcript panel while live → single `speaker N` lines. ✅
4. Stop the meeting and wait for the background reconciliation sweep to finish (seconds–minutes).
5. Re-open the transcript → every line is duplicated with alternating `speaker 1` / `speaker` labels. ❌

## Root cause

The duplication is a **client-side merge failure**, not a double DB insert. The data flow:

1. **While live**, transcription segments are written to `meeting_transcript_segments` with Deepgram's diarization labels (`speaker 1`, `speaker 2`, …) stored in `speaker_name` (`crates/screenpipe-audio/src/meeting_streaming/deepgram_live.rs`, `resolve_speaker_name`).
2. **When the meeting ends**, the reconciliation sweep runs `mirror_live_meeting_to_audio_transcriptions` (`crates/screenpipe-db/src/db/meetings.rs:695`), which copies each live segment into `audio_transcriptions` with `transcription_engine='live'`, the **identical `captured_at` timestamp**, and **`speaker_id = NULL`** (the free-text Deepgram label is intentionally not carried over; a later backfill stamps the global speaker id).
3. **The UI fetcher** `fetchMeetingAudio` pulls from both:
   - `GET /meetings/:id/transcript` → the live segments, labeled `speaker 1` (the routed endpoint already dedups live-vs-background server-side within ±15s), and
   - `GET /search?content_type=audio` → raw `audio_transcriptions` rows, **including the mirrored copies** with an empty speaker name (rendered as the generic `speaker` fallback).
4. `mergeMeetingAudioChunks` was supposed to collapse the two copies, but its dedup key was `[timestamp_rounded_to_sec, deviceType, speakerName, normalizedText]`. Since the same utterance carries `"speaker 1"` from one endpoint and `""` from the other, the keys differ, both rows survive, and the panel renders both.

This also explains why the live view is clean: while the meeting is running, the mirrored rows don't exist yet (the sweep only runs on `meeting_ended`), so `/search` returns nothing for those chunks and only one copy is ever in play.


