### PR TITLE
fix(chat): reuse empty chat on +new instead of minting a new id (#4719)

### DIFF
--- a/apps/screenpipe-app-tauri/app/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/home/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react";
 import { emit } from "@tauri-apps/api/event";
 import {
+  getOrCreateEmptyChatId,
   isSessionForeground,
   sessionRecordFromMeta,
   useChatStore,
@@ -132,23 +133,30 @@ function HomeContent() {
   }, [setActiveSection]);
 
   const startNewChat = useCallback(() => {
-    const id = crypto.randomUUID();
     const store = useChatStore.getState();
+    // Reuse an existing empty chat instead of minting a fresh uuid every
+    // time (#4719). Repeatedly hitting "+ new chat" otherwise floods the
+    // sidebar with stray untitled rows and mints ids that the panel and the
+    // other window then have to reconcile.
+    const { id, isNew } = getOrCreateEmptyChatId();
+    // Clean up any *other* stray empty drafts, keeping the one we reuse.
     Object.values(store.sessions).forEach((s) => {
-      if (s.draft) store.actions.drop(s.id);
+      if (s.draft && s.id !== id) store.actions.drop(s.id);
     });
-    store.actions.upsert({
-      id,
-      title: "untitled",
-      preview: "",
-      status: "idle",
-      messageCount: 0,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      pinned: false,
-      unread: false,
-      draft: true,
-    });
+    if (isNew) {
+      store.actions.upsert({
+        id,
+        title: "untitled",
+        preview: "",
+        status: "idle",
+        messageCount: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        pinned: false,
+        unread: false,
+        draft: true,
+      });
+    }
     store.actions.setCurrent(id);
     void emit("chat-load-conversation", { conversationId: id });
   }, [setActiveSection]);

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -1473,7 +1473,7 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     // hitting "+ new chat" in the middle of a stream would silently
     // discard everything the user couldn't yet see, even though the
     // Pi process keeps running. Mirrors the snapshot in loadConversation.
-    const { useChatStore } = await import("@/lib/stores/chat-store");
+    const { useChatStore, getOrCreateEmptyChatId } = await import("@/lib/stores/chat-store");
     const store = useChatStore.getState();
     const outgoingSid = piSessionIdRef.current;
     if (outgoingSid && store.sessions[outgoingSid]) {
@@ -1519,7 +1519,10 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
     // Pair with setCurrent so the router immediately knows the new id is
     // foreground (and won't accumulate writes for it). See the matching
     // pairing in loadConversation for the same reasoning.
-    const newSid = explicitId ?? crypto.randomUUID();
+    // Reuse an existing empty chat when the caller didn't pin an id (#4719),
+    // so a header "+ new chat" (or an agent-evicted / post-delete restart)
+    // doesn't mint a throwaway uuid when a blank chat is already available.
+    const newSid = explicitId ?? getOrCreateEmptyChatId().id;
     piSessionIdRef.current = newSid;
     piSessionSyncedRef.current = true;
     store.actions.setCurrent(newSid);

--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
@@ -257,6 +257,45 @@ describe("chat-store: getOrCreateEmptyChatId (no spam on +new)", () => {
     expect(isNew).toBe(false);
   });
 
+  it("does NOT reuse on-disk-hydrated conversations that carry no in-memory messages (#4719 regression)", () => {
+    // Disk-synced sidebar rows have no `messages` array but a real
+    // messageCount. A naive messages.length check treated them as empty,
+    // making "+ new chat" hop through the sidebar instead of opening fresh.
+    useChatStore.setState({
+      sessions: {
+        diskChat: baseRecord({
+          id: "diskChat",
+          kind: "chat",
+          messageCount: 6,
+          messages: undefined,
+        }),
+      },
+      currentId: null,
+      panelSessionId: null,
+    });
+    const { id, isNew } = getOrCreateEmptyChatId();
+    expect(isNew).toBe(true);
+    expect(id).not.toBe("diskChat");
+  });
+
+  it("does NOT reuse pipe-run / pipe-watch sessions (#4719 regression)", () => {
+    useChatStore.setState({
+      sessions: {
+        pipeRun: baseRecord({
+          id: "pipeRun",
+          kind: "pipe-run",
+          messageCount: 0,
+          messages: [],
+        }),
+      },
+      currentId: null,
+      panelSessionId: "pipeRun",
+    });
+    const { id, isNew } = getOrCreateEmptyChatId();
+    expect(isNew).toBe(true);
+    expect(id).not.toBe("pipeRun");
+  });
+
   it("repeated '+ new chat' (via the entry-point flow) never floods empty rows (#4719)", () => {
     // Mirrors app/home/page.tsx startNewChat: get-or-create, upsert a draft
     // only when new, then set current. Clicking "+ new chat" N times with no

--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
@@ -256,6 +256,29 @@ describe("chat-store: getOrCreateEmptyChatId (no spam on +new)", () => {
     expect(id).toBe("newEmpty");
     expect(isNew).toBe(false);
   });
+
+  it("repeated '+ new chat' (via the entry-point flow) never floods empty rows (#4719)", () => {
+    // Mirrors app/home/page.tsx startNewChat: get-or-create, upsert a draft
+    // only when new, then set current. Clicking "+ new chat" N times with no
+    // message sent must leave exactly ONE empty session, not N.
+    const clickNewChat = () => {
+      const store = useChatStore.getState();
+      const { id, isNew } = getOrCreateEmptyChatId();
+      if (isNew) {
+        store.actions.upsert(baseRecord({ id, messages: [], draft: true }));
+      }
+      store.actions.setCurrent(id);
+      return id;
+    };
+
+    const first = clickNewChat();
+    const second = clickNewChat();
+    const third = clickNewChat();
+
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(Object.keys(useChatStore.getState().sessions)).toEqual([first]);
+  });
 });
 
 describe("chat-store: setCurrent clears unread atomically", () => {

--- a/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
@@ -712,20 +712,31 @@ export function sessionRecordFromMeta(m: ConversationMeta): SessionRecord {
 }
 
 /**
- * "+ new chat" semantics. If the user already has an empty chat
- * (no user message sent yet), return its id instead of spawning a
+ * "+ new chat" semantics. If the user already has a blank chat
+ * (no message sent yet), return its id instead of spawning a
  * new one — repeatedly clicking the button otherwise floods the
  * sidebar with empty rows. Picks the panel's current session first
  * (most likely the one the user is staring at), then falls back to
- * any other empty session newest-first.
+ * any other blank chat newest-first.
+ *
+ * A session is only reusable when it is a genuine blank CHAT draft:
+ *   - `kind` is "chat" (or unset) — never a `pipe-run` / `pipe-watch`.
+ *   - `messageCount === 0` — this is what excludes on-disk-hydrated
+ *     sidebar rows. Those carry no in-memory `messages` array (see the
+ *     SessionRecord doc), so a naive `messages.length === 0` check would
+ *     treat every real conversation on disk as "empty" and make "+ new
+ *     chat" hop through the sidebar instead of opening a fresh one (#4719).
+ *   - no loaded `user` message — belt-and-suspenders for a foreground
+ *     draft that already has an unsent user turn before its count updates.
  *
  * Returns `{ id, isNew }` so callers can decide whether to upsert.
  */
 export function getOrCreateEmptyChatId(): { id: string; isNew: boolean } {
   const state = useChatStore.getState();
-  const isEmpty = (s: SessionRecord) => {
+  const isReusableBlankChat = (s: SessionRecord) => {
+    if (s.kind && s.kind !== "chat") return false;
+    if (s.messageCount > 0) return false;
     const msgs = (s.messages as Array<{ role?: string }> | undefined) ?? [];
-    if (msgs.length === 0) return true;
     return !msgs.some((m) => m?.role === "user");
   };
 
@@ -733,12 +744,12 @@ export function getOrCreateEmptyChatId(): { id: string; isNew: boolean } {
   const panelId = state.panelSessionId;
   if (panelId) {
     const panel = state.sessions[panelId];
-    if (panel && isEmpty(panel)) return { id: panelId, isNew: false };
+    if (panel && isReusableBlankChat(panel)) return { id: panelId, isNew: false };
   }
 
-  // Otherwise any other empty session, newest first by createdAt.
+  // Otherwise any other blank chat, newest first by createdAt.
   const empties = Object.values(state.sessions)
-    .filter(isEmpty)
+    .filter(isReusableBlankChat)
     .sort((a, b) => b.createdAt - a.createdAt);
   if (empties.length > 0) return { id: empties[0].id, isNew: false };
 


### PR DESCRIPTION
### Description:

Follow-up to #4706 for issue #4719.

- The "+ new chat" entry points minted a fresh `crypto.randomUUID()` on every click. Repeated clicks left stray untitled rows in the sidebar and created ids the panel and the other window then had to reconcile.
- Both entry points (`startNewChat` in the home window, `startNewConversation` in the chat panel) now go through the existing `getOrCreateEmptyChatId` helper, so an already-empty chat is reused instead of a new one being created.
- When the caller pins a specific id (e.g. the sidebar generating an id up front), that path is unchanged.
- Added a unit test: clicking "+ new chat" repeatedly with no message sent leaves exactly one empty chat.
