### PR TITLE
fix(chat): stop save fallback minting phantom chat ids (#4719)

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -488,7 +488,20 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     // during startNewConversation (setConversationId(null) → … →
     // setConversationId(newSid)); without the fallback the save would mint
     // a fresh uuid and duplicate the conversation.
-    const convId = conversationId || piSessionIdRef.current || crypto.randomUUID();
+    //
+    // Never mint a fresh id here (issue #4719). If `conversationId` and the
+    // ref are both transiently empty (the null-id window inside
+    // startNewConversation), fall back to the store's `currentId` — the last
+    // stable id the panel published — and if even that is missing, SKIP the
+    // save rather than invent one. A `crypto.randomUUID()` fallback would
+    // persist a phantom twin file for what is really one conversation, which
+    // is exactly the cross-window duplicate this issue tracks.
+    const { useChatStore } = await import("@/lib/stores/chat-store");
+    const convId =
+      conversationId ||
+      piSessionIdRef.current ||
+      useChatStore.getState().currentId;
+    if (!convId) return;
 
     // Try to load existing conversation to preserve createdAt + title + kind.
     const { loadConversationFile } = await import("@/lib/chat-storage");

--- a/apps/screenpipe-app-tauri/lib/__tests__/save-conversation-race.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/__tests__/save-conversation-race.test.tsx
@@ -225,6 +225,51 @@ describe("saveConversation race (PR #3600 / issue #3636 candidate)", () => {
     expect(saveCalls[0].id).toBe("fresh-sid");
   });
 
+  it("NO PHANTOM ID: falls back to store.currentId when conversationId and ref are both empty (#4719)", async () => {
+    // Deepest null-id window: conversationId is null AND the ref hasn't been
+    // reseeded yet. The save must adopt the last stable id the panel
+    // published to the store — NOT mint a fresh uuid twin.
+    useChatStore.setState({ currentId: "store-current-id" });
+    const messages = [{ id: "u1", role: "user" as const, content: "hi", timestamp: 1 }];
+
+    const { result } = renderHook(() =>
+      useHarness({
+        initialMessages: messages,
+        initialConversationId: null,
+        initialPiSessionId: "", // ref transiently empty
+      }),
+    );
+
+    await act(async () => {
+      await result.current.hook.saveConversation(messages);
+    });
+
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].id).toBe("store-current-id");
+  });
+
+  it("NO PHANTOM ID: skips the save entirely when no stable id exists (#4719)", async () => {
+    // conversationId null, ref empty, store.currentId null → there is no
+    // stable id to write under. Pre-fix this minted crypto.randomUUID() and
+    // wrote a phantom twin file. Now it must write NOTHING.
+    useChatStore.setState({ currentId: null });
+    const messages = [{ id: "u1", role: "user" as const, content: "hi", timestamp: 1 }];
+
+    const { result } = renderHook(() =>
+      useHarness({
+        initialMessages: messages,
+        initialConversationId: null,
+        initialPiSessionId: "",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.hook.saveConversation(messages);
+    });
+
+    expect(saveCalls).toHaveLength(0);
+  });
+
   it("preserves browserState from the shadow cache when the disk file does not exist yet", async () => {
     const messages = [{ id: "u1", role: "user" as const, content: "hello", timestamp: 1 }];
     setCachedBrowserState("fresh-sid", {


### PR DESCRIPTION
### Description:

Follow-up to #4706 for issue #4719.

- tests passing:

<img width="1200" height="392" alt="image" src="https://github.com/user-attachments/assets/557d3592-280f-410e-9bed-7c696f72ed71" />


- `saveConversation` used to fall back to `crypto.randomUUID()` when both `conversationId` and `piSessionIdRef` were briefly empty (the null-id window inside `startNewConversation`). That minted a brand-new id and wrote a duplicate chat file to disk.
- Now it falls back to the store's `currentId` instead, and skips the save entirely when no stable id exists — it never invents one.
- This removes the last id-minting path in the save flow, so a single chat can no longer be persisted twice.
- Added two unit tests: the `store.currentId` fallback, and the skip-instead-of-mint case.

Note: this closes the phantom-id write; the remaining cross-window id work is tracked in #4719 as separate PRs.
