### PR TITLE
fix(audio): insulate WASAPI capture threads from process priority drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "cpal"
 version = "0.15.3"
-source = "git+https://github.com/screenpipe/cpal.git?rev=c7a610aee5c6037c9c69dc5bf7f2a850da8d8b12#c7a610aee5c6037c9c69dc5bf7f2a850da8d8b12"
+source = "git+https://github.com/EzraEllette/cpal.git?rev=93647b9b5de39d6d4fd9f0a8224fbc0921e1e6bd#93647b9b5de39d6d4fd9f0a8224fbc0921e1e6bd"
 dependencies = [
  "alsa",
  "cidre 0.15.1 (git+https://github.com/yury/cidre.git?rev=8481f3f0dc7dd39bb5be80d9424bfac0cad3801a)",

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -23,7 +23,7 @@ oasgen = { workspace = true }
 # (fixes SetThreadPriority being called with a thread id instead of a handle,
 # so the WASAPI capture/render thread priority boost silently never applied)
 # merges, then swap back to https://github.com/screenpipe/cpal.git.
-cpal = { git = "https://github.com/EzraEllette/cpal.git", rev = "93647b9b5de39d6d4fd9f0a8224fbc0921e1e6bd" }
+cpal = { git = "https://github.com/screenpipe/cpal.git" }
 
 # Wav encoding
 hound = { workspace = true }

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -19,11 +19,7 @@ oasgen = { workspace = true }
 
 # Cross-platform audio capture. Tracks screenpipe/cpal main, which carries
 # the Windows WASAPI AEC and macOS VoiceProcessingIO patches.
-# TODO(#4916): temporarily pinned to EzraEllette/cpal until screenpipe/cpal#5
-# (fixes SetThreadPriority being called with a thread id instead of a handle,
-# so the WASAPI capture/render thread priority boost silently never applied)
-# merges, then swap back to https://github.com/screenpipe/cpal.git.
-cpal = { git = "https://github.com/screenpipe/cpal.git" }
+cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "e7edfa174466e87a467d1a58e3a4aec233ff8a21" }
 
 # Wav encoding
 hound = { workspace = true }

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -19,7 +19,11 @@ oasgen = { workspace = true }
 
 # Cross-platform audio capture. Tracks screenpipe/cpal main, which carries
 # the Windows WASAPI AEC and macOS VoiceProcessingIO patches.
-cpal = { git = "https://github.com/screenpipe/cpal.git", rev = "c7a610aee5c6037c9c69dc5bf7f2a850da8d8b12" }
+# TODO(#4916): temporarily pinned to EzraEllette/cpal until screenpipe/cpal#5
+# (fixes SetThreadPriority being called with a thread id instead of a handle,
+# so the WASAPI capture/render thread priority boost silently never applied)
+# merges, then swap back to https://github.com/screenpipe/cpal.git.
+cpal = { git = "https://github.com/EzraEllette/cpal.git", rev = "93647b9b5de39d6d4fd9f0a8224fbc0921e1e6bd" }
 
 # Wav encoding
 hound = { workspace = true }

--- a/crates/screenpipe-audio/src/core/process_tap/windows.rs
+++ b/crates/screenpipe-audio/src/core/process_tap/windows.rs
@@ -54,7 +54,10 @@ use windows::Win32::System::Com::{
     CoCreateInstance, CoInitializeEx, CoUninitialize, IAgileObject, IAgileObject_Impl, CLSCTX_ALL,
     COINIT_MULTITHREADED,
 };
-use windows::Win32::System::Threading::{CreateEventW, WaitForSingleObject};
+use windows::Win32::System::Threading::{
+    CreateEventW, GetCurrentThread, SetThreadPriority, WaitForSingleObject,
+    THREAD_PRIORITY_TIME_CRITICAL,
+};
 
 use crate::core::stream::AudioStreamConfig;
 use crate::utils::audio::audio_to_mono;
@@ -332,6 +335,13 @@ fn run_capture_loop(
     is_disconnected: Arc<AtomicBool>,
     label: &str,
 ) {
+    // Insulates this capture thread from the process's BELOW_NORMAL priority
+    // class (and foreground contention generally) the same way cpal's WASAPI
+    // backend does for its own capture threads.
+    unsafe {
+        let _ = SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+    }
+
     while !is_disconnected.load(Ordering::Relaxed) {
         let wait = unsafe { WaitForSingleObject(capture.sample_ready.0, CAPTURE_WAIT_MS) };
         if wait == WAIT_TIMEOUT {


### PR DESCRIPTION
## Summary
Fixes #4916.

The screenpipe cpal fork tries to boost WASAPI capture/render threads to `THREAD_PRIORITY_TIME_CRITICAL`, but the boost call has the known upstream 0.15.x bug: it passes a thread **id** where `SetThreadPriority` requires a thread **handle**, so the call always fails with `ERROR_INVALID_HANDLE` and the error is silently discarded. Net effect: `cpal_wasapi_in`/`cpal_wasapi_out` threads run at default priority instead of the intended `TIME_CRITICAL`.

With the engine process running at `BELOW_NORMAL_PRIORITY_CLASS` (#4849), unboosted capture threads land at Windows base priority 6 — preemptable by every Normal-class thread. The WASAPI shared-mode buffer is only tens of ms, so capture-thread starvation under all-core load can silently drop audio: no error, no log, no metric.

## Fix
1. **cpal fork**: [screenpipe/cpal#5](https://github.com/screenpipe/cpal/pull/5) swaps `GetCurrentThreadId()` (cast into a `HANDLE`) for the `GetCurrentThread()` pseudo-handle, which `SetThreadPriority` actually accepts. This crate pins to that fork commit (`EzraEllette/cpal@93647b9`) as an interim measure — once screenpipe/cpal#5 merges, this should be repointed back to `https://github.com/screenpipe/cpal.git` (left a `TODO(#4916)` comment on the dependency).
2. **Meeting process-loopback tap**: `crates/screenpipe-audio/src/core/process_tap/windows.rs`'s capture thread (`run_capture_loop`, spawned via plain `spawn_blocking`) had the same exposure with no priority handling at all. Added the same `SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL)` boost there.

## Testing
- `cargo check -p screenpipe-audio --locked` on Windows (x86_64-pc-windows-msvc): compiles clean, no new warnings from either change (the two pre-existing warnings in the check output are unrelated deprecations in `screenpipe-core`/`speaker/embedding.rs`).
- Verified the `Cargo.lock` diff is scoped to only the `cpal` package's git source (manually patched instead of via `cargo update -p cpal`, which triggered an unrelated cascade of transitive-dependency downgrades across the lockfile that I reverted).

## Follow-ups (out of scope here)
- Once [screenpipe/cpal#5](https://github.com/screenpipe/cpal/pull/5) merges, bump `crates/screenpipe-audio/Cargo.toml` back to `https://github.com/screenpipe/cpal.git` at the merged rev.
- `ee/sdk/recorder-core` pins an older cpal rev (`01b68e6`, an ancestor of the buggy `c7a610a`) and is excluded from this workspace — not touched here since it's outside the issue's scope, but likely has the same bug.
- The issue also suggested (optionally) logging `AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY` in cpal's `stream.rs` for observability. Left out of the fork PR since cpal has zero logging dependencies today and adding one felt like scope creep for a one-line bug fix.