### PR TITLE
fix(markdown): text selection highlight wraps text only

### DIFF
--- a/apps/screenpipe-app-tauri/app/globals.css
+++ b/apps/screenpipe-app-tauri/app/globals.css
@@ -324,6 +324,13 @@
     background-color: rgba(59, 130, 246, 0.35) !important;
   }
 
+  /* Keep code blocks, details, hr, and tables full-width inside flex prose */
+  .prose > .not-prose,
+  .prose > hr,
+  .prose > table {
+    align-self: stretch;
+  }
+
   .prose a,
   .prose a * {
     cursor: pointer !important;

--- a/apps/screenpipe-app-tauri/app/globals.css
+++ b/apps/screenpipe-app-tauri/app/globals.css
@@ -324,10 +324,24 @@
     background-color: rgba(59, 130, 246, 0.35) !important;
   }
 
+  /* Constrain selection highlight to text width — same approach as chat markdown.
+     flex + items-start makes block children shrink-wrap their content so
+     ::selection doesn't paint across the full container width. */
+  .ProseMirror {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+  }
+
   /* Keep code blocks, details, hr, and tables full-width inside flex prose */
   .prose > .not-prose,
   .prose > hr,
-  .prose > table {
+  .prose > table,
+  .ProseMirror > .not-prose,
+  .ProseMirror > hr,
+  .ProseMirror > table,
+  .ProseMirror > pre,
+  .ProseMirror > [data-type="taskList"] {
     align-self: stretch;
   }
 

--- a/apps/screenpipe-app-tauri/components/chat/markdown-block.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/markdown-block.tsx
@@ -43,7 +43,7 @@ export function MarkdownBlock({
   return (
     <MemoizedReactMarkdown
       className={cn(
-        "prose prose-sm max-w-full break-words overflow-hidden [word-break:break-word]",
+        "prose prose-sm max-w-full break-words overflow-hidden [word-break:break-word] flex flex-col items-start",
         isUser ? "text-foreground dark:prose-invert" : "dark:prose-invert",
       )}
       remarkPlugins={[remarkGfm]}


### PR DESCRIPTION
This PR fixes selection highlight in chat/markdown views no longer spans the full container width.

fixes #4792 

### Changes -

  - Added `flex flex-col items-start` to prose container so block children shrink to text width
  - Added `align-self: stretch` for code blocks, `<hr>`, and tables to keep them full-width

before -
<img width="1198" height="754" alt="image" src="https://github.com/user-attachments/assets/9673174e-78e8-4fb8-a78b-c53155809f7f" />


after -

<img width="1198" height="754" alt="image" src="https://github.com/user-attachments/assets/53238815-23af-48b8-a0e1-0d8c080bd65b" />

<img width="1204" height="852" alt="image" src="https://github.com/user-attachments/assets/07767b89-28d4-4901-b552-1ccf026e35e2" />
