### PR TITLE
fix(audio): stop building throwaway ORT sessions in boot-time model pre-download

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1388,7 +1388,13 @@ async fn main() {
                             }
                         },
                         async {
-                            match screenpipe_audio::speaker::models::get_or_download_model(
+                            // File-only fetch — NOT get_or_download_model, which also builds
+                            // an ORT session. That session would be immediately discarded here
+                            // and would compete for CPU with the real session build that
+                            // SegmentationManager does moments later for the same file (root
+                            // cause of the "ort session init: timed out after 30s" boot warning
+                            // observed on the macos-15-intel CI runner).
+                            match screenpipe_audio::speaker::models::ensure_model_file(
                                 screenpipe_audio::speaker::models::PyannoteModel::Segmentation
                             ).await {
                                 Ok(p) => info!("segmentation model pre-download complete: {:?}", p),
@@ -1396,7 +1402,7 @@ async fn main() {
                             }
                         },
                         async {
-                            match screenpipe_audio::speaker::models::get_or_download_model(
+                            match screenpipe_audio::speaker::models::ensure_model_file(
                                 screenpipe_audio::speaker::models::PyannoteModel::Embedding
                             ).await {
                                 Ok(p) => info!("embedding model pre-download complete: {:?}", p),

--- a/crates/screenpipe-audio/src/speaker/models.rs
+++ b/crates/screenpipe-audio/src/speaker/models.rs
@@ -36,14 +36,39 @@ pub async fn get_or_download_model(model_type: PyannoteModel) -> Result<LoadedMo
     get_or_download_model_with_retries(model_type, MAX_RECOVERY_RETRIES).await
 }
 
+/// Ensure the model file is on disk without building an ORT session for it.
+///
+/// Callers that only want the file warmed in cache (e.g. main.rs's opportunistic
+/// boot-time pre-download) must use this instead of `get_or_download_model` —
+/// that one unconditionally calls `create_session`, which is a real CPU-bound
+/// ONNX Runtime graph load/optimize, not just a disk check. A pre-download call
+/// that builds (and immediately discards) a session competes for CPU with the
+/// *real* session build that `SegmentationManager`/`EmbeddingExtractor` does
+/// moments later on the same file, and on a CPU-constrained host that
+/// self-inflicted contention is enough to trip `ORT_INIT_TIMEOUT` on both sides
+/// (observed on GitHub's `macos-15-intel` runner: concurrent pre-download +
+/// on-demand session builds for the same model pushed session build time from
+/// the normal sub-second range past the 30s watchdog).
+pub async fn ensure_model_file(model_type: PyannoteModel) -> Result<PathBuf> {
+    let (url, filename, model_path_lock, downloading_flag) = model_state(model_type);
+    let cache_dir = get_cache_dir()?;
+    let downloader = ModelDownloader::new(
+        url.to_string(),
+        filename.to_string(),
+        cache_dir,
+        downloading_flag,
+        model_path_lock,
+    );
+    downloader.ensure_model_available().await
+}
+
 async fn get_or_download_model_with_retries(
     model_type: PyannoteModel,
     max_retries: u8,
 ) -> Result<LoadedModel> {
     let mut retry_count = 0;
     loop {
-        let (url, filename, model_path_lock, downloading_flag) = model_state(model_type);
-        let cache_dir = get_cache_dir()?;
+        let (_, filename, model_path_lock, _) = model_state(model_type);
 
         {
             let mut cached = model_path_lock.lock().await;
@@ -58,14 +83,7 @@ async fn get_or_download_model_with_retries(
             }
         }
 
-        let downloader = ModelDownloader::new(
-            url.to_string(),
-            filename.to_string(),
-            cache_dir,
-            downloading_flag,
-            model_path_lock,
-        );
-        let path = downloader.ensure_model_available().await?;
+        let path = ensure_model_file(model_type).await?;
 
         match create_session(&path) {
             Ok(session) => return Ok(LoadedModel { path, session }),


### PR DESCRIPTION
## description

Investigation into the "ort session init: timed out after 30s (likely an ONNX Runtime init hang on this host)" warning seen during boot on the `macos-15-intel` CI runner (surfaced while building the Intel launch-smoke test in #4978). Root-caused and fixed the CPU-contention bug that was causing it — this is not the previously-fixed ORT rc.12 global-init hang (`ort-init-smoke.yml` already covers that, and passes cleanly on this same runner in isolation).

related issue: none (investigation task, no tracked issue)

### what was happening

`get_or_download_model()` in `crates/screenpipe-audio/src/speaker/models.rs` only ever cached the model **file path**, never the built `ort::Session`. Every caller re-built a full session (graph parse + `GraphOptimizationLevel::Level3`) from scratch on every call. At boot, up to three independent call sites did this concurrently for the same model files:

1. `main.rs`'s opportunistic pre-download task (`tokio::join!` of Segmentation + Embedding) — this one builds a session **purely to throw it away**, since the task only wants the file on disk.
2. `SegmentationManager::new()`'s own sequential load.
3. `EmbeddingExtractor::new()`'s own load.

Each session build is forced single-threaded (`with_intra_threads(1)/with_inter_threads(1)`), but nothing stops 2-3 of them running concurrently on separate OS threads. On a CPU-constrained CI VM that contention was enough to push a session build that should take "well under a second" (per the watchdog module's own doc comment) past the 30s `ORT_INIT_TIMEOUT`.

**Evidence it's contention, not a real ORT hang or an Intel-architecture issue:**
- Pulled app-log timestamps from 3 separate real `macos-intel-launch-smoke.yml` CI runs (7/6, three different times) — identical pattern every time: segmentation session times out, then embedding session times out ~7s later, both hitting the exact 30s mark measured from when their respective `create_session` calls actually started.
- A same-day ARM64 (`macos-15`) e2e run doing the *identical* downloads + session builds went from `building_audio` to `ready` in ~2 seconds, no contention, no timeout — ever seen on ARM.
- The minimal `ort-smoke` reproduction (bare `Session::builder()`, no file, no concurrent work) already passes on `macos-15-intel` in isolation, ruling out the rc.12 global-init hang as the cause here.

### the fix

Added `ensure_model_file()` — a download-only path with no session build — and switched `main.rs`'s pre-download task to use it instead of `get_or_download_model()`. This matches the pattern Silero VAD's pre-download already used correctly (`SileroVad::ensure_model_downloaded()`), and removes 2 of the 3 concurrent, wasted session builds during boot. The real consumers (`SegmentationManager::new()`, `EmbeddingExtractor::new()`) are untouched — they still validate the model actually loads.

### how to test

1. `cargo test -p screenpipe-audio --lib speaker::models::` — existing unit tests pass unchanged.
2. `cargo check -p screenpipe-audio --lib` — compiles clean, no new warnings.
3. Best real-world validation is re-running `macos-intel-launch-smoke.yml` (or `e2e-test.yml`'s macOS job) a few times and confirming the "ort session init: timed out after 30s" warning no longer appears in the app boot log.

### note

A distinct, likely larger perf issue was found in passing and is **not** addressed here: `crates/screenpipe-audio/src/speaker/segment.rs:199` rebuilds the segmentation ORT session on *every audio chunk* during real recording (not just at boot). Flagged separately for its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)