### PR TITLE
fix(feedback): stop "Send Logs & Feedback" silently doing nothing

### DIFF
--- a/apps/screenpipe-app-tauri/components/share-logs-button.tsx
+++ b/apps/screenpipe-app-tauri/components/share-logs-button.tsx
@@ -221,11 +221,15 @@ export const ShareLogsButton = ({
   };
 
   const sendLogs = async () => {
-    const logFiles = await getLogFiles();
-    if (!logFiles.length) return;
-
     setIsSending(true);
     try {
+      // Log files are best-effort. If none are found (fresh install, or an
+      // unreadable/misconfigured data dir — common on Windows), we still send
+      // the feedback text, screenshot, settings and console logs, which are
+      // valuable on their own. Bailing here silently was the original bug:
+      // clicking the button did nothing, with no toast and no spinner.
+      const logFiles = await getLogFiles();
+
       const BASE_URL = "https://screenpipe.com";
       const identifier = settings.user?.id || machineId;
       const type = settings.user?.id ? "user" : "machine";

--- a/apps/screenpipe-app-tauri/src-tauri/src/log_files.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/log_files.rs
@@ -4,7 +4,8 @@
 
 //! Tauri commands for listing log files and resolving data directories.
 
-use std::path::PathBuf;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
 
 use tauri::AppHandle;
 use tauri::Manager;
@@ -25,30 +26,26 @@ pub struct LogFile {
 pub async fn get_log_files(app: AppHandle) -> Result<Vec<LogFile>, String> {
     let data_dir = get_screenpipe_data_dir(&app).map_err(|e| e.to_string())?;
     let screenpipe_data_dir = get_data_dir(&app).map_err(|e| e.to_string())?;
-    let mut log_files = Vec::new();
+    Ok(collect_log_files(&[data_dir, screenpipe_data_dir]).await)
+}
 
-    let mut entries = Vec::new();
-    let mut dir = tokio::fs::read_dir(&data_dir)
-        .await
-        .map_err(|e| e.to_string())?;
-    let mut screenpipe_dir = tokio::fs::read_dir(&screenpipe_data_dir)
-        .await
-        .map_err(|e| e.to_string())?;
+/// Gather `.log` files from the given directories, newest first.
+///
+/// Resilience is the whole point of this helper: a directory that can't be read
+/// (missing, unmounted, permission denied — all common on Windows with a custom
+/// `dataDir`) is skipped with a warning instead of failing the entire command.
+/// Previously a single unreadable dir made `get_log_files` return `Err`, which
+/// the UI silently swallowed, so "Send Logs & Feedback" did nothing at all.
+///
+/// Files are deduped by canonical path so overlapping directories (e.g. the
+/// default `dataDir`, where both inputs resolve to the same path) don't list
+/// every log twice.
+async fn collect_log_files(dirs: &[PathBuf]) -> Vec<LogFile> {
+    let mut seen: HashSet<PathBuf> = HashSet::new();
+    let mut entries: Vec<(PathBuf, std::fs::Metadata)> = Vec::new();
 
-    while let Some(entry) = dir.next_entry().await.map_err(|e| e.to_string())? {
-        if let Ok(metadata) = entry.metadata().await {
-            entries.push((entry, metadata));
-        }
-    }
-
-    while let Some(entry) = screenpipe_dir
-        .next_entry()
-        .await
-        .map_err(|e| e.to_string())?
-    {
-        if let Ok(metadata) = entry.metadata().await {
-            entries.push((entry, metadata));
-        }
+    for dir_path in dirs {
+        collect_from_dir(dir_path, &mut seen, &mut entries).await;
     }
 
     entries.sort_by_key(|(_, metadata)| {
@@ -62,31 +59,69 @@ pub async fn get_log_files(app: AppHandle) -> Result<Vec<LogFile>, String> {
         )
     });
 
-    for (entry, metadata) in entries {
-        let path = entry.path();
-        if let Some(extension) = path.extension() {
-            if extension == "log" {
-                let modified = metadata
-                    .modified()
-                    .map_err(|e| e.to_string())?
-                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
-                    .map_err(|e| e.to_string())?
-                    .as_secs();
+    entries
+        .into_iter()
+        .map(|(path, metadata)| {
+            let modified = metadata
+                .modified()
+                .ok()
+                .and_then(|m| m.duration_since(std::time::SystemTime::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
 
-                log_files.push(LogFile {
-                    name: path
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .to_string(),
-                    path: path.to_string_lossy().to_string(),
-                    modified_at: modified,
-                });
+            LogFile {
+                name: path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string(),
+                path: path.to_string_lossy().to_string(),
+                modified_at: modified,
+            }
+        })
+        .collect()
+}
+
+/// Push `.log` entries from a single directory into `entries`, deduping by
+/// canonical path via `seen`. A directory that can't be opened is logged and
+/// skipped rather than propagated as an error.
+async fn collect_from_dir(
+    dir_path: &Path,
+    seen: &mut HashSet<PathBuf>,
+    entries: &mut Vec<(PathBuf, std::fs::Metadata)>,
+) {
+    let mut dir = match tokio::fs::read_dir(dir_path).await {
+        Ok(dir) => dir,
+        Err(e) => {
+            warn!("skipping unreadable log dir {:?}: {}", dir_path, e);
+            return;
+        }
+    };
+
+    loop {
+        match dir.next_entry().await {
+            Ok(Some(entry)) => {
+                let path = entry.path();
+                if path.extension().map(|ext| ext == "log").unwrap_or(false) {
+                    if let Ok(metadata) = entry.metadata().await {
+                        // Canonicalize for dedup; fall back to the raw path if
+                        // the file vanished between listing and canonicalizing.
+                        let key = tokio::fs::canonicalize(&path)
+                            .await
+                            .unwrap_or_else(|_| path.clone());
+                        if seen.insert(key) {
+                            entries.push((path, metadata));
+                        }
+                    }
+                }
+            }
+            Ok(None) => break,
+            Err(e) => {
+                warn!("error reading entry in {:?}: {}", dir_path, e);
+                break;
             }
         }
     }
-
-    Ok(log_files)
 }
 
 pub fn get_data_dir(app: &AppHandle) -> anyhow::Result<PathBuf> {
@@ -119,4 +154,92 @@ pub fn get_data_dir(app: &AppHandle) -> anyhow::Result<PathBuf> {
 
 pub fn get_screenpipe_data_dir(_app: &AppHandle) -> anyhow::Result<PathBuf> {
     Ok(screenpipe_core::paths::default_screenpipe_data_dir())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    async fn write_file(dir: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, contents).await.unwrap();
+        path
+    }
+
+    fn names(files: &[LogFile]) -> HashSet<String> {
+        files.iter().map(|f| f.name.clone()).collect()
+    }
+
+    #[tokio::test]
+    async fn collects_only_log_files() {
+        let dir = tempdir().unwrap();
+        write_file(dir.path(), "screenpipe.log", "hello").await;
+        write_file(dir.path(), "notes.txt", "ignore me").await;
+        write_file(dir.path(), "db.sqlite", "ignore me too").await;
+
+        let files = collect_log_files(&[dir.path().to_path_buf()]).await;
+
+        assert_eq!(names(&files), HashSet::from(["screenpipe.log".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn missing_dir_is_skipped_not_fatal() {
+        let good = tempdir().unwrap();
+        write_file(good.path(), "app.log", "data").await;
+        let missing = good.path().join("does-not-exist");
+
+        // A missing directory must not sink the whole call — this is the exact
+        // condition that made "Send Logs & Feedback" silently do nothing.
+        let files = collect_log_files(&[missing, good.path().to_path_buf()]).await;
+
+        assert_eq!(names(&files), HashSet::from(["app.log".to_string()]));
+    }
+
+    #[tokio::test]
+    async fn all_dirs_missing_returns_empty_without_error() {
+        let base = tempdir().unwrap();
+        let a = base.path().join("nope-a");
+        let b = base.path().join("nope-b");
+
+        let files = collect_log_files(&[a, b]).await;
+
+        assert!(files.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dedupes_when_dirs_resolve_to_same_path() {
+        // Mirrors the `dataDir == "default"` case where both inputs point at the
+        // same directory; each log must appear exactly once.
+        let dir = tempdir().unwrap();
+        write_file(dir.path(), "one.log", "x").await;
+        write_file(dir.path(), "two.log", "y").await;
+
+        let same = dir.path().to_path_buf();
+        let files = collect_log_files(&[same.clone(), same]).await;
+
+        assert_eq!(files.len(), 2);
+        assert_eq!(
+            names(&files),
+            HashSet::from(["one.log".to_string(), "two.log".to_string()])
+        );
+    }
+
+    #[tokio::test]
+    async fn merges_logs_across_distinct_dirs() {
+        let a = tempdir().unwrap();
+        let b = tempdir().unwrap();
+        write_file(a.path(), "a.log", "1").await;
+        write_file(b.path(), "b.log", "2").await;
+
+        let files =
+            collect_log_files(&[a.path().to_path_buf(), b.path().to_path_buf()]).await;
+
+        assert_eq!(
+            names(&files),
+            HashSet::from(["a.log".to_string(), "b.log".to_string()])
+        );
+    }
 }


### PR DESCRIPTION
### Description:

Fixes #4995 

- test passing:

<img width="1296" height="512" alt="image" src="https://github.com/user-attachments/assets/592edbca-aff0-49ab-86fd-9100c6a57a00" />


- **Root cause:** the send flow returned early with a bare `return` when no log files were found, *before* any UI feedback fired. On Windows, a missing or misconfigured data dir makes the Rust `get_log_files` command return `Err`, which the UI collapsed to an empty list → the button silently did nothing.
- **Frontend:** the button never no-ops now. It shows the "sending…" spinner immediately and always ends in a success or failure toast. Feedback text, screenshot, and settings are sent even when no log files exist.
- **Backend:** `get_log_files` skips an unreadable/missing directory (with a warning) instead of failing the entire command, so logs still attach whenever *any* directory is readable.
- **Backend:** log files are deduped by canonical path, so the default data dir (where both lookup paths resolve to the same folder) no longer lists every log twice.
- **Tests:** added cargo unit tests covering missing dirs, dedup, extension filtering, and multi-dir merge.

### Testing

- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml log_files` → **5 passed**
- No Tauri command surface changed, so `bun run bindings:check` stays green.
