### PR TITLE
fix(permissions): recovery modal + honest tray state when app boots with screen recording already denied

### DIFF
--- a/apps/screenpipe-app-tauri/components/status/permission-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/status/permission-banner.tsx
@@ -20,6 +20,12 @@ interface PermissionState {
  */
 export function PermissionBanner() {
   const [permissions, setPermissions] = useState<PermissionState | null>(null);
+  // Screen denial reported by the engine's capture modules (ScreenCaptureKit
+  // ground truth). The polled doPermissionsCheck below rides
+  // CGPreflightScreenCaptureAccess, whose per-process cached answer can stay
+  // "granted" after macOS actually revoked capture (e.g. macOS 26 monthly
+  // re-approval) — the exact silent-gap scenario of #4819/#4726.
+  const [engineScreenDenied, setEngineScreenDenied] = useState(false);
 
   const { isMac } = usePlatform();
 
@@ -45,20 +51,38 @@ export function PermissionBanner() {
   }, [checkPermissions]);
 
   // Also listen for permission-lost events for instant response
-  useTauriEvent("permission-lost", () => {
+  useTauriEvent("permission-lost", (event) => {
+    const payload = event.payload as { screen_recording?: boolean } | undefined;
+    if (payload?.screen_recording) setEngineScreenDenied(true);
+    checkPermissions();
+  });
+
+  // permission_needed re-fires periodically while screen recording stays
+  // denied (#4819) — including when the denial predates this webview.
+  useTauriEvent("permission_needed", (event) => {
+    const payload = event.payload as { kind?: string } | undefined;
+    if (payload?.kind === "screen_recording") setEngineScreenDenied(true);
+    checkPermissions();
+  });
+
+  useTauriEvent("permission-restored", (event) => {
+    const payload = event.payload as { kind?: string } | undefined;
+    if (payload?.kind === "screen_recording") setEngineScreenDenied(false);
     checkPermissions();
   });
 
   // Don't render on non-Mac or while loading
   if (!isMac || !permissions) return null;
 
+  const screenOk = permissions.screenOk && !engineScreenDenied;
+
   // Don't render if all permissions are granted
-  if (permissions.screenOk && permissions.micOk && permissions.accessibilityOk) return null;
+  if (screenOk && permissions.micOk && permissions.accessibilityOk) return null;
 
 
 
   const missingPerms: string[] = [];
-  if (!permissions.screenOk) missingPerms.push("screen recording");
+  if (!screenOk) missingPerms.push("screen recording");
   if (!permissions.micOk) missingPerms.push("microphone");
   if (!permissions.accessibilityOk) missingPerms.push("accessibility");
 
@@ -85,12 +109,12 @@ export function PermissionBanner() {
             // (e.g. mic prompt, accessibility prompt). If the permission was already
             // denied, it falls back to opening System Settings internally.
             try {
-              if (!permissions.screenOk) await requestPermissionWithFlow("screenRecording");
+              if (!screenOk) await requestPermissionWithFlow("screenRecording");
               else if (!permissions.micOk) await commands.requestPermission("microphone");
               else if (!permissions.accessibilityOk) await requestPermissionWithFlow("accessibility");
             } catch {
               // fallback to opening settings directly
-              if (!permissions.screenOk) await openPermissionSettingsWithFlow("screenRecording");
+              if (!screenOk) await openPermissionSettingsWithFlow("screenRecording");
               else if (!permissions.micOk) await commands.openPermissionSettings("microphone");
               else if (!permissions.accessibilityOk) await openPermissionSettingsWithFlow("accessibility");
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/engine_events/permission.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/engine_events/permission.rs
@@ -90,6 +90,26 @@ fn handle_needed(app: &AppHandle, data: &Value) {
         debug!("permission_needed received during onboarding — suppressed");
         return;
     }
+    // Suppress while recording is deliberately off (tray stop / stop_screenpipe).
+    // The engine re-emits permission_needed periodically while screen recording
+    // stays denied (#4819); nagging a user who isn't trying to record is noise.
+    if let Some(state) = app.try_state::<crate::recording::RecordingState>() {
+        if !state.capture_intended() {
+            debug!("permission_needed while capture intent is off — suppressed");
+            return;
+        }
+    }
+    // The recovery window is already in the user's face — don't re-emit (the
+    // webview hook would call showWindow again and steal focus). The periodic
+    // re-notification only needs to bring the window back if it was closed
+    // without the permission being fixed, or was never shown (boot race where
+    // this bridge wasn't connected yet).
+    if let Some(win) = tauri::Manager::get_webview_window(app, "permission-recovery") {
+        if win.is_visible().unwrap_or(false) {
+            debug!("permission_needed while recovery window already visible — suppressed");
+            return;
+        }
+    }
     let kind = data.get("kind").and_then(|v| v.as_str()).unwrap_or("");
     info!(kind = %kind, "permission_needed (from engine)");
     // Forward raw payload — frontend PermissionNeededPayload expects { kind }.

--- a/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
@@ -140,6 +140,20 @@ impl ServerCore {
         info!("Starting server core on port {}", config.port);
         crate::health::set_boot_phase("starting", Some("starting server"));
 
+        // Permission monitor: poll for TCC transitions + re-notify while screen
+        // recording stays denied (#4819). The CLI engine starts this in its own
+        // main; the desktop app never did, so a boot with the permission already
+        // denied produced no event, no recovery modal, and days of silent
+        // recording gaps (#4726). PreflightOnly: the capture probe false-positives
+        // for windowed apps on macOS 15+, and stale preflight "granted" answers
+        // must never be reported as restorations (the vision watcher reports
+        // those from ScreenCaptureKit ground truth). Called on every server
+        // (re)start because the poll task dies with this runtime; start_with
+        // detects a dead poller and respawns it.
+        screenpipe_engine::permission_monitor::start_with(
+            screenpipe_engine::permission_monitor::ScreenCheckMode::PreflightOnly,
+        );
+
         // --- Environment setup ---
         std::env::set_var("SCREENPIPE_FD_LIMIT", "8192");
         if !config.analytics_id.is_empty() {

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -51,6 +51,13 @@ struct TrayMenuData {
     /// Internal plan id from /api/user (standard|pro|team|enterprise|lifetime|none).
     subscription_plan: Option<String>,
     has_permission_issue: bool,
+    /// Screen recording specifically is denied — capture is producing nothing.
+    /// Sourced from both the TCC preflight and the permission monitor's
+    /// last-known state (which carries ScreenCaptureKit ground truth from the
+    /// vision watcher, catching stale-preflight cases like the macOS 26
+    /// monthly re-approval expiring). The tray must never claim "Recording"
+    /// while this is true (#4819).
+    screen_permission_denied: bool,
     app_ui_hidden: bool,
     disable_timeline: bool,
 }
@@ -118,18 +125,28 @@ fn prefetch_tray_menu_data(app: &AppHandle) -> TrayMenuData {
 
     let app_ui_hidden = is_app_ui_hidden();
 
-    let has_permission_issue = if onboarding_completed || app_ui_hidden {
+    let (has_permission_issue, screen_permission_denied) = if onboarding_completed || app_ui_hidden
+    {
         #[cfg(target_os = "macos")]
         {
             let perms = crate::permissions::do_permissions_check(false);
-            !perms.screen_recording.permitted() || !perms.microphone.permitted()
+            // The preflight can report stale "granted" while ScreenCaptureKit
+            // is actually denied (macOS 26 monthly re-approval); the permission
+            // monitor's last-known state carries the eager capture-module
+            // reports, so OR the two signals.
+            let screen_denied = !perms.screen_recording.permitted()
+                || !screenpipe_engine::permission_monitor::snapshot().screen;
+            (
+                screen_denied || !perms.microphone.permitted(),
+                screen_denied,
+            )
         }
         #[cfg(not(target_os = "macos"))]
         {
-            false
+            (false, false)
         }
     } else {
-        false
+        (false, false)
     };
 
     TrayMenuData {
@@ -140,6 +157,7 @@ fn prefetch_tray_menu_data(app: &AppHandle) -> TrayMenuData {
         cloud_subscribed,
         subscription_plan,
         has_permission_issue,
+        screen_permission_denied,
         app_ui_hidden,
         disable_timeline,
     }
@@ -445,6 +463,7 @@ fn snapshot_menu_state(data: &TrayMenuData, effective_status: RecordingStatus) -
         recording_status: Some(effective_status),
         onboarding_completed: data.onboarding_completed,
         has_permission_issue: data.has_permission_issue,
+        screen_permission_denied: data.screen_permission_denied,
         devices: recording_info
             .devices
             .iter()
@@ -550,6 +569,10 @@ struct MenuState {
     recording_status: Option<RecordingStatus>,
     onboarding_completed: bool,
     has_permission_issue: bool,
+    /// Mirrors `TrayMenuData::screen_permission_denied` so the "⚠ Not
+    /// recording — no screen permission" status line appears/disappears
+    /// without waiting for another state change to trigger a rebuild.
+    screen_permission_denied: bool,
     /// Device names + active status for change detection
     devices: Vec<(String, bool)>,
     /// Whether user has a cloud (Business+) subscription (triggers menu rebuild on login)
@@ -814,18 +837,31 @@ fn create_dynamic_menu(
 
     // --- Recording status + devices ---
     let effective_status = get_effective_recording_status();
-    let status_text = match effective_status {
-        RecordingStatus::Starting => "○ Starting…",
-        RecordingStatus::Recording => "● Recording",
-        RecordingStatus::Paused => "◐ Paused",
-        RecordingStatus::ScheduledPause => "○ Outside work hours",
-        RecordingStatus::Stopped => "○ Stopped",
-        RecordingStatus::Error => "○ Error",
+    // Screen permission denied trumps Recording/Starting: vision captures
+    // nothing on a TCC denial, so a green "Recording" would be a lie — the
+    // exact lie behind multi-day silent gaps in #4726/#4819.
+    let screen_denied_while_on = data.screen_permission_denied
+        && matches!(
+            effective_status,
+            RecordingStatus::Recording | RecordingStatus::Starting
+        );
+    let status_text = if screen_denied_while_on {
+        "⚠ Not recording — no screen permission"
+    } else {
+        match effective_status {
+            RecordingStatus::Starting => "○ Starting…",
+            RecordingStatus::Recording => "● Recording",
+            RecordingStatus::Paused => "◐ Paused",
+            RecordingStatus::ScheduledPause => "○ Outside work hours",
+            RecordingStatus::Stopped => "○ Stopped",
+            RecordingStatus::Error => "○ Error",
+        }
     };
     menu_builder = menu_builder.item(&PredefinedMenuItem::separator(app)?);
 
-    if effective_status == RecordingStatus::Recording
-        || effective_status == RecordingStatus::Starting
+    if !screen_denied_while_on
+        && (effective_status == RecordingStatus::Recording
+            || effective_status == RecordingStatus::Starting)
     {
         menu_builder = menu_builder.item(
             &MenuItemBuilder::with_id("privacy_info", "Your data stays local")
@@ -949,8 +985,11 @@ fn create_dynamic_menu(
         }
     }
 
-    // Show "fix permissions" when recording is in error state
-    if effective_status == RecordingStatus::Error && data.has_permission_issue {
+    // Show "fix permissions" whenever a required permission is missing — not
+    // only in Error state. A TCC denial leaves the status at Recording/Starting
+    // while capturing nothing (#4819), so gating on Error hid the only escape
+    // hatch exactly when it was needed.
+    if data.has_permission_issue {
         menu_builder = menu_builder
             .item(&MenuItemBuilder::with_id("fix_permissions", "⚠ Fix permissions").build(app)?);
     }

--- a/crates/screenpipe-core/src/permissions.rs
+++ b/crates/screenpipe-core/src/permissions.rs
@@ -26,6 +26,18 @@ impl PermissionStatus {
     }
 }
 
+/// Test hook: `SCREENPIPE_SIMULATE_SCREEN_PERMISSION_DENIED=1` forces every
+/// screen-recording check to report `Denied`. Lets e2e tests (and manual QA)
+/// exercise the boot-with-permission-denied path — recovery modal, tray
+/// "not recording" state, `permission_needed` re-notification (#4819) —
+/// without mutating the machine's real TCC database via `tccutil reset`,
+/// which would revoke the developer's actual grant.
+fn simulate_screen_denied() -> bool {
+    std::env::var("SCREENPIPE_SIMULATE_SCREEN_PERMISSION_DENIED")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// Result of checking all required permissions.
 #[derive(Debug)]
 pub struct PermissionsCheck {
@@ -216,6 +228,9 @@ mod macos_screen_recording {
 /// CLI: always uses `preflight() || capture_probe()` on every macOS version.
 #[cfg(target_os = "macos")]
 pub fn check_screen_recording() -> PermissionStatus {
+    if simulate_screen_denied() {
+        return PermissionStatus::Denied;
+    }
     if macos_screen_recording::preflight() || macos_screen_recording::capture_probe() {
         PermissionStatus::Granted
     } else {
@@ -230,6 +245,9 @@ pub fn check_screen_recording() -> PermissionStatus {
 /// and benefit from the full probe chain to avoid false-negative preflight stalls.
 #[cfg(target_os = "macos")]
 pub fn check_screen_recording_tauri() -> PermissionStatus {
+    if simulate_screen_denied() {
+        return PermissionStatus::Denied;
+    }
     let ok = if macos_screen_recording::is_sequoia_or_later() && !cfg!(debug_assertions) {
         macos_screen_recording::preflight()
     } else {
@@ -244,6 +262,9 @@ pub fn check_screen_recording_tauri() -> PermissionStatus {
 
 #[cfg(not(target_os = "macos"))]
 pub fn check_screen_recording_tauri() -> PermissionStatus {
+    if simulate_screen_denied() {
+        return PermissionStatus::Denied;
+    }
     PermissionStatus::NotNeeded
 }
 
@@ -306,6 +327,9 @@ pub fn check_microphone() -> PermissionStatus {
 
 #[cfg(not(target_os = "macos"))]
 pub fn check_screen_recording() -> PermissionStatus {
+    if simulate_screen_denied() {
+        return PermissionStatus::Denied;
+    }
     PermissionStatus::NotNeeded
 }
 

--- a/crates/screenpipe-engine/src/permission_monitor.rs
+++ b/crates/screenpipe-engine/src/permission_monitor.rs
@@ -12,7 +12,7 @@
 //! Detection comes from two sources that funnel through a single emission
 //! path (so events are deduped and dedup'd state is shared):
 //!
-//! 1. **Polling** (this task). Every 5s checks `check_permissions()` and
+//! 1. **Polling** (this task). Every 5s checks the OS permission state and
 //!    emits on transition. The only way to detect accessibility state
 //!    changes (no stream-failure signal for that permission).
 //!
@@ -29,6 +29,39 @@
 //! Both paths call [`report_state`] which holds a single [`STATE`] mutex
 //! and emits only if the new value differs from the last-known value.
 //!
+//! ## Screen check mode
+//!
+//! The screen-recording poll check depends on the host process
+//! ([`ScreenCheckMode`]):
+//!
+//! - **CLI** (`Full`): `preflight() || capture_probe()` — the capture probe
+//!   is reliable for a windowless process on every macOS version.
+//! - **Desktop app** (`PreflightOnly`): the capture probe false-positives
+//!   for windowed apps on macOS 15+ (it returns the app's own windows), so
+//!   only `CGPreflightScreenCaptureAccess` is consulted. Preflight answers
+//!   are cached per-process by macOS: a `false` is trustworthy, but a
+//!   `true` can be stale (e.g. macOS 26 monthly re-approval expiring while
+//!   the app runs). In this mode the poll therefore only ever reports
+//!   screen *denied* — restoration comes exclusively from the vision
+//!   monitor watcher's eager success report, which reflects ScreenCaptureKit
+//!   ground truth.
+//!
+//! ## Boot-with-denied + re-notification (#4819)
+//!
+//! Transition-only emission has a hole: when the process *boots* with
+//! screen recording already denied (TCC reset, macOS update, revoked while
+//! the app was off) there is no transition, so the app used to capture
+//! nothing for days while claiming to record. The poll loop therefore also
+//! re-emits `permission_needed` for a *persistently denied* screen
+//! permission: once as soon as the denial is observed, twice more at
+//! [`NEEDED_EARLY_RETRY`] spacing (delivery to the webview rides an
+//! in-process WebSocket that may not be connected yet during boot — early
+//! repeats defeat that race), then every [`RENOTIFY_INTERVAL`] while the
+//! denial persists. Only screen recording nags long-term: it is the
+//! permission that makes the whole app useless (system audio fails on the
+//! same TCC), and unlike accessibility or microphone it is never a
+//! deliberate user opt-out.
+//!
 //! ## Wake grace period
 //!
 //! On wake, `CGPreflightScreenCaptureAccess` and friends can transiently
@@ -40,10 +73,13 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use once_cell::sync::Lazy;
-use screenpipe_core::permissions::{check_permissions, PermissionStatus};
+use screenpipe_core::permissions::{
+    check_accessibility, check_microphone, check_screen_recording, check_screen_recording_tauri,
+    PermissionStatus,
+};
 use screenpipe_events::{send_event, PermissionEvent, PermissionKind};
 use tokio::task::JoinHandle;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Poll interval for the reconcile loop. Vision emits eagerly via
 /// `report_state` so this only matters for (a) accessibility transitions
@@ -62,9 +98,37 @@ const WAKE_GRACE: Duration = Duration::from_secs(10);
 /// stuck in the recovery modal when they re-grant quickly.
 const EMIT_COOLDOWN: Duration = Duration::from_secs(5);
 
+/// Spacing of the first re-notifications after a screen denial is observed.
+/// Short, because their job is to survive the boot window where the app's
+/// event bridge (WS client + webview listeners) isn't attached yet.
+const NEEDED_EARLY_RETRY: Duration = Duration::from_secs(60);
+
+/// Number of closely-spaced notifications before dropping to the long
+/// interval (the initial emission counts as the first).
+const NEEDED_EARLY_EMITS: u32 = 3;
+
+/// Long-term nag interval while screen recording stays denied. The user
+/// believes they are recording; a few reminders a day is proportionate.
+const RENOTIFY_INTERVAL: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// How the poll loop checks screen-recording permission. See module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenCheckMode {
+    /// `preflight || capture_probe`. Correct for windowless (CLI) processes.
+    Full,
+    /// Preflight only; a `true` is treated as unknown (never reported as a
+    /// restoration). Correct for the windowed desktop app on macOS 15+.
+    PreflightOnly,
+}
+
 struct LastKnown {
     granted: bool,
     last_lost_at: Option<Instant>,
+    /// While denied: how many `permission_needed` re-notifications have been
+    /// emitted for this denial episode, and when the last one went out.
+    /// Reset on every transition (either direction).
+    needed_emits: u32,
+    last_needed_at: Option<Instant>,
 }
 
 impl LastKnown {
@@ -72,8 +136,23 @@ impl LastKnown {
         Self {
             granted,
             last_lost_at: None,
+            needed_emits: 0,
+            last_needed_at: None,
         }
     }
+}
+
+/// Last-known permission state as accumulated from polls and eager
+/// capture-module reports. `screen == false` reflects ScreenCaptureKit
+/// ground truth (or a trustworthy preflight denial) — unlike a raw
+/// `CGPreflightScreenCaptureAccess` call, which can report stale "granted"
+/// while capture is actually failing. Consumed by the tray so it never
+/// renders "recording" while vision is disabled by TCC (#4819).
+#[derive(Debug, Clone, Copy)]
+pub struct PermissionSnapshot {
+    pub screen: bool,
+    pub microphone: bool,
+    pub accessibility: bool,
 }
 
 struct State {
@@ -86,6 +165,12 @@ struct State {
     keychain: LastKnown,
     wake_grace_until: Option<Instant>,
     started: bool,
+    screen_check: ScreenCheckMode,
+    /// Stamped by the poll loop every tick. In the desktop app the poll task
+    /// dies with its tokio runtime on recording restarts; a stale stamp lets
+    /// `start_with` detect the dead poller and respawn instead of trusting
+    /// the process-lifetime `started` flag.
+    last_poll_tick: Option<Instant>,
 }
 
 static STATE: Lazy<Mutex<State>> = Lazy::new(|| {
@@ -100,37 +185,57 @@ static STATE: Lazy<Mutex<State>> = Lazy::new(|| {
         keychain: LastKnown::new(true),
         wake_grace_until: None,
         started: false,
+        screen_check: ScreenCheckMode::Full,
+        last_poll_tick: None,
     })
 });
 
-/// Start the monitor. Idempotent — calling twice returns early; the first
-/// call wins. Returns the join handle of the polling task (first call) or
-/// `None` on subsequent calls.
+/// Start the monitor with [`ScreenCheckMode::Full`] (CLI behavior).
 pub fn start() -> Option<JoinHandle<()>> {
+    start_with(ScreenCheckMode::Full)
+}
+
+/// Start the monitor. Idempotent while the poll task is alive — calling
+/// again returns `None`. If a previous poll task died with its runtime
+/// (desktop app recording restarts run the server on a fresh runtime), a new
+/// one is spawned that keeps the accumulated state, so eager denial reports
+/// from the previous session aren't wiped by a stale preflight re-seed.
+pub fn start_with(mode: ScreenCheckMode) -> Option<JoinHandle<()>> {
     {
         let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
-        if state.started {
+        let poller_alive = state.started
+            && matches!(state.last_poll_tick, Some(t) if t.elapsed() < POLL_INTERVAL * 3);
+        if poller_alive {
             return None;
         }
+        let respawn = state.started;
         state.started = true;
-        // Seed last-known with current state so the first poll tick doesn't
-        // emit spurious events for permissions that were already denied at
-        // process start.
-        let perms = check_permissions();
-        state.screen = LastKnown::new(perms.screen_recording.is_granted());
-        state.mic = LastKnown::new(perms.microphone.is_granted());
-        state.accessibility = LastKnown::new(perms.accessibility.is_granted());
-        // For keychain, avoid probing the keychain key until encryption is actually
-        // requested by the app (via encrypted settings/explicit opt-in). Otherwise
-        // macOS can show a keychain permission modal before onboarding.
-        state.keychain = LastKnown::new(keychain_accessible());
-        info!(
-            screen = state.screen.granted,
-            mic = state.mic.granted,
-            accessibility = state.accessibility.granted,
-            keychain = state.keychain.granted,
-            "permission monitor started"
-        );
+        state.screen_check = mode;
+        state.last_poll_tick = Some(Instant::now());
+        if respawn {
+            warn!("permission monitor poll task died (runtime restart?) — respawning");
+        } else {
+            // Seed last-known with current state so the first poll tick doesn't
+            // emit spurious `lost` events for permissions that were already
+            // denied at process start. A screen permission seeded as denied is
+            // NOT swallowed: the re-notify pass emits `permission_needed` for
+            // it (see module docs, #4819).
+            state.screen = LastKnown::new(check_screen(mode).is_granted());
+            state.mic = LastKnown::new(check_microphone().is_granted());
+            state.accessibility = LastKnown::new(check_accessibility().is_granted());
+            // For keychain, avoid probing the keychain key until encryption is actually
+            // requested by the app (via encrypted settings/explicit opt-in). Otherwise
+            // macOS can show a keychain permission modal before onboarding.
+            state.keychain = LastKnown::new(keychain_accessible());
+            info!(
+                screen = state.screen.granted,
+                mic = state.mic.granted,
+                accessibility = state.accessibility.granted,
+                keychain = state.keychain.granted,
+                ?mode,
+                "permission monitor started"
+            );
+        }
     }
 
     Some(tokio::spawn(run()))
@@ -181,6 +286,15 @@ pub fn report_state(kind: PermissionKind, now_granted: bool, reason: Option<&str
     }
 
     entry.granted = now_granted;
+    // New episode either way — restart the re-notification ladder. A fresh
+    // loss counts the `permission_lost` emission below as its first
+    // notification so the modal isn't immediately re-shown by the next tick.
+    entry.needed_emits = if now_granted { 0 } else { 1 };
+    entry.last_needed_at = if now_granted {
+        None
+    } else {
+        Some(Instant::now())
+    };
     if !now_granted {
         entry.last_lost_at = Some(Instant::now());
     }
@@ -201,6 +315,17 @@ pub fn report_state(kind: PermissionKind, now_granted: bool, reason: Option<&str
         PermissionEvent::lost(kind, reason.map(str::to_owned))
     };
     let _ = send_event(evt.event_name(), evt);
+}
+
+/// Last-known permission state. Defaults to all-granted until the monitor
+/// is started or a capture module reports otherwise.
+pub fn snapshot() -> PermissionSnapshot {
+    let state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+    PermissionSnapshot {
+        screen: state.screen.granted,
+        microphone: state.mic.granted,
+        accessibility: state.accessibility.granted,
+    }
 }
 
 /// Notify the monitor that the system just woke from sleep. Suppresses
@@ -227,37 +352,104 @@ pub(crate) fn wake_grace_active() -> bool {
 
 async fn run() {
     let mut ticker = tokio::time::interval(POLL_INTERVAL);
-    // First tick fires immediately — skip it, we already seeded state.
-    ticker.tick().await;
-
+    // First tick fires immediately — don't skip it: the re-notify pass must
+    // run promptly so a boot-with-denied screen permission surfaces the
+    // recovery modal right away instead of one poll interval later. The
+    // report_state calls are no-ops on the first tick (state was just seeded).
     loop {
         ticker.tick().await;
-        let perms = check_permissions();
-        report_state(
-            PermissionKind::ScreenRecording,
-            granted(perms.screen_recording),
-            Some("poll"),
-        );
+        let mode = {
+            let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+            state.last_poll_tick = Some(Instant::now());
+            state.screen_check
+        };
+
+        match mode {
+            ScreenCheckMode::Full => {
+                report_state(
+                    PermissionKind::ScreenRecording,
+                    check_screen(mode).is_granted(),
+                    Some("poll"),
+                );
+            }
+            ScreenCheckMode::PreflightOnly => {
+                // A preflight `false` is trustworthy; a `true` can be stale
+                // (macOS caches the answer per-process), so never report a
+                // restoration from here — the vision monitor watcher reports
+                // it eagerly when ScreenCaptureKit actually works again.
+                if !check_screen(mode).is_granted() {
+                    report_state(
+                        PermissionKind::ScreenRecording,
+                        false,
+                        Some("poll (preflight)"),
+                    );
+                }
+            }
+        }
         report_state(
             PermissionKind::Microphone,
-            granted(perms.microphone),
+            check_microphone().is_granted(),
             Some("poll"),
         );
         report_state(
             PermissionKind::Accessibility,
-            granted(perms.accessibility),
+            check_accessibility().is_granted(),
             Some("poll"),
         );
-        report_state(
-            PermissionKind::Keychain,
-            keychain_accessible(),
-            Some("poll"),
-        );
+        report_state(PermissionKind::Keychain, keychain_accessible(), Some("poll"));
+
+        emit_screen_needed_if_due();
     }
 }
 
-fn granted(status: PermissionStatus) -> bool {
-    status.is_granted()
+/// Re-notification pass for a persistently denied screen permission (#4819).
+/// See module docs for the schedule. Consumers of `permission_needed`
+/// (the app's event bridge) decide whether to surface it — they gate on
+/// onboarding completion and recording intent.
+fn emit_screen_needed_if_due() {
+    {
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(state.wake_grace_until, Some(until) if Instant::now() < until) {
+            return;
+        }
+        let entry = &mut state.screen;
+        if entry.granted {
+            return;
+        }
+        if !needed_due(
+            entry.needed_emits,
+            entry.last_needed_at.map(|t| t.elapsed()),
+        ) {
+            return;
+        }
+        entry.needed_emits = entry.needed_emits.saturating_add(1);
+        entry.last_needed_at = Some(Instant::now());
+    }
+
+    info!("screen recording still denied — re-emitting permission_needed");
+    let evt = PermissionEvent::needed(PermissionKind::ScreenRecording);
+    let _ = send_event(evt.event_name(), evt);
+}
+
+/// Pure scheduling rule for `permission_needed` re-notifications:
+/// immediately when never notified, then [`NEEDED_EARLY_RETRY`] spacing for
+/// the first [`NEEDED_EARLY_EMITS`] notifications, then [`RENOTIFY_INTERVAL`].
+fn needed_due(emits: u32, since_last: Option<Duration>) -> bool {
+    let Some(since) = since_last else {
+        return true;
+    };
+    if emits < NEEDED_EARLY_EMITS {
+        since >= NEEDED_EARLY_RETRY
+    } else {
+        since >= RENOTIFY_INTERVAL
+    }
+}
+
+fn check_screen(mode: ScreenCheckMode) -> PermissionStatus {
+    match mode {
+        ScreenCheckMode::Full => check_screen_recording(),
+        ScreenCheckMode::PreflightOnly => check_screen_recording_tauri(),
+    }
 }
 
 /// Read-only probe of the OS keychain. Returns `true` if the encryption key
@@ -287,5 +479,32 @@ fn keychain_accessible() -> bool {
         KeyResult::Unavailable => true,
         // AccessDenied = had access, now don't. This is the only real loss.
         KeyResult::AccessDenied => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn needed_due_fires_immediately_when_never_notified() {
+        assert!(needed_due(0, None));
+    }
+
+    #[test]
+    fn needed_due_early_retries_use_short_spacing() {
+        // 1st and 2nd re-notification: 60s spacing.
+        assert!(!needed_due(1, Some(Duration::from_secs(30))));
+        assert!(needed_due(1, Some(NEEDED_EARLY_RETRY)));
+        assert!(!needed_due(2, Some(Duration::from_secs(59))));
+        assert!(needed_due(2, Some(Duration::from_secs(61))));
+    }
+
+    #[test]
+    fn needed_due_drops_to_long_interval_after_early_emits() {
+        assert!(!needed_due(NEEDED_EARLY_EMITS, Some(Duration::from_secs(3600))));
+        assert!(needed_due(NEEDED_EARLY_EMITS, Some(RENOTIFY_INTERVAL)));
+        assert!(!needed_due(100, Some(RENOTIFY_INTERVAL - Duration::from_secs(1))));
+        assert!(needed_due(100, Some(RENOTIFY_INTERVAL)));
     }
 }

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -7,7 +7,9 @@
 use anyhow::Result;
 use dashmap::{DashMap, DashSet};
 use screenpipe_db::DatabaseManager;
-use screenpipe_screen::monitor::{get_monitor_by_id, list_monitors};
+use screenpipe_screen::monitor::{
+    get_monitor_by_id, list_monitors, list_monitors_detailed, MonitorListError,
+};
 use screenpipe_screen::PipelineMetrics;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -262,8 +264,34 @@ impl VisionManager {
         *status = VisionManagerStatus::Running;
         drop(status);
 
-        // Get all monitors and start recording on each (filtered by user selection)
-        let monitors = list_monitors().await;
+        // Get all monitors and start recording on each (filtered by user selection).
+        // Permission denial is handled explicitly: 0 monitors from a TCC denial
+        // used to fall through to the "stale monitor_ids?" diagnosis below,
+        // sending triage down the wrong path (#4819).
+        let monitors = match list_monitors_detailed().await {
+            Ok(monitors) => monitors,
+            Err(MonitorListError::PermissionDenied) => {
+                *self.status.write().await = VisionManagerStatus::Stopped;
+                crate::permission_monitor::report_state(
+                    screenpipe_events::PermissionKind::ScreenRecording,
+                    false,
+                    Some("VisionManager::start list_monitors PermissionDenied"),
+                );
+                warn!(
+                    "VisionManager: screen recording permission denied — vision capture \
+                     is disabled. Grant access in System Settings > Privacy & Security > \
+                     Screen Recording"
+                );
+                return Err(anyhow::anyhow!(
+                    "screen recording permission denied (0 monitors enumerable)"
+                ));
+            }
+            Err(e) => {
+                *self.status.write().await = VisionManagerStatus::Stopped;
+                warn!("VisionManager: failed to enumerate monitors: {e}");
+                return Err(anyhow::anyhow!("failed to enumerate monitors: {e}"));
+            }
+        };
         let total_monitors = monitors.len();
         for monitor in monitors {
             if !self.is_monitor_allowed(&monitor) {
@@ -317,6 +345,18 @@ impl VisionManager {
             // Roll status back so the next .start() attempt isn't blocked by the
             // idempotency guard above.
             *self.status.write().await = VisionManagerStatus::Stopped;
+            if total_monitors == 0 {
+                // Permission denial was already handled at enumeration above;
+                // an empty-but-successful listing means the displays are gone
+                // (screen locked at boot, clamshell, displays asleep).
+                warn!(
+                    "VisionManager: 0 monitors enumerated (screen locked or displays \
+                     unavailable?) — the monitor watcher will retry"
+                );
+                return Err(anyhow::anyhow!(
+                    "no monitors enumerated (0 enumerated, 0 started)"
+                ));
+            }
             warn!(
                 "VisionManager: no monitors matched the allowed list \
                  ({} enumerated, 0 started) — stale monitor_ids?",


### PR DESCRIPTION
Fixes #4819 — root cause of the multi-day silent recording gaps in #4726.

## The bug

When screenpipe launches while macOS screen-recording permission is **already denied**, the recovery modal never appears and the tray keeps showing a green "recording" state — the app silently captures nothing (no screen frames, no system audio) for days.

Investigation found **three compounding root causes** in the desktop app (which embeds the engine in-process):

1. **The desktop app never started `permission_monitor`** — only the standalone CLI binary calls `start()`. In the app there was no poller and no seeded state; the only signal was the vision watcher's single eager `permission_lost` report, which fires during capture bootstrap **before the `/ws/events` bridge or webview listeners exist**, gets dropped, and is then deduped for the entire process lifetime.
2. **The seed swallowed boot-with-denied state** (the issue's original finding): `report_state` only emits on transitions, and a boot-with-denied seed means no transition ever happens.
3. **The tray lied**: status stayed "● Recording"/"○ Starting…", and the "⚠ Fix permissions" item only rendered in `Error` state — which a TCC denial never reaches.

Bonus finding: `CGPreflightScreenCaptureAccess` (used by `do_permissions_check`, the tray, and the home banner) caches its answer per-process and can report stale "granted" while ScreenCaptureKit is actually denied (macOS 26 monthly re-approval) — so preflight-based UI missed the denial too.

## The fix

```
before                               after
┌──────────────────────┐             ┌──────────────────────────────────┐
│ tray: ● Recording    │             │ tray: ⚠ Not recording —          │
│ (nothing captured,   │             │       no screen permission       │
│  no modal, for days) │             │       ⚠ Fix permissions          │
└──────────────────────┘             └──────────────────────────────────┘
                                     ┌──────────────────────────────────┐
                                     │  fix permissions        (modal)  │
                                     │  screen recording      ✗ denied  │
                                     │  [Open System Settings]          │
                                     │  re-nags every 4h while broken   │
                                     └──────────────────────────────────┘
```

- **`permission_monitor`**: new `start_with(ScreenCheckMode)`. The app uses `PreflightOnly` (the capture probe false-positives for windowed apps on macOS 15+) and **never reports screen "restored" from a stale preflight** — restores come only from the vision watcher's ScreenCaptureKit success report.
- **Re-notification while denied (#4819's ask)**: `permission_needed` re-emits immediately when a persistent screen denial is observed, twice more at 60s spacing (defeats the boot race where the in-process WS bridge isn't connected yet), then every 4h. A mid-session `permission_lost` counts as the first notification so the modal isn't double-shown.
- **`server_core`**: starts the monitor on every server (re)start; a poll-tick liveness stamp detects the poll task dying with its tokio runtime (recording restarts) and respawns it.
- **Event bridge**: the nag is suppressed when capture is deliberately stopped (tray stop) and when the recovery window is already visible (no focus stealing).
- **Tray**: status shows "⚠ Not recording — no screen permission" whenever vision is TCC-disabled (permission-monitor state ORed with preflight), "Your data stays local" is suppressed in that state, and "⚠ Fix permissions" shows whenever a required permission is missing — not only in `Error`.
- **Home banner**: also trusts engine permission events (`permission-lost` / `permission_needed` / `permission-restored`) instead of only the cached-preflight poll.
- **Vision manager**: enumerates via `list_monitors_detailed()` and handles `PermissionDenied` explicitly (eager `report_state` + accurate log) instead of the misleading `"(0 enumerated, 0 started) — stale monitor_ids?"` that sent #4726 triage down the wrong path.
- **Test hook**: `SCREENPIPE_SIMULATE_SCREEN_PERMISSION_DENIED=1` forces all screen checks to `Denied`, so QA/e2e can exercise this whole path without `tccutil reset`-ing the machine's real TCC grant.

## Testing

- `cargo check` clean on `screenpipe-core` + `screenpipe-engine`; `tsc --noEmit` clean on the app frontend.
- Unit tests added for the re-notification schedule (`needed_due` ladder).
- [ ] in progress: full app-crate check + live run with `SCREENPIPE_SIMULATE_SCREEN_PERMISSION_DENIED=1` (screenshots of modal + tray to follow — will move PR out of draft after)

Regression guardrails from TESTING.md respected: tray is never recreated (menu text only), no false "Error" on transients (permission state only flips on real TCC reports / trustworthy preflight denials), restores still exit the modal promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)