### PR TITLE
fix(a11y): Windows walk budgets inoperative — mid-walk deadline, fragile-provider gap, lightweight focused metadata

### DIFF
--- a/crates/screenpipe-a11y/src/platform/windows.rs
+++ b/crates/screenpipe-a11y/src/platform/windows.rs
@@ -1704,6 +1704,46 @@ pub(crate) fn get_effective_app_name(hwnd: HWND, pid: u32) -> String {
     effective
 }
 
+/// Cheaply resolve the focused window's (app name, window title) without any
+/// UIA/COM calls: `GetForegroundWindow` + cached process-name lookup +
+/// `GetWindowTextW`. Used by the engine's capture throttles (walk budget,
+/// terminal-OCR rate limit) to identify the focused app on non-AppSwitch
+/// triggers. The app name goes through [`get_effective_app_name`] so it matches
+/// the names produced by the tree walker and app-switch events.
+///
+/// Returns `None` when there is no usable foreground window, including the
+/// transient shell-internal windows (MSCTFIME UI, Shell_TrayWnd) that briefly
+/// steal focus on clicks — attributing those to explorer.exe would poison the
+/// per-app throttle state.
+pub fn get_focused_app_window_lightweight() -> Option<(String, Option<String>)> {
+    unsafe {
+        let hwnd = GetForegroundWindow();
+        if hwnd.is_invalid() {
+            return None;
+        }
+        if is_transient_shell_window(hwnd) {
+            return None;
+        }
+
+        let mut pid: u32 = 0;
+        GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        if pid == 0 {
+            return None;
+        }
+        let app_name = get_effective_app_name(hwnd, pid);
+
+        let mut title_buf = [0u16; 512];
+        let len = GetWindowTextW(hwnd, &mut title_buf);
+        let window_title = if len > 0 {
+            Some(String::from_utf16_lossy(&title_buf[..len as usize]))
+        } else {
+            None
+        };
+
+        Some((app_name, window_title))
+    }
+}
+
 fn get_process_name_uncached(pid: u32) -> Option<String> {
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::System::Diagnostics::ToolHelp::{

--- a/crates/screenpipe-a11y/src/platform/windows_uia.rs
+++ b/crates/screenpipe-a11y/src/platform/windows_uia.rs
@@ -9,13 +9,15 @@
 
 use crate::config::UiCaptureConfig;
 use crate::events::{AccessibilityNode, ElementBounds, ElementContext, WindowTreeSnapshot};
+use crate::tree::TruncationReason;
 use chrono::Utc;
 use crossbeam_channel::Sender;
 use parking_lot::Mutex;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tracing::{debug, error, trace, warn};
 
@@ -88,6 +90,98 @@ pub struct ClickElementRequest {
     pub x: i32,
     pub y: i32,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+/// Default wall-clock budget when the caller doesn't provide one (tests,
+/// ad-hoc captures). Generous on purpose — the capture pipelines pass their
+/// own, much tighter budget via `capture_window_tree_bounded`.
+#[cfg(test)]
+const DEFAULT_TREE_CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A captured tree plus whether (and why) the walk stopped early.
+pub(crate) struct CapturedTree {
+    pub root: AccessibilityNode,
+    pub truncation: TruncationReason,
+}
+
+/// Shared node-count + wall-clock budget for a single tree capture.
+/// Records the first limit hit so callers can report truncation.
+struct TreeBudget {
+    max_elements: usize,
+    deadline: Instant,
+    count: usize,
+    truncation: TruncationReason,
+}
+
+impl TreeBudget {
+    fn new(max_elements: usize, deadline: Instant) -> Self {
+        Self {
+            max_elements,
+            deadline,
+            count: 0,
+            truncation: TruncationReason::None,
+        }
+    }
+
+    /// True once either limit is hit; records the reason on first hit.
+    fn exhausted(&mut self) -> bool {
+        if self.count >= self.max_elements {
+            if self.truncation == TruncationReason::None {
+                self.truncation = TruncationReason::MaxNodes;
+            }
+            return true;
+        }
+        if Instant::now() >= self.deadline {
+            if self.truncation == TruncationReason::None {
+                self.truncation = TruncationReason::Timeout;
+            }
+            return true;
+        }
+        false
+    }
+}
+
+/// How long a "this window needs the TreeWalker fallback" verdict stays valid.
+/// TTL'd because HWNDs get recycled by the OS and a provider can start
+/// populating the cached subtree later; re-probing costs one cross-process
+/// call, so a stale verdict is cheap to correct.
+const WALKER_FALLBACK_MEMO_TTL: Duration = Duration::from_secs(300);
+
+/// Process-wide memo of windows whose UIA provider requires the per-element
+/// TreeWalker fallback (Chromium/Electron). Shared across capture pipelines —
+/// the paired-capture path recreates its `UiaContext` per walk, so this can't
+/// live on the context.
+fn walker_fallback_memo() -> &'static Mutex<HashMap<isize, Instant>> {
+    static MEMO: OnceLock<Mutex<HashMap<isize, Instant>>> = OnceLock::new();
+    MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// True if `hwnd` was recently observed to need the TreeWalker fallback.
+fn needs_walker_fallback(hwnd: HWND) -> bool {
+    let mut memo = walker_fallback_memo().lock();
+    let key = hwnd.0 as isize;
+    match memo.get(&key) {
+        Some(seen) if seen.elapsed() < WALKER_FALLBACK_MEMO_TTL => true,
+        Some(_) => {
+            memo.remove(&key);
+            false
+        }
+        None => false,
+    }
+}
+
+/// Record that `hwnd`'s provider needs the TreeWalker fallback.
+fn remember_walker_fallback(hwnd: HWND) {
+    let mut memo = walker_fallback_memo().lock();
+    if memo.len() >= 64 {
+        memo.retain(|_, seen| seen.elapsed() < WALKER_FALLBACK_MEMO_TTL);
+    }
+    memo.insert(hwnd.0 as isize, Instant::now());
+}
+
+/// Drop the fallback verdict for `hwnd` (cached path produced a real tree).
+fn forget_walker_fallback(hwnd: HWND) {
+    walker_fallback_memo().lock().remove(&(hwnd.0 as isize));
 }
 
 /// UIA context holding COM objects (single-thread only, not Send)
@@ -167,52 +261,109 @@ impl UiaContext {
         }
     }
 
-    /// Capture the full accessibility tree of a window by HWND.
-    /// Uses CacheRequest to batch all property reads into minimal cross-process calls.
-    /// Falls back to TreeWalker for apps whose UIA providers don't populate
-    /// the cached subtree (Chromium, Electron, etc.).
+    /// Capture the full accessibility tree of a window by HWND with a default
+    /// wall-clock budget. Kept as the convenience entry point for tests —
+    /// production pipelines pass their own budget via
+    /// [`Self::capture_window_tree_bounded`].
+    #[cfg(test)]
     pub(crate) fn capture_window_tree(
         &self,
         hwnd: HWND,
         max_elements: usize,
     ) -> Option<AccessibilityNode> {
+        self.capture_window_tree_bounded(hwnd, max_elements, DEFAULT_TREE_CAPTURE_TIMEOUT)
+            .map(|captured| captured.root)
+    }
+
+    /// Capture the full accessibility tree of a window by HWND, bounded by both
+    /// a node cap and a wall-clock deadline.
+    ///
+    /// Uses CacheRequest to batch all property reads into minimal cross-process
+    /// calls. Falls back to TreeWalker for apps whose UIA providers don't
+    /// populate the cached subtree (Chromium, Electron, etc.).
+    ///
+    /// The deadline is checked between elements, so the walk overruns it by at
+    /// most one element fetch. The initial `ElementFromHandleBuildCache` is a
+    /// single synchronous COM call that cannot be interrupted — the deadline
+    /// mainly bounds the per-element TreeWalker fallback, which is serviced on
+    /// the target app's UI thread and freezes it for the duration of the walk.
+    pub(crate) fn capture_window_tree_bounded(
+        &self,
+        hwnd: HWND,
+        max_elements: usize,
+        timeout: Duration,
+    ) -> Option<CapturedTree> {
+        let deadline = Instant::now() + timeout;
+
+        // Windows already known to need the per-element fallback (Chromium/
+        // Electron) go straight to it, so the walker gets the full wall-clock
+        // budget instead of paying for a cached attempt that returns a handful
+        // of titlebar nodes every single walk.
+        if needs_walker_fallback(hwnd) {
+            let mut walker_budget = TreeBudget::new(max_elements, deadline);
+            if let Some(root) = self.capture_window_tree_walker(hwnd, &mut walker_budget) {
+                return Some(CapturedTree {
+                    root,
+                    truncation: walker_budget.truncation,
+                });
+            }
+            // Walker setup failed (window gone, provider error) — fall through
+            // to the cached path rather than dropping the capture.
+        }
+
         unsafe {
             let element = self
                 .automation
                 .ElementFromHandleBuildCache(hwnd, &self.cache_request)
                 .ok()?;
 
-            let mut count = 0;
-            let root = self.build_node(&element, max_elements, &mut count);
+            let mut budget = TreeBudget::new(max_elements, deadline);
+            let root = self.build_node(&element, &mut budget);
+            let count = budget.count;
 
             // Some UIA providers (notably Chromium/Electron) don't populate the
             // cached subtree via ElementFromHandleBuildCache, returning only a
             // handful of titlebar nodes. When this happens, fall back to
-            // TreeWalker which makes individual COM calls per element.
+            // TreeWalker which makes individual COM calls per element. The
+            // fallback shares the deadline (a capture never exceeds `timeout`)
+            // but gets a fresh node budget, matching the count comparison below.
             if count <= 10 {
-                if let Some(walker_root) = self.capture_window_tree_walker(hwnd, max_elements) {
+                let mut walker_budget = TreeBudget::new(max_elements, deadline);
+                if let Some(walker_root) = self.capture_window_tree_walker(hwnd, &mut walker_budget)
+                {
                     let walker_count = walker_root.node_count();
                     if walker_count > count {
                         debug!(
                             "Cache returned {} nodes, walker returned {} - using walker result",
                             count, walker_count
                         );
-                        return Some(walker_root);
+                        remember_walker_fallback(hwnd);
+                        return Some(CapturedTree {
+                            root: walker_root,
+                            truncation: walker_budget.truncation,
+                        });
                     }
                 }
+            } else {
+                // Cached path works for this window — clear any stale memo
+                // (HWND recycling, provider started populating the cache).
+                forget_walker_fallback(hwnd);
             }
 
-            Some(root)
+            Some(CapturedTree {
+                root,
+                truncation: budget.truncation,
+            })
         }
     }
 
     /// Fallback tree capture using TreeWalker for UIA providers that don't
     /// support cached subtree (e.g. Chromium, Electron apps).
-    /// Walks the tree element-by-element via GetFirstChild/GetNextSibling.
+    /// Walks the tree element-by-element via COM calls, bounded by `budget`.
     fn capture_window_tree_walker(
         &self,
         hwnd: HWND,
-        max_elements: usize,
+        budget: &mut TreeBudget,
     ) -> Option<AccessibilityNode> {
         unsafe {
             // Get a live element (required for TreeWalker navigation)
@@ -222,21 +373,20 @@ impl UiaContext {
                 .BuildUpdatedCache(&self.walker_cache_request)
                 .ok()?;
 
-            let mut count = 0;
-            Some(self.build_node_walker(&cached_root, max_elements, &mut count))
+            Some(self.build_node_walker(&cached_root, budget))
         }
     }
 
     /// Recursively build an AccessibilityNode using TreeWalker navigation.
     /// Unlike build_node which reads pre-cached children, this walks the tree
-    /// one element at a time via COM calls.
+    /// one element at a time via COM calls (~2 cross-process round trips per
+    /// element), so the budget's deadline is checked before every fetch.
     fn build_node_walker(
         &self,
         element: &IUIAutomationElement,
-        max_elements: usize,
-        count: &mut usize,
+        budget: &mut TreeBudget,
     ) -> AccessibilityNode {
-        *count += 1;
+        budget.count += 1;
 
         let control_type = self.get_control_type_name(element);
         let name = self.get_cached_string(element, UIA_NamePropertyId);
@@ -256,23 +406,23 @@ impl UiaContext {
             self.get_cached_string(element, UIA_LocalizedControlTypePropertyId);
 
         let mut children = Vec::new();
-        if *count < max_elements {
+        if !budget.exhausted() {
             unsafe {
                 // Navigate to first child via TreeWalker
                 if let Ok(child) = self
                     .tree_walker
                     .GetFirstChildElementBuildCache(element, &self.walker_cache_request)
                 {
-                    children.push(self.build_node_walker(&child, max_elements, count));
+                    children.push(self.build_node_walker(&child, budget));
                     // Iterate siblings
                     let mut current = child;
-                    while *count < max_elements {
+                    while !budget.exhausted() {
                         match self
                             .tree_walker
                             .GetNextSiblingElementBuildCache(&current, &self.walker_cache_request)
                         {
                             Ok(next) => {
-                                children.push(self.build_node_walker(&next, max_elements, count));
+                                children.push(self.build_node_walker(&next, budget));
                                 current = next;
                             }
                             Err(_) => break,
@@ -304,13 +454,15 @@ impl UiaContext {
     }
 
     /// Recursively build an AccessibilityNode from a cached UIA element.
+    /// The subtree is already materialized in-process, so per-node work is a
+    /// local property read — the budget's deadline is a cheap safety net here;
+    /// the node cap does most of the bounding.
     fn build_node(
         &self,
         element: &IUIAutomationElement,
-        max_elements: usize,
-        count: &mut usize,
+        budget: &mut TreeBudget,
     ) -> AccessibilityNode {
-        *count += 1;
+        budget.count += 1;
 
         let control_type = self.get_control_type_name(element);
         let name = self.get_cached_string(element, UIA_NamePropertyId);
@@ -330,17 +482,17 @@ impl UiaContext {
             self.get_cached_string(element, UIA_LocalizedControlTypePropertyId);
 
         let mut children = Vec::new();
-        if *count < max_elements {
+        if !budget.exhausted() {
             unsafe {
                 // Walk cached children (already fetched via TreeScope_Subtree)
                 if let Ok(child_array) = element.GetCachedChildren() {
                     if let Ok(len) = child_array.Length() {
                         for i in 0..len {
-                            if *count >= max_elements {
+                            if budget.exhausted() {
                                 break;
                             }
                             if let Ok(child) = child_array.GetElement(i) {
-                                children.push(self.build_node(&child, max_elements, count));
+                                children.push(self.build_node(&child, budget));
                             }
                         }
                     }
@@ -926,7 +1078,7 @@ const FRAGILE_UIA_TREE_PROVIDERS: &[&str] = &["outlook.exe"];
 
 /// Returns true if `app_name` is a process whose UIA provider can crash when we capture
 /// its full accessibility tree. See [`FRAGILE_UIA_TREE_PROVIDERS`].
-fn is_fragile_uia_tree_provider(app_name: &str) -> bool {
+pub(crate) fn is_fragile_uia_tree_provider(app_name: &str) -> bool {
     let lower = app_name.to_ascii_lowercase();
     FRAGILE_UIA_TREE_PROVIDERS.iter().any(|p| lower == *p)
 }
@@ -969,9 +1121,24 @@ fn capture_and_send(
         return;
     }
 
-    // Capture the tree
-    let root = match uia.capture_window_tree(hwnd, config.tree_max_elements) {
-        Some(root) => root,
+    // Capture the tree, bounded by a wall-clock deadline: the per-element
+    // TreeWalker fallback (Chromium/Electron) is serviced synchronously on the
+    // target app's UI thread, so an unbounded walk visibly freezes the app.
+    const PERIODIC_TREE_WALK_TIMEOUT: Duration = Duration::from_millis(250);
+    let root = match uia.capture_window_tree_bounded(
+        hwnd,
+        config.tree_max_elements,
+        PERIODIC_TREE_WALK_TIMEOUT,
+    ) {
+        Some(captured) => {
+            if captured.truncation != TruncationReason::None {
+                debug!(
+                    "Tree capture for {} truncated ({:?})",
+                    app_name, captured.truncation
+                );
+            }
+            captured.root
+        }
         None => {
             trace!("Failed to capture tree for hwnd {:?}", hwnd.0);
             return;
@@ -1160,6 +1327,94 @@ mod tests {
         assert!(!is_fragile_uia_tree_provider("chrome.exe"));
         assert!(!is_fragile_uia_tree_provider("notepad.exe"));
         assert!(!is_fragile_uia_tree_provider(""));
+    }
+
+    #[test]
+    fn test_tree_budget_max_nodes() {
+        let mut budget = TreeBudget::new(2, Instant::now() + Duration::from_secs(60));
+        assert!(!budget.exhausted());
+        assert_eq!(budget.truncation, TruncationReason::None);
+
+        budget.count = 2;
+        assert!(budget.exhausted());
+        assert_eq!(budget.truncation, TruncationReason::MaxNodes);
+
+        // First-hit reason sticks even if the deadline also passes later.
+        budget.deadline = Instant::now() - Duration::from_secs(1);
+        assert!(budget.exhausted());
+        assert_eq!(budget.truncation, TruncationReason::MaxNodes);
+    }
+
+    #[test]
+    fn test_tree_budget_deadline() {
+        let mut budget = TreeBudget::new(10_000, Instant::now() - Duration::from_millis(1));
+        assert!(budget.exhausted());
+        assert_eq!(budget.truncation, TruncationReason::Timeout);
+    }
+
+    #[test]
+    fn test_walker_fallback_memo_roundtrip() {
+        // Distinct pointer value so parallel tests sharing the process-wide
+        // memo can't interfere.
+        let hwnd = HWND(0x5EED_F00D_usize as *mut _);
+
+        assert!(!needs_walker_fallback(hwnd));
+        remember_walker_fallback(hwnd);
+        assert!(needs_walker_fallback(hwnd));
+        forget_walker_fallback(hwnd);
+        assert!(!needs_walker_fallback(hwnd));
+    }
+
+    /// Live test: the wall-clock deadline truncates a real capture.
+    /// Focus a Chromium/Electron window (whose provider forces the
+    /// per-element TreeWalker fallback) for the strongest signal, then run:
+    /// cargo test -p screenpipe-a11y test_live_bounded_capture -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn test_live_bounded_capture_truncates() {
+        unsafe {
+            CoInitializeEx(None, COINIT_APARTMENTTHREADED)
+                .ok()
+                .expect("COM init failed");
+        }
+        let uia = UiaContext::new().expect("UIA init failed");
+        let hwnd = unsafe { GetForegroundWindow() };
+        assert!(!hwnd.is_invalid(), "No foreground window");
+
+        // Reference walk with a generous budget.
+        let start = std::time::Instant::now();
+        let full = uia
+            .capture_window_tree_bounded(hwnd, 10_000, Duration::from_secs(10))
+            .expect("capture failed");
+        let full_ms = start.elapsed().as_millis();
+        println!(
+            "full walk:    {} nodes in {}ms (truncation: {:?})",
+            full.root.node_count(),
+            full_ms,
+            full.truncation
+        );
+
+        // Tightly bounded walk must come back promptly. The deadline can't
+        // interrupt the initial ElementFromHandleBuildCache COM call, so the
+        // assertion is loose — the point is it doesn't run for seconds.
+        let start = std::time::Instant::now();
+        let bounded = uia
+            .capture_window_tree_bounded(hwnd, 10_000, Duration::from_millis(50))
+            .expect("capture failed");
+        let bounded_ms = start.elapsed().as_millis();
+        println!(
+            "bounded 50ms: {} nodes in {}ms (truncation: {:?})",
+            bounded.root.node_count(),
+            bounded_ms,
+            bounded.truncation
+        );
+
+        assert!(
+            bounded_ms < 5_000,
+            "bounded walk took {}ms — deadline not honored",
+            bounded_ms
+        );
+        unsafe { CoUninitialize() };
     }
 
     #[test]

--- a/crates/screenpipe-a11y/src/platform/windows_uia.rs
+++ b/crates/screenpipe-a11y/src/platform/windows_uia.rs
@@ -108,7 +108,11 @@ pub(crate) struct CapturedTree {
 /// Records the first limit hit so callers can report truncation.
 struct TreeBudget {
     max_elements: usize,
-    deadline: Instant,
+    /// `None` = node cap only. Used for the cached path: its subtree is
+    /// already materialized in-process by the time nodes are built, so a
+    /// deadline there can only discard data that was already paid for —
+    /// it cannot shorten the target app's freeze.
+    deadline: Option<Instant>,
     count: usize,
     truncation: TruncationReason,
 }
@@ -117,13 +121,23 @@ impl TreeBudget {
     fn new(max_elements: usize, deadline: Instant) -> Self {
         Self {
             max_elements,
-            deadline,
+            deadline: Some(deadline),
             count: 0,
             truncation: TruncationReason::None,
         }
     }
 
-    /// True once either limit is hit; records the reason on first hit.
+    /// Budget bounded by node count only (cached, in-process tree builds).
+    fn node_capped(max_elements: usize) -> Self {
+        Self {
+            max_elements,
+            deadline: None,
+            count: 0,
+            truncation: TruncationReason::None,
+        }
+    }
+
+    /// True once a limit is hit; records the reason on first hit.
     fn exhausted(&mut self) -> bool {
         if self.count >= self.max_elements {
             if self.truncation == TruncationReason::None {
@@ -131,11 +145,13 @@ impl TreeBudget {
             }
             return true;
         }
-        if Instant::now() >= self.deadline {
-            if self.truncation == TruncationReason::None {
-                self.truncation = TruncationReason::Timeout;
+        if let Some(deadline) = self.deadline {
+            if Instant::now() >= deadline {
+                if self.truncation == TruncationReason::None {
+                    self.truncation = TruncationReason::Timeout;
+                }
+                return true;
             }
-            return true;
         }
         false
     }
@@ -275,18 +291,22 @@ impl UiaContext {
             .map(|captured| captured.root)
     }
 
-    /// Capture the full accessibility tree of a window by HWND, bounded by both
-    /// a node cap and a wall-clock deadline.
+    /// Capture the full accessibility tree of a window by HWND, bounded by a
+    /// node cap and a wall-clock deadline.
     ///
     /// Uses CacheRequest to batch all property reads into minimal cross-process
     /// calls. Falls back to TreeWalker for apps whose UIA providers don't
     /// populate the cached subtree (Chromium, Electron, etc.).
     ///
-    /// The deadline is checked between elements, so the walk overruns it by at
-    /// most one element fetch. The initial `ElementFromHandleBuildCache` is a
-    /// single synchronous COM call that cannot be interrupted — the deadline
-    /// mainly bounds the per-element TreeWalker fallback, which is serviced on
-    /// the target app's UI thread and freezes it for the duration of the walk.
+    /// The deadline bounds the per-element TreeWalker fallback (~2 cross-process
+    /// COM round-trips per element, serviced on the target app's UI thread — the
+    /// unbounded-freeze path), checked before every element fetch so it overruns
+    /// by at most one element. The cached path is different: its one
+    /// `ElementFromHandleBuildCache` call is synchronous and cannot be
+    /// interrupted, and afterwards the subtree is already materialized
+    /// in-process — so building it is bounded by the node cap only. Truncating
+    /// that local build on the deadline would discard data the target app
+    /// already paid to produce without shortening its freeze.
     pub(crate) fn capture_window_tree_bounded(
         &self,
         hwnd: HWND,
@@ -317,7 +337,9 @@ impl UiaContext {
                 .ElementFromHandleBuildCache(hwnd, &self.cache_request)
                 .ok()?;
 
-            let mut budget = TreeBudget::new(max_elements, deadline);
+            // Node cap only: the whole subtree was materialized by the single
+            // COM call above; building nodes from it is local work.
+            let mut budget = TreeBudget::node_capped(max_elements);
             let root = self.build_node(&element, &mut budget);
             let count = budget.count;
 
@@ -325,8 +347,9 @@ impl UiaContext {
             // cached subtree via ElementFromHandleBuildCache, returning only a
             // handful of titlebar nodes. When this happens, fall back to
             // TreeWalker which makes individual COM calls per element. The
-            // fallback shares the deadline (a capture never exceeds `timeout`)
-            // but gets a fresh node budget, matching the count comparison below.
+            // fallback runs against the original deadline (so a slow cached
+            // attempt shrinks its window) with a fresh node budget, matching
+            // the count comparison below.
             if count <= 10 {
                 let mut walker_budget = TreeBudget::new(max_elements, deadline);
                 if let Some(walker_root) = self.capture_window_tree_walker(hwnd, &mut walker_budget)
@@ -455,8 +478,7 @@ impl UiaContext {
 
     /// Recursively build an AccessibilityNode from a cached UIA element.
     /// The subtree is already materialized in-process, so per-node work is a
-    /// local property read — the budget's deadline is a cheap safety net here;
-    /// the node cap does most of the bounding.
+    /// local property read; callers pass a node-cap-only budget.
     fn build_node(
         &self,
         element: &IUIAutomationElement,
@@ -1340,7 +1362,7 @@ mod tests {
         assert_eq!(budget.truncation, TruncationReason::MaxNodes);
 
         // First-hit reason sticks even if the deadline also passes later.
-        budget.deadline = Instant::now() - Duration::from_secs(1);
+        budget.deadline = Some(Instant::now() - Duration::from_secs(1));
         assert!(budget.exhausted());
         assert_eq!(budget.truncation, TruncationReason::MaxNodes);
     }
@@ -1350,6 +1372,16 @@ mod tests {
         let mut budget = TreeBudget::new(10_000, Instant::now() - Duration::from_millis(1));
         assert!(budget.exhausted());
         assert_eq!(budget.truncation, TruncationReason::Timeout);
+    }
+
+    #[test]
+    fn test_tree_budget_node_capped_ignores_time() {
+        // Cached-path budget: no deadline, only the node cap binds.
+        let mut budget = TreeBudget::node_capped(3);
+        assert!(!budget.exhausted());
+        budget.count = 3;
+        assert!(budget.exhausted());
+        assert_eq!(budget.truncation, TruncationReason::MaxNodes);
     }
 
     #[test]
@@ -1365,9 +1397,12 @@ mod tests {
         assert!(!needs_walker_fallback(hwnd));
     }
 
-    /// Live test: the wall-clock deadline truncates a real capture.
+    /// Live test: the wall-clock deadline bounds a real capture.
     /// Focus a Chromium/Electron window (whose provider forces the
-    /// per-element TreeWalker fallback) for the strongest signal, then run:
+    /// per-element TreeWalker fallback) to see `Timeout` truncation — the
+    /// deadline binds that path. Windows served by the cached path return
+    /// their full (node-capped) tree regardless of the deadline, since the
+    /// subtree arrives in one COM call. Run:
     /// cargo test -p screenpipe-a11y test_live_bounded_capture -- --ignored --nocapture
     #[test]
     #[ignore]

--- a/crates/screenpipe-a11y/src/tree/windows.rs
+++ b/crates/screenpipe-a11y/src/tree/windows.rs
@@ -216,6 +216,15 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
             return Ok(TreeWalkResult::Skipped(SkipReason::ExcludedApp));
         }
 
+        // Skip apps whose in-process UIA providers crash the host process when an
+        // external client materializes their full subtree (Outlook Classic on Sent
+        // Items) — same exemption as the periodic worker path. OCR still captures
+        // the on-screen content for these apps.
+        if crate::platform::windows_uia::is_fragile_uia_tree_provider(&app_name) {
+            debug!(app = %app_name, pid, "a11y: skipped — fragile UIA tree provider (crash-prone)");
+            return Ok(TreeWalkResult::Skipped(SkipReason::ExcludedApp));
+        }
+
         // Get window title
         let window_name = unsafe {
             let mut buf = [0u16; 512];
@@ -275,11 +284,18 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
             return Ok(TreeWalkResult::NotFound);
         }
 
-        // Capture the accessibility tree
-        let root = match uia.capture_window_tree(hwnd, effective_max_nodes) {
-            Some(tree) => tree,
-            None => return Ok(TreeWalkResult::NotFound),
-        };
+        // Capture the accessibility tree, bounded by the remaining wall-clock
+        // budget. The in-walk deadline truncates the per-element TreeWalker
+        // fallback (Chromium/Electron), which is serviced synchronously on the
+        // target app's UI thread and freezes it for the duration of the walk.
+        let remaining_budget = effective_timeout.saturating_sub(start.elapsed());
+        let captured =
+            match uia.capture_window_tree_bounded(hwnd, effective_max_nodes, remaining_budget) {
+                Some(captured) => captured,
+                None => return Ok(TreeWalkResult::NotFound),
+            };
+        let root = captured.root;
+        let truncation_reason = captured.truncation;
 
         // Get monitor dimensions for normalizing element bounds to 0-1 coords
         let monitor_rect = get_monitor_rect(hwnd);
@@ -342,7 +358,6 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
             walk_duration
         );
 
-        // Windows walker doesn't have timeout-based truncation yet — report as complete
         // Per-app document_path resolution from on-disk state files
         // (Obsidian config + VS Code-fork state.vscdb). Returns None
         // for any unknown app or any failure — never panics.
@@ -360,8 +375,8 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
             walk_duration,
             content_hash,
             simhash,
-            truncated: false,
-            truncation_reason: super::TruncationReason::None,
+            truncated: truncation_reason != super::TruncationReason::None,
+            truncation_reason,
             max_depth_reached: 0,
         }))
     }
@@ -1019,9 +1034,11 @@ mod tests {
     #[test]
     fn test_incognito_detection() {
         use crate::incognito::is_title_private;
-        assert!(is_title_private("Enter Password - Chrome"));
         assert!(is_title_private("Private Browsing - Firefox"));
         assert!(is_title_private("New Tab - Google Chrome (Incognito)"));
         assert!(!is_title_private("Calculator"));
+        // Bare "password"/"private" words are deliberately NOT incognito
+        // indicators (false-positive reduction — see incognito/titles.rs).
+        assert!(!is_title_private("Enter Password - Chrome"));
     }
 }

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1911,6 +1911,7 @@ fn is_ocr_heavy_app(app_name: &str) -> bool {
         || contains_ascii_case_insensitive(app_name, "hyper")
         || contains_ascii_case_insensitive(app_name, "warp")
         || app_name.eq_ignore_ascii_case("obsidian")
+        || app_name.eq_ignore_ascii_case("obsidian.exe")
 }
 
 fn contains_ascii_case_insensitive(haystack: &str, needle: &str) -> bool {
@@ -1928,6 +1929,11 @@ fn is_lock_screen_app(app_name: &str) -> bool {
     app_name.eq_ignore_ascii_case("loginwindow")
         || app_name.eq_ignore_ascii_case("screensaverengine")
         || app_name.eq_ignore_ascii_case("lockscreen")
+        // Windows: LockApp.exe hosts the lock screen UI, LogonUI.exe the
+        // credential prompt. Both must be recognized here — an unrecognized
+        // Some(app) would otherwise clear the global screen-locked flag.
+        || app_name.eq_ignore_ascii_case("lockapp.exe")
+        || app_name.eq_ignore_ascii_case("logonui.exe")
 }
 
 /// How long the persistent stream's frame-delivery sequence may stay flat
@@ -2598,7 +2604,54 @@ fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
     })
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+/// Windows: `GetForegroundWindow` + cached process-name lookup — no UIA/COM.
+/// The app name matches what the tree walker reports (both go through
+/// `get_effective_app_name`), so the walk budget's per-app cost tracking keys
+/// line up across `should_walk` and `record_walk`.
+///
+/// **Caching**: capture triggers fire on every click / typing pause / visual
+/// change, and the focused window rarely changes between triggers. A 1-second
+/// TTL bounds staleness below human perception while collapsing the common
+/// case to a single atomic load — same rationale as the macOS implementation.
+#[cfg(target_os = "windows")]
+fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
+    use arc_swap::ArcSwap;
+    use std::sync::OnceLock;
+    use std::time::{Duration, Instant};
+
+    const CACHE_TTL: Duration = Duration::from_secs(1);
+
+    static CACHE: OnceLock<ArcSwap<(Option<LightweightFocusedMetadata>, Instant)>> =
+        OnceLock::new();
+    let cache = CACHE.get_or_init(|| {
+        // Seed with an already-expired timestamp. Windows `Instant` counts
+        // from boot, so subtracting can fail in the first seconds after boot
+        // (autostart) — fall back to "fresh", costing one stale-second at most.
+        let expired = Instant::now()
+            .checked_sub(CACHE_TTL + Duration::from_secs(1))
+            .unwrap_or_else(Instant::now);
+        ArcSwap::from_pointee((None, expired))
+    });
+
+    let now = Instant::now();
+    {
+        let snap = cache.load();
+        if now.duration_since(snap.1) < CACHE_TTL {
+            return snap.0.clone();
+        }
+    }
+
+    let fresh = screenpipe_a11y::platform::windows::get_focused_app_window_lightweight().map(
+        |(app_name, window_name)| LightweightFocusedMetadata {
+            app_name: Some(app_name),
+            window_name,
+        },
+    );
+    cache.store(std::sync::Arc::new((fresh.clone(), now)));
+    fresh
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn get_focused_metadata_lightweight() -> Option<LightweightFocusedMetadata> {
     None
 }
@@ -3222,7 +3275,11 @@ mod tests {
         assert!(is_ocr_heavy_app("WezTerm"));
         assert!(is_ocr_heavy_app("com.mitchellh.ghostty.WARP"));
         assert!(is_ocr_heavy_app("Obsidian"));
+        // Windows process names carry the extension.
+        assert!(is_ocr_heavy_app("Obsidian.exe"));
+        assert!(is_ocr_heavy_app("wezterm-gui.exe"));
         assert!(!is_ocr_heavy_app("Chrome"));
+        assert!(!is_ocr_heavy_app("chrome.exe"));
     }
 
     #[test]
@@ -3230,7 +3287,12 @@ mod tests {
         assert!(is_lock_screen_app("loginwindow"));
         assert!(is_lock_screen_app("ScreenSaverEngine"));
         assert!(is_lock_screen_app("LOCKSCREEN"));
+        // Windows lock screen host + credential UI. Must be recognized or a
+        // Some(app) at the lock screen clears the global screen-locked flag.
+        assert!(is_lock_screen_app("LockApp.exe"));
+        assert!(is_lock_screen_app("LogonUI.exe"));
         assert!(!is_lock_screen_app("Finder"));
+        assert!(!is_lock_screen_app("explorer.exe"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #4845

## What was broken

Three related defects left the Windows a11y walk budgeting system effectively inoperative (a11y+input cohort telemetry: **117% avg CPU vs 72%** for others):

1. **No mid-walk wall-clock timeout** — the walk timeout was only checked *before* the walk started. Once started, the Chromium/Electron per-element TreeWalker fallback (~2 cross-process COM round-trips per element, serviced synchronously on the target app's UI thread) was bounded only by node count (5,000–10,000 nodes).
2. **Fragile-provider exemption missing on the value-producing path** — `is_fragile_uia_tree_provider` (Outlook Classic crash vector) was only checked in the periodic worker; the paired-capture walker that actually persists text had no such check.
3. **Walk budgets + terminal-OCR throttle were dead code on Windows** — they depend on `get_focused_metadata_lightweight`, which was a stub returning `None` on Windows, so per-app walk budgets, the heavy-OCR-app throttle, and lock-screen detection never engaged for non-AppSwitch triggers.

## Walk timeline, before → after

```
BEFORE (Chromium/Electron window, per capture trigger)
────────────────────────────────────────────────────────────────────────
 cache attempt      per-element TreeWalker fallback (unbounded duration)
 ├────┤├──────────────────────────────────────────────────── ⋯ ────────┤
 0     ~10 titlebar nodes → rediscover fallback, walk up to 10,000 nodes
       └─ serviced ON the target app's UI thread → foreground freeze

AFTER
────────────────────────────────────────────────────────────────────────
 walk 1: cache attempt → ≤10 nodes → fallback (shares 250ms deadline)
 ├────┤├──────────────────┤ truncated=true, reason=Timeout
 0                     250ms   └─ hwnd memoized as "needs walker"

 walk 2+: straight to TreeWalker with the FULL wall-clock budget
 ├─────────────────────────┤ deadline checked before every element fetch
 0                      250ms  (adaptive tiers shrink this to 100–150ms
                                for apps that repeatedly walk slow)
```

## Changes

### 1. In-walk wall-clock deadline (`platform/windows_uia.rs`, `tree/windows.rs`)
- New `capture_window_tree_bounded(hwnd, max_elements, timeout)` returns the tree **plus a `TruncationReason`**. A `TreeBudget` threads through both tree-build paths; the deadline is checked before every element fetch in the **per-element TreeWalker fallback** (the unbounded-freeze path this issue is about), so a walk overruns it by at most one element.
- The **cached path is deliberately node-cap-only**: its single `ElementFromHandleBuildCache` call is synchronous (can't be interrupted), and once it returns the subtree is already materialized in-process — truncating the local build on the deadline would discard data the target app already paid to produce without shortening its freeze. (A live run proved this matters: a 163ms cached call under a 50ms budget would have yielded 1 node out of a 768-node tree.)
- **Both pipelines honor it**: the paired-capture walker passes its remaining `effective_walk_timeout()` budget (250ms default, 100–150ms for heavy-tier apps), and the periodic worker (`capture_and_send`) uses a 250ms cap.
- The paired path now reports real `truncated`/`truncation_reason` values instead of hardcoded `false`/`None` — so `record_walk` sees truncation and the adaptive budget escalates tiers correctly, and the `ax_*` telemetry counters (`truncated_timeout`) become meaningful on Windows.
- **Per-hwnd "needs walker fallback" memoization** (5-min TTL, process-wide): Chromium/Electron windows skip the pointless cached attempt on subsequent walks and give the TreeWalker the full budget. TTL + eviction handles HWND recycling; a window whose cached path starts working clears its memo entry.

### 2. Fragile-provider exemption on the paired path (`tree/windows.rs`)
`walk_focused_window` now skips apps in `FRAGILE_UIA_TREE_PROVIDERS` (Outlook Classic — crashes its own host process when an external client materializes its Sent Items grid), matching the periodic worker. OCR still captures these apps' content.

### 3. Windows `get_focused_metadata_lightweight` (`event_driven_capture.rs`, `platform/windows.rs`)
- New `get_focused_app_window_lightweight()`: `GetForegroundWindow` + cached process-name lookup + `GetWindowTextW` — no UIA/COM. Skips transient shell windows (MSCTFIME UI etc.) so throttle state isn't poisoned with explorer.exe. App names go through `get_effective_app_name`, so walk-budget keys line up across `should_walk` (trigger app) and `record_walk` (snapshot app).
- Engine-side implementation mirrors the macOS 1s-TTL `ArcSwap` cache.
- This single change reactivates three existing systems on Windows: **per-app adaptive walk budgets**, the **terminal/Obsidian OCR throttle**, and **lock-screen skip**.
- Follow-on fixes required by app names now flowing on Windows:
  - `is_lock_screen_app` recognizes `LockApp.exe`/`LogonUI.exe` — without this, a `Some(app)` at the lock screen would have *cleared* the global screen-locked flag.
  - `is_ocr_heavy_app` matches `Obsidian.exe` (Windows process names carry the extension).

### Drive-by
- Fixed stale `test_incognito_detection` assertion (`"Enter Password - Chrome"` stopped matching when incognito keywords were tightened in 6b45f9609 for false-positive reduction; the Windows-only test was missed).

## Testing

- `cargo test -p screenpipe-a11y --lib` — **all pass** (190 + new tests), including new unit tests:
  - `test_tree_budget_max_nodes` / `test_tree_budget_deadline` — truncation reason recording, first-hit-wins
  - `test_walker_fallback_memo_roundtrip` — memo insert/hit/forget
  - extended `test_fragile_uia_provider_detection`
- `cargo test -p screenpipe-engine --lib event_driven_capture` — **all pass**, including extended `lock_screen_app_detection` / `ocr_heavy_app_detection` for Windows process names.
- **Live bounded-capture test** on a real Windows 11 desktop (`test_live_bounded_capture_truncates`, `#[ignore]`d like the other live UIA tests). Two runs against real windows:

```
# deadline enforcement (mid-development, deadline applied to both paths):
full walk:    768 nodes in 252ms (truncation: None)
bounded 50ms: 1 nodes   in 163ms (truncation: Timeout)   <- walk stopped at deadline

# final semantics (deadline binds the fallback; cached path node-capped):
full walk:    335 nodes in 224ms (truncation: None)
bounded 50ms: 335 nodes in 124ms (truncation: None)      <- materialized tree kept
```

The first run proves the deadline machinery fires mid-walk. It also exposed why the cached path must not be time-truncated: the 163ms was one uninterruptible `ElementFromHandleBuildCache` COM call that had *already* materialized the full tree — discarding it saved the target app nothing. Final semantics: cache-path windows keep their (node-capped) tree; Chromium/Electron fallback walks stop at the deadline.

## Impact

- A single Electron/Chromium window can no longer take an unbounded-duration walk per capture trigger; the paired-capture walk is now hard-capped at the adaptive budget (250ms default), directly capping the foreground-freeze class measured in #4835.
- Windows machines now get the same per-app cost caps as macOS: expensive apps decay to Heavy/Critical tiers (walks at most every 5s/60s with 1000/500-node caps), terminals cap at 1 OCR capture per 30s.

Related: #4835 (orphaned periodic walker — this issue caps the remaining paired-capture walks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
