### PR TITLE
[pr] fix(a11y): correct stale incognito test assertion in tree/windows.rs

### DIFF
--- a/crates/screenpipe-a11y/src/tree/windows.rs
+++ b/crates/screenpipe-a11y/src/tree/windows.rs
@@ -1019,7 +1019,8 @@ mod tests {
     #[test]
     fn test_incognito_detection() {
         use crate::incognito::is_title_private;
-        assert!(is_title_private("Enter Password - Chrome"));
+        // bare "password" was deliberately removed from privacy filters (false positives)
+        assert!(!is_title_private("Enter Password - Chrome"));
         assert!(is_title_private("Private Browsing - Firefox"));
         assert!(is_title_private("New Tab - Google Chrome (Incognito)"));
         assert!(!is_title_private("Calculator"));


### PR DESCRIPTION
## description

`test_incognito_detection` in `crates/screenpipe-a11y/src/tree/windows.rs` asserted that `is_title_private("Enter Password - Chrome")` returns `true`, which contradicts the incognito module's own tests (`incognito/titles.rs::test_no_false_positive_private_in_title` and `incognito/mod.rs::test_no_false_positives_on_normal_windows` both assert the opposite). Bare "password" matching was deliberately removed from privacy filters due to false positives (see the comment near `excluded_window_pattern_strings` in `crates/screenpipe-a11y/src/config.rs`), so the tree-side test was stale and made `cargo test -p screenpipe-a11y` fail.

This flips the stale assertion to `!is_title_private(...)` with a one-line comment explaining why, keeping the rest of the test (private-browsing positives and a negative case) intact.

related issue: n/a — test-only fix, no behavior change

## before

```
running 1 test
test tree::windows::tests::test_incognito_detection ... FAILED

assertion failed: is_title_private("Enter Password - Chrome")
```

## after

```
running 1 test
test tree::windows::tests::test_incognito_detection ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 194 filtered out
```

All 37 incognito-related tests in the crate pass (`cargo test -p screenpipe-a11y incognito`).

## how to test

1. `cargo test -p screenpipe-a11y test_incognito_detection`
2. `cargo test -p screenpipe-a11y incognito` (runs the full incognito test surface, 37 tests)

## desktop app checklist (if applicable)

Not applicable — no Tauri commands or exported types touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

