### PR TITLE
fix(audio): bound audio channel capacity — stop multi-GB backlog on high-RAM machines

### DIFF
--- a/crates/screenpipe-config/src/defaults.rs
+++ b/crates/screenpipe-config/src/defaults.rs
@@ -88,7 +88,7 @@ pub fn detect_tier() -> DeviceTier {
 /// Database configuration tuned per device tier.
 ///
 /// Controls SQLite PRAGMA values and connection pool sizes.
-/// `Default` returns the High-tier values matching the previous hardcoded settings.
+/// `Default` returns the High-tier channel caps.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DbConfig {
     /// SQLite `mmap_size` pragma in bytes.
@@ -192,7 +192,7 @@ pub const WAL_SAFETY_PRAGMAS: [(&str, &str); 4] = [
 /// Audio/transcription channel capacities tuned per device tier.
 ///
 /// Controls the `crossbeam::channel::bounded` sizes in `AudioManager`.
-/// `Default` returns the High-tier values matching the previous hardcoded settings.
+/// `Default` returns the High-tier channel caps.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChannelConfig {
     /// Capacity for the audio recording channel.
@@ -207,23 +207,26 @@ impl ChannelConfig {
         match tier {
             DeviceTier::High => Self::default(),
             DeviceTier::Mid => Self {
-                recording_capacity: 500,
-                transcription_capacity: 500,
+                recording_capacity: 12,
+                transcription_capacity: 12,
             },
             DeviceTier::Low => Self {
-                recording_capacity: 100,
-                transcription_capacity: 100,
+                recording_capacity: 8,
+                transcription_capacity: 8,
             },
         }
     }
 }
 
 impl Default for ChannelConfig {
-    /// High-tier defaults — identical to the previous hardcoded values (1000).
+    /// High-tier cap for the audio recording + transcription channels.
+    /// Items are multi-MB audio segments; the previous 1000 allowed ~24GB of
+    /// buffered audio to accumulate when transcription lagged. Bounded low so a
+    /// slow transcriber drops old audio instead of leaking memory.
     fn default() -> Self {
         Self {
-            recording_capacity: 1000,
-            transcription_capacity: 1000,
+            recording_capacity: 16,
+            transcription_capacity: 16,
         }
     }
 }


### PR DESCRIPTION
## Problem

https://github.com/user-attachments/assets/15e9e8fc-1960-47dd-8c73-e4719e7bc944


The audio **recording** and **transcription-result** channels are bounded, but their capacity is scaled *up* with the machine's RAM tier:

```rust
// crates/screenpipe-config/src/defaults.rs
Low  => 100
Mid  => 500
High => 1000   // ≥24 GB RAM, ≥8 cores
```

Both channels carry items that embed a raw audio segment (`AudioInput`, and `TranscriptionResult { input: AudioInput, .. }`), which is multi-MB — **~24 MB observed on a 48 kHz session**. So on a High-tier machine each channel can buffer up to **~1000 × 24 MB ≈ 24 GB** of audio (~48 GB across both) whenever transcription can't keep up.

This surfaces as a slow memory "leak": on macOS the process `phys_footprint` climbs to **10 GB+ over days** (it stays invisible to RSS/`resource_usage` telemetry because the cold pages get compressed/swapped — RSS reads flat/low while Activity Monitor climbs). Users have reported it at up to ~19.6 GB.

## Root cause

Scaling capacity *up* with RAM is backwards for a queue of large items — more RAM should not mean a bigger **audio backlog**. When the consumer (transcription, then DB writes) falls behind — common on large-DB / CPU-contended installs — the channels fill toward their oversized ceiling instead of shedding load.

Attribution via `MallocStackLogging` on a long-running session: the dominant live allocation is exactly these ~24 MB audio buffers, built in `run_record_and_transcribe` and parked in the channels awaiting a lagging transcriber.

## Fix

Bound the channels to a small fixed size, decoupled from RAM tier:

```
Low => 8    Mid => 12    High => 16
```

Under sustained lag the existing `whisper_sender.send_timeout(30s)` path drops old audio (already the fallback) instead of buffering tens of GB. Transcription **coverage** is unchanged — it's bounded by transcriber throughput, not buffer depth — while memory is bounded. In steady state (transcriber keeping up) the channels sit near-empty and the cap never engages, so normal operation is unaffected.

The exact numbers are a judgement call and easy to tune; the essential change is decoupling the cap from RAM and keeping it small for a large-item queue.

## Verification

Clean `phys_footprint` (no instrumentation), macOS, **under sustained transcription lag** the whole window:

| build | footprint over ~90 min |
|---|---|
| before (`app-v2.5.87`) | climbs ~1–2 GB/h, unbounded → 10 GB+ over days |
| after (this change) | **flat, plateaus ~2.5 GB** |

Existing `channel_config` tier-ordering tests still hold (`low < mid < high`).
