### PR TITLE
ci: replace retired macos-13 runner with macos-15-intel

### DIFF
--- a/.github/workflows/ort-init-smoke.yml
+++ b/.github/workflows/ort-init-smoke.yml
@@ -11,7 +11,7 @@
 # strategy and actually runs the init under a 60s deadline — exit 1 == HANG.
 #
 # Covers the two platforms that lacked any ONNX init coverage (macOS Intel via
-# macos-13, Windows ARM64 via windows-11-arm) plus the rest.
+# macos-15-intel, Windows ARM64 via windows-11-arm) plus the rest.
 name: ORT init smoke
 
 on:
@@ -45,7 +45,12 @@ jobs:
           - { label: linux-x64, runner: ubuntu-latest }
           - { label: windows-x64, runner: windows-2022 }
           - { label: windows-arm64, runner: windows-11-arm }
-          - { label: macos-intel, runner: macos-13 }
+          # macos-13 was retired by GitHub in Dec 2025 (actions/runner-images#13046);
+          # macos-15-intel is the current — and per runner-images#13027, final —
+          # hosted x86_64 macOS image. A job pinned to macos-13 doesn't fail fast:
+          # it just queues for 24h waiting on a runner that will never come, then
+          # gets cancelled.
+          - { label: macos-intel, runner: macos-15-intel }
           - { label: macos-arm64, runner: macos-latest }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-cli-npm.yml
+++ b/.github/workflows/test-cli-npm.yml
@@ -44,7 +44,11 @@ jobs:
           timeout 15 bunx screenpipe@0.3.139 record 2>&1 || echo "--- exited (expected on CI due to screen recording permission) ---"
 
   test-macos-x64:
-    runs-on: macos-13  # Intel
+    # macos-13 was retired by GitHub in Dec 2025 (actions/runner-images#13046) —
+    # a job pinned to it just queues 24h for a runner that never comes, then
+    # gets cancelled. macos-15-intel is the current (and final) hosted x86_64
+    # macOS image.
+    runs-on: macos-15-intel  # Intel
     steps:
       - name: Verify blank slate
         run: |


### PR DESCRIPTION
## What

`.github/workflows/ort-init-smoke.yml` and `.github/workflows/test-cli-npm.yml` both pin an Intel macOS leg to `macos-13`. GitHub fully retired that hosted image in December 2025 (`actions/runner-images#13046`, [changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)).

A job pinned to a retired label doesn't fail fast — it queues forever waiting on a runner that will never be provisioned, then gets auto-cancelled at the 24h default job timeout. That's exactly what's been happening:

```
$ gh run view 28716953880 --repo screenpipe/screenpipe --json jobs
macos-intel job: started 2026-07-04T19:19:49Z, completed (cancelled) 2026-07-05T19:19:49Z
```

Every other matrix leg in that same run (linux-x64, windows-arm64, macos-arm64, windows-x64) finished in under 2 minutes. `macos-intel` has been silently burning a full day and reporting `cancelled` on every single run since the image was pulled.

## Fix

Swap `macos-13` → `macos-15-intel`, GitHub's current (and per `actions/runner-images#13027`, final) hosted x86_64 macOS image, supported into August 2027.

## Verification

Dispatched `ort-init-smoke.yml` directly against this branch — all 5 matrix legs pass, `macos-intel` included, and it now actually runs instead of hanging:

https://github.com/EzraEllette/screenpipe/actions/runs/28814503109

```
macos-intel:   completed/success
macos-arm64:   completed/success
windows-arm64: completed/success
linux-x64:     completed/success
windows-x64:   completed/success
```

`test-cli-npm.yml` is `workflow_dispatch`-only and hasn't had a real trigger since 2026-02-11, so this pre-empts it hitting the same wall next time it's run.

Found while working on #4978 (new Intel launch-smoke test) — needed a working Intel runner label for that and discovered this one was already dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)