### PR TITLE
refactor(chat): source pipe-watch messages from store, drop mirror effect (useEffect cleanup phase 1)

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-session-runtime.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-session-runtime.ts
@@ -17,7 +17,6 @@ import type { ContentBlock, Message } from "@/lib/chat/types";
 
 interface UseChatSessionRuntimeOptions {
   conversationId: string | null;
-  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setIsStreaming: React.Dispatch<React.SetStateAction<boolean>>;
   isLoading: boolean;
@@ -36,7 +35,6 @@ interface UseChatSessionRuntimeOptions {
 
 export function useChatSessionRuntime({
   conversationId,
-  setMessages,
   setIsLoading,
   setIsStreaming,
   isLoading,
@@ -97,15 +95,8 @@ export function useChatSessionRuntime({
     };
   }, [conversationId, handleAgentEventDataRef, piSessionIdRef]);
 
-  const pipeWatchMessages = useChatStore((state) =>
-    conversationId && state.sessions[conversationId]?.kind === "pipe-watch"
-      ? state.sessions[conversationId]?.messages
-      : undefined,
-  );
-  useEffect(() => {
-    if (!pipeWatchMessages) return;
-    setMessages(pipeWatchMessages as any);
-  }, [pipeWatchMessages, setMessages]);
+  // Pipe-watch messages are now sourced directly from the store in the parent
+  // (standalone-chat.tsx) — no store→local mirror effect needed here.
 
   const pipeWatchIsLoading = useChatStore((state) => {
     if (!conversationId) return undefined;

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -80,6 +80,7 @@ import {
   usePipeGenerationCompletion,
 } from "@/components/chat/standalone/hooks/use-chat-window-events";
 import type { ContentBlock, Message } from "@/lib/chat/types";
+import { useChatStore } from "@/lib/stores/chat-store";
 import { AGENT_TOPICS, type AgentEventEnvelope } from "@/lib/events/types";
 
 // Session ID is per-conversation — set on mount (new conv) and updated on load/new.
@@ -190,7 +191,10 @@ export function StandaloneChat({
     setInput,
     inputRef,
   });
-  const [messages, setMessages] = useState<Message[]>([]);
+  // Local buffer for regular (agent) sessions. Pipe-watch sessions source
+  // their messages from the chat store instead — see the `messages` derivation
+  // below, after `conversationId` is known.
+  const [localMessages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [highlightedMessageId, setHighlightedMessageId] = useState<string | null>(null);
@@ -473,6 +477,21 @@ export function StandaloneChat({
   const [conversationId, setConversationId] = useState<string | null>(
     initialSessionIdRef.current,
   );
+
+  // Pipe-watch sessions keep their messages in the chat store, not in this
+  // component's local state. Read them from the store directly and fall back to
+  // the local buffer for regular sessions, instead of an effect that mirrored
+  // the store into local state (an extra render + a frame of stale messages).
+  // Pipe-watch and regular sessions are mutually exclusive — the agent
+  // foreground handler early-returns for pipe-watch — so the two sources never
+  // feed the same session. Every `messages` reader below is unchanged.
+  const pipeWatchMessages = useChatStore((state) =>
+    conversationId && state.sessions[conversationId]?.kind === "pipe-watch"
+      ? state.sessions[conversationId]?.messages
+      : undefined,
+  );
+  const messages = (pipeWatchMessages ?? localMessages) as Message[];
+
   const {
     consumePendingAttachments,
     stagePendingAttachments,
@@ -753,7 +772,6 @@ export function StandaloneChat({
     startPipeExecution,
   } = useChatSessionRuntime({
     conversationId,
-    setMessages,
     setIsLoading,
     setIsStreaming,
     isLoading,


### PR DESCRIPTION
### Description:

Phase 1 of the useEffect cleanup (#4791) — the **store→local sync** item, the last Phase-1 checkbox.

**Before:** an effect in `use-chat-session-runtime.ts` mirrored a pipe-watch session's store messages into `standalone-chat`'s local `messages` state whenever they changed — a classic store→`setState` sync (extra render + one frame of stale messages).

**After:** source messages at the single point they're read. In `standalone-chat.tsx` the local `useState` is renamed `localMessages` (setter kept as `setMessages`, so all ~10 writers and ~15 readers are textually **unchanged**), and `messages` becomes:
```ts
const pipeWatchMessages = useChatStore(sel);           // store selector, read directly
const messages = (pipeWatchMessages ?? localMessages) as Message[];
```
The mirror effect + its selector are removed from the hook, along with the now-unused `setMessages` param.

**Why it's safe:** pipe-watch and regular sessions are mutually exclusive — the agent foreground handler early-returns for `kind === "pipe-watch"` — so the two message sources never feed the same session. Behavior is preserved for both kinds, and the derived value is immediate (removes the prior one-frame staleness).

⚠️ **This touches the core chat message pipeline.** Existing tests + typecheck pass, but they don't cover pipe-watch message rendering — please sanity-check **(a) a normal chat streaming turn** and **(b) a pipe-watch session** before merge.

Net: −1 `useEffect`. Independent of #4889/#4895/#4891 except it also edits `use-chat-session-runtime.ts` (which #4889 touches) — see note below.

Verification:
- `bun run typecheck` → 0 errors
- `bun run lint:effects` → 0 errors
- vitest (chat) → 17/17 pass
