### PR TITLE
[pr] test(pipes): fix cron scheduler tests failing deterministically on non-UTC machines

### DIFF
--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -7336,21 +7336,33 @@ mod tests {
         }
     }
 
+    /// Parse a raw cron schedule string through the production entry point
+    /// (`parse_schedule`) and unwrap the cron, so tests that pin `now` via
+    /// `cron_should_fire` still cover the string→cron glue `should_run` uses.
+    fn parse_cron(s: &str) -> CronSchedule {
+        match parse_schedule(s) {
+            Some(ParsedSchedule::Cron(c)) => *c,
+            other => panic!("expected cron for {:?}, got {:?}", s, other.is_some()),
+        }
+    }
+
     #[test]
     fn test_should_run_human_daily() {
         // Wall-clock cron only fires when we're actually inside the scheduled
-        // slot (within CRON_GRACE_WINDOW). Anchor to the current hour:minute
-        // so the slot is "right now" regardless of when the test runs.
-        let now = Utc::now();
+        // slot (within CRON_GRACE_WINDOW). `should_run` evaluates crons against
+        // the machine's LOCAL timezone (issue #3851), so anchor the slot to
+        // Local::now() — anchoring to Utc::now() puts the slot hours away on
+        // any non-UTC machine and both assertions break.
+        let now = Local::now();
         let cron_str = format!("0 {} {} * * * *", now.minute(), now.hour());
-        let yesterday = now - chrono::Duration::hours(25);
+        let yesterday = (now - chrono::Duration::hours(25)).with_timezone(&Utc);
         // Last run was yesterday, current minute's slot just passed → fire.
         assert!(should_run(&cron_str, yesterday));
 
         // Same cron, but last_run is "right now" (this slot already claimed) →
         // don't re-fire. `cron.after(last_run)` is strictly after, so the next
         // candidate is tomorrow's slot.
-        assert!(!should_run(&cron_str, now));
+        assert!(!should_run(&cron_str, now.with_timezone(&Utc)));
     }
 
     #[test]
@@ -7359,13 +7371,13 @@ mod tests {
         // just because today's cron slot already passed. Should wait until the
         // next future slot. Regression test: a user reported creating an
         // "every day at 7am" pipe at 5:39pm that fired 12 seconds later.
-        let now = Utc::now();
-        // Pick an hour that's unambiguously outside the grace window from now
-        // (6h away in either direction).
-        let safe_hour = (now.hour() + 6) % 24;
-        let cron_str = format!("0 0 {} * * * *", safe_hour);
+        // Pin `now` through the `cron_should_fire` seam (the exact decision
+        // `should_run` delegates to) instead of anchoring an hour to the real
+        // clock, which drifts into the grace window on non-UTC machines.
+        let cron = parse_cron("0 0 7 * * * *"); // every day at 07:00
+        let now = Utc.with_ymd_and_hms(2026, 6, 5, 17, 39, 0).unwrap();
         assert!(
-            !should_run(&cron_str, DateTime::UNIX_EPOCH),
+            !cron_should_fire(&cron, DateTime::UNIX_EPOCH, now),
             "newly-installed cron pipe must not fire immediately on install — \
              should wait for the next scheduled slot, not catch up from 1970"
         );
@@ -7374,13 +7386,15 @@ mod tests {
     #[test]
     fn test_should_run_cron_stale_last_run_waits() {
         // App was off for days. On restart, a daily cron whose slot passed
-        // hours ago must NOT fire immediately — wait for the next slot.
-        let now = Utc::now();
-        let safe_hour = (now.hour() + 6) % 24;
-        let cron_str = format!("0 0 {} * * * *", safe_hour);
+        // hours ago (beyond CRON_CATCHUP_WINDOW) must NOT fire immediately —
+        // wait for the next slot. Pinned `now`: the slot is 16:30 daily, so
+        // its most recent occurrence was 18h before `now` and the next is 6h
+        // after — unambiguously outside the catch-up window in any timezone.
+        let cron = parse_cron("0 30 16 * * * *");
+        let now = Utc.with_ymd_and_hms(2026, 6, 5, 10, 30, 30).unwrap();
         let three_days_ago = now - chrono::Duration::days(3);
         assert!(
-            !should_run(&cron_str, three_days_ago),
+            !cron_should_fire(&cron, three_days_ago, now),
             "after extended downtime, cron must wait for the next slot \
              instead of firing stale catch-up runs"
         );
@@ -7390,10 +7404,12 @@ mod tests {
     fn test_should_run_cron_within_grace_fires() {
         // Slot was hit moments ago (typical: scheduler tick lag, brief sleep).
         // Within grace → fire even though last_run is far in the past.
-        let now = Utc::now();
-        let cron_str = format!("0 {} {} * * * *", now.minute(), now.hour());
+        // `now` is pinned 30s past the 10:30:00 slot so the assertion holds
+        // in any timezone.
+        let cron = parse_cron("0 30 10 * * * *");
+        let now = Utc.with_ymd_and_hms(2026, 6, 5, 10, 30, 30).unwrap();
         let yesterday = now - chrono::Duration::hours(25);
-        assert!(should_run(&cron_str, yesterday));
+        assert!(cron_should_fire(&cron, yesterday, now));
     }
 
     #[test]
@@ -7401,15 +7417,13 @@ mod tests {
         // Regression: app was offline during the scheduled slot. When it restarts
         // minutes (or hours) after the slot, the pipe must still fire — not silently
         // wait until tomorrow. Reproduces the "morning-brief didn't run" report where
-        // the app started at 7:12am after missing the 7am slot.
-        use chrono::Timelike;
-        let now = Utc::now();
-        // Build a cron expression whose last slot was ~12 minutes ago
-        let slot_time = now - chrono::Duration::minutes(12);
-        let cron_str = format!("0 {} {} * * * *", slot_time.minute(), slot_time.hour());
+        // the app started at 7:12am after missing the 7am slot — pinned literally:
+        // slot at 07:00, `now` at 07:12 (past grace, inside the catch-up window).
+        let cron = parse_cron("0 0 7 * * * *");
+        let now = Utc.with_ymd_and_hms(2026, 6, 5, 7, 12, 0).unwrap();
         let last_run = now - chrono::Duration::hours(25); // ran yesterday
         assert!(
-            should_run(&cron_str, last_run),
+            cron_should_fire(&cron, last_run, now),
             "pipe whose slot passed 12 minutes ago must fire on app restart, not wait until tomorrow"
         );
     }


### PR DESCRIPTION
## description

Four tests in `crates/screenpipe-core/src/pipes/mod.rs` fail deterministically on any machine whose local timezone differs from UTC, while passing on UTC CI runners:

- `pipes::tests::test_should_run_human_daily`
- `pipes::tests::test_should_run_cron_within_grace_fires`
- `pipes::tests::test_should_run_cron_missed_slot_catchup`
- `pipes::tests::test_should_run_cron_stale_last_run_waits`

**Root cause:** `should_run`'s cron path evaluates schedules against the user's **local** timezone via `cron_should_fire(&cron, last_run, Local::now())` (the #3851 fix), but the tests anchored their cron hour/minute to `Utc::now()`. On a UTC-7 machine the "current minute" slot in the cron string is 7 hours away in local time, so the grace-window assertions fail:

```
test built cron slot from Utc::now()      → "0 48 21 * * * *"  (21:48)
should_run evaluates at Local::now()      → 14:48 PDT

  14:48 local                                   21:48 local
──────┬───────────────────────────────────────────────┬────────
     now                                     slot the test wrote
      └─ grace window ends 14:53                       │
                        slot is 7h away → "should fire" asserts fail
```

**The fix (test-only — `should_run` / `cron_should_fire` runtime semantics untouched):**

- The three window-precision tests (`within_grace_fires`, `missed_slot_catchup`, `stale_last_run_waits`) now call `cron_should_fire` directly with a pinned `Utc` "now" — the seam already exists (`cron_should_fire` is generic over `Tz`, and `cron_fires_relative_to_scheduled_time` already used it this way). They no longer consult the machine clock or timezone at all. A small `parse_cron` helper routes each cron string through the production `parse_schedule` entry point so the string→cron glue the old tests exercised stays covered.
- `test_should_run_human_daily` stays end-to-end through `should_run` (keeping one integration test on the real cron path) but anchors its slot to `Local::now()` to match the implementation. Race-safe against minute/hour/midnight ticks between building the cron string and evaluating it.
- Bonus: `test_should_run_cron_fresh_install_waits` wasn't failing here but has the same disease latently — its `(utc_hour + 6) % 24` "safe hour" equals the local hour on a UTC+6 machine, so it would flake there during the first 5 minutes of any hour. Converted to the same pinned-now style, encoding the original bug report literally (7am pipe installed at 17:39).

related issue: fallout from the #3851 local-timezone cron fix (no separate issue filed)

## before

On a Pacific Time machine (UTC-7), at the parent commit:

```
$ tzutil /g
Pacific Standard Time

$ cargo test -p screenpipe-core --lib -- test_should_run_cron test_should_run_human

failures:
    pipes::tests::test_should_run_cron_missed_slot_catchup
    pipes::tests::test_should_run_cron_stale_last_run_waits
    pipes::tests::test_should_run_cron_within_grace_fires
    pipes::tests::test_should_run_human_daily

test result: FAILED. 1 passed; 4 failed; 0 ignored; 0 measured; 354 filtered out
```

## after

Same PDT machine, this PR — all scheduler/parse tests green:

```
$ cargo test -p screenpipe-core --lib -- test_should_run cron_fires parse_schedule human_schedule should_run_config

test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 329 filtered out
```

And under a **real UTC system timezone** (chrono's `Local` on Windows reads the system timezone and ignores `TZ`, so the system clock was flipped with `tzutil` and reverted immediately after) — confirms UTC CI stays green:

```
tz-during-run: UTC
test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 329 filtered out
tz-restored: Pacific Standard Time
```

## how to test

1. On a non-UTC machine, check out the parent commit and run `cargo test -p screenpipe-core --lib -- test_should_run cron_fires` → 4 failures.
2. Check out this PR, run the same command → all pass.
3. Simulate UTC and re-run: `TZ=UTC cargo test ...` on Linux/macOS, or `tzutil /s UTC` (then revert) on Windows → all pass. The three converted tests are timezone-independent by construction (pinned `Utc` now, no `Local` involved).

## desktop app checklist (if applicable)

Not applicable — test-only change in `screenpipe-core`, no Tauri commands or exported types touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)