### PR TITLE
fix(meeting-notes): stop gating speaker rename on file path

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/replay-strip.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/replay-strip.tsx
@@ -296,7 +296,13 @@ export function ReplayStrip({ meetingId, segments, timeRange }: ReplayStripProps
   if (sampleSorted.length === 0) return null;
 
   const speakerLabel = activeChunk?.speakerName || (activeChunk?.isInput ? "me" : "speaker");
-  const showSpeakerPopover = !!activeChunk?.audioChunkId && !!activeChunk?.audioFilePath;
+  // Only a real (positive) audio_chunk_id can be reassigned via
+  // /speakers/reassign — audioFilePath is merely for the optional playback
+  // preview inside the popover and can legitimately be empty (e.g. a
+  // background chunk with a corrupted file_path) without blocking renaming.
+  // Live-only rows get a synthetic negative audioChunkId (see
+  // fetchRoutedMeetingTranscript) and must stay excluded.
+  const showSpeakerPopover = (activeChunk?.audioChunkId ?? 0) > 0;
 
   return (
     <section className="border-t border-border pt-5">

--- a/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
@@ -998,7 +998,11 @@ function SpeakerParagraph({
       style={{ contain: "layout paint" }}
     >
       <div className="flex items-baseline gap-2 mb-1">
-        {block.firstAudioFilePath ? (
+        {/* Gate on chunk id, not file path: reassignment only needs a real
+            audio_chunk_id. firstAudioFilePath can legitimately be empty
+            (e.g. a background chunk with a corrupted file_path) without
+            that blocking renaming — it's only used for playback preview. */}
+        {block.firstAudioChunkId > 0 ? (
           <SpeakerAssignPopover
             audioChunkId={block.firstAudioChunkId}
             speakerId={block.speakerId ?? undefined}

--- a/apps/screenpipe-app-tauri/components/speaker-assign-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/speaker-assign-popover.tsx
@@ -315,24 +315,28 @@ export function SpeakerAssignPopover({
 						</div>
 					)}
 
-					{/* Audio preview toggle */}
-					<div className="pt-2 border-t">
-						<Button
-							variant="ghost"
-							size="sm"
-							className="w-full justify-start text-xs"
-							onClick={() => setShowAudioPreview(!showAudioPreview)}
-						>
-							<Volume2 className="h-3 w-3 mr-2" />
-							{showAudioPreview ? "Hide audio preview" : "Play audio to confirm"}
-						</Button>
+					{/* Audio preview toggle — only offered when we actually have a file
+					    to play; audioFilePath can be empty (e.g. a corrupted
+					    file_path) even though the chunk itself is still assignable. */}
+					{audioFilePath && (
+						<div className="pt-2 border-t">
+							<Button
+								variant="ghost"
+								size="sm"
+								className="w-full justify-start text-xs"
+								onClick={() => setShowAudioPreview(!showAudioPreview)}
+							>
+								<Volume2 className="h-3 w-3 mr-2" />
+								{showAudioPreview ? "Hide audio preview" : "Play audio to confirm"}
+							</Button>
 
-						{showAudioPreview && (
-							<div className="mt-2">
-								<MediaComponent filePath={audioFilePath} />
-							</div>
-						)}
-					</div>
+							{showAudioPreview && (
+								<div className="mt-2">
+									<MediaComponent filePath={audioFilePath} />
+								</div>
+							)}
+						</div>
+					)}
 
 					{/* Mark as noise button */}
 					{speakerId && (


### PR DESCRIPTION
## Summary
- Fixes #4986 — Windows users could rename the first speaker in a meeting, then every other speaker's line silently became unresponsive (looked identical to a clickable name, but wasn't).
- Root cause: the rename popover was gated on `firstAudioFilePath`/`audioFilePath` being truthy, but `/speakers/reassign` only needs a real `audio_chunk_id` — the file path is only used for the optional "play audio to confirm" preview.
- On Windows, `audio_chunks.file_path` can legitimately come back as `''` or `.` for some chunks (same underlying data issue previously patched defensively in PR #4581 for the speaker-settings queries, but never for the query backing the meeting-notes transcript panel — tracked separately in #4988). A chunk with a valid id but a corrupted path was silently rendered as plain text instead of the rename popover.
- Fix: gate on the chunk id (`> 0`, since live-only rows carry a synthetic negative id) instead of the file path, in both places the popover is mounted (`transcript-panel.tsx`, `replay-strip.tsx`). Also hide the now-reachable "play audio to confirm" button when there's no file to play, rather than showing a dead button.

## Test plan
- [x] `bun run typecheck` — no new errors introduced (pre-existing unrelated `@tanstack/react-query` resolution errors in this worktree, untouched by this change)
- [x] `bunx vitest run components/meeting-notes/replay-strip.test.tsx` — passes
- [x] `cargo test -p screenpipe-app tauri_bindings_are_current` — passes (frontend-only change, no Tauri command surface touched)
- [ ] Manual verification on Windows with a meeting containing a chunk with corrupted `file_path` (couldn't reproduce locally — no Windows machine in this environment; reasoning verified via code trace of `list_meeting_transcript_segments` / `fetchRoutedMeetingTranscript` / `groupBySpeaker`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)