### PR TITLE
Add enterprise screenshot capture controls

### DIFF
--- a/apps/screenpipe-app-tauri/components/enterprise-locked-setting.tsx
+++ b/apps/screenpipe-app-tauri/components/enterprise-locked-setting.tsx
@@ -28,6 +28,8 @@ export function LockedSetting({
  * Drop-in Switch replacement that respects enterprise managed values.
  * If admin enforced a value, the switch is locked to that value.
  * Otherwise behaves exactly like a normal Switch.
+ * Positive UI toggles often back inverted `disable…` settings. In that case a
+ * managed value of "true" means the feature is forced off.
  *
  * Usage: replace <Switch .../> with <ManagedSwitch settingKey="disableAudio" .../>
  */
@@ -42,7 +44,10 @@ export function ManagedSwitch({
   const managed = getManagedValue(settingKey);
 
   if (managed !== undefined) {
-    return <Switch checked={managed === "true"} disabled {...rest} />;
+    const managedChecked = settingKey.startsWith("disable")
+      ? managed === "false"
+      : managed === "true";
+    return <Switch checked={managedChecked} disabled {...rest} />;
   }
 
   return (

--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -18,6 +18,7 @@ import { Settings } from "@/lib/hooks/use-settings";
 import { FONT_SIZE_DEFAULT, FONT_SIZE_OPTIONS } from "@/lib/utils/font-size";
 import { open } from "@tauri-apps/plugin-shell";
 import type { SettingsField } from "./settings-search";
+import { ManagedSwitch } from "@/components/enterprise-locked-setting";
 
 /** Settings search index for this section. Co-located with the component so adding a field here means updating one file. See `SettingsField` in `./settings-search` for the schema. */
 export const searchIndex: SettingsField[] = [
@@ -25,6 +26,7 @@ export const searchIndex: SettingsField[] = [
   { label: "Font Size" },
   { label: "Chat Always on Top", keywords: ["pin", "window"] },
   { label: "Show Shortcut Reminder" },
+  { label: "Timeline / rewind", keywords: ["rewind", "timeline", "backend"] },
   { label: "Overlay Size" },
   { label: "Sidebar translucency", keywords: ["vibrancy", "translucent"] },
 ];
@@ -147,16 +149,18 @@ export function DisplaySection() {
                 <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
                   <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                    Disable Timeline
+                    Timeline / rewind
                     <HelpTooltip text="Turn off the timeline / rewind feature. Skips the in-memory hot frame cache (warm-up + per-frame/audio buffering) that only the timeline uses, and disables the native macOS Live Text overlay that can otherwise leak a selection layer over other windows (e.g. the chat input) and block typing. Restarts screenpipe to apply." />
                   </h3>
-                  <p className="text-xs text-muted-foreground">Hide rewind and skip its background work</p>
+                  <p className="text-xs text-muted-foreground">Show rewind and keep its background cache work on</p>
                 </div>
               </div>
-              <Switch
+              <ManagedSwitch
+                settingKey="disableTimeline"
                 id="disableTimeline"
-                checked={settings?.disableTimeline ?? false}
+                checked={!(settings?.disableTimeline ?? false)}
                 onCheckedChange={async (checked) => {
+                  const disabled = !checked;
                   // Collapse double-invoke (rapid toggle / re-render) into one
                   // restart — two overlapping stop/spawn cycles raced before.
                   if (timelineRestartingRef.current) return;
@@ -164,12 +168,12 @@ export function DisplaySection() {
                   try {
                     // Persist first (awaited) so the backend reads the new value
                     // on restart and the shortcut-reminder guard sees it.
-                    await updateSettings({ disableTimeline: checked });
+                    await updateSettings({ disableTimeline: disabled });
                     // The screenpipe shortcut only opens the timeline, so its
                     // reminder overlay is meaningless once the timeline is off —
                     // tear it down on disable, restore it on re-enable.
                     try {
-                      if (checked) {
+                      if (disabled) {
                         await commands.hideShortcutReminder();
                       } else if (settings?.showShortcutOverlay) {
                         await commands.showShortcutReminder(settings.showScreenpipeShortcut);
@@ -183,7 +187,7 @@ export function DisplaySection() {
                       await new Promise((r) => setTimeout(r, 500));
                       await commands.spawnScreenpipe(null);
                       toast({
-                        title: checked ? "timeline disabled" : "timeline enabled",
+                        title: disabled ? "timeline disabled" : "timeline enabled",
                         description: "screenpipe restarted to apply the change.",
                       });
                     } catch (e) {

--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -26,11 +26,13 @@ export const searchIndex: SettingsField[] = [
   // conditional: platform/OS-gated (Windows-only / macOS CoreAudio tap).
   { label: "Echo cancellation mode", keywords: ["echo", "aec", "voiceprocessingio", "wasapi"], conditional: true },
   { label: "CoreAudio system audio capture", keywords: ["coreaudio", "system audio"], conditional: true },
-  { label: "Screen recording", keywords: ["screen", "video"] },
-  { label: "Use all monitors", keywords: ["monitor", "display"] },
+  { label: "Screen context capture", keywords: ["screen", "video", "accessibility"] },
+  { label: "Screenshot images", keywords: ["screenshot", "pixels", "ocr", "jpeg"] },
+  { label: "Screenshot-to-video compaction", keywords: ["screenshot", "jpeg", "mp4", "timeline", "rewind"] },
+  { label: "Use all monitors", keywords: ["monitor", "display"], conditional: true },
   // conditional: monitor picker only renders when "Use all monitors" is off — paired right under that toggle.
   { label: "Monitors", conditional: true },
-  { label: "Recording quality", keywords: ["fps", "quality"] },
+  { label: "Recording quality", keywords: ["fps", "quality"], conditional: true },
   // conditional: hidden when screen recording is off (same gate as Recording quality).
   { label: "Capture frequency", keywords: ["screenshot", "interval", "idle", "cadence", "every", "minimum"], conditional: true },
   { label: "HD recording for meetings", keywords: ["hd", "meeting"] },
@@ -319,6 +321,7 @@ const SERVER_RESTART_SETTINGS = new Set<keyof SettingsStore>([
   "piiBackend",
   "useChineseMirror",
   "enableWorkflowEvents",
+  "disableSnapshotCompaction",
 ]);
 
 type AudioPipelineSnapshot = {
@@ -2046,6 +2049,8 @@ export function RecordingSettings() {
 
   const aecMode = getAecMode(settings, isMacOS, isWindows);
   const aecDetails = AEC_MODE_DETAILS[aecMode];
+  const screenContextEnabled = !settings.disableVision;
+  const screenshotImagesEnabled = screenContextEnabled && !(settings.disableScreenshots ?? false);
 
   const handleAecModeChange = useCallback((mode: AecMode) => {
     handleSettingsChange(getAecModeSettings(mode), true);
@@ -3711,15 +3716,15 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
       <div className="space-y-2 pt-2">
         <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1">Screen</h2>
 
-        {/* Screen Recording Toggle */}
+        {/* Screen context capture toggle */}
         <Card className="border-border bg-card">
           <CardContent className="px-3 py-2.5">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2.5">
                 <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
-                  <h3 className="text-sm font-medium text-foreground">Screen recording</h3>
-                  <p className="text-xs text-muted-foreground">Capture screenshots from your monitors</p>
+                  <h3 className="text-sm font-medium text-foreground">Screen context capture</h3>
+                  <p className="text-xs text-muted-foreground">Capture app/window context, accessibility text, screenshot images, and OCR fallback</p>
                 </div>
               </div>
               <ManagedSwitch settingKey="disableVision" id="disableVision" checked={!settings.disableVision} onCheckedChange={(checked) => handleSettingsChange({ disableVision: !checked }, true)} />
@@ -3727,7 +3732,6 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
           </CardContent>
         </Card>
 
-        {/* Use All Monitors - right below disable screen recording */}
         {!settings.disableVision && (
           <Card className="border-border bg-card">
             <CardContent className="px-3 py-2.5">
@@ -3735,8 +3739,56 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                 <div className="flex items-center space-x-2.5">
                   <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
                   <div>
+                    <h3 className="text-sm font-medium text-foreground">Screenshot images</h3>
+                    <p className="text-xs text-muted-foreground">Capture screen pixels and store JPEG screenshots for visual evidence and OCR fallback</p>
+                  </div>
+                </div>
+                <ManagedSwitch
+                  settingKey="disableScreenshots"
+                  id="disableScreenshots"
+                  checked={!(settings.disableScreenshots ?? false)}
+                  onCheckedChange={(checked) => handleSettingsChange({ disableScreenshots: !checked }, true)}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {!settings.disableVision && (
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                      Screenshot-to-video compaction
+                      <HelpTooltip text="Converts stored screenshot JPEGs into MP4 chunks for rewind playback. Turn this off for task-mining or accessibility-text-only deployments that do not need visual rewind playback." />
+                    </h3>
+                    <p className="text-xs text-muted-foreground">Convert screenshot JPEGs into MP4 chunks for rewind playback</p>
+                  </div>
+                </div>
+                <ManagedSwitch
+                  settingKey="disableSnapshotCompaction"
+                  id="disableSnapshotCompaction"
+                  checked={!(settings.disableSnapshotCompaction ?? false)}
+                  onCheckedChange={(checked) => handleSettingsChange({ disableSnapshotCompaction: !checked }, true)}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Use All Monitors - right below screen capture toggles */}
+        {screenshotImagesEnabled && (
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
                     <h3 className="text-sm font-medium text-foreground">Use all monitors</h3>
-                    <p className="text-xs text-muted-foreground">Take screenshot from all available monitors</p>
+                    <p className="text-xs text-muted-foreground">Capture screenshot images from all available monitors</p>
                   </div>
                 </div>
                 <Switch id="useAllMonitors" checked={settings.useAllMonitors} onCheckedChange={(checked) => handleSettingsChange({ useAllMonitors: checked }, true)} />
@@ -3748,7 +3800,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
         {/* Monitor Selection — paired directly under "Use all monitors" so
             the picker it reveals sits next to the toggle that controls it,
             not buried below the quality/frequency/HD cards. */}
-        {!settings.disableVision && !settings.useAllMonitors && (
+        {screenshotImagesEnabled && !settings.useAllMonitors && (
           <Card className="border-border bg-card overflow-hidden">
             <CardContent className="px-3 py-2.5">
               <div className="flex items-center space-x-2.5 mb-3">
@@ -3818,7 +3870,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
         )}
 
         {/* Recording quality — single knob for crispness + disk cost */}
-        {!settings.disableVision && (
+        {screenshotImagesEnabled && (
           <Card className="border-border bg-card">
             <CardContent className="px-3 py-2.5">
               <div className="flex items-center justify-between gap-3">
@@ -3858,7 +3910,7 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
             feel capture is too sparse. Backed by `idleCaptureIntervalMs`
             (null = follow the power profile). Needs a recording restart to
             take effect, hence handleSettingsChange(..., true). */}
-        {!settings.disableVision && (() => {
+        {screenshotImagesEnabled && (() => {
           const idleMs = settings.idleCaptureIntervalMs ?? null;
           const seconds = idleMs == null ? 0 : Math.round(idleMs / 1000);
           return (

--- a/apps/screenpipe-app-tauri/lib/hooks/managed-settings.test.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/managed-settings.test.ts
@@ -29,6 +29,23 @@ describe("computeManagedSettingUpdates", () => {
     expect(r.engineChanged).toBe(true);
   });
 
+  it("enforces screenshot and timeline backend controls", () => {
+    const r = computeManagedSettingUpdates(
+      {
+        disableScreenshots: "true",
+        disableTimeline: "true",
+        disableSnapshotCompaction: "true",
+      },
+      {},
+    );
+    expect(r.engineUpdates).toMatchObject({
+      disableScreenshots: true,
+      disableTimeline: true,
+      disableSnapshotCompaction: true,
+    });
+    expect(r.engineChanged).toBe(true);
+  });
+
   it("forces a valid transcription engine (string value)", () => {
     const r = computeManagedSettingUpdates(
       { audioTranscriptionEngine: "deepgram" },
@@ -53,8 +70,9 @@ describe("computeManagedSettingUpdates", () => {
   });
 
   it("forcing a value equal to the current/default does NOT trigger a restart", () => {
-    // disableVision default is false; forcing false on a fresh device = no change
+    // disabled toggles default to false; forcing false on a fresh device = no change
     expect(computeManagedSettingUpdates({ disableVision: "false" }, {}).engineChanged).toBe(false);
+    expect(computeManagedSettingUpdates({ disableScreenshots: "false" }, {}).engineChanged).toBe(false);
     // already-matching stored value
     expect(
       computeManagedSettingUpdates({ disableAudio: "true" }, { disableAudio: true }).engineChanged,

--- a/apps/screenpipe-app-tauri/lib/hooks/managed-settings.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/managed-settings.ts
@@ -7,11 +7,11 @@
 // use-enterprise-policy.ts pulls in.
 //
 // History/severity: only PII + keyboard/click were ever applied. `disableAudio`
-// (#4586) and now `disableVision` / `disableMeetingDetector` / `listen_on_lan` /
-// `audioTranscriptionEngine` were exposed in the policy UI but NEVER enforced on
-// the device — silent no-ops. So a `disableVision: "Always off"` ("Screen
-// recording: Always off") policy left screens recording + uploading anyway — a
-// real privacy/compliance hole, the same bug class as the audio one.
+// (#4586) and now `disableVision` / `disableScreenshots` / timeline work /
+// `disableMeetingDetector` / `listen_on_lan` / `audioTranscriptionEngine` were
+// exposed in the policy UI but NEVER enforced on the device — silent no-ops.
+// So a `disableVision: "Always off"` policy left screens recording + uploading
+// anyway — a real privacy/compliance hole, the same bug class as the audio one.
 
 // Allowed transcription-engine values mirror the policy dropdown; an unknown
 // value is ignored rather than written to the store.
@@ -31,6 +31,9 @@ export const ENGINE_BOOL_POLICY_KEYS: Record<string, string> = {
   disableClickCapture: "disableClickCapture",
   disableAudio: "disableAudio",
   disableVision: "disableVision",
+  disableScreenshots: "disableScreenshots",
+  disableTimeline: "disableTimeline",
+  disableSnapshotCompaction: "disableSnapshotCompaction",
   disableMeetingDetector: "disableMeetingDetector",
   listen_on_lan: "listenOnLan",
 };
@@ -42,6 +45,9 @@ export const ENGINE_BOOL_DEFAULTS: Record<string, boolean> = {
   disableClickCapture: false,
   disableAudio: false,
   disableVision: false,
+  disableScreenshots: false,
+  disableTimeline: false,
+  disableSnapshotCompaction: false,
   disableMeetingDetector: false,
   listenOnLan: false,
 };

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -651,6 +651,7 @@ let DEFAULT_SETTINGS: Settings = {
 			searchShortcut: "Control+Super+K",
 			lockVaultShortcut: "Super+Shift+L",
 			disableVision: false,
+			disableScreenshots: false,
 			useAllMonitors: true,
 			showShortcutOverlay: true,
 			chatHistory: {

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -2736,9 +2736,17 @@ batchMaxDurationSecs?: number | null;
  */
 vocabularyWords?: VocabEntry[];
 /**
- * Disable all screen capture.
+ * Disable the entire vision pipeline (screen images + accessibility/OCR).
+ * Prefer `disableScreenshots` when the goal is to stop image capture while
+ * keeping accessibility text and UI events.
  */
 disableVision: boolean;
+/**
+ * Stop taking screenshot images while keeping accessibility-tree capture.
+ * This skips visual-diff screenshots, full screenshot capture, JPEG writes,
+ * and OCR fallback.
+ */
+disableScreenshots?: boolean;
 /**
  * Disable the timeline / rewind feature. When true, the engine skips
  * timeline-only work: warming the hot frame cache from the DB at startup

--- a/apps/screenpipe-app-tauri/lib/utils/validation.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/validation.ts
@@ -84,6 +84,7 @@ export const settingsStoreSchema = z.object({
   includedWindows: z.array(z.string()),
   ignoredUrls: z.array(z.string()),
   disableVision: z.boolean(),
+  disableScreenshots: z.boolean().optional(),
   useAllMonitors: z.boolean(),
   fps: z.number().min(0.1, "FPS must be at least 0.1").max(60, "FPS cannot exceed 60"),
 

--- a/crates/screenpipe-capture/src/paired_capture.rs
+++ b/crates/screenpipe-capture/src/paired_capture.rs
@@ -6,7 +6,7 @@
 //!
 //! This module is the core of event-driven capture. When an event triggers
 //! (click, app switch, typing pause, etc.), it:
-//! 1. Takes a screenshot
+//! 1. Receives a screenshot from the caller when image capture is enabled
 //! 2. Walks the accessibility tree (in parallel)
 //! 3. Writes the JPEG snapshot to disk
 //! 4. Inserts a frame with accessibility text + snapshot path into the DB
@@ -73,9 +73,10 @@ pub struct CaptureContext<'a> {
     pub languages: Vec<screenpipe_core::Language>,
     /// When Some, this frame references another frame's elements (dedup).
     pub elements_ref_frame_id: Option<i64>,
-    /// When true, skip screenshot acquisition and JPEG encode.
+    /// When true, skip JPEG encode and OCR fallback. The caller also skips
+    /// screenshot acquisition and supplies a tiny placeholder image.
     /// The accessibility tree walk still runs — metadata row is still written.
-    /// Set by AudioPaused and FullPause power profiles.
+    /// Set by AudioPaused / FullPause power profiles and enterprise policy.
     pub screenshot_disabled: bool,
 }
 
@@ -155,19 +156,20 @@ pub async fn paired_capture(
     // which returns non-empty but low-quality text (raw buffer content
     // without visual formatting). For these apps we always run OCR to get
     // proper bounding-box text positions for the selectable overlay.
-    let app_prefers_ocr = ctx.app_name.is_some_and(|name| {
-        let n = name.to_lowercase();
-        // Terminal emulators whose AX text is raw buffer and not useful
-        // for bounding-box overlay. OCR produces better results.
-        // Note: Ghostty, iTerm2, and Terminal.app were removed — they have
-        // full AX support and the thin-detection heuristic handles them
-        // correctly. See https://github.com/screenpipe/screenpipe/issues/2685
-        n.contains("wezterm")
-            || n.contains("alacritty")
-            || n.contains("kitty")
-            || n.contains("hyper")
-            || n.contains("warp")
-    });
+    let app_prefers_ocr = !ctx.screenshot_disabled
+        && ctx.app_name.is_some_and(|name| {
+            let n = name.to_lowercase();
+            // Terminal emulators whose AX text is raw buffer and not useful
+            // for bounding-box overlay. OCR produces better results.
+            // Note: Ghostty, iTerm2, and Terminal.app were removed — they have
+            // full AX support and the thin-detection heuristic handles them
+            // correctly. See https://github.com/screenpipe/screenpipe/issues/2685
+            n.contains("wezterm")
+                || n.contains("alacritty")
+                || n.contains("kitty")
+                || n.contains("hyper")
+                || n.contains("warp")
+        });
     let has_accessibility_text = !app_prefers_ocr
         && tree_snapshot
             .map(|s| !s.text_content.is_empty())
@@ -182,11 +184,13 @@ pub async fn paired_capture(
             .map(|s| a11y_content_is_thin(s, ctx.window_name, ctx.browser_url, ctx.app_name))
             .unwrap_or(false);
 
-    // Run OCR when: no a11y text, app prefers OCR, OR a11y text is thin (hybrid).
+    // Run OCR when screenshots are available and: no a11y text, app prefers
+    // OCR, OR a11y text is thin (hybrid). With screenshots disabled we keep
+    // a11y-only frames and never burn CPU on OCR over a placeholder image.
     // Time the OCR step so the caller can feed `PipelineMetrics::record_ocr`
     // (ocr_completed / avg_ocr_latency_ms). `ocr_duration_ms` is Some only when
     // OCR actually ran — None when accessibility text was sufficient.
-    let ocr_ran = !has_accessibility_text || a11y_is_thin;
+    let ocr_ran = !ctx.screenshot_disabled && (!has_accessibility_text || a11y_is_thin);
     let ocr_started = Instant::now();
     let (ocr_text, ocr_text_json) = if ocr_ran {
         // Windows native OCR is async, so call it directly (not inside spawn_blocking)
@@ -673,6 +677,43 @@ mod tests {
         assert_eq!(result.capture_trigger, "click");
         assert!(result.accessibility_text.is_none());
         assert!(result.text_source.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_paired_capture_screenshot_disabled_skips_snapshot_and_ocr() {
+        let tmp = TempDir::new().unwrap();
+        let snapshot_writer = SnapshotWriter::new(tmp.path(), 80, 1920);
+        let db = DatabaseManager::new("sqlite::memory:", Default::default())
+            .await
+            .unwrap();
+
+        let ctx = CaptureContext {
+            db: &db,
+            snapshot_writer: &snapshot_writer,
+            image: test_image(),
+            captured_at: Utc::now(),
+            monitor_id: 0,
+            device_name: "test_monitor",
+            app_name: Some("TestApp"),
+            window_name: Some("TestWindow"),
+            browser_url: None,
+            document_path: None,
+            focused: true,
+            capture_trigger: "click",
+            use_pii_removal: false,
+            languages: vec![],
+            elements_ref_frame_id: None,
+            screenshot_disabled: true,
+        };
+
+        let result = paired_capture(&ctx, None).await.unwrap();
+
+        assert!(result.frame_id > 0);
+        assert_eq!(result.snapshot_path, "");
+        assert!(result.accessibility_text.is_none());
+        assert!(result.text_source.is_none());
+        assert!(result.ocr_duration_ms.is_none());
+        assert_eq!(std::fs::read_dir(tmp.path()).unwrap().count(), 0);
     }
 
     #[tokio::test]

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -206,9 +206,18 @@ pub struct RecordingSettings {
     pub vocabulary: Vec<VocabEntry>,
 
     // ── Vision ─────────────────────────────────────────────────────────
-    /// Disable all screen capture.
+    /// Disable the entire vision pipeline (screen images + accessibility/OCR).
+    /// Prefer `disableScreenshots` when the goal is to stop image capture while
+    /// keeping accessibility text and UI events.
     #[serde(rename = "disableVision")]
     pub disable_vision: bool,
+
+    /// Stop taking screenshot images while keeping accessibility-tree capture.
+    /// This skips visual-diff screenshots, full screenshot capture, JPEG writes,
+    /// and OCR fallback. Useful for enterprise task mining where a11y text and
+    /// UI events are enough and screen pixels are too expensive or sensitive.
+    #[serde(rename = "disableScreenshots", default)]
+    pub disable_screenshots: bool,
 
     /// Disable the timeline / rewind feature. When true, the engine skips
     /// timeline-only work: warming the hot frame cache from the DB at startup
@@ -682,6 +691,7 @@ impl Default for RecordingSettings {
             batch_max_duration_secs: None,
             vocabulary: vec![],
             disable_vision: false,
+            disable_screenshots: false,
             disable_timeline: false,
             monitor_ids: vec![],
             use_all_monitors: true,
@@ -941,6 +951,7 @@ mod tests {
             "vadSensitivity": "high",
             "filterMusic": false,
             "disableVision": false,
+            "disableScreenshots": false,
             "monitorIds": [],
             "useAllMonitors": true,
             "fps": 0.5,

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -537,9 +537,13 @@ pub struct RecordArgs {
     #[arg(long, default_value_t = false)]
     pub filter_music: bool,
 
-    /// Disable vision recording
+    /// Disable the full vision pipeline (screen images + accessibility/OCR)
     #[arg(long, default_value_t = false)]
     pub disable_vision: bool,
+
+    /// Disable screenshot pixels/JPEG/OCR while keeping accessibility-tree capture
+    #[arg(long, default_value_t = false)]
+    pub disable_screenshots: bool,
 
     /// Windows to ignore (case-insensitive contains). Use `App::Title` to
     /// scope to one window of one app (e.g. `Slack::#hr`). `::title` matches
@@ -801,6 +805,7 @@ pub struct RecordArgSources {
     pub pii_redaction_pseudonyms: bool,
     pub filter_music: bool,
     pub disable_vision: bool,
+    pub disable_screenshots: bool,
     pub ignored_windows: bool,
     pub included_windows: bool,
     pub ignored_urls: bool,
@@ -856,6 +861,7 @@ impl RecordArgSources {
             pii_redaction_pseudonyms: from_command_line(record, "pii_redaction_pseudonyms"),
             filter_music: from_command_line(record, "filter_music"),
             disable_vision: from_command_line(record, "disable_vision"),
+            disable_screenshots: from_command_line(record, "disable_screenshots"),
             ignored_windows: from_command_line(record, "ignored_windows"),
             included_windows: from_command_line(record, "included_windows"),
             ignored_urls: from_command_line(record, "ignored_urls"),
@@ -903,6 +909,7 @@ impl RecordArgSources {
             || self.pii_redaction_pseudonyms
             || self.filter_music
             || self.disable_vision
+            || self.disable_screenshots
             || self.ignored_windows
             || self.included_windows
             || self.ignored_urls
@@ -1046,6 +1053,7 @@ impl RecordArgs {
             port: self.port,
             disable_audio: self.disable_audio,
             disable_vision: self.disable_vision,
+            disable_screenshots: self.disable_screenshots,
             // CLI has no --disable-timeline flag; the desktop app drives this
             // toggle. Default to enabled (timeline on) for the engine binary.
             disable_timeline: false,
@@ -1358,6 +1366,9 @@ impl RecordArgs {
         }
         if sources.disable_vision {
             settings.disable_vision = self.disable_vision;
+        }
+        if sources.disable_screenshots {
+            settings.disable_screenshots = self.disable_screenshots;
         }
         // An explicit --monitor-id or --use-all-monitors means the user wants
         // vision on, so it clears a persisted disable_vision:true (the #3648

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -317,6 +317,10 @@ pub struct EventDrivenCaptureConfig {
     pub visual_check_interval_ms: u64,
     /// Frame difference threshold (0.0–1.0) above which a VisualChange trigger fires.
     pub visual_change_threshold: f64,
+    /// Disable screenshot pixels while keeping accessibility-tree capture.
+    /// When true, visual checks, full screenshot capture, JPEG writes, and OCR
+    /// fallback are skipped.
+    pub disable_screenshots: bool,
     /// User-pinned guaranteed-capture floor (ms). When `Some`, this is an
     /// explicit "always capture at least every N ms" choice and it must
     /// survive PowerProfile transitions — a battery-saver switch (whose
@@ -337,6 +341,7 @@ impl Default for EventDrivenCaptureConfig {
             capture_on_clipboard: true,
             visual_check_interval_ms: 3_000, // check every 3 seconds
             visual_change_threshold: 0.05,   // ~5% difference triggers capture
+            disable_screenshots: false,
             idle_capture_interval_override_ms: None, // follow PowerProfile unless pinned
         }
     }
@@ -656,10 +661,11 @@ pub async fn event_driven_capture_loop(
         monitor_id, device_name
     );
 
-    let mut visual_check_enabled = config.visual_check_interval_ms > 0;
+    let screenshots_disabled_by_config = config.disable_screenshots;
+    let mut screenshot_disabled = screenshots_disabled_by_config;
+    let mut visual_check_enabled = config.visual_check_interval_ms > 0 && !screenshot_disabled;
     let mut visual_check_interval = Duration::from_millis(config.visual_check_interval_ms);
     let mut visual_change_threshold = config.visual_change_threshold;
-    let mut screenshot_disabled = false;
 
     let mut state = EventDrivenCapture::new(config);
     let mut power_profile_rx = power_profile_rx;
@@ -1112,12 +1118,18 @@ pub async fn event_driven_capture_loop(
                 snapshot_writer.set_quality(effective_q);
                 visual_check_interval = Duration::from_millis(profile.visual_check_interval_ms);
                 visual_change_threshold = profile.visual_change_threshold;
-                visual_check_enabled = profile.visual_check_interval_ms > 0;
-                screenshot_disabled = profile.screenshot_disabled;
-                if profile.screenshot_disabled {
+                screenshot_disabled = screenshots_disabled_by_config || profile.screenshot_disabled;
+                visual_check_enabled = profile.visual_check_interval_ms > 0 && !screenshot_disabled;
+                if visual_check_enabled && frame_comparer.is_none() {
+                    frame_comparer =
+                        Some(FrameComparer::new(FrameComparisonConfig::max_performance()));
+                } else if !visual_check_enabled {
+                    frame_comparer = None;
+                }
+                if screenshot_disabled {
                     info!(
-                        "power profile {:?}: screenshots disabled for monitor {} — a11y walk continues",
-                        profile.name, monitor_id
+                        "screenshots disabled for monitor {} (power profile {:?}, managed/config={}) — a11y walk continues",
+                        monitor_id, profile.name, screenshots_disabled_by_config
                     );
                 }
             }
@@ -1450,7 +1462,9 @@ pub async fn event_driven_capture_loop(
                         // buffer. Deterministic — idle content, look-alike
                         // window switches, and other-monitor activity all still
                         // advance the sequence, so none of them can false-trip.
-                        if freeze_watch.observe(monitor.last_capture_seq(), Instant::now()) {
+                        if !screenshot_disabled
+                            && freeze_watch.observe(monitor.last_capture_seq(), Instant::now())
+                        {
                             warn!(
                                 "monitor {}: capture stream frozen — no new frame delivered for \
                                  ~{}s; invalidating persistent stream to rebuild it",
@@ -2090,20 +2104,30 @@ async fn do_capture(
     let captured_at = Utc::now();
     let bypass_capture_throttles = bypasses_capture_throttles(trigger);
 
-    // Resolve ignored windows to SCK window IDs so ScreenCaptureKit
-    // excludes them from the capture buffer (zero overhead, pixel-perfect).
-    // Sort + dedup so the persistent stream isn't needlessly recreated when
-    // transient windows (tooltips, popups) cause ordering changes.
-    let mut excluded_ids = get_excluded_sck_window_ids(&params.window_filters);
-    excluded_ids.sort_unstable();
-    excluded_ids.dedup();
+    let image = if screenshot_disabled {
+        debug!(
+            "screenshot capture skipped for monitor {} (trigger={})",
+            params.monitor_id,
+            trigger.as_str()
+        );
+        image::DynamicImage::new_rgba8(1, 1)
+    } else {
+        // Resolve ignored windows to SCK window IDs so ScreenCaptureKit
+        // excludes them from the capture buffer (zero overhead, pixel-perfect).
+        // Sort + dedup so the persistent stream isn't needlessly recreated when
+        // transient windows (tooltips, popups) cause ordering changes.
+        let mut excluded_ids = get_excluded_sck_window_ids(&params.window_filters);
+        excluded_ids.sort_unstable();
+        excluded_ids.dedup();
 
-    // Take screenshot (with ignored windows excluded at the OS level)
-    let (image, capture_dur) = capture_monitor_image(params.monitor, &excluded_ids).await?;
-    debug!(
-        "screenshot captured in {:?} for monitor {}",
-        capture_dur, params.monitor_id
-    );
+        // Take screenshot (with ignored windows excluded at the OS level)
+        let (image, capture_dur) = capture_monitor_image(params.monitor, &excluded_ids).await?;
+        debug!(
+            "screenshot captured in {:?} for monitor {}",
+            capture_dur, params.monitor_id
+        );
+        image
+    };
 
     // Skip frames that are unusable for indexing.  Two cases:
     //   1. Near-all-black — an ignored window covering the monitor; SCK fills
@@ -2116,25 +2140,27 @@ async fn do_capture(
     // write, but still return the image so the frame comparer stays updated
     // (prevents re-triggering on the same bad frame). The caller records the
     // matching telemetry counter from `corrupt`.
-    if let Some(kind) = frame_corruption(&image) {
-        match kind {
-            // Green is the notable, rarer signal — surface it at warn so it
-            // shows up in shared logs. Black is common (DRM / excluded window).
-            CorruptKind::GreenBand => warn!(
+    if !screenshot_disabled {
+        if let Some(kind) = frame_corruption(&image) {
+            match kind {
+                // Green is the notable, rarer signal — surface it at warn so it
+                // shows up in shared logs. Black is common (DRM / excluded window).
+                CorruptKind::GreenBand => warn!(
                 "captured frame has a green decode-garbage band on monitor {} — skipping DB write",
                 params.monitor_id
             ),
-            CorruptKind::Black => debug!(
-                "captured frame is mostly black on monitor {} — skipping DB write",
-                params.monitor_id
-            ),
+                CorruptKind::Black => debug!(
+                    "captured frame is mostly black on monitor {} — skipping DB write",
+                    params.monitor_id
+                ),
+            }
+            return Ok(CaptureOutput {
+                result: None,
+                image,
+                elements_deduped: false,
+                corrupt: Some(kind),
+            });
         }
-        return Ok(CaptureOutput {
-            result: None,
-            image,
-            elements_deduped: false,
-            corrupt: Some(kind),
-        });
     }
 
     // Walk accessibility tree on blocking thread (AX APIs are synchronous).

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -30,6 +30,10 @@ pub struct RecordingConfig {
     // Feature toggles
     pub disable_audio: bool,
     pub disable_vision: bool,
+    /// Disable screenshot image capture while keeping accessibility/UI-event
+    /// capture alive. This skips visual-diff images, full screenshot capture,
+    /// JPEG writes, and OCR fallback.
+    pub disable_screenshots: bool,
     /// Disable the timeline / rewind feature. Skips timeline-only backend work
     /// (hot frame cache warm-up + per-frame/audio buffering into the hot cache
     /// that only the timeline streaming endpoint consumes).
@@ -271,6 +275,7 @@ impl RecordingConfig {
             disable_audio: settings.disable_audio
                 || settings.audio_capture_mode.eq_ignore_ascii_case("disabled"),
             disable_vision: settings.disable_vision,
+            disable_screenshots: settings.disable_screenshots,
             disable_timeline: settings.disable_timeline,
             use_pii_removal: settings.use_pii_removal,
             async_pii_redaction: settings.async_pii_redaction,
@@ -512,6 +517,7 @@ impl RecordingConfig {
             pause_on_drm_content: self.pause_on_drm_content,
             languages: self.languages.clone(),
             video_quality: self.video_quality.clone(),
+            disable_screenshots: self.disable_screenshots,
             idle_capture_interval_ms: self.idle_capture_interval_ms,
             visual_check_interval_ms: self.visual_check_interval_ms,
             visual_change_threshold: self.visual_change_threshold,
@@ -758,6 +764,7 @@ mod tests {
         assert!(vision.ignore_incognito_windows);
         assert!(vision.pause_on_drm_content);
         assert_eq!(vision.video_quality, "high");
+        assert!(!vision.disable_screenshots);
         assert_eq!(vision.idle_capture_interval_ms, Some(2_000));
         assert_eq!(vision.visual_check_interval_ms, Some(350));
         assert_eq!(vision.visual_change_threshold, Some(0.18));

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -47,6 +47,8 @@ pub struct VisionManagerConfig {
     /// snapshot max width via `screenpipe_core::video::*`. Values: "low",
     /// "balanced" (default), "high", "max".
     pub video_quality: String,
+    /// Skip screenshot pixels/JPEG/OCR while keeping accessibility-tree capture.
+    pub disable_screenshots: bool,
 
     /// Mitsukeru fork: overrides for `EventDrivenCaptureConfig`.
     /// Each field is applied only when `Some(_)`. None = follow active PowerProfile.
@@ -486,6 +488,7 @@ impl VisionManager {
         // baseline ceiling (`min(profile, baseline)`) at runtime.
         let mut capture_config = EventDrivenCaptureConfig {
             jpeg_quality: baseline_q,
+            disable_screenshots: self.config.disable_screenshots,
             ..EventDrivenCaptureConfig::default()
         };
         // Mitsukeru fork: apply per-parameter CLI / settings overrides if any.
@@ -748,6 +751,7 @@ mod tests {
             pause_on_drm_content: false,
             languages: vec![Language::English],
             video_quality: "balanced".to_string(),
+            disable_screenshots: false,
             idle_capture_interval_ms: None,
             visual_check_interval_ms: None,
             visual_change_threshold: None,


### PR DESCRIPTION
## Summary
- add a new disableScreenshots setting that stops screenshot pixels, JPEG screenshots, OCR fallback, and visual-diff capture while keeping accessibility-tree capture alive
- move screenshot-to-video compaction out of Display and into Recording > Screen, beside screenshot image controls
- hide screenshot-specific controls like monitors, quality, and capture frequency when screenshot images are off
- expose/enforce enterprise-managed controls for screenshot images, rewind timeline backend work, and screenshot-to-video compaction
- rename confusing settings into screen context capture, screenshot images, rewind timeline backend, and screenshot-to-video compaction
- fix managed disable-switch display so enterprise-forced disabled states render correctly

## Validation
- cargo fmt
- git diff --check
- bun test lib/hooks/managed-settings.test.ts
- cargo test -p screenpipe-capture test_paired_capture_screenshot_disabled_skips_snapshot_and_ocr
- cargo test -p screenpipe-engine event_driven_capture::tests::test_default_config
- cargo test -p screenpipe-engine recording_config::tests::vision_filters_and_capture_triggers_flow_to_vision_manager_config

## Notes
- App typecheck/lint are currently blocked in the local install by missing existing node modules (@tanstack/react-query, @radix-ui/react-context-menu, eslint-plugin-react-x), not by this diff.
- An initial broad app test run hit an unrelated existing team-crypto timeout; the focused managed-settings suite above passes.