### PR TITLE
[codex] fix Intel Mac window exclusion crash

### DIFF
--- a/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
+++ b/crates/screenpipe-screen/src/capture_screenshot_by_window.rs
@@ -392,6 +392,7 @@ impl Rect {
 #[cfg(target_os = "macos")]
 #[derive(Debug, Clone)]
 pub struct CGWindowInfo {
+    window_id: u32,
     pid: i32,
     layer: i32,
     bounds: Rect,
@@ -429,6 +430,28 @@ fn get_cg_window_list() -> (Vec<CGWindowInfo>, HashSet<u32>) {
                     continue;
                 }
                 let dict = dict_ref as core_foundation::dictionary::CFDictionaryRef;
+
+                // Extract CG window number. This matches ScreenCaptureKit's
+                // SCWindow.windowID, so it can be used for SCK exclusions
+                // without touching SCWindow.title/applicationName.
+                let window_id_key = CFString::new("kCGWindowNumber");
+                let mut window_id_val = std::ptr::null();
+                if core_foundation::dictionary::CFDictionaryGetValueIfPresent(
+                    dict,
+                    window_id_key.as_concrete_TypeRef() as *const _,
+                    &mut window_id_val,
+                ) == 0
+                    || window_id_val.is_null()
+                {
+                    continue;
+                }
+                let window_id_num = CFNumber::wrap_under_get_rule(
+                    window_id_val as core_foundation::number::CFNumberRef,
+                );
+                let Some(window_id) = window_id_num.to_i64().and_then(|id| u32::try_from(id).ok())
+                else {
+                    continue;
+                };
 
                 // Extract PID
                 let pid_key = CFString::new("kCGWindowOwnerPID");
@@ -531,6 +554,7 @@ fn get_cg_window_list() -> (Vec<CGWindowInfo>, HashSet<u32>) {
                 };
 
                 windows.push(CGWindowInfo {
+                    window_id,
                     pid: w_pid as i32,
                     layer,
                     bounds,
@@ -919,36 +943,8 @@ pub fn get_excluded_sck_window_ids(window_filters: &WindowFilters) -> Vec<u32> {
         return Vec::new();
     }
 
-    let excluded = match cidre::objc::ar_pool(|| -> Result<Vec<u32>, String> {
-        let windows = SckWindow::all().map_err(|e| e.to_string())?;
-        let mut excluded = Vec::new();
-
-        for w in &windows {
-            let app_name = w.app_name().unwrap_or_default();
-            let title = w.title().unwrap_or_default();
-
-            if app_name.is_empty() {
-                continue;
-            }
-
-            if !window_filters.is_valid(&app_name, &title) {
-                if let Ok(id) = w.id() {
-                    excluded.push(id);
-                }
-            }
-        }
-
-        Ok(excluded)
-    }) {
-        Ok(ids) => ids,
-        Err(e) => {
-            debug!(
-                "get_excluded_sck_window_ids: failed to enumerate windows: {}",
-                e
-            );
-            return Vec::new();
-        }
-    };
+    let (cg_windows, _) = get_cg_window_list();
+    let excluded = excluded_sck_window_ids_from_cg_windows(&cg_windows, window_filters);
 
     if !excluded.is_empty() {
         debug!(
@@ -956,6 +952,31 @@ pub fn get_excluded_sck_window_ids(window_filters: &WindowFilters) -> Vec<u32> {
             excluded.len(),
             excluded
         );
+    }
+
+    excluded
+}
+
+/// Resolve filtered windows to SCK-compatible window IDs using CGWindowList metadata.
+///
+/// This intentionally avoids `sck_rs::Window::all()`: on Intel macOS 15, the SCK
+/// window title/application string bridge can return a bad string object and
+/// crash in CFStringGetLength before Rust can handle the error (#4874/#4968).
+#[cfg(target_os = "macos")]
+fn excluded_sck_window_ids_from_cg_windows(
+    cg_windows: &[CGWindowInfo],
+    window_filters: &WindowFilters,
+) -> Vec<u32> {
+    let mut excluded = Vec::new();
+
+    for window in cg_windows {
+        if window.window_id == 0 || window.owner_name.is_empty() {
+            continue;
+        }
+
+        if !window_filters.is_valid(&window.owner_name, &window.window_name) {
+            excluded.push(window.window_id);
+        }
     }
 
     excluded
@@ -1722,6 +1743,7 @@ mod tests {
             title: &str,
         ) -> CGWindowInfo {
             CGWindowInfo {
+                window_id: pid as u32,
                 pid,
                 layer,
                 bounds: Rect {
@@ -1760,6 +1782,49 @@ mod tests {
                 find_topmost_pid_on_monitor(&windows, &monitor_1080p()),
                 Some(100)
             );
+        }
+
+        #[test]
+        fn test_excluded_sck_ids_from_cg_windows_respects_ignore_patterns() {
+            let windows = vec![
+                make_window(111, 0, 0, 0, 800, 600, "Password Manager", "Vault"),
+                make_window(222, 0, 0, 0, 800, 600, "Notes", "Daily note"),
+            ];
+            let filters = WindowFilters::new(&["password".to_string()], &[], &[]);
+
+            assert_eq!(
+                excluded_sck_window_ids_from_cg_windows(&windows, &filters),
+                vec![111]
+            );
+        }
+
+        #[test]
+        fn test_excluded_sck_ids_from_cg_windows_respects_include_patterns() {
+            let windows = vec![
+                make_window(111, 0, 0, 0, 800, 600, "Terminal", "Build"),
+                make_window(222, 0, 0, 0, 800, 600, "Notes", "Daily note"),
+            ];
+            let filters = WindowFilters::new(&[], &["terminal".to_string()], &[]);
+
+            assert_eq!(
+                excluded_sck_window_ids_from_cg_windows(&windows, &filters),
+                vec![222]
+            );
+        }
+
+        #[test]
+        fn test_excluded_sck_ids_from_cg_windows_skips_unusable_rows() {
+            let missing_owner = make_window(111, 0, 0, 0, 800, 600, "", "Vault");
+            let mut missing_id = make_window(222, 0, 0, 0, 800, 600, "Password Manager", "Vault");
+            missing_id.window_id = 0;
+
+            let filters = WindowFilters::new(&["vault".to_string()], &[], &[]);
+
+            assert!(excluded_sck_window_ids_from_cg_windows(
+                &[missing_owner, missing_id],
+                &filters
+            )
+            .is_empty());
         }
 
         #[test]


### PR DESCRIPTION
## What

Hotfixes the launch/capture crash reported in #4968 by removing the fragile `sck_rs::Window::all()` call from the window-exclusion path.

This also mitigates the same crash path documented in #4874.

## Root Cause

`get_excluded_sck_window_ids()` enumerated `SCWindow` objects through `sck-rs` so it could map app/window filters to ScreenCaptureKit exclusion IDs. On Intel macOS 15, that path can crash inside CoreFoundation before Rust sees an error:

`SCWindow.title/applicationName -> cidre CFString bridge -> CFStringGetLength(null)`

That function runs during capture setup, so one bad/null SCK string can crash the worker on launch.

## Change

- Use existing `CGWindowListCopyWindowInfo` metadata for the exclusion pass.
- Extract `kCGWindowNumber`, which matches the SCK `SCWindow.windowID`.
- Preserve the existing include/ignore window-filter behavior.
- Avoid touching SCK title/application strings in this path.

## Impact

Startup/capture setup no longer depends on the crashing SCK window-enumeration bridge just to compute excluded window IDs.

## Checks

- `cargo test -p screenpipe-screen capture_screenshot_by_window --lib`
- `cargo check -p screenpipe-screen --target x86_64-apple-darwin`
- `git diff --check`

## Test Ask

Please do not merge/release this as fully fixed until someone smoke-tests it on a real Intel Mac:

- launch app on Intel macOS 15 with Screen Recording permission granted
- verify it stays up through initial capture
- if possible, add an ignored app/window and confirm capture still excludes/blacks it out

Remaining risk: `sck_rs::Window::all()` still needs upstream hardening for any other call sites. This PR removes it from the observed launch/capture crash path.
