### PR TITLE
fix(tray): stop stuck "Starting…" when capture handle desyncs from a healthy engine

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -638,6 +638,7 @@ fn apply_capture_session_status(
     capture_running: Option<bool>,
     start_in_progress: bool,
     schedule_paused: bool,
+    capture_intended: bool,
 ) -> RecordingStatus {
     if !server_responding {
         return base_status;
@@ -662,7 +663,20 @@ fn apply_capture_session_status(
     }
 
     match capture_running {
-        Some(false) => RecordingStatus::Paused,
+        // Capture handle reads absent. Distinguish a real user pause from a
+        // handle/engine desync using capture intent (`wants_recording`), the
+        // same signal the crash watchdog uses to tell a deliberate stop from a
+        // crash:
+        //   - intent OFF → the user stopped capture (tray/shortcut "stop
+        //     recording", which keeps the server up) → honest Paused.
+        //   - intent ON  → the local handle is stale while the engine is
+        //     healthy and /health already derived Recording. Happens when
+        //     capture is torn down and re-spawned out-of-band (audio-toggle
+        //     restart, health-watchdog engine respawn) without the handle being
+        //     re-stored, or when `capture.try_lock()` briefly contends. Trust
+        //     /health instead of pinning the tray on Paused/"Starting…" forever
+        //     (2026-06-11 device 40af21d0, 2026-07-03 enterprise field reports).
+        Some(false) if !capture_intended => RecordingStatus::Paused,
         _ => base_status,
     }
 }
@@ -841,20 +855,29 @@ pub async fn start_health_check(app: tauri::AppHandle) -> Result<()> {
                 current_status,
             );
 
-            let (capture_running, start_in_progress_raw) = if let Some(recording_state) =
-                app.try_state::<crate::recording::RecordingState>()
-            {
-                let start_in_progress = recording_state.is_starting.load(Ordering::SeqCst)
-                    || recording_state.is_starting_capture.load(Ordering::SeqCst);
-                let capture_running = recording_state
-                    .capture
-                    .try_lock()
-                    .ok()
-                    .map(|capture| capture.is_some());
-                (capture_running, start_in_progress)
-            } else {
-                (None, false)
-            };
+            let (capture_running, start_in_progress_raw, capture_intended) =
+                if let Some(recording_state) =
+                    app.try_state::<crate::recording::RecordingState>()
+                {
+                    let start_in_progress = recording_state.is_starting.load(Ordering::SeqCst)
+                        || recording_state.is_starting_capture.load(Ordering::SeqCst);
+                    let capture_running = recording_state
+                        .capture
+                        .try_lock()
+                        .ok()
+                        .map(|capture| capture.is_some());
+                    // Source of truth for "the user wants capture on" — lets the
+                    // tray tell a deliberate pause (intent OFF → Paused) from a
+                    // handle desync while the engine is healthy (intent ON →
+                    // trust /health, don't stick on "Starting…"/Paused).
+                    (
+                        capture_running,
+                        start_in_progress,
+                        recording_state.capture_intended(),
+                    )
+                } else {
+                    (None, false, false)
+                };
             // Clamp the flag so a leaked atomic / contended capture lock can't
             // pin the tray on "Starting…" forever while capture is actually
             // flowing (see START_PIN_CEILING).
@@ -887,6 +910,7 @@ pub async fn start_health_check(app: tauri::AppHandle) -> Result<()> {
                 capture_running,
                 start_in_progress,
                 schedule_paused,
+                capture_intended,
             );
 
             // Bring the embedded engine back if it has crashed while capture
@@ -1636,37 +1660,218 @@ mod tests {
 
     #[test]
     fn test_capture_absent_with_live_server_is_paused() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(false), false, false);
+        // Genuine user pause: handle absent AND intent OFF → honest Paused.
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(false),
+            false,
+            false,
+            false, // capture_intended = false (user stopped capture)
+        );
         assert_eq!(status, RecordingStatus::Paused);
     }
 
     #[test]
     fn test_capture_absent_while_starting_stays_starting() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(false), true, false);
+        // Start flag asserted (intent ON while starting) → Starting wins over
+        // both the Paused and the desync branches.
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(false),
+            true,
+            false,
+            true,
+        );
         assert_eq!(status, RecordingStatus::Starting);
     }
 
     #[test]
     fn test_capture_status_does_not_mask_connection_error() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Stopped, false, Some(false), false, false);
+        let status = apply_capture_session_status(
+            RecordingStatus::Stopped,
+            false,
+            Some(false),
+            false,
+            false,
+            true,
+        );
         assert_eq!(status, RecordingStatus::Stopped);
     }
 
     #[test]
     fn test_running_capture_keeps_recording_status() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(true), false, false);
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(true),
+            false,
+            false,
+            true,
+        );
         assert_eq!(status, RecordingStatus::Recording);
     }
 
     #[test]
     fn test_running_capture_wins_over_stale_starting_flag() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(true), true, false);
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(true),
+            true,
+            false,
+            true,
+        );
         assert_eq!(status, RecordingStatus::Recording);
+    }
+
+    // ── Capture-intent desync (the "stuck on Starting…" tray bug) ───────────
+    //
+    // Field report (2026-07-03, Windows enterprise): after toggling audio the
+    // engine restarted, the app's in-memory `capture` handle was left None
+    // while the engine kept recording and /health stayed healthy. The tray read
+    // `capture_running == Some(false)` → Paused → the "starting" icon and sat
+    // there forever. The fix: only surface Paused when the user actually stopped
+    // capture (intent OFF); when intent is still ON, a None handle means a
+    // handle/engine desync, so trust /health (base_status) instead.
+    //
+    // Helper to keep the truth-table tests readable.
+    fn capture_status(capture_running: Option<bool>, intended: bool) -> RecordingStatus {
+        apply_capture_session_status(
+            RecordingStatus::Recording, // base_status derived from a healthy /health
+            true,                       // server_responding
+            capture_running,
+            false, // start_in_progress
+            false, // schedule_paused
+            intended,
+        )
+    }
+
+    #[test]
+    fn test_handle_absent_intent_on_is_recording_not_paused() {
+        // THE FIX / primary regression guard: healthy engine, handle desynced to
+        // None, user still wants recording → must show Recording, never Paused.
+        assert_eq!(
+            capture_status(Some(false), true),
+            RecordingStatus::Recording,
+            "desynced handle with intent ON must trust /health, not stick on Paused"
+        );
+    }
+
+    #[test]
+    fn test_handle_absent_intent_off_is_paused() {
+        // The genuine pause the Paused state exists for.
+        assert_eq!(capture_status(Some(false), false), RecordingStatus::Paused);
+    }
+
+    #[test]
+    fn test_handle_present_is_recording_regardless_of_intent() {
+        // A live handle is authoritative: Some(true) → Recording either way.
+        assert_eq!(capture_status(Some(true), true), RecordingStatus::Recording);
+        assert_eq!(capture_status(Some(true), false), RecordingStatus::Recording);
+    }
+
+    #[test]
+    fn test_lock_contended_is_recording_regardless_of_intent() {
+        // None = `capture.try_lock()` failed (contention). Never Paused — falls
+        // through to base_status for both intent values.
+        assert_eq!(capture_status(None, true), RecordingStatus::Recording);
+        assert_eq!(capture_status(None, false), RecordingStatus::Recording);
+    }
+
+    #[test]
+    fn test_start_flag_beats_desync_trust() {
+        // While genuinely starting (flag asserted), Starting wins even with
+        // intent ON and a None handle — we don't want to prematurely claim
+        // Recording before the first capture is up.
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(false),
+            true, // start_in_progress
+            false,
+            true, // intended
+        );
+        assert_eq!(status, RecordingStatus::Starting);
+    }
+
+    #[test]
+    fn test_schedule_pause_beats_desync_trust() {
+        // Schedule pause is the honest state even when intent is ON and the
+        // handle is None — never leak a misleading Recording outside work hours.
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(false),
+            false,
+            true, // schedule_paused
+            true, // intended
+        );
+        assert_eq!(status, RecordingStatus::ScheduledPause);
+    }
+
+    #[test]
+    fn test_server_down_beats_desync_trust() {
+        // Connection error short-circuits before the intent logic: surface the
+        // real base_status (Stopped/boot), never a desync-"Recording".
+        let status = apply_capture_session_status(
+            RecordingStatus::Stopped,
+            false, // server_responding = false
+            Some(false),
+            false,
+            false,
+            true, // intended
+        );
+        assert_eq!(status, RecordingStatus::Stopped);
+    }
+
+    #[test]
+    fn test_paused_and_starting_share_starting_icon() {
+        // Both non-recording "amber" states render the same icon, which is why a
+        // Paused desync was indistinguishable from a real "Starting…" and the
+        // fix (not entering Paused on desync) is what actually clears the tray.
+        assert_eq!(status_to_icon_key(RecordingStatus::Paused), "starting");
+        assert_eq!(status_to_icon_key(RecordingStatus::Starting), "starting");
+        assert_eq!(status_to_icon_key(RecordingStatus::Recording), "healthy");
+        assert!(!is_unhealthy_icon(status_to_icon_key(RecordingStatus::Paused)));
+    }
+
+    #[test]
+    fn test_audio_toggle_restart_scenario_never_sticks_on_starting() {
+        // Replays the reported sequence tick-by-tick. After an audio-toggle
+        // restart: server healthy, intent stays ON, but the capture handle is
+        // left None (desync). Across every subsequent poll the tray must resolve
+        // to Recording — never latch Paused/Starting.
+        let base = decide_status(
+            &make_healthy_response(),
+            Duration::from_secs(600), // well past any startup grace
+            STARTUP_GRACE_PERIOD,
+            true,
+            0,
+            CONSECUTIVE_FAILURES_THRESHOLD,
+            0,
+            CONSECUTIVE_UNHEALTHY_THRESHOLD,
+            RecordingStatus::Recording,
+        );
+        assert_eq!(base, RecordingStatus::Recording);
+
+        for tick in 0..10 {
+            // is_starting cleared after the 300s clamp trips, so start flag = false.
+            let status = apply_capture_session_status(
+                base,
+                true,
+                Some(false), // handle desynced to None post-restart
+                false,       // start flag no longer asserted
+                false,       // no schedule
+                true,        // intent ON — user never stopped recording
+            );
+            assert_eq!(
+                status,
+                RecordingStatus::Recording,
+                "tick {tick}: desync must not pin the tray on a non-recording state"
+            );
+        }
     }
 
     // ── Work-hours schedule pause ───────────────────────────────────────────
@@ -1681,8 +1886,14 @@ mod tests {
     // honest ScheduledPause so the tray can say "outside work hours".
     #[test]
     fn test_schedule_paused_overrides_stuck_starting() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(false), true, true);
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(false),
+            true,
+            true,
+            true,
+        );
         assert_eq!(status, RecordingStatus::ScheduledPause);
     }
 
@@ -1691,8 +1902,14 @@ mod tests {
     // recording but nothing is captured" footgun. schedule_paused wins.
     #[test]
     fn test_schedule_paused_overrides_recording() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(true), false, true);
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(true),
+            false,
+            true,
+            true,
+        );
         assert_eq!(status, RecordingStatus::ScheduledPause);
     }
 
@@ -1700,8 +1917,14 @@ mod tests {
     // the stale-start-flag path still yields Starting, exactly as before.
     #[test]
     fn test_within_schedule_leaves_starting_untouched() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Recording, true, Some(false), true, false);
+        let status = apply_capture_session_status(
+            RecordingStatus::Recording,
+            true,
+            Some(false),
+            true,
+            false,
+            true,
+        );
         assert_eq!(status, RecordingStatus::Starting);
     }
 
@@ -1710,8 +1933,14 @@ mod tests {
     // state, never a stale "outside work hours".
     #[test]
     fn test_schedule_paused_ignored_when_server_down() {
-        let status =
-            apply_capture_session_status(RecordingStatus::Stopped, false, Some(false), false, true);
+        let status = apply_capture_session_status(
+            RecordingStatus::Stopped,
+            false,
+            Some(false),
+            false,
+            true,
+            true,
+        );
         assert_eq!(status, RecordingStatus::Stopped);
     }
 


### PR DESCRIPTION
## Problem

On Windows (reproduced on enterprise, but the logic is cross-platform), the tray icon gets **stuck on "Starting…" forever** even though the engine is fully healthy and capturing. Confirmed live: `/health` reports `Recording`, a11y walks + `ui_events` are actively writing, yet the tray never leaves the amber "starting" state.

### Root cause

The tray status is computed by `apply_capture_session_status`. It reads `capture_running` from the app's in-memory handle:

```rust
let capture_running = recording_state.capture.try_lock().ok().map(|c| c.is_some());
```

When that handle is `Some(false)` (handle present but `None` inside), the code unconditionally returned `RecordingStatus::Paused`, which maps to the **same "starting" icon** as `Starting` (`status_to_icon_key`).

The handle desyncs to `None` while the engine keeps recording whenever capture is torn down and re-spawned **out-of-band** — e.g. toggling audio (which restarts the engine) or the health watchdog's engine respawn — without the new handle being stored back into `RecordingState.capture`. The `is_starting_capture` flag also leaked in the field log (the 300s `START_PIN_CEILING` clamp caught it: `start-in-progress flag stuck for >300s` fired), so after the clamp the status fell through to the `Some(false) → Paused` branch and latched there.

This is the same class of incident the existing code comments already document (2026-06-11, device `40af21d0`: "pinned on Starting for hours while /health showed capture flowing").

## Fix

Use **capture intent** (`wants_recording`) — the existing source of truth the crash watchdog already uses to tell a deliberate stop from a crash — as the tiebreaker for the absent-handle case:

- **intent OFF** → the user genuinely stopped capture (tray/shortcut "stop recording", server stays up) → honest `Paused`.
- **intent ON** → the handle is stale while the engine is healthy and `/health` already derived `Recording` → **trust `/health`**, don't pin on `Paused`/"Starting…".

```rust
match capture_running {
    Some(false) if !capture_intended => RecordingStatus::Paused,
    _ => base_status,
}
```

The polling loop now reads `recording_state.capture_intended()` and threads it through. Precedence is unchanged: server-down, `schedule_paused`, live `Some(true)`, and the `start_in_progress` (Starting) branches all still win before this point, so a genuinely-starting or scheduled-pause state is never mislabeled.

## Tests

`cargo test -p screenpipe-app health::` — rigorous edge-case coverage added:

- **Primary regression guard**: absent handle + intent ON + healthy server → `Recording`, never `Paused`.
- **Intent × handle truth table**: `Some(false)`/`Some(true)`/`None` × intent on/off.
- **Precedence**: start-flag, `schedule_paused`, and server-down each beat the new desync-trust branch.
- **Icon characterization**: documents that `Paused` and `Starting` share the "starting" icon (why the desync was invisible).
- **Scenario replay**: tick-by-tick replay of the audio-toggle-restart sequence (intent ON, handle `None`, healthy) asserting the tray resolves to `Recording` on every poll and never latches.
- All 9 pre-existing `apply_capture_session_status` call sites updated to the new signature with their intent semantics made explicit.

## Impact

Pure status/tray-layer change — no capture behavior changes. Capture was always working; this stops the tray from lying about it.
