### PR TITLE
fix(chat): preset resets to default after visiting settings

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-session-lifecycle.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-session-lifecycle.ts
@@ -84,7 +84,19 @@ export function usePiSessionLifecycle({
     const presets = aiPresets ?? [];
     const fallback = presets.find((preset) => preset.defaultPreset) ?? presets[0];
     setActivePreset((prev) => {
-      if (!prev) return fallback;
+      if (!prev) {
+        // On fresh mount after a navigation (e.g. settings → home), restore
+        // the user's last-selected preset from localStorage instead of
+        // falling back to the default. localStorage is written by
+        // handleSetActivePreset on explicit user selection.
+        let savedId: string | null = null;
+        try { savedId = localStorage.getItem("chat-active-preset-id"); } catch {}
+        if (savedId) {
+          const saved = presets.find((preset) => preset.id === savedId);
+          if (saved) return saved;
+        }
+        return fallback;
+      }
       const stillThere = presets.find((preset) => preset.id === prev.id);
       if (stillThere) {
         return stillThere.provider === prev.provider &&

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -212,6 +212,12 @@ export function StandaloneChat({
     } else {
       activePresetRef.current = preset;
       setActivePreset(preset);
+      // Persist to localStorage so the preset survives full navigation
+      // (settings → home). Only for direct user selection, not the
+      // lifecycle fallback which uses the function form.
+      if (preset?.id) {
+        try { localStorage.setItem("chat-active-preset-id", preset.id); } catch {}
+      }
     }
   }, []);
   const isStreamingRef = useRef(false);


### PR DESCRIPTION
This PR fixes the preset model resetting to default when navigating to settings and back. other pages (timeline, pipes,
meetings) hide the chat with css so state survives, but settings does a full page navigation that unmounts the component and loses activePreset.

Fix: write the selected preset id to localStorage on user selection, read it back on mount before falling back to the default.

before -



https://github.com/user-attachments/assets/715f3ef5-b66e-4644-a3f9-b37a5adf37b5



after -

https://github.com/user-attachments/assets/a9d5c9b0-6a87-4a2b-a66f-edf86963f9a7



