### PR TITLE
fix(capture): close race stranding live WGC session behind persistent-capture disable flag

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -210,6 +210,7 @@ commits: `6dd5d98e`, `831ad258`
 - [ ] **OCR bounding boxes normalized on Windows/Linux** — On Windows and Linux, verify that OCR bounding boxes are correctly normalized to the 0-1 range, ensuring consistent text overlay and interaction. (`aba74513`)
 - [ ] **Debounced monitor capture errors** — Simulate transient monitor capture errors. Verify that these errors are debounced and do not lead to excessive error logging or app crashes.
 - [ ] **Focus-aware capture** — Enable "Only record focused monitor" in settings. Verify that Screenpipe only captures frames and runs OCR for the monitor that currently has the focused window. (`886b5c05d`)
+- [ ] **no stranded WGC session after persistent-capture disable (Windows)** — Force repeated persistent WGC init failures on one monitor (e.g. flaky driver, monitor sleep during init) while captures overlap (event-driven engine's capture timeout drops the future but the detached blocking closure keeps running, so two closures can race on the same monitor's shared state). After the "persistent capture disabled for monitor N" warning, verify no live WGC session remains: GPU usage for the app drops to per-frame-capture levels and no `CopyResource` work continues for that monitor. The disable path drains any concurrently stored session under the mutex, and the store path re-checks the disable flag under the same mutex — a session stored behind `persistent_capture_disabled == true` would otherwise leak GPU textures until refresh/stream release.
 
 ### 6. Battery Saver Mode
 

--- a/crates/screenpipe-screen/src/monitor/windows.rs
+++ b/crates/screenpipe-screen/src/monitor/windows.rs
@@ -78,13 +78,23 @@ impl SafeMonitor {
             }
 
             match crate::wgc_capture::PersistentCapture::new(monitor_id) {
-                Ok(capture) => {
+                Ok(mut capture) => {
                     // First frame — allow longer timeout for WGC to deliver
                     match capture.get_latest_image(std::time::Duration::from_millis(500)) {
                         Ok(img) => {
                             let mut guard = persistent.lock().map_err(|e| {
                                 anyhow::anyhow!("persistent capture mutex poisoned: {}", e)
                             })?;
+                            // Re-check under the mutex: a concurrent capture on the same
+                            // Arcs may have tripped the disable flag since the check at
+                            // the top. Storing now would strand a live WGC session that
+                            // no future capture_image() call can reach (early return at
+                            // the disabled check happens before the mutex is touched).
+                            if persistent_disabled.load(Ordering::Relaxed) {
+                                drop(guard);
+                                capture.stop();
+                                return Ok(img);
+                            }
                             *guard = Some(capture);
                             persistent_failures.store(0, Ordering::Relaxed);
                             return Ok(img);
@@ -92,6 +102,7 @@ impl SafeMonitor {
                         Err(e) => {
                             Self::record_persistent_init_failure(
                                 monitor_id,
+                                &persistent,
                                 &persistent_disabled,
                                 &persistent_failures,
                                 &e.to_string(),
@@ -103,6 +114,7 @@ impl SafeMonitor {
                 Err(e) => {
                     Self::record_persistent_init_failure(
                         monitor_id,
+                        &persistent,
                         &persistent_disabled,
                         &persistent_failures,
                         &e.to_string(),
@@ -197,6 +209,7 @@ impl SafeMonitor {
 
     fn record_persistent_init_failure(
         monitor_id: u32,
+        persistent: &std::sync::Mutex<Option<crate::wgc_capture::PersistentCapture>>,
         persistent_disabled: &Arc<AtomicBool>,
         persistent_failures: &Arc<AtomicU32>,
         reason: &str,
@@ -210,6 +223,20 @@ impl SafeMonitor {
                     failures,
                     reason
                 );
+            }
+            // Drain under the mutex after setting the flag: a concurrent
+            // capture_image() that passed the early disabled check may have
+            // stored (or be about to store) a live session. Its store path
+            // re-checks the flag under this same mutex, so between the two
+            // no live WGC session can survive behind disabled == true.
+            if let Ok(mut guard) = persistent.lock() {
+                if let Some(mut capture) = guard.take() {
+                    capture.stop();
+                    tracing::warn!(
+                        "stopped concurrently stored persistent WGC session for monitor {} after disable",
+                        monitor_id
+                    );
+                }
             }
         } else {
             tracing::debug!(
@@ -301,19 +328,29 @@ mod tests {
 
     #[test]
     fn test_persistent_capture_disables_after_three_failures() {
+        let persistent: std::sync::Mutex<Option<crate::wgc_capture::PersistentCapture>> =
+            std::sync::Mutex::new(None);
         let disabled = Arc::new(AtomicBool::new(false));
         let failures = Arc::new(AtomicU32::new(0));
 
-        SafeMonitor::record_persistent_init_failure(1, &disabled, &failures, "err 1");
+        SafeMonitor::record_persistent_init_failure(1, &persistent, &disabled, &failures, "err 1");
         assert!(!disabled.load(Ordering::Relaxed));
         assert_eq!(failures.load(Ordering::Relaxed), 1);
 
-        SafeMonitor::record_persistent_init_failure(1, &disabled, &failures, "err 2");
+        SafeMonitor::record_persistent_init_failure(1, &persistent, &disabled, &failures, "err 2");
         assert!(!disabled.load(Ordering::Relaxed));
         assert_eq!(failures.load(Ordering::Relaxed), 2);
 
-        SafeMonitor::record_persistent_init_failure(1, &disabled, &failures, "err 3");
+        SafeMonitor::record_persistent_init_failure(1, &persistent, &disabled, &failures, "err 3");
         assert!(disabled.load(Ordering::Relaxed));
         assert_eq!(failures.load(Ordering::Relaxed), 3);
+        // Disable must also drain any stored session (race: a concurrent
+        // capture may store a live session right as the flag trips).
+        assert!(persistent.lock().unwrap().is_none());
+
+        // Further failures after disable must not panic or re-log; drain stays idempotent.
+        SafeMonitor::record_persistent_init_failure(1, &persistent, &disabled, &failures, "err 4");
+        assert!(disabled.load(Ordering::Relaxed));
+        assert!(persistent.lock().unwrap().is_none());
     }
 }


### PR DESCRIPTION
## Problem

A verified race in `crates/screenpipe-screen/src/monitor/windows.rs` can strand a **live `PersistentCapture`** (WGC session holding GPU textures + doing per-frame GPU `CopyResource`) behind the `persistent_capture_disabled` flag, where no capture path can ever reach it again.

`SafeMonitor` is `#[derive(Clone)]` with Arc-shared `persistent_capture` / `persistent_capture_disabled` / `persistent_capture_failures`. `capture_image()` runs its work in a detached `spawn_blocking` closure — and the event-driven engine's `capture_with_timeout` drops the future on timeout while that closure keeps running, so the next trigger can start a second closure racing the first on the same Arcs.

### The race (failures counter at 2)

```
 T1 (init succeeds)                      T2 (init fails)
 ──────────────────                      ───────────────
 disabled? → false  ✓ pass early check
 PersistentCapture::new() → Ok
 get_latest_image() → Ok(img)
                                         PersistentCapture::new() → Err
                                         fetch_add: failures 2 → 3
                                         swap disabled = true   ⚠
 lock mutex
 *guard = Some(capture)   ← stores LIVE session, no re-check
 unlock
 ──────────────────────────────────────────────────────────
 End state: disabled == true  +  live WGC session stored
 Every later capture_image() early-returns on the flag
 BEFORE touching the mutex → take+stop path unreachable
 until refresh() / release_capture_stream() / drop.
 GPU textures + per-frame CopyResource leak meanwhile.
```

(Success also only resets the failures counter — it never clears `disabled`, so the state is permanent for the session.)

## Fix

Purely defensive, no restructuring of the capture path. Both halves of the window are closed under the existing session mutex — closing only one still leaks in one interleaving:

1. **Store path**: after locking the mutex to store a freshly initialized session, re-check `persistent_capture_disabled`. If set, `stop()` the new session instead of storing it (the already-captured frame is still returned).
2. **Disable path**: `record_persistent_init_failure` now takes the session mutex and, whenever it trips the disable threshold, drains (take + `stop()`) any stored session under the mutex.

Why both: with only the store-side re-check, T1 can read a stale `false` under the mutex and store, with T2's `swap(true)` landing a moment later and never touching the mutex. With both operations inside the same mutex, release/acquire ordering serializes them — whichever critical section runs **second** cleans up:

```
 Order A: store CS first → drain CS takes + stops the stored session ✓
 Order B: drain CS first → store CS observes disabled == true
          (swap happened-before drain's unlock) → stops new session ✓
```

## Testing

- Extended `test_persistent_capture_disables_after_three_failures`: asserts the disable path leaves the session slot drained, and that a 4th failure after disable is idempotent (no panic, slot stays empty).
- `cargo test -p screenpipe-screen --lib monitor` — 12 passed, 0 failed, 1 ignored (live-desktop WGC test).
- `cargo check -p screenpipe-screen` — no new warnings.
- Added a regression entry to `TESTING.md` (vision pipeline section) describing the repro (overlapping captures racing on one monitor via the event engine's timeout path) and the verification signal (GPU usage drops to per-frame levels after the "persistent capture disabled" warning; no lingering `CopyResource` work).

Found by a 3-verifier adversarial review (2 upheld, 1 refuted on the assumption that production callers are serial per monitor — the event engine's timeout path breaks that serialization). Severity low, but the leaked session costs GPU work for the rest of the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
