### PR TITLE
refactor(app): ref-mirror sweep — mirror latest values in render (useEffect cleanup phase 1)

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/chat-history-view.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/chat-history-view.tsx
@@ -84,9 +84,8 @@ export function ChatHistoryView({
   // Increment to invalidate in-flight loads from a previous tab/query.
   const loadTokenRef = React.useRef(0);
 
-  useEffect(() => {
-    conversationsRef.current = conversations;
-  }, [conversations]);
+  // Latest value mirrored during render (read only from the load-more callback).
+  conversationsRef.current = conversations;
 
   const load = useCallback(
     async (mode: "reset" | "append" = "reset") => {

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
@@ -67,9 +67,8 @@ export function useChatComposerShell() {
   const [chipPrefixWidth, setChipPrefixWidth] = useState(0);
   const [chipScrollTop, setChipScrollTop] = useState(0);
 
-  useEffect(() => {
-    inputValueRef.current = input;
-  }, [input]);
+  // Latest value mirrored during render (consumed only from callbacks).
+  inputValueRef.current = input;
 
   useLayoutEffect(() => {
     if (!connectionChip) {

--- a/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
@@ -149,9 +149,8 @@ export function MeetingNotesSection({
   // depend on `fetchPage` (intentionally stable) and shouldn't re-bind
   // when the query changes, but they still need to reuse it.
   const appliedQueryRef = useRef(appliedQuery);
-  useEffect(() => {
-    appliedQueryRef.current = appliedQuery;
-  }, [appliedQuery]);
+  // Latest value mirrored during render (read only from fetch callbacks).
+  appliedQueryRef.current = appliedQuery;
 
   // Track an in-flight open-meeting-note request so the "selection
   // vanished" effect below doesn't reset selectedId during the brief
@@ -223,9 +222,8 @@ export function MeetingNotesSection({
   // setContent, which re-parses the markdown and visually tightens loose
   // lists and paragraph spacing.
   const selectedIdRef = useRef(selectedId);
-  useEffect(() => {
-    selectedIdRef.current = selectedId;
-  }, [selectedId]);
+  // Latest value mirrored during render (read only from callbacks).
+  selectedIdRef.current = selectedId;
   useEffect(() => {
     const handler = () => {
       if (document.visibilityState !== "visible") return;
@@ -316,9 +314,8 @@ export function MeetingNotesSection({
   // identity changes (e.g. after the user expands the sidebar by hand,
   // which is exactly the wrong moment to re-collapse it).
   const onFocusModeChangeRef = useRef(onFocusModeChange);
-  useEffect(() => {
-    onFocusModeChangeRef.current = onFocusModeChange;
-  }, [onFocusModeChange]);
+  // Latest callback mirrored during render (invoked only from callbacks below).
+  onFocusModeChangeRef.current = onFocusModeChange;
   useEffect(() => {
     onFocusModeChangeRef.current?.(selectedId !== null);
   }, [selectedId]);

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-editor.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-editor.tsx
@@ -170,9 +170,9 @@ function NoteEditor(
   // whether an incoming `value` originated from the editor itself (skip) vs
   // an external source like the server or AI summary (apply).
   const lastEmittedRef = useRef<string | null>(null);
-  useEffect(() => {
-    onChangeRef.current = onChange;
-  }, [onChange]);
+  // Latest callback mirrored during render (invoked only from the editor's
+  // onUpdate handler).
+  onChangeRef.current = onChange;
 
   const insertImages = useCallback(
     (dataUrls: string[], at?: { clientX: number; clientY: number }) => {


### PR DESCRIPTION
### Description:

Phase 1 of the useEffect cleanup (#4791) — a follow-up sweep to #4889. #4889 converted the ref-mirror effects in the audit's sample files; this extends the exact same pattern to the remaining pure ref-mirror effects elsewhere.

A "ref-mirror" effect is one whose sole body is `someRef.current = value` with `[value]` deps. Each ref converted here is read **only from callbacks or later effects — never during render** — so assigning during render is behavior-identical and drops the effect.

- `meeting-notes/index.tsx` — `appliedQueryRef`, `selectedIdRef`, `onFocusModeChangeRef`
- `chat/chat-history-view.tsx` — `conversationsRef`
- `meeting-notes/note-editor.tsx` — `onChangeRef`
- `chat/standalone/hooks/use-chat-composer-shell.ts` — `inputValueRef`

Deliberately **left alone** (not blind sweeping):
- `prev*` / `usePrevious` refs — their effect timing is load-bearing (they must hold the *previous committed* value during render).
- `note-editor.tsx` `editorRef` — its effect has cleanup logic, so it's not a pure mirror.

Net: −6 `useEffect`, no behavior change, no UI change. Independent of #4889/#4891 (no shared files).

Verification:
- `bun run typecheck` → 0 errors
- `bun run lint:effects` → 0 errors
- vitest (meeting-notes + chat) → 39/39 pass
