### PR TITLE
Remove stale offline mode references

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/managed-settings.test.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/managed-settings.test.ts
@@ -79,10 +79,10 @@ describe("computeManagedSettingUpdates", () => {
     ).toBe(false);
   });
 
-  it("ignores offlineMode — it has no device-side setting (tracked separately)", () => {
-    const r = computeManagedSettingUpdates({ offlineMode: "true" }, {});
-    expect(r.engineUpdates).not.toHaveProperty("offlineMode");
-    expect(r.liveUpdates).not.toHaveProperty("offlineMode");
+  it("ignores unknown policy keys", () => {
+    const r = computeManagedSettingUpdates({ retiredPolicyToggle: "true" }, {});
+    expect(r.engineUpdates).not.toHaveProperty("retiredPolicyToggle");
+    expect(r.liveUpdates).not.toHaveProperty("retiredPolicyToggle");
     expect(r.engineChanged).toBe(false);
     expect(r.liveChanged).toBe(false);
   });

--- a/apps/screenpipe-app-tauri/lib/hooks/managed-settings.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/managed-settings.ts
@@ -64,10 +64,6 @@ export interface ManagedSettingUpdates {
 /**
  * Pure: given the policy `lockedSettings` and the device's current settings,
  * compute which managed values to write and whether a restart is needed.
- *
- * NOTE: `offlineMode` is intentionally absent — there is no device setting it
- * maps to (no engine/runtime reader), so it can't be enforced through the store
- * and is tracked as a separate issue rather than half-applied here.
  */
 export function computeManagedSettingUpdates(
   locked: Record<string, unknown>,

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -502,7 +502,7 @@ async fn main() {
         }
     }
 
-    // Check if telemetry is disabled via store setting (analyticsEnabled) or offline mode
+    // Check if telemetry is disabled via store setting (analyticsEnabled)
     let store_path = screenpipe_core::paths::default_screenpipe_data_dir().join("store.bin");
     let store_json = std::fs::read(&store_path).ok().and_then(|data| {
         if data.len() >= 8 && &data[..8] == b"SPSTORE1" {

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -704,10 +704,10 @@ impl PiExecutor {
         Ok(())
     }
 
-    /// Install or remove the web-search extension based on provider and offline mode.
+    /// Install or remove the web-search extension based on provider.
     /// Web search uses the screenpipe cloud backend, so we only enable it
     /// for screenpipe-cloud to avoid sending data to our backend when the
-    /// user chose a local/custom provider. Always removed in offline mode.
+    /// user chose a local/custom provider.
     pub fn ensure_web_search_extension(project_dir: &Path, provider: Option<&str>) -> Result<()> {
         let ext_dir = project_dir.join(".pi").join("extensions");
         let ext_path = ext_dir.join("web-search.ts");
@@ -1121,14 +1121,14 @@ impl PiExecutor {
     /// `Ok(model)`  → the requested model is allowed (or we can't validate).
     /// `Err(model)` → requested not allowed; the returned value is the fallback.
     fn pick_allowed_model(requested: &str, allowed: &[String]) -> Result<String, String> {
-        // No catalog, or only the offline/degraded fallback sentinel → we
+        // No catalog, or only the gateway fallback sentinel → we
         // couldn't actually validate, so don't second-guess the requested
         // model. Without the sentinel check the `["auto"]` list returned by
         // `fallback_cloud_models` when the gateway is unreachable would
         // masquerade as a one-model tier and spuriously downgrade a
         // deliberately-chosen premium model, firing a bogus `model_fallback`
-        // notice on every offline run.
-        if allowed.is_empty() || Self::is_offline_fallback_catalog(allowed) {
+        // notice on every degraded run.
+        if allowed.is_empty() || Self::is_gateway_fallback_catalog(allowed) {
             return Ok(requested.to_string());
         }
         // "auto" is always valid: the gateway picks an allowed model server-side.
@@ -1145,7 +1145,7 @@ impl PiExecutor {
         Err(fallback)
     }
 
-    /// `true` when `allowed` is exactly the offline/degraded fallback catalog
+    /// `true` when `allowed` is exactly the unvalidated gateway fallback catalog
     /// (`["auto"]`) produced by [`fallback_cloud_models`] when the gateway's
     /// `/v1/models` is unreachable. It carries no real tier information, so we
     /// treat it like an empty catalog and never let it drive a downgrade.
@@ -1155,7 +1155,7 @@ impl PiExecutor {
     /// concrete model ids), and even if one appeared `auto` is always accepted
     /// by the gateway, so passing the requested model through for its
     /// server-side auto-pick stays correct.
-    fn is_offline_fallback_catalog(allowed: &[String]) -> bool {
+    fn is_gateway_fallback_catalog(allowed: &[String]) -> bool {
         allowed.len() == 1 && allowed[0] == "auto"
     }
 
@@ -3305,22 +3305,22 @@ mod tests {
             Ok("claude-opus-4".to_string())
         );
 
-        // Offline sentinel ["auto"] (gateway unreachable → fallback_cloud_models)
+        // Gateway fallback sentinel ["auto"] (gateway unreachable → fallback_cloud_models)
         // must be treated like an empty catalog: it is NOT a one-model tier, so
         // a deliberately-chosen premium model passes through unchanged instead
         // of being spuriously downgraded. This is the #3763 offline regression.
-        let offline_sentinel = vec!["auto".to_string()];
+        let gateway_fallback = vec!["auto".to_string()];
         assert_eq!(
-            PiExecutor::pick_allowed_model("claude-opus-4", &offline_sentinel),
+            PiExecutor::pick_allowed_model("claude-opus-4", &gateway_fallback),
             Ok("claude-opus-4".to_string())
         );
         assert_eq!(
-            PiExecutor::pick_allowed_model("auto", &offline_sentinel),
+            PiExecutor::pick_allowed_model("auto", &gateway_fallback),
             Ok("auto".to_string())
         );
-        assert!(PiExecutor::is_offline_fallback_catalog(&offline_sentinel));
+        assert!(PiExecutor::is_gateway_fallback_catalog(&gateway_fallback));
         // A real single-model tier on a concrete id is NOT the sentinel.
-        assert!(!PiExecutor::is_offline_fallback_catalog(&[
+        assert!(!PiExecutor::is_gateway_fallback_catalog(&[
             "claude-haiku-4-5".to_string()
         ]));
     }


### PR DESCRIPTION
## summary
- remove the remaining desktop/core references to the retired offline-mode setting path
- stop treating `offlineMode` as a special managed-policy key; unknown retired policy keys are ignored generically
- clean up stale offline-mode wording in telemetry and Pi gateway-fallback comments/names
- leave Enhanced AI untouched

## validation
- `bun test apps/screenpipe-app-tauri/lib/hooks/managed-settings.test.ts`
- `git diff --check`
- source sweep: no `offlineMode`, `offline_mode`, `Offline Mode`, or `offline mode` references remain in `apps/screenpipe-app-tauri`, `crates/screenpipe-core`, `crates/screenpipe-engine`, or `packages`
- source sweep: `Enhanced AI`, `enhanced-ai-toggle`, `settings?.enhancedAI`, and `setEnhancedAiSuggestions` remain present

## note
- current desktop source/history shows the old visible Settings -> Privacy -> Offline Mode card was already removed in v2.4.133; this PR removes the stale leftovers that remained.
