### PR TITLE
fix(chat): home connect tiles UX — open dialog + balanced grid

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
@@ -267,9 +267,7 @@ export function SummaryCards({
             tabIndex={0}
             onClick={openConnection}
             onKeyDown={(e) => e.key === "Enter" && openConnection()}
-            className={`group relative text-left p-2 border bg-muted/10 hover:bg-foreground hover:text-background hover:border-foreground transition-all duration-150 cursor-pointer ${
-              isBrowseAll ? "border-border/40" : "border-dashed border-border/60"
-            }`}
+            className="group relative text-left p-2 border border-border/40 bg-muted/10 hover:bg-foreground hover:text-background hover:border-foreground transition-all duration-150 cursor-pointer"
           >
             <div className="mb-0.5 flex h-4 w-4 items-center justify-center">
               {isBrowseAll
@@ -277,7 +275,7 @@ export function SummaryCards({
                 : <ConnectionSuggestionIcon name={connection.icon} />}
             </div>
             <div className="text-[11px] font-medium group-hover:text-background mb-0.5 leading-tight pr-4">
-              {isBrowseAll ? connection.title.toLowerCase() : `+ ${connection.title.toLowerCase()}`}
+              {connection.title.toLowerCase()}
             </div>
             <div className="text-[10px] text-muted-foreground group-hover:text-background/60 leading-tight line-clamp-1">
               {connection.description}

--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
@@ -172,8 +172,21 @@ export function SummaryCards({
     onSendMessage(template.prompt, `\u{1F4CC} ${template.title}`);
   };
 
+  // Keep the 3-column grid rows full: only show as many per-app setup suggestions
+  // as leave no orphan cells in the last row. Setup suggestions are for *unconnected*
+  // apps, so a typical user has plenty (>= a full row); the trim only kicks in for
+  // someone who has connected almost everything, where a tidy 2-row grid reads fine.
+  const GRID_COLUMNS = 3;
+  const alwaysOnCardCount =
+    featured.length + 1 /* custom summary */ + (discover.length > 0 ? 1 : 0) + 1 /* browse all */;
+  const setupRowRemainder =
+    (alwaysOnCardCount + connectionSetupSuggestions.length) % GRID_COLUMNS;
+  const rowFilledConnectionSuggestions = connectionSetupSuggestions.slice(
+    0,
+    Math.max(0, connectionSetupSuggestions.length - setupRowRemainder),
+  );
   const visibleConnectionSetupSuggestions = [
-    ...connectionSetupSuggestions,
+    ...rowFilledConnectionSuggestions,
     { id: "connections", title: "Connect Apps", description: "Browse all connections", icon: "connections" },
   ];
 

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -948,42 +948,6 @@ export function StandaloneChat({
     turnIntentLedgerRef,
   });
 
-  const openInlineConnectionCard = useCallback((connectionId: string) => {
-    if (connectionId === "connections") {
-      openConnectionSetup(connectionId);
-      return;
-    }
-
-    const connection = allConnectionItems.find((item) => item.id === connectionId);
-    const connectionName = connection?.name || connectionId;
-    const message: Message = {
-      id: `connection-action-${connectionId}-${Date.now()}`,
-      role: "assistant",
-      content: "",
-      timestamp: Date.now(),
-      contentBlocks: [
-        {
-          type: "connection_action",
-          connectionId,
-          connectionName,
-          icon: connection?.icon || connectionId,
-          description: connection?.description,
-          pendingActionLabel: `continue with ${connectionName}`,
-          pendingActionPrompt: `${connectionName} is connected now. Continue the action we were discussing, but ask me for confirmation before writing to ${connectionName}.`,
-        },
-      ],
-    };
-
-    setMessages((prev) => {
-      const alreadyVisible = prev.some((row) =>
-        row.contentBlocks?.some(
-          (block) => block.type === "connection_action" && block.connectionId === connectionId,
-        ),
-      );
-      return alreadyVisible ? prev : [...prev, message];
-    });
-  }, [allConnectionItems, openConnectionSetup]);
-
   const answerPiExtensionUiRequest = useCallback(async (
     requestId: string | undefined,
     response: JsonValue,
@@ -1383,7 +1347,7 @@ export function StandaloneChat({
         }}
         summaryCardsProps={{
           onSendMessage: sendMessage,
-          onOpenConnection: openInlineConnectionCard,
+          onOpenConnection: openConnectionSetup,
           connectionSetupSuggestions,
           autoSuggestions: connectionAwareSuggestions,
           suggestionsRefreshing,

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/connection-suggestions.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/connection-suggestions.test.ts
@@ -101,6 +101,12 @@ describe("connection suggestions", () => {
         description: "Search your docs",
         icon: "notion",
       },
+      {
+        id: "google-docs",
+        title: "Connect Google Docs",
+        description: "Search your docs",
+        icon: "google-docs",
+      },
     ]);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/chat/connection-suggestions.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/connection-suggestions.ts
@@ -355,6 +355,6 @@ export function buildConnectionSetupSuggestions(
       a.fallbackRank - b.fallbackRank ||
       a.suggestion.title.localeCompare(b.suggestion.title)
     )
-    .slice(0, 2)
+    .slice(0, 3)
     .map((entry) => entry.suggestion);
 }


### PR DESCRIPTION
### Description:

**1. connect tiles open the connections dialog (not an inline chat card)**

- before:

https://github.com/user-attachments/assets/12f42558-8998-4af0-a88b-aeb84f49c80f

- after:

https://github.com/user-attachments/assets/6cc8a87f-e489-4703-a087-059f89eb97ed


- clicking a home-screen connect tile (e.g. "connect google calendar") now opens the connections dialog scoped to that app, instead of dropping an inline connect card into a new chat
- restores the pre-#4630 behavior and makes every connection tile consistent — "connect apps" already opened the dialog
- keeps the app-aware inline connection flow intact: when the agent asks for a connection mid-conversation it still surfaces the inline connect card (that path is untouched)
- dropped the redundant "+ " prefix and the dashed border on setup tiles so the label reads "connect google calendar" and the grid looks like one system

**2. keep the home card grid rows balanced**

- before:

<img width="1948" height="1326" alt="image" src="https://github.com/user-attachments/assets/b077c541-45ba-4364-844b-5c2e8febb9d6" />


- after:

<img width="1191" height="812" alt="image" src="https://github.com/user-attachments/assets/12babf5e-74fc-457b-b30e-362f99726355" />


- the 3-column grid held a variable card count (6, 7, or 8), so 7/8 left an odd orphan cell in the last row
- now shows only as many per-app setup suggestions as keep the last row full, so the grid is always complete rows (2 or 3 rows, never a dangling cell)
- setup suggestions are for *unconnected* apps, so a typical user has a full row of them; the trim only kicks in for someone who has connected almost everything, where a tidy 2-row grid reads fine

**root cause (1):** #4630 rewired the home tile handler from `openConnectionSetup` to `openInlineConnectionCard`; this points it back and removes the now-dead callback.

**tests:** updated `connection-suggestions.test.ts` for the raised suggestion cap (2 → 3, so a full row can fill). No other unit/e2e changes needed — nothing covered the removed home-tile path, and the agent-driven flow (`screenpipe_connect_app` + its `connection-gate` tests) is unchanged.