### PR TITLE
fix(audio): don't assert meeting-process detection unsupported on Windows

### DIFF
--- a/crates/screenpipe-audio/src/meeting_processes.rs
+++ b/crates/screenpipe-audio/src/meeting_processes.rs
@@ -552,7 +552,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     #[test]
     fn unsupported_platform_stub_reports_no_processes() {
         let snapshot = current_input_processes();


### PR DESCRIPTION
## Summary
- `unsupported_platform_stub_reports_no_processes` in [meeting_processes.rs](crates/screenpipe-audio/src/meeting_processes.rs) was gated `#[cfg(not(target_os = "macos"))]`, so it ran on Windows too and asserted `!snapshot.supported`.
- Windows has a real WASAPI-based `current_input_processes()` implementation (lines 199-326) that always returns `supported: true`, so the test failed on Windows with `assertion failed: !snapshot.supported`.
- Fixed the cfg gate to `not(any(target_os = "macos", target_os = "windows"))`, matching the actual unsupported-stub platform module (line 523), which only compiles for non-macOS, non-Windows targets.

## Test plan
- [x] `cargo test -p screenpipe-audio --lib meeting_processes` passes on Windows (5 passed, 0 failed)