### PR TITLE
[pr] gitignore stray dev/null dir created by git-lfs in Claude worktrees on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ screenpipe-app-tauri/src-tauri/.next/
 
 # Claude Code
 .claude/worktrees/
+# Claude desktop app runs `git worktree add` with `-c core.hooksPath=/dev/null`;
+# on Windows git-lfs resolves that as a relative path and drops its hooks into
+# a literal dev/null/ dir at the worktree root. Harmless but noisy — ignore it.
+/dev/null/
 .claude/*.local* # local changes are specific to the individual developer, let's not check them in for everyone.
 .claude/*.lock
 apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-arm64-1.19.2/


### PR DESCRIPTION
## description

Every worktree the Claude desktop app creates in this repo on Windows grows a stray untracked directory literally named `dev/null/` at the worktree root, containing the four stock git-lfs hooks (`post-checkout`, `post-commit`, `post-merge`, `pre-push`). This PR ignores it.

Root cause (verified with `GIT_TRACE=1` and a minimal repro, not a screenpipe bug):

1. The Claude desktop app suppresses repo hooks by prepending `-c core.hooksPath=/dev/null` to the git commands it runs, including the `git worktree add` in its worktree-creation flow.
2. Since this repo tracks `*.onnx`/`*.wav` via git-lfs, the checkout spawns `git-lfs filter-process`, which inherits that config through `GIT_CONFIG_PARAMETERS` and auto-reinstalls its hooks on every filter run.
3. On Windows, Go's `filepath.IsAbs("/dev/null")` is `false`, so git-lfs resolves the path *relative to the worktree root* → literal `<worktree>\dev\null\`. On macOS/Linux the write fails silently against the real `/dev/null`, so only Windows worktrees are affected.

Minimal repro on any Windows checkout of this repo:

```
GIT_CONFIG_PARAMETERS="'core.hooksPath=/dev/null'" git worktree add --no-track -B probe <path> origin/main
# → <path>/dev/null/ appears with the 4 LFS hooks
```

The stray hooks are never executed (worktree config points `core.hooksPath` at the main repo's hooks dir), so the dir is pure noise — but it reappears in every new worktree until the upstream bug is fixed, pollutes `git status`, and risks being swept into a commit by `git add -A`. Ignoring `/dev/null/` (anchored to the repo root, so it can't hide anything under `crates/` etc.) is the pragmatic repo-side mitigation. The tracked `dev/` directory is unaffected. An upstream report to Anthropic/git-lfs is being filed separately.

related issue: n/a (root cause is in the Claude desktop app + git-lfs, tracked upstream)

## before

```
$ git status --short
?? dev/null/

$ ls dev/null/
post-checkout  post-commit  post-merge  pre-push
```

## after

```
$ git status --short
$                                      # clean — dev/null/ ignored

$ git check-ignore -v dev/null/post-checkout
.gitignore:75:/dev/null/	dev/null/post-checkout
```

## how to test

1. `mkdir -p dev/null && touch dev/null/post-checkout` (simulates the artifact; or run the repro above on Windows)
2. `git status --short` → no `?? dev/null/` entry
3. `git check-ignore -v dev/null/post-checkout` → matches the new `.gitignore:75` rule
4. `rm -rf dev/null`

## desktop app checklist (if applicable)

Not applicable — `.gitignore`-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)