### PR TITLE
fix(audio): drain NSRunningApplication lookups in an autorelease pool (macOS RSS leak)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8171,6 +8171,7 @@ dependencies = [
  "infer",
  "knf-rs",
  "lazy_static",
+ "libc",
  "libpulse-binding",
  "libpulse-simple-binding",
  "libsamplerate-sys",

--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -165,6 +165,8 @@ criterion = { workspace = true }
 strsim = { workspace = true }
 futures = { workspace = true }
 tracing-subscriber = { workspace = true }
+# macOS autorelease-leak repro test reads peak RSS via getrusage.
+libc = { workspace = true }
 
 
 [features]

--- a/crates/screenpipe-audio/src/core/process_tap/macos.rs
+++ b/crates/screenpipe-audio/src/core/process_tap/macos.rs
@@ -196,26 +196,33 @@ mod exclusions {
     /// AudioObjectID. The result is sorted+deduped so snapshots can be
     /// compared with `==`.
     pub fn resolve_to_audio_object_ids(bundle_ids: &[String]) -> Vec<u32> {
-        let mut out = Vec::new();
-        for bid in bundle_ids {
-            let bid_ns = ns::String::with_str(bid);
-            let apps = ns::RunningApp::with_bundle_id(&bid_ns);
-            for app in apps.iter() {
-                let pid = app.pid();
-                if let Ok(proc) = ca::Process::with_pid(pid) {
-                    // ca::Process(pub Obj) where Obj(pub u32) is #[repr(transparent)].
-                    // The inner u32 is the AudioObjectID that the tap descriptor
-                    // expects (wrapped in ns::Number, see build_object_id_array).
-                    let audio_obj_id = proc.0 .0;
-                    if audio_obj_id != 0 {
-                        out.push(audio_obj_id);
+        // Wrap in an autorelease pool — `ns::RunningApp::with_bundle_id` returns
+        // autoreleased NSRunningApplication objects (+ NSLock/LaunchServices
+        // LSASN when their pid is read). Without draining they accumulate on the
+        // caller's thread across tap rebuilds. Same leak class as owner_metadata
+        // in meeting_processes.rs and get_frontmost_pid in screenpipe-screen.
+        cidre::objc::ar_pool(|| {
+            let mut out = Vec::new();
+            for bid in bundle_ids {
+                let bid_ns = ns::String::with_str(bid);
+                let apps = ns::RunningApp::with_bundle_id(&bid_ns);
+                for app in apps.iter() {
+                    let pid = app.pid();
+                    if let Ok(proc) = ca::Process::with_pid(pid) {
+                        // ca::Process(pub Obj) where Obj(pub u32) is #[repr(transparent)].
+                        // The inner u32 is the AudioObjectID that the tap descriptor
+                        // expects (wrapped in ns::Number, see build_object_id_array).
+                        let audio_obj_id = proc.0 .0;
+                        if audio_obj_id != 0 {
+                            out.push(audio_obj_id);
+                        }
                     }
                 }
             }
-        }
-        out.sort_unstable();
-        out.dedup();
-        out
+            out.sort_unstable();
+            out.dedup();
+            out
+        })
     }
 
     /// Convert AudioObjectIDs into the `ns::Array<ns::Number>` shape the tap

--- a/crates/screenpipe-audio/src/meeting_processes.rs
+++ b/crates/screenpipe-audio/src/meeting_processes.rs
@@ -186,13 +186,119 @@ mod platform {
         let Some(pid) = pid else {
             return (None, None);
         };
-        let Some(app) = ns::RunningApp::with_pid(pid) else {
-            return (None, None);
-        };
-        (
-            app.localized_name().map(|s| s.to_string()),
-            app.bundle_id().map(|s| s.to_string()),
-        )
+        // Wrap in an autorelease pool — `ns::RunningApp::with_pid` returns an
+        // autoreleased NSRunningApplication, and reading its name/bundle-id
+        // lazily allocates an NSLock + a LaunchServices LSASN. Without draining,
+        // every poll of the audio-process meeting watcher leaks one such object
+        // triple: ACTIVE_POLL_INTERVAL is 1s and screenpipe's own always-on mic
+        // process is always in the input list, so this runs ~1x/sec and grew to
+        // ~49k retained instances over ~14.5h. Same precedent as get_frontmost_pid
+        // in screenpipe-screen. See leak_repro below.
+        cidre::objc::ar_pool(|| {
+            let Some(app) = ns::RunningApp::with_pid(pid) else {
+                return (None, None);
+            };
+            (
+                app.localized_name().map(|s| s.to_string()),
+                app.bundle_id().map(|s| s.to_string()),
+            )
+        })
+    }
+
+    /// Reproduction + regression guard for the NSRunningApplication autorelease
+    /// leak (2026-07-04). Phase 1 drives the pre-fix (unwrapped) body; phase 2
+    /// drives the fixed [`owner_metadata`]. Peak RSS (`ru_maxrss`) climbs in
+    /// phase 1 and stays flat in phase 2.
+    ///
+    /// `#[ignore]` because it's a memory/perf repro, not a fast unit test. Run:
+    ///   cargo test -p screenpipe-audio --lib meeting_processes::platform::leak_repro -- --ignored --nocapture
+    #[cfg(test)]
+    mod leak_repro {
+        use cidre::{ns, objc};
+
+        /// Peak resident memory in bytes (`ru_maxrss` is bytes on Darwin,
+        /// despite the rusage man page claiming KB).
+        fn peak_rss_bytes() -> u64 {
+            unsafe {
+                let mut ru: libc::rusage = std::mem::zeroed();
+                libc::getrusage(libc::RUSAGE_SELF, &mut ru);
+                ru.ru_maxrss as u64
+            }
+        }
+
+        fn fmt_mb(b: u64) -> String {
+            format!("{:.1} MB", (b as f64) / (1024.0 * 1024.0))
+        }
+
+        /// The pre-fix body, verbatim, so the test can prove the leak the fix
+        /// removes (unwrapped `with_pid` + property reads, no `ar_pool`).
+        fn owner_metadata_unwrapped(pid: i32) -> (Option<String>, Option<String>) {
+            let Some(app) = ns::RunningApp::with_pid(pid) else {
+                return (None, None);
+            };
+            (
+                app.localized_name().map(|s| s.to_string()),
+                app.bundle_id().map(|s| s.to_string()),
+            )
+        }
+
+        #[test]
+        #[ignore = "macOS NSRunningApplication autorelease-leak repro; prints RSS deltas"]
+        fn owner_metadata_autorelease_leak() {
+            const N: usize = 30_000;
+
+            // Cycle over the real running-app pids (collected inside a pool so the
+            // enumeration itself doesn't pollute the measurement). Falls back to
+            // self pid on a bare host with no other apps.
+            let pids: Vec<i32> = objc::ar_pool(|| {
+                let ws = ns::Workspace::shared();
+                let apps = ws.running_apps();
+                (0..apps.len()).map(|i| apps[i].pid()).collect()
+            });
+            let pids = if pids.is_empty() {
+                vec![std::process::id() as i32]
+            } else {
+                pids
+            };
+
+            // Warm one-time LaunchServices caches so they don't count as "leak".
+            for &pid in &pids {
+                let _ = super::owner_metadata(Some(pid));
+                let _ = owner_metadata_unwrapped(pid);
+            }
+
+            // -- Phase 1: pre-fix body (no ar_pool) — should leak --
+            let before1 = peak_rss_bytes();
+            for i in 0..N {
+                let _ = owner_metadata_unwrapped(pids[i % pids.len()]);
+            }
+            let delta1 = peak_rss_bytes().saturating_sub(before1);
+            eprintln!("[repro] {N} calls WITHOUT ar_pool: +{}", fmt_mb(delta1));
+
+            // -- Phase 2: fixed owner_metadata (ar_pool) — should stay flat --
+            let before2 = peak_rss_bytes();
+            for i in 0..N {
+                let _ = super::owner_metadata(Some(pids[i % pids.len()]));
+            }
+            let delta2 = peak_rss_bytes().saturating_sub(before2);
+            eprintln!("[repro] {N} calls WITH    ar_pool: +{}", fmt_mb(delta2));
+            eprintln!(
+                "[repro] leak delta (phase1 - phase2): {}",
+                fmt_mb(delta1.saturating_sub(delta2))
+            );
+
+            assert!(
+                delta1 > 2 * 1024 * 1024,
+                "expected >2 MB growth without ar_pool; got {} — leak not reproduced",
+                fmt_mb(delta1)
+            );
+            assert!(
+                delta1 > 3 * delta2.max(1),
+                "fixed path should leak <=1/3 of unwrapped; phase1={}, phase2={}",
+                fmt_mb(delta1),
+                fmt_mb(delta2)
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

A long-running macOS instance grows RSS steadily (observed ~4 GB → ~5.7 GB phys_footprint over ~14.5 h of one process's uptime). Live diagnosis pinned a genuine slow leak in the **audio meeting-detection path**.

### Evidence (live `heap` diff, 316 s apart, no restart)

Three object types grow **in lockstep at ~0.93/sec** — a fingerprint:

| class | Δ over 316 s | rate |
|---|---|---|
| `NSRunningApplication` (AppKit) | **+294** | 0.93 / s |
| `NSLock` (Foundation) | **+294** | 0.93 / s |
| `LSASN` (LaunchServices) | **+294** | 0.93 / s |
| `non-object` (their string/retinue buffers) | +10,399 | ≈ 294 × ~35 |

At ~14.5 h uptime this had accumulated **~49k** retained `NSRunningApplication` (+`NSLock` +`LSASN`), plus their untyped string retinue in the malloc heap. (`ps` RSS looked ~2× the real footprint because MALLOC_SMALL also holds several GB of *reclaimable* freed heap — separate issue, not this leak.)

## Root cause

`ns::RunningApp::…` returns an **autoreleased** `NSRunningApplication`; reading its name/bundle-id lazily allocates an `NSLock` + a LaunchServices `LSASN`. Without an autorelease pool on the calling thread, each call leaks that object triple.

Two call sites in `screenpipe-audio` were **missing the `cidre::objc::ar_pool(…)` wrap** that every other running-apps caller already has (the campaign that added them to `screenpipe-screen` / `a11y` / `engine` — see the `get_frontmost_pid` comment about a prior "~800 MB+ leak over hours" — missed these):

```
audio-process meeting watcher
  loop @ ACTIVE_POLL_INTERVAL = 1s   (used whenever any input process is present)
    → current_input_processes()
      → collect_input_processes()
        → owner_metadata(pid)         ← ns::RunningApp::with_pid + name/bundle_id, NO ar_pool
```

Because **screenpipe records the mic continuously, its own input process is always present**, so the loop runs at the 1 s cadence and calls the unwrapped `owner_metadata` at least once per second → exactly the measured ~1 leak/sec.

- **Primary** (~1/sec): `crates/screenpipe-audio/src/meeting_processes.rs` `owner_metadata` — called at line 117 for every input process *before* the `is_screenpipe_process` skip.
- **Secondary** (tap rebuilds): `crates/screenpipe-audio/src/core/process_tap/macos.rs` `resolve_to_audio_object_ids` — unwrapped `ns::RunningApp::with_bundle_id`.

## Fix

Wrap both bodies in `cidre::objc::ar_pool(|| { … })`, identical to the existing pattern (`get_frontmost_pid`, `find_running_meeting_apps`, `query_frontmost_app_name_uncached`, …). No behavior change; autoreleased objects drain per call.

## Test

New repro + regression guard: `meeting_processes::platform::leak_repro::owner_metadata_autorelease_leak` (mirrors the existing `screenpipe-screen` leak repro). It drives 30k calls through the **pre-fix (unwrapped) body** vs 30k through the **fixed `owner_metadata`**, comparing peak RSS, and asserts:
- phase 1 (unwrapped) grows **> 2 MB** — proves the leak reproduces;
- phase 1 leaks **> 3×** phase 2 — proves `ar_pool` stops it.

```
cargo test -p screenpipe-audio --no-default-features --lib \
  meeting_processes::platform::leak_repro -- --ignored --nocapture
```

> ⏳ Verification build (cold compile of this crate) is running as I open this; I'll post the actual before/after RSS deltas from the test as a comment. Marking **draft** until then.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
