### PR TITLE
fix(settings): back button preserves navigation context

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -803,8 +803,10 @@ function HomeContent() {
   }, [setActiveSection]);
 
   const openSettings = useCallback((section: string = "general") => {
-    router.push(`/settings?section=${section}`);
-  }, [router]);
+    const chatId = activeSection === "home" ? useChatStore.getState().currentId : null;
+    const fromParam = chatId ? `home:${chatId}` : activeSection;
+    router.push(`/settings?section=${section}&from=${fromParam}`);
+  }, [router, activeSection]);
   const clearConnectionFocusRequest = useCallback(() => {
     setConnectionFocusRequest(null);
   }, []);

--- a/apps/screenpipe-app-tauri/app/settings/page.tsx
+++ b/apps/screenpipe-app-tauri/app/settings/page.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/lib/utils";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { AppSidebar, SidebarProvider, useSidebarContext } from "@/components/app-sidebar";
 import { useQueryState } from "nuqs";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { AccountSection, searchIndex as accountSearchIndex } from "@/components/settings/account-section";
 import ShortcutSection, { searchIndex as shortcutsSearchIndex } from "@/components/settings/shortcut-section";
 import { AIPresets, searchIndex as aiSearchIndex } from "@/components/settings/ai-presets";
@@ -205,6 +205,8 @@ function ReferralSection() {
 
 function SettingsContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const fromSection = searchParams.get("from");
   const { isSectionHidden, isEnterprise } = useEnterprisePolicy();
   const { isTranslucent } = useSidebarContext();
 
@@ -369,7 +371,19 @@ function SettingsContent() {
         <div className={cn("px-4 py-3 border-b", isTranslucent ? "vibrant-sidebar-border" : "border-border")}>
           <button
             data-testid="settings-back-to-app"
-            onClick={() => router.push("/home")}
+            onClick={() => {
+              let section = fromSection;
+              let chatId: string | null = null;
+              // Parse "home:<chatId>" format to restore the active chat
+              if (fromSection?.startsWith("home:")) {
+                section = "home";
+                chatId = fromSection.slice(5);
+              }
+              if (chatId) {
+                localStorage.setItem("pending-chat-conversation", chatId);
+              }
+              router.push(section ? `/home?section=${section}` : "/home");
+            }}
             className={cn(
               "flex items-center space-x-1.5 text-sm transition-colors w-full",
               isTranslucent ? "vibrant-nav-item" : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
This PR fixes Back to app button in settings now returns you to the page you were on (timeline, meetings, pipes, etc.) instead of always going to home. If you were in a specific chat, it restores that conversation too. Uses URL param to carry context no stale localStorage on app close/crash.

Before -


https://github.com/user-attachments/assets/41baa1f5-2736-4280-a370-0ae2bc0202a8



After -

https://github.com/user-attachments/assets/e11484db-c2f1-416b-aabe-b38bf4261e07
