### PR TITLE
fix(chat): hide thinking blocks, clean up work groups

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-message-list.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-message-list.tsx
@@ -429,13 +429,10 @@ export function ChatMessageList({
           const blocks = lastAssistant?.contentBlocks;
           let loaderPhase: LoaderPhase = "analyzing";
           let toolName: string | undefined;
-          const thinkingSecs: number | undefined = undefined;
 
           if (blocks && blocks.length > 0) {
             const lastBlock = blocks[blocks.length - 1];
-            if (lastBlock.type === "thinking" && lastBlock.isThinking) {
-              loaderPhase = "thinking";
-            } else if (lastBlock.type === "tool" && lastBlock.toolCall.isRunning) {
+            if (lastBlock.type === "tool" && lastBlock.toolCall.isRunning) {
               loaderPhase = "tool";
               toolName = lastBlock.toolCall.toolName;
             } else if (lastBlock.type === "text" && lastBlock.text) {
@@ -459,7 +456,6 @@ export function ChatMessageList({
               <GridDissolveLoader
                 phase={loaderPhase}
                 toolName={toolName}
-                thinkingSecs={thinkingSecs}
               />
             </motion.div>
           );

--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -57,7 +57,7 @@ function MermaidDiagramBlock({ chart }: { chart: string }) {
 }
 
 // Animation phase for the grid dissolve loader.
-export type LoaderPhase = "analyzing" | "thinking" | "tool" | "streaming";
+export type LoaderPhase = "analyzing" | "tool" | "streaming";
 
 // Grid dissolve loading indicator — 5x4 grid of cells with animation patterns
 // that shift based on what the model is doing. Geometric, screen-capture themed.
@@ -65,12 +65,10 @@ export function GridDissolveLoader({
   phase = "analyzing",
   label,
   toolName,
-  thinkingSecs,
 }: {
   phase?: LoaderPhase;
   label?: string;
   toolName?: string;
-  thinkingSecs?: number;
 }) {
   const ROWS = 3;
   const COLS = 5;
@@ -103,7 +101,7 @@ export function GridDissolveLoader({
             const fill = tick % (ROWS + 1);
             return row <= fill || row === scanRow % ROWS;
           }
-          // analyzing / thinking: scan line is bright, other cells flicker
+          // analyzing: scan line is bright, other cells flicker
           if (row === scanRow % ROWS) return true;
           return Math.random() > 0.6;
         });
@@ -114,7 +112,6 @@ export function GridDissolveLoader({
   }, [phase]);
 
   const displayLabel = label ?? (
-    phase === "thinking" ? `thinking${thinkingSecs != null ? ` ${thinkingSecs}s` : ""}...` :
     phase === "tool" ? (toolName ?? "running tool...") :
     phase === "streaming" ? "writing..." :
     "analyzing..."
@@ -522,42 +519,6 @@ function ToolCallRailItem({ toolCall, isLast }: { toolCall: ToolCall; isLast: bo
           )}
         </AnimatePresence>
       </div>
-    </div>
-  );
-}
-
-function ThinkingBlock({ text, isThinking, durationMs, defaultExpanded = false }: { text: string; isThinking: boolean; durationMs?: number; defaultExpanded?: boolean }) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
-  const [elapsed, setElapsed] = useState(0);
-  const startRef = useRef(Date.now());
-
-  useEffect(() => {
-    if (!isThinking) return;
-    const id = window.setInterval(() => setElapsed(Math.floor((Date.now() - startRef.current) / 1000)), 1000);
-    return () => window.clearInterval(id);
-  }, [isThinking]);
-
-  const seconds = isThinking ? elapsed : durationMs ? Math.round(durationMs / 1000) : 0;
-
-  return (
-    <div className="rounded-lg border border-border/30 bg-muted/20 text-xs overflow-hidden max-w-full">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-3 py-2 hover:bg-muted/40 transition-colors text-left"
-      >
-        <div className={cn("h-2 w-2 rounded-full", isThinking ? "bg-foreground/60 animate-pulse" : "bg-foreground/30")} />
-        <span className="font-mono text-muted-foreground">
-          {isThinking ? `thinking... (${seconds}s)` : `thought for ${seconds}s`}
-        </span>
-        <span className="ml-auto text-muted-foreground">{expanded ? "▾" : "▸"}</span>
-      </button>
-      {expanded && text.trim() && (
-        <div className="px-3 py-2 border-t border-border/30">
-          <div className="pl-3 border-l-2 border-border/40 text-muted-foreground font-mono whitespace-pre-wrap break-words max-h-[300px] overflow-y-auto text-[11px] leading-relaxed">
-            {text}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -875,6 +875,66 @@ function collapseHiddenWorkGroups(grouped: GroupedBlock[]): GroupedBlock[] {
   return out;
 }
 
+/**
+ * Merge all tool/work groups into a single "Worked for Xs" rail at the top.
+ * Intermediate narration text between tool calls is dropped — only the
+ * final text block (the actual response after all tools finish) renders
+ * as visible prose. Connection-action blocks always render outside.
+ */
+function mergeWorkAndIntermediateText(groups: GroupedBlock[]): GroupedBlock[] {
+  // Find the last work/tool group — everything up to that boundary is
+  // "work". Text after is the final response.
+  let lastWorkIdx = -1;
+  for (let i = groups.length - 1; i >= 0; i--) {
+    if (groups[i].type === "work-group" || groups[i].type === "tool-group") {
+      lastWorkIdx = i;
+      break;
+    }
+  }
+
+  // No tool calls at all → nothing to merge, show text as-is.
+  if (lastWorkIdx === -1) return groups;
+
+  // Accumulate all tool calls and duration into one work group.
+  // Intermediate text (model narration between tools) is dropped.
+  const allToolCalls: ToolCall[] = [];
+  let totalDurationMs = 0;
+  let firstKey: number | null = null;
+  const finalBlocks: GroupedBlock[] = [];
+
+  for (let i = 0; i <= lastWorkIdx; i++) {
+    const g = groups[i];
+    if (g.type === "work-group") {
+      firstKey ??= g.key;
+      allToolCalls.push(...g.toolCalls);
+      totalDurationMs += g.durationMs;
+    } else if (g.type === "tool-group") {
+      firstKey ??= g.key;
+      allToolCalls.push(...g.toolCalls);
+    } else if (g.type === "connection-action") {
+      finalBlocks.push(g);
+    }
+    // text and thinking blocks before the boundary are dropped
+  }
+
+  // Build the merged work group
+  if (allToolCalls.length > 0) {
+    finalBlocks.unshift({
+      type: "work-group",
+      toolCalls: allToolCalls,
+      durationMs: totalDurationMs,
+      key: firstKey ?? 0,
+    });
+  }
+
+  // Everything after lastWorkIdx is the final response
+  for (let i = lastWorkIdx + 1; i < groups.length; i++) {
+    finalBlocks.push(groups[i]);
+  }
+
+  return finalBlocks;
+}
+
 function InlineConnectionActionCard({
   block,
   connected,
@@ -1356,13 +1416,8 @@ export function MessageContent({
   // Group consecutive tool blocks into collapsible containers
   if (message.contentBlocks && message.contentBlocks.length > 0) {
     const grouped = groupContentBlocks(message.contentBlocks);
-    const displayGroups = collapseHiddenWorkGroups(grouped);
-    // When the message has no rendered prose (no text block — common for
-    // pipe-run executions whose entire output is thinking + tool calls),
-    // expand thinking blocks by default. Otherwise the collapsed
-    // "thought for 0s" pill is the only visible thing on the message
-    // and the chat panel reads as empty even though there's real
-    // content to see.
+    const collapsed = collapseHiddenWorkGroups(grouped);
+    const displayGroups = mergeWorkAndIntermediateText(collapsed);
     const hasText = grouped.some((g) => g.type === "text");
     const stoppedSummary = message.stoppedByUser
       ? formatStoppedWorkDuration(message.workDurationMs)

--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -1196,38 +1196,42 @@ function ToolCallGroup({
     }
   }, [isWorking, runningSummary]);
 
-  // Auto-expand while running, auto-collapse when done (user can override).
-  // `defaultExpanded` keeps the group open even when done — used for
-  // messages whose entire output is tool calls (typical pipe-runs)
-  // where the tool result is the whole story.
-  const isExpanded = manualExpand !== null ? manualExpand : (hasRunningTool || defaultExpanded);
+  // While working → always expanded, no user toggle.
+  // When done → auto-collapse (user can re-expand). `defaultExpanded`
+  // keeps it open even when done for messages whose entire output is
+  // tool calls (typical pipe-runs without a final prose response).
+  const isExpanded = isWorking
+    ? true
+    : manualExpand !== null ? manualExpand : defaultExpanded;
 
   return (
     <div className="w-full min-w-0 self-stretch">
       <div className="mb-2 w-full min-w-full">
-        {/* Header bar — clickable to toggle */}
-        <button
-          onClick={() => setManualExpand(isExpanded ? false : true)}
-          className="w-full flex items-center gap-1.5 py-1 text-left min-w-0 group cursor-pointer"
-        >
-          {/* Summary text */}
-          <span className="truncate text-xs font-mono text-foreground/50 group-hover:text-foreground/80 transition-colors duration-150">
-            <WorkSummaryText
-              text={isWorking ? runningSummary : summary || `${total} steps`}
-              animateRunningDuration={isWorking}
-            />
-            {hasError && allDone && (
-              <span className="ml-1.5 text-foreground/30">· {toolCalls.filter(tc => tc.isError).length} failed</span>
+        {/* Header — plain text while working, clickable with chevron when done */}
+        {isWorking ? (
+          <div className="w-full flex items-center gap-1.5 py-1 text-left min-w-0">
+            <span className="truncate text-xs font-mono text-foreground/50">
+              <WorkSummaryText text={runningSummary} animateRunningDuration />
+            </span>
+          </div>
+        ) : (
+          <button
+            onClick={() => setManualExpand(isExpanded ? false : true)}
+            className="w-full flex items-center gap-1.5 py-1 text-left min-w-0 group cursor-pointer"
+          >
+            <span className="truncate text-xs font-mono text-foreground/50 group-hover:text-foreground/80 transition-colors duration-150">
+              <WorkSummaryText text={summary || `${total} steps`} animateRunningDuration={false} />
+              {hasError && (
+                <span className="ml-1.5 text-foreground/30">· {toolCalls.filter(tc => tc.isError).length} failed</span>
+              )}
+            </span>
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5 flex-shrink-0 text-foreground/30 group-hover:text-foreground/60 transition-colors duration-150" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 flex-shrink-0 text-foreground/30 group-hover:text-foreground/60 transition-colors duration-150" />
             )}
-          </span>
-
-          {/* Expand chevron */}
-          {isExpanded ? (
-            <ChevronDown className="h-3.5 w-3.5 flex-shrink-0 text-foreground/30 group-hover:text-foreground/60 transition-colors duration-150" />
-          ) : (
-            <ChevronRight className="h-3.5 w-3.5 flex-shrink-0 text-foreground/30 group-hover:text-foreground/60 transition-colors duration-150" />
-          )}
-        </button>
+          </button>
+        )}
         <div className="w-full min-w-full border-t border-border/50" />
       </div>
 

--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -1383,6 +1383,28 @@ export function MessageContent({
     const grouped = groupContentBlocks(message.contentBlocks);
     const collapsed = collapseHiddenWorkGroups(grouped);
     const displayGroups = mergeWorkAndIntermediateText(collapsed);
+
+    // If all blocks were absorbed (e.g. thinking-only message with no tool
+    // calls), show a "Thought for Xs" header so the bubble isn't blank.
+    // Skip while still generating — the loader handles that state.
+    if (displayGroups.length === 0 && !isGenerating) {
+      const thinkingMs = grouped
+        .filter((g): g is Extract<GroupedBlock, { type: "thinking" }> => g.type === "thinking")
+        .reduce((sum, g) => sum + (g.durationMs ?? 0), 0);
+      const fallbackLabel = thinkingMs > 0
+        ? formatWorkDuration(thinkingMs)
+        : message.workDurationMs
+          ? formatWorkDuration(message.workDurationMs)
+          : "thought";
+      return (
+        <div className="space-y-2 min-w-0 w-full overflow-hidden">
+          <WorkStatusHeader label={fallbackLabel} />
+          {sourceFooter}
+          {retryCta}
+        </div>
+      );
+    }
+
     const hasText = grouped.some((g) => g.type === "text");
     const stoppedSummary = message.stoppedByUser
       ? formatStoppedWorkDuration(message.workDurationMs)

--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -11,7 +11,6 @@ import { SourceCitationFooter } from "@/components/chat/source-citation-footer";
 import { MarkdownBlock } from "@/components/chat/markdown-block";
 import { getFaviconUrl } from "@/components/rewind/timeline/favicon-utils";
 import { IntegrationIcon } from "@/components/settings/connections-section";
-import { useSettings } from "@/lib/hooks/use-settings";
 import { useFeedbackStore } from "@/lib/stores/feedback-store";
 import { cn } from "@/lib/utils";
 import type { Message, ToolCall, ContentBlock } from "@/lib/chat/types";
@@ -816,12 +815,10 @@ function groupContentBlocks(blocks: ContentBlock[]): GroupedBlock[] {
   return result;
 }
 
-function collapseHiddenWorkGroups(grouped: GroupedBlock[], hideThinkingBlocks: boolean): GroupedBlock[] {
-  // Run always: collapsing consecutive tool-groups into a single
-  // "Worked for X min" rail is useful regardless of the thinking-block
-  // visibility setting. `hideThinkingBlocks` only controls whether
-  // thinking blocks get absorbed into the work-group (true) or shown
-  // as separate pills (false).
+function collapseHiddenWorkGroups(grouped: GroupedBlock[]): GroupedBlock[] {
+  // Collapse consecutive tool-groups into a single "Worked for X min"
+  // rail. Thinking blocks are always absorbed — their duration folds
+  // into the work-group and they never render as separate pills.
 
   const out: GroupedBlock[] = [];
   let pendingToolCalls: ToolCall[] = [];
@@ -864,15 +861,9 @@ function collapseHiddenWorkGroups(grouped: GroupedBlock[], hideThinkingBlocks: b
     }
 
     if (group.type === "thinking") {
-      if (hideThinkingBlocks) {
-        pendingDurationMs += group.durationMs ?? 0;
-        pendingKey ??= group.key;
-        continue;
-      }
-      // Show thinking pills inline — flush pending tool work first so
-      // ordering is preserved and the thinking pill renders separately.
-      flushPending();
-      out.push(group);
+      // Always absorb thinking duration into the pending work-group
+      pendingDurationMs += group.durationMs ?? 0;
+      pendingKey ??= group.key;
       continue;
     }
 
@@ -1239,8 +1230,6 @@ export function MessageContent({
   onDismissConnectionAction?: (messageId: string, connectionId: string) => void;
 }) {
   const isUser = message.role === "user";
-  const { settings } = useSettings();
-  const hideThinkingBlocks = settings?.hideThinkingBlocks ?? true;
   const sourceCitations = isUser ? [] : sourceCitationsFromMessage(message);
   const sourceFooter = !deferSourceFooter && sourceCitations.length > 0 ? (
     <SourceCitationFooter citations={sourceCitations} onOpenFile={onOpenViewerPath} />
@@ -1367,7 +1356,7 @@ export function MessageContent({
   // Group consecutive tool blocks into collapsible containers
   if (message.contentBlocks && message.contentBlocks.length > 0) {
     const grouped = groupContentBlocks(message.contentBlocks);
-    const displayGroups = collapseHiddenWorkGroups(grouped, hideThinkingBlocks);
+    const displayGroups = collapseHiddenWorkGroups(grouped);
     // When the message has no rendered prose (no text block — common for
     // pipe-run executions whose entire output is thinking + tool calls),
     // expand thinking blocks by default. Otherwise the collapsed
@@ -1403,13 +1392,9 @@ export function MessageContent({
             );
           }
           if (group.type === "thinking") {
-            // Settings → Display → Hide Thinking Blocks (default true). Even
-            // when shown the block starts collapsed: the "thought for Xs"
-            // pill is enough signal that the assistant did chain-of-thought
-            // work — auto-expanding (the c092166e0 behavior) drew the eye
-            // to raw reasoning instead of the response.
-            if (hideThinkingBlocks) return null;
-            return <ThinkingBlock key={`thinking-${group.key}`} text={group.text} isThinking={group.isThinking} durationMs={group.durationMs} />;
+            // Thinking blocks are always hidden — guard until
+            // collapseHiddenWorkGroups absorbs them fully.
+            return null;
           }
           if (group.type === "connection-action") {
             const liveConnection = connectionItems.find((connection) => connection.id === group.block.connectionId);

--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -279,30 +279,6 @@ export function DisplaySection() {
                 <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
                   <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                    Hide Thinking Blocks
-                    <HelpTooltip text="Don't render the collapsible model-reasoning blocks in chat. The model still emits them; this just hides them from the transcript." />
-                  </h3>
-                  <p className="text-xs text-muted-foreground">Hide model reasoning in chat transcript</p>
-                </div>
-              </div>
-              <Switch
-                checked={settings?.hideThinkingBlocks ?? true}
-                onCheckedChange={(checked) =>
-                  handleSettingsChange({ hideThinkingBlocks: checked })
-                }
-                className="ml-4"
-              />
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <MessageSquare className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
                     Show Chat Suggestions
                     <HelpTooltip text="Show the follow-up questions and suggested-prompt chips above the chat input. The X on the chips hides them too." />
                   </h3>

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -321,8 +321,6 @@ export type Settings = SettingsStore & {
 	localRetentionMode?: "media" | "lean" | "all";
 	/** Apply macOS vibrancy effect to sidebar for a translucent glass look */
 	translucentSidebar?: boolean;
-	/** Hide model "thinking" reasoning blocks in chat (default: true) */
-	hideThinkingBlocks?: boolean;
 	/** Show the chat suggestion chips above the input — the "follow up"
 	 *  questions and the connection-aware suggested prompts. The single inline
 	 *  X on the chips flips this to false; re-enable from Settings → Display.

--- a/apps/screenpipe-app-tauri/lib/pipe-ndjson-to-chat.ts
+++ b/apps/screenpipe-app-tauri/lib/pipe-ndjson-to-chat.ts
@@ -177,6 +177,20 @@ export function parsePipeNdjsonToMessages(raw: string, pipeName?: string): ChatM
           pendingLastTs = msgTs;
         }
         const toolBlocks = Array.isArray(content) ? extractToolCalls(content, i) : [];
+        // Extract thinking blocks from the content array so their
+        // duration is absorbed by collapseHiddenWorkGroups
+        if (Array.isArray(content)) {
+          for (const block of content) {
+            if (block.type === "thinking") {
+              pendingBlocks.push({
+                type: "thinking",
+                text: block.thinking || block.text || "",
+                isThinking: false,
+                durationMs: undefined,
+              });
+            }
+          }
+        }
         if (text.trim()) {
           pendingBlocks.push({ type: "text", text: text.trim() });
           pendingTexts.push(text.trim());

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -3170,12 +3170,6 @@ showRestartNotifications?: boolean;
  */
 translucentSidebar?: boolean;
 /**
- * When true (default), hide model "thinking" reasoning blocks in the chat
- * transcript. The model still emits them server-side; we just don't
- * render the collapsible block in the UI.
- */
-hideThinkingBlocks?: boolean;
-/**
  * UI theme: "light", "dark", or "system".
  */
 uiTheme?: string;

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -973,12 +973,6 @@ pub struct SettingsStore {
     #[serde(rename = "translucentSidebar", default)]
     pub translucent_sidebar: bool,
 
-    /// When true (default), hide model "thinking" reasoning blocks in the chat
-    /// transcript. The model still emits them server-side; we just don't
-    /// render the collapsible block in the UI.
-    #[serde(rename = "hideThinkingBlocks", default = "default_true")]
-    pub hide_thinking_blocks: bool,
-
     /// UI theme: "light", "dark", or "system".
     #[serde(rename = "uiTheme", default = "default_ui_theme")]
     pub ui_theme: String,
@@ -1403,7 +1397,6 @@ Rules:
             translucent_sidebar: true,
             #[cfg(not(target_os = "macos"))]
             translucent_sidebar: false,
-            hide_thinking_blocks: true,
             ui_theme: "system".to_string(),
             minimize_to_tray_on_close: false,
             extra: std::collections::HashMap::new(),


### PR DESCRIPTION
 This PR fixes several chat UI issues around thinking blocks, work group behavior, and the streaming loader.

* Removed thinking blocks and folded thinking time into work group duration tracking.
* Work groups now stay expanded while tools run and auto-collapse when finished.
* Merged all tool activity into a single work rail and removed intermediate narration.
* Simplified loader flow from `analyzing → thinking → tool → streaming` to `analyzing → tool → streaming`.
* Fixed pipe-run thinking blocks so their duration is correctly included in work groups.


Before -

<img width="1026" height="551" alt="image" src="https://github.com/user-attachments/assets/6357b733-4df2-4cbe-97cb-daf0a483dde5" />
<img width="1026" height="551" alt="image" src="https://github.com/user-attachments/assets/4a415842-c06e-4811-9fab-8331bd4532fc" />


After -

<img width="1003" height="551" alt="image" src="https://github.com/user-attachments/assets/bb554c06-89ff-4fe6-ab43-ce8f94e0b967" />



**NOTE** - `hideThinkingBlocks` setting removed thinking is now always folded into work-group rails. Existing stored values are silently ignored on next read.
