### PR TITLE
fix(audio): stop multi-GB phys_footprint leak — cache segmentation ONNX session (+ bound speaker clusters)

### DIFF
--- a/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
+++ b/crates/screenpipe-audio/src/segmentation/segmentation_manager.rs
@@ -71,7 +71,9 @@ impl SegmentationManager {
             None
         };
 
-        let embedding_manager = Arc::new(StdMutex::new(EmbeddingManager::new(usize::MAX)));
+        let embedding_manager = Arc::new(StdMutex::new(EmbeddingManager::new(
+            crate::speaker::embedding_manager::DEFAULT_MAX_SPEAKERS,
+        )));
         Ok(SegmentationManager {
             embedding_manager,
             embedding_extractor: AsyncMutex::new(embedding_extractor),

--- a/crates/screenpipe-audio/src/speaker/embedding_manager.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding_manager.rs
@@ -280,7 +280,10 @@ mod tests {
         // memory leak and a per-segment CPU leak (search_speaker scans every
         // cluster). The default must now be finite.
         assert_ne!(DEFAULT_MAX_SPEAKERS, usize::MAX);
-        assert!(DEFAULT_MAX_SPEAKERS >= 256, "cap must be generous enough not to harm real diarization");
+        assert!(
+            DEFAULT_MAX_SPEAKERS >= 256,
+            "cap must be generous enough not to harm real diarization"
+        );
 
         // Feed far more distinct (orthogonal, so never matching) embeddings than
         // the cap. Without a bound this would allocate one cluster each; with the

--- a/crates/screenpipe-audio/src/speaker/embedding_manager.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding_manager.rs
@@ -8,6 +8,23 @@ use std::collections::HashMap;
 
 const MAX_SPEAKER_EXAMPLES: usize = 10;
 
+/// Upper bound on distinct speaker clusters kept in memory when no meeting is
+/// active (meetings set their own tighter cap via `set_max_speakers`).
+///
+/// The clusters were previously unbounded (`usize::MAX`) and only ever dropped
+/// by `clear_speakers`, which is called *between meetings*. In a long,
+/// continuous, no-meeting session — screenpipe's normal always-on mode — system
+/// audio (podcasts, videos, music) and varied voices spawn a fresh cluster
+/// almost every speech segment, so `speakers` / `speaker_examples` grew without
+/// limit for the life of the process. That is a slow memory leak *and* a
+/// per-segment CPU leak: `search_speaker` scans every cluster (and up to
+/// `MAX_SPEAKER_EXAMPLES` embeddings each) on every segment, so cost climbs with
+/// cluster count. Bounding it makes `search_speaker` force-merge into the
+/// closest existing cluster once full (the same path meetings already use),
+/// which caps both memory and per-segment work. 1024 is far more distinct
+/// speakers than any real session needs, so normal diarization is unaffected.
+pub const DEFAULT_MAX_SPEAKERS: usize = 1024;
+
 #[derive(Debug, Clone)]
 pub struct EmbeddingManager {
     max_speakers: usize,
@@ -82,9 +99,12 @@ impl EmbeddingManager {
         self.max_speakers = max;
     }
 
-    /// Reset max_speakers to unlimited (usize::MAX).
+    /// Reset max_speakers to the no-meeting default cap.
+    /// Called when a meeting ends. Previously reset to `usize::MAX`
+    /// (unbounded); now bounded by [`DEFAULT_MAX_SPEAKERS`] so a long
+    /// no-meeting session can't grow speaker clusters without limit.
     pub fn reset_max_speakers(&mut self) {
-        self.max_speakers = usize::MAX;
+        self.max_speakers = DEFAULT_MAX_SPEAKERS;
     }
 
     /// Clear all speakers and reset the ID counter.
@@ -250,6 +270,48 @@ mod tests {
         let id = mgr.search_speaker(vec![0.0, 0.0, 0.0, 1.0], 0.0);
         assert!(id.is_some());
         assert_eq!(mgr.speaker_count(), 4);
+    }
+
+    #[test]
+    fn no_meeting_default_is_bounded_not_unbounded() {
+        // Regression: the no-meeting default used to be `usize::MAX`, so speaker
+        // clusters grew without limit for the life of a long, continuous,
+        // no-meeting session (screenpipe's normal always-on mode) — a slow
+        // memory leak and a per-segment CPU leak (search_speaker scans every
+        // cluster). The default must now be finite.
+        assert_ne!(DEFAULT_MAX_SPEAKERS, usize::MAX);
+        assert!(DEFAULT_MAX_SPEAKERS >= 256, "cap must be generous enough not to harm real diarization");
+
+        // Feed far more distinct (orthogonal, so never matching) embeddings than
+        // the cap. Without a bound this would allocate one cluster each; with the
+        // bound, search_speaker force-merges into the closest existing cluster
+        // once full, so the count stays capped.
+        let cap = 8usize;
+        let n = cap * 12;
+        let mut mgr = EmbeddingManager::new(cap);
+        for i in 0..n {
+            let mut e = vec![0.0f32; n]; // one-hot => all mutually orthogonal
+            e[i] = 1.0;
+            mgr.search_speaker(e, 0.999);
+        }
+        assert!(
+            mgr.speaker_count() <= cap,
+            "clusters must stay bounded by the cap; got {} for cap {}",
+            mgr.speaker_count(),
+            cap
+        );
+
+        // A manager whose meeting cap is lifted (meeting ended) also falls back
+        // to the finite default, not unbounded.
+        let mut mgr2 = EmbeddingManager::new(2);
+        mgr2.set_max_speakers(2);
+        mgr2.reset_max_speakers();
+        // 3 orthogonal embeddings now succeed (default cap >> 3), proving reset
+        // re-enabled creation, while remaining finite (asserted above).
+        mgr2.search_speaker(vec![1.0, 0.0, 0.0], 0.999);
+        mgr2.search_speaker(vec![0.0, 1.0, 0.0], 0.999);
+        mgr2.search_speaker(vec![0.0, 0.0, 1.0], 0.999);
+        assert_eq!(mgr2.speaker_count(), 3);
     }
 
     #[test]

--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -4,7 +4,12 @@
 
 use anyhow::{Context, Result};
 use ndarray::{ArrayBase, Axis, IxDyn, ViewRepr};
-use std::{cmp::Ordering, collections::VecDeque, path::Path, sync::Arc, sync::Mutex};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, VecDeque},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, OnceLock},
+};
 use tracing::error;
 
 use super::{embedding::EmbeddingExtractor, embedding_manager::EmbeddingManager};
@@ -166,14 +171,49 @@ fn handle_new_segment(
     }
 }
 
+/// A segmentation ONNX session shared across chunks.
+///
+/// `output_name` is the model's output node ("output", or "y" on older
+/// exports; see `super::resolve_output_name`), resolved once at load.
+struct SegSession {
+    session: Mutex<ort::session::Session>,
+    output_name: String,
+}
+
+/// Process-wide cache of segmentation sessions, keyed by model path.
+///
+/// Previously `SegmentIterator::new` called `create_session` on EVERY audio
+/// chunk — loading the ~5.7MB model and building a Level3-optimized graph each
+/// time. Under the pipeline's mixed-size allocation churn the freed session
+/// buffers were not returned to the OS, so `phys_footprint` climbed for the
+/// life of the process (RSS-flat / phys-climbing). The embedding extractor was
+/// already cached and reused; the segmentation session was not. Cache + reuse
+/// one session per model path so the per-chunk allocation churn disappears.
+static SEG_SESSION_CACHE: OnceLock<Mutex<HashMap<PathBuf, Arc<SegSession>>>> = OnceLock::new();
+
+fn cached_seg_session(model_path: &Path) -> Result<Arc<SegSession>> {
+    let cache = SEG_SESSION_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let key = model_path.to_path_buf();
+    if let Some(existing) = cache.lock().unwrap().get(&key) {
+        return Ok(existing.clone());
+    }
+    // Build outside the lock (create_session runs under a watchdog and can be
+    // slow); if another thread wins the race, `or_insert` keeps the first one.
+    let session = super::create_session(model_path)?;
+    let output_name = super::resolve_output_name(&super::session_output_names(&session), "output")?;
+    let built = Arc::new(SegSession {
+        session: Mutex::new(session),
+        output_name,
+    });
+    let mut map = cache.lock().unwrap();
+    Ok(map.entry(key).or_insert(built).clone())
+}
+
 pub struct SegmentIterator {
     samples: Vec<f32>,
     sample_rate: u32,
-    session: ort::session::Session,
-    // Output node name of the segmentation model, resolved once at load time.
-    // Canonical exports name it "output"; older exports name it "y" — see
-    // `super::resolve_output_name`.
-    output_name: String,
+    /// Shared, cached segmentation session (see `cached_seg_session`).
+    seg: Arc<SegSession>,
     embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
     embedding_manager: Arc<Mutex<EmbeddingManager>>,
     current_position: usize,
@@ -196,9 +236,7 @@ impl SegmentIterator {
         embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
         embedding_manager: Arc<Mutex<EmbeddingManager>>,
     ) -> Result<Self> {
-        let session = super::create_session(model_path.as_ref())?;
-        let output_name =
-            super::resolve_output_name(&super::session_output_names(&session), "output")?;
+        let seg = cached_seg_session(model_path.as_ref())?;
         let window_size = (sample_rate * 10) as usize;
 
         let padded_samples = {
@@ -210,8 +248,7 @@ impl SegmentIterator {
         Ok(Self {
             samples,
             sample_rate,
-            session,
-            output_name,
+            seg,
             embedding_extractor,
             embedding_manager,
             current_position: 0,
@@ -260,12 +297,12 @@ impl SegmentIterator {
             .to_owned();
 
         let inputs = ort::inputs![ort::value::TensorRef::from_array_view(array.view())?];
-        let ort_outs = self
-            .session
+        let mut sess_guard = self.seg.session.lock().unwrap();
+        let ort_outs = sess_guard
             .run(inputs)
             .context("Failed to run the session")?;
         let ort_out = ort_outs
-            .get(&self.output_name)
+            .get(&self.seg.output_name)
             .context("Output tensor not found")?;
 
         let ort_out = ort_out
@@ -279,6 +316,9 @@ impl SegmentIterator {
             }
         }
         drop(ort_outs);
+        // Release the shared session before the mutation loop below (which
+        // borrows &mut self via flush_speeching_segment); the run is done.
+        drop(sess_guard);
 
         for max_index in frame_classes {
             if max_index != 0 {


### PR DESCRIPTION
## Root cause (verified)

The reported multi-GB `phys_footprint` growth (RSS-flat, climbing for hours, gated on transcribed speech) is caused by **`SegmentIterator::new` creating a brand-new ONNX segmentation session on every audio chunk** (`create_session` inside `get_segments`). It loads the ~5.7 MB pyannote model and builds a Level3-optimized ORT graph *per 30 s chunk*, then drops it. The embedding extractor is created once and cached — the segmentation session was not.

Under the audio pipeline's mixed-size allocation churn, the macOS system allocator does **not** return those freed session buffers to the OS (the app's `malloc_zone_pressure_relief` reclaims none of them), so `phys_footprint` climbs linearly while RSS stays flat.

## How it was found (real-pipeline loop + bisect)

I drove the **real** pipeline in a loop — `prepare_segments` → segments → `process_transcription_result` → temp SQLite DB, real pyannote models, real speech WAV — sampling macOS `phys_footprint` and toggling stages:

| config | before | after this fix |
|---|---|---|
| full (seg+embed+DB) | **105 MB/1k chunks — CLIMBED** | **23.5 MB/1k — PLATEAUED** |
| get_segments, no DB | **76 MB/1k — CLIMBED** | **16 MB/1k — PLATEAUED** |
| fallback (no get_segments) | 2 MB/1k — PLATEAUED | (control) |
| DB-only | 5 MB/1k — PLATEAUED | (control) |

Removing the per-chunk session creation flips the curve from a linear climb to a flat plateau (~4.5× lower end-to-end growth). A standalone allocator repro confirmed the mechanism: diverse-size churn with a **bounded, fully-freed** working set still left ~2× the live set resident after freeing everything + `pressure_relief` — freed memory the system allocator never returns.

## Fixes

1. **`segment.rs` — cache the segmentation session** (primary). One session per model path in a process-wide `OnceLock` map, shared behind a `Mutex` and locked per window run — mirroring how the embedding extractor is already cached. This removes the per-chunk allocation churn that drove the climb.

2. **`embedding_manager.rs` / `segmentation_manager.rs` — bound speaker clusters** (secondary, related). `EmbeddingManager` defaulted to `max_speakers = usize::MAX` outside meetings and was only cleared *between meetings*, so a long no-meeting session grew speaker clusters without limit — a smaller memory leak **and** a per-segment CPU leak (`search_speaker` scans every cluster). Bounded to `DEFAULT_MAX_SPEAKERS = 1024` (reuses the existing force-merge path meetings already use).

## Verification

- Real-pipeline loop before/after numbers above (macOS `phys_footprint`).
- `cargo test -p screenpipe-audio --lib speaker::` → 26 passed, 1 ignored (incl. new `no_meeting_default_is_bounded_not_unbounded` regression test; existing segmentation/diarization tests still pass, confirming the cached session produces correct segments).

## Notes

- Not a 0.4.25 regression: both leak-telemetry fields (`phys_footprint_gb`, `leak_suspected`) only exist on 0.4.25+, so earlier versions were blind to it; the per-chunk `create_session` and the `usize::MAX` speaker default both predate 0.4.24. Long-standing, revealed by the new telemetry.
- Ruled out along the way (each isolated + loop-tested): the bounded audio channels (PR #5001 — the reported user's channels were empty), the per-request Deepgram `reqwest::Client` (flat under churn), and the segmentation/embedding ORT *runs* in isolation (plateau) — it's specifically the per-chunk session *construction* churn that leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
