### PR TITLE
fix(meeting-notes): block phantom meetings from WhatsApp/Telegram/Signal voice notes

### DIFF
--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/model.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/model.rs
@@ -215,6 +215,22 @@ pub(crate) struct ResolvedSession {
     pub(crate) live_evidence: bool,
 }
 
+/// Result of scanning a messaging app's AX tree for call UI evidence.
+///
+/// When a native platform has `requires_call_signal: true`, the audio-process
+/// detector runs this scan before promoting the candidate to `Native`. If
+/// `is_in_call` is false the candidate is downgraded to `NonMeeting`,
+/// blocking phantom meetings from voice notes (#4776).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallSignalEvidence {
+    /// Lowercased platform name (e.g. "whatsapp", "signal", "telegram").
+    pub platform: String,
+    /// Whether the AX scan found call signals confirming a real call.
+    pub is_in_call: bool,
+    /// Human-readable descriptions of which signals matched (for debug logging).
+    pub matched_signals: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SuppressedSession {
     pub(crate) session_key: ProcessKey,

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -247,6 +247,26 @@ pub(crate) fn resolve_process_candidate(
     }
 
     if let Some((platform, profile_index)) = resolve_native_platform(process, profiles) {
+        // Signal voice note gate (#4776): Signal is an Electron app whose AX
+        // tree is opaque, so we can't scan for call UI. Instead we use the
+        // process bundle ID: voice notes use the `.helper` subprocess while
+        // real calls use `.helper.Renderer`. If the bundle doesn't contain
+        // "renderer", it's a voice note — block it.
+        if platform == "Signal" {
+            let bundle = process
+                .bundle_id
+                .as_deref()
+                .or(process.owner_bundle_id.as_deref())
+                .unwrap_or("");
+            if !bundle.to_lowercase().contains("renderer") {
+                debug!(
+                    "audio-process meeting detector: Signal blocked — voice note helper \
+                     (bundle={:?}, no .Renderer suffix)",
+                    bundle
+                );
+                return ResolvedMeetingCandidate::NonMeeting;
+            }
+        }
         let profile = profile_index.and_then(|idx| profiles.get(idx));
         if candidate_is_ignored(&platform, profile, process, ignored_terms, None, None, None) {
             return ResolvedMeetingCandidate::Ignored;
@@ -391,9 +411,15 @@ pub(crate) fn known_native_bundle_platform(field_lower: &str) -> Option<&'static
     if field_lower.contains("discord") {
         return Some("Discord");
     }
-    // Signal, WhatsApp, and Telegram are intentionally NOT matched here.
-    // They must fall through to the profile-matching loop below so they get
-    // a profile index, which is needed to check `requires_call_signal` (#4776).
+    // Signal is kept here (not gated) because its Electron AX tree is opaque
+    // — we can't distinguish calls from voice notes, so requires_call_signal
+    // is false and it doesn't need a profile index for the gate (#4776).
+    if field_lower.contains("signal") {
+        return Some("Signal");
+    }
+    // WhatsApp and Telegram are intentionally NOT matched here. They must
+    // fall through to the profile-matching loop below so they get a profile
+    // index, which is needed to check `requires_call_signal` (#4776).
     if field_lower.contains("skype") {
         return Some("Skype");
     }

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -365,8 +365,7 @@ pub(crate) fn process_identity_fields(process: &AudioInputProcess) -> Vec<String
         // "\u{200e}WhatsApp"). Strip them so profile name matching works.
         s.chars()
             .filter(|c| {
-                !c.is_control()
-                    && !matches!(c, '\u{200e}' | '\u{200f}' | '\u{200b}' | '\u{feff}')
+                !c.is_control() && !matches!(c, '\u{200e}' | '\u{200f}' | '\u{200b}' | '\u{feff}')
             })
             .collect::<String>()
             .trim()
@@ -743,8 +742,7 @@ pub(crate) async fn build_candidates(
     // call UI (e.g. Calling_Window). Only run during pre-active states —
     // once a meeting is Active the platform is settled.
     if needs_ax_resolution(state) {
-        let call_evidence =
-            scan_messaging_call_signals(&candidates, profiles).await;
+        let call_evidence = scan_messaging_call_signals(&candidates, profiles).await;
         candidates.retain(|candidate| {
             if let ResolvedMeetingCandidate::Native { platform, .. } = candidate {
                 let platform_lower = platform.to_lowercase();
@@ -758,10 +756,7 @@ pub(crate) async fn build_candidates(
                     // real call. If the AX scan timed out or the process had no
                     // PID, no evidence is produced and we err on the side of NOT
                     // starting a phantom meeting.
-                    match call_evidence
-                        .iter()
-                        .find(|e| e.platform == platform_lower)
-                    {
+                    match call_evidence.iter().find(|e| e.platform == platform_lower) {
                         Some(evidence) if evidence.is_in_call => {
                             // Real call confirmed — allow.
                         }

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -252,20 +252,29 @@ pub(crate) fn resolve_process_candidate(
         // process bundle ID: voice notes use the `.helper` subprocess while
         // real calls use `.helper.Renderer`. If the bundle doesn't contain
         // "renderer", it's a voice note — block it.
-        if platform == "Signal" {
-            let bundle = process
-                .bundle_id
-                .as_deref()
-                .or(process.owner_bundle_id.as_deref())
-                .unwrap_or("");
-            if !bundle.to_lowercase().contains("renderer") {
-                debug!(
-                    "audio-process meeting detector: Signal blocked — voice note helper \
-                     (bundle={:?}, no .Renderer suffix)",
-                    bundle
-                );
-                return ResolvedMeetingCandidate::NonMeeting;
-            }
+        //
+        // `bundle_id`/`owner_bundle_id` are macOS-only fields (always `None` on
+        // Windows — see `screenpipe_audio::meeting_processes::platform`), so
+        // the heuristic only fires when one of them is actually present.
+        // Applying it unconditionally used to fail closed on Windows: with
+        // both fields `None`, `unwrap_or("")` always produced a string that
+        // never contains "renderer", so it silently blocked EVERY Windows
+        // Signal session, including real calls (#4998 review). When the
+        // discriminating field is structurally absent, fail open instead —
+        // matching pre-gate behavior on platforms this heuristic can't reach.
+        let signal_bundle = process
+            .bundle_id
+            .as_deref()
+            .or(process.owner_bundle_id.as_deref());
+        if platform == "Signal"
+            && signal_bundle.is_some_and(|b| !b.to_lowercase().contains("renderer"))
+        {
+            debug!(
+                "audio-process meeting detector: Signal blocked — voice note helper \
+                 (bundle={:?}, no .Renderer suffix)",
+                signal_bundle
+            );
+            return ResolvedMeetingCandidate::NonMeeting;
         }
         let profile = profile_index.and_then(|idx| profiles.get(idx));
         if candidate_is_ignored(&platform, profile, process, ignored_terms, None, None, None) {
@@ -338,11 +347,22 @@ pub(crate) fn resolve_native_platform(
     }
 
     for (idx, profile) in profiles.iter().enumerate() {
-        let matches = profile.app_identifiers.macos_app_names.iter().any(|name| {
-            fields
-                .iter()
-                .any(|field| field.eq_ignore_ascii_case(name) || field == &name.to_lowercase())
-        });
+        // Match against both macOS app names and Windows process names: identity
+        // fields are macOS bundle ids/app names on macOS and Windows exe names
+        // (e.g. "whatsapp.exe") on Windows, so a profile with only
+        // `macos_app_names` populated (WhatsApp, Telegram, ...) would otherwise
+        // never resolve on Windows once it's not also in
+        // `known_native_bundle_platform` (#4998 review).
+        let matches = profile
+            .app_identifiers
+            .macos_app_names
+            .iter()
+            .chain(profile.app_identifiers.windows_process_names.iter())
+            .any(|name| {
+                fields
+                    .iter()
+                    .any(|field| field.eq_ignore_ascii_case(name) || field == &name.to_lowercase())
+            });
         if matches {
             return Some((platform_name_for_profile(profile, false), Some(idx)));
         }

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -339,7 +339,19 @@ pub(crate) fn process_identity_fields(process: &AudioInputProcess) -> Vec<String
     ]
     .into_iter()
     .flatten()
-    .map(|s| s.trim().to_lowercase())
+    .map(|s| {
+        // macOS NSRunningApp.localized_name() can prepend invisible Unicode
+        // formatting characters (e.g. U+200E LEFT-TO-RIGHT MARK on WhatsApp:
+        // "\u{200e}WhatsApp"). Strip them so profile name matching works.
+        s.chars()
+            .filter(|c| {
+                !c.is_control()
+                    && !matches!(c, '\u{200e}' | '\u{200f}' | '\u{200b}' | '\u{feff}')
+            })
+            .collect::<String>()
+            .trim()
+            .to_lowercase()
+    })
     .filter(|s| !s.is_empty())
     .collect()
 }
@@ -379,15 +391,9 @@ pub(crate) fn known_native_bundle_platform(field_lower: &str) -> Option<&'static
     if field_lower.contains("discord") {
         return Some("Discord");
     }
-    if field_lower.contains("signal") {
-        return Some("Signal");
-    }
-    if field_lower.contains("whatsapp") {
-        return Some("WhatsApp");
-    }
-    if field_lower.contains("telegram") {
-        return Some("Telegram");
-    }
+    // Signal, WhatsApp, and Telegram are intentionally NOT matched here.
+    // They must fall through to the profile-matching loop below so they get
+    // a profile index, which is needed to check `requires_call_signal` (#4776).
     if field_lower.contains("skype") {
         return Some("Skype");
     }
@@ -599,6 +605,80 @@ pub(crate) fn acquire_input_processes(
     )
 }
 
+/// Scan messaging apps (those with `requires_call_signal: true`) for call UI
+/// evidence in the AX tree. Returns a `CallSignalEvidence` per scanned app.
+///
+/// Only called during pre-active states (`needs_ax_resolution`) and only for
+/// `Native` candidates whose profile requires call signal verification.
+/// Platform-agnostic: delegates to `MeetingUiScanner::scan_process` which
+/// uses AX on macOS, UIA on Windows, and is a no-op on other platforms.
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+async fn scan_messaging_call_signals(
+    candidates: &[ResolvedMeetingCandidate],
+    profiles: &[MeetingDetectionProfile],
+) -> Vec<CallSignalEvidence> {
+    let to_scan: Vec<(String, i32, usize)> = candidates
+        .iter()
+        .filter_map(|c| {
+            if let ResolvedMeetingCandidate::Native {
+                platform, process, ..
+            } = c
+            {
+                let profile_idx = profiles
+                    .iter()
+                    .position(|p| platform_name_for_profile(p, false) == *platform)?;
+                let profile = &profiles[profile_idx];
+                if profile.requires_call_signal {
+                    Some((platform.clone(), process.pid?, profile_idx))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if to_scan.is_empty() {
+        return Vec::new();
+    }
+
+    let profiles = profiles.to_vec();
+    let scan = tokio::task::spawn_blocking(move || {
+        let scanner = crate::meeting_watcher::shared::scanner::MeetingUiScanner::new();
+        to_scan
+            .into_iter()
+            .map(|(platform, pid, profile_idx)| {
+                let profile = &profiles[profile_idx];
+                let result = scanner.scan_process(pid, profile);
+                debug!(
+                    "audio-process meeting detector: call signal scan for {} (pid {}): \
+                     is_in_call={}, signals={:?}",
+                    platform, pid, result.is_in_call, result.matched_signals
+                );
+                CallSignalEvidence {
+                    platform: platform.to_lowercase(),
+                    is_in_call: result.is_in_call,
+                    matched_signals: result.matched_signals,
+                }
+            })
+            .collect()
+    });
+    match tokio::time::timeout(Duration::from_secs(5), scan).await {
+        Ok(Ok(results)) => results,
+        _ => Vec::new(),
+    }
+}
+
+/// Stub: no call signal scanning on unsupported platforms.
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+async fn scan_messaging_call_signals(
+    _candidates: &[ResolvedMeetingCandidate],
+    _profiles: &[MeetingDetectionProfile],
+) -> Vec<CallSignalEvidence> {
+    Vec::new()
+}
+
 /// Run the full candidate pipeline for one snapshot: sticky tracking, optional
 /// AX fallback, profile/URL resolution, then ignore/suppression filtering.
 /// Returns `(candidates, live_candidates)`.
@@ -630,6 +710,58 @@ pub(crate) async fn build_candidates(
         resolve_tracked_candidates(db, profiles, ignored_terms, &tracked, ax_candidates).await;
 
     candidates.retain(|candidate| !matches!(candidate, ResolvedMeetingCandidate::Ignored));
+
+    // Call signal gate for messaging-first platforms (#4776): apps like
+    // WhatsApp/Signal/Telegram grab the mic for voice notes identically to
+    // calls. Before promoting them to Native, scan their AX tree for real
+    // call UI (e.g. Calling_Window). Only run during pre-active states —
+    // once a meeting is Active the platform is settled.
+    if needs_ax_resolution(state) {
+        let call_evidence =
+            scan_messaging_call_signals(&candidates, profiles).await;
+        candidates.retain(|candidate| {
+            if let ResolvedMeetingCandidate::Native { platform, .. } = candidate {
+                let platform_lower = platform.to_lowercase();
+                // Check if this platform requires call signal verification.
+                let requires_gate = profiles.iter().any(|p| {
+                    p.requires_call_signal
+                        && platform_name_for_profile(p, false).to_lowercase() == platform_lower
+                });
+                if requires_gate {
+                    // Fail-closed: block unless we have explicit evidence of a
+                    // real call. If the AX scan timed out or the process had no
+                    // PID, no evidence is produced and we err on the side of NOT
+                    // starting a phantom meeting.
+                    match call_evidence
+                        .iter()
+                        .find(|e| e.platform == platform_lower)
+                    {
+                        Some(evidence) if evidence.is_in_call => {
+                            // Real call confirmed — allow.
+                        }
+                        Some(_) => {
+                            debug!(
+                                "audio-process meeting detector: {} blocked by call signal gate \
+                                 (voice note / idle, no call UI found)",
+                                platform
+                            );
+                            return false;
+                        }
+                        None => {
+                            debug!(
+                                "audio-process meeting detector: {} blocked by call signal gate \
+                                 (no evidence produced — scan may have timed out)",
+                                platform
+                            );
+                            return false;
+                        }
+                    }
+                }
+            }
+            true
+        });
+    }
+
     filter_suppressed_candidates(&mut candidates, suppressed_sessions);
     let live_candidates: Vec<_> = candidates
         .iter()

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -1408,3 +1408,120 @@ fn zoom_not_filtered_by_call_signal_gate() {
         "Zoom must not be affected by call signal gate"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #4998 review: Windows identity shape for WhatsApp/Telegram, and the Signal
+// bundle-id gate must not fail closed on Windows (where bundle_id/
+// owner_bundle_id are structurally absent, not merely non-"renderer").
+// ---------------------------------------------------------------------------
+
+/// Windows-shaped WhatsApp process: no bundle_id/owner_bundle_id (those are
+/// macOS-only fields), identity carried entirely by the `.exe` process name.
+fn whatsapp_process_windows() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("wasapi:whatsapp.exe:99".to_string()),
+        audio_object_id: None,
+        pid: Some(99),
+        bundle_id: None,
+        process_name: Some("whatsapp.exe".to_string()),
+        owner_app_name: None,
+        owner_bundle_id: None,
+        first_seen_at_ms: None,
+    }
+}
+
+/// Windows-shaped Telegram process: same shape as above.
+fn telegram_process_windows() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("wasapi:telegram.exe:102".to_string()),
+        audio_object_id: None,
+        pid: Some(102),
+        bundle_id: None,
+        process_name: Some("telegram.exe".to_string()),
+        owner_app_name: None,
+        owner_bundle_id: None,
+        first_seen_at_ms: None,
+    }
+}
+
+/// Windows-shaped Signal process: same shape as above (a real call — Windows
+/// has no `.helper`/`.helper.Renderer` bundle-id distinction to gate on).
+fn signal_process_windows() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("wasapi:signal.exe:200".to_string()),
+        audio_object_id: None,
+        pid: Some(200),
+        bundle_id: None,
+        process_name: Some("signal.exe".to_string()),
+        owner_app_name: None,
+        owner_bundle_id: None,
+        first_seen_at_ms: None,
+    }
+}
+
+#[test]
+fn whatsapp_resolves_to_native_on_windows_identity_shape() {
+    // Windows never populates bundle_id/owner_bundle_id, so identity is
+    // carried only by `process_name` = "whatsapp.exe". Before the #4998
+    // review fix, the profile-matching fallback loop only checked
+    // `macos_app_names` ("whatsapp"), which never matches "whatsapp.exe",
+    // so WhatsApp (and real WhatsApp calls, not just voice notes) could never
+    // resolve as a Native candidate on Windows at all.
+    let profiles = load_detection_profiles();
+    let process = whatsapp_process_windows();
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(
+        result.is_some(),
+        "WhatsApp should resolve as native from Windows process_name alone"
+    );
+    let (platform, profile_index) = result.unwrap();
+    assert_eq!(platform, "WhatsApp");
+    assert!(
+        profile_index.is_some(),
+        "WhatsApp must still get a profile index on Windows for call signal gating"
+    );
+}
+
+#[test]
+fn telegram_resolves_to_native_on_windows_identity_shape() {
+    let profiles = load_detection_profiles();
+    let process = telegram_process_windows();
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(
+        result.is_some(),
+        "Telegram should resolve as native from Windows process_name alone"
+    );
+    let (platform, profile_index) = result.unwrap();
+    assert_eq!(platform, "Telegram");
+    assert!(
+        profile_index.is_some(),
+        "Telegram must still get a profile index on Windows for call signal gating"
+    );
+}
+
+#[test]
+fn signal_windows_call_not_blocked_by_macos_only_renderer_gate() {
+    // On Windows, bundle_id/owner_bundle_id are always None (structurally
+    // absent, not merely "not containing renderer"). Before the #4998 review
+    // fix, `unwrap_or("")` fed into `.contains("renderer")` always evaluated
+    // to false, so this gate silently blocked EVERY Signal session on
+    // Windows, including real calls. It must fail open there instead.
+    let profiles = load_detection_profiles();
+    let process = signal_process_windows();
+    let session_key = ProcessKey::from_process(&process).unwrap();
+    let result = resolve_process_candidate(
+        session_key,
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
+    assert!(
+        matches!(result, ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "Signal"),
+        "Signal on Windows should resolve as Native (fail open, no bundle-id \
+         discriminator available on this platform): got {:?}",
+        result
+    );
+}

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -1088,15 +1088,30 @@ fn whatsapp_process() -> AudioInputProcess {
     }
 }
 
+/// Signal call: uses the .helper.Renderer subprocess (real WebRTC call).
 fn signal_process() -> AudioInputProcess {
     AudioInputProcess {
-        audio_session_id: Some("coreaudio-process:600:input:built-in-mic".to_string()),
-        audio_object_id: Some(600),
-        pid: Some(101),
-        bundle_id: Some("org.whispersystems.signal-desktop".to_string()),
-        process_name: Some("Signal".to_string()),
-        owner_app_name: Some("Signal".to_string()),
-        owner_bundle_id: Some("org.whispersystems.signal-desktop".to_string()),
+        audio_session_id: Some("coreaudio-process:115:input:BuiltInMicrophoneDevice".to_string()),
+        audio_object_id: Some(115),
+        pid: Some(63225),
+        bundle_id: Some("org.whispersystems.signal-desktop.helper.Renderer".to_string()),
+        process_name: None,
+        owner_app_name: None,
+        owner_bundle_id: None,
+        first_seen_at_ms: None,
+    }
+}
+
+/// Signal voice note: uses the .helper subprocess (no .Renderer suffix).
+fn signal_voice_note_process() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("coreaudio-process:116:input:BuiltInMicrophoneDevice".to_string()),
+        audio_object_id: Some(116),
+        pid: Some(63247),
+        bundle_id: Some("org.whispersystems.signal-desktop.helper".to_string()),
+        process_name: None,
+        owner_app_name: None,
+        owner_bundle_id: None,
         first_seen_at_ms: None,
     }
 }
@@ -1152,23 +1167,65 @@ fn whatsapp_resolves_to_native_with_profile_index() {
 }
 
 #[test]
-fn signal_resolves_to_native_with_profile_index() {
+fn signal_resolves_to_native_without_gate() {
     let profiles = load_detection_profiles();
     let process = signal_process();
     let result = resolve_native_platform(&process, &profiles);
     assert!(result.is_some(), "Signal should resolve as native");
     let (platform, profile_index) = result.unwrap();
     assert_eq!(platform, "Signal");
+    // Signal resolves via known_native_bundle_platform (no profile index)
+    // because its Electron AX tree is opaque — requires_call_signal is
+    // false and the gate is not needed.
     assert!(
-        profile_index.is_some(),
-        "Signal must have a profile index for call signal gating"
+        profile_index.is_none(),
+        "Signal should resolve via known_native_bundle_platform, not profile loop"
     );
-    // Signal's Electron AX tree is opaque (buttons show title="-"), so
-    // requires_call_signal is false until Signal exposes call UI.
-    let profile = &profiles[profile_index.unwrap()];
+}
+
+#[test]
+fn signal_voice_note_blocked_by_renderer_gate() {
+    // Signal voice notes use the .helper subprocess (no .Renderer suffix).
+    // The bundle-based gate should block them as NonMeeting.
+    let profiles = load_detection_profiles();
+    let process = signal_voice_note_process();
+    let session_key = ProcessKey::from_process(&process).unwrap();
+    let result = resolve_process_candidate(
+        session_key,
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
     assert!(
-        !profile.requires_call_signal,
-        "Signal profile must have requires_call_signal = false (opaque AX tree)"
+        matches!(result, ResolvedMeetingCandidate::NonMeeting),
+        "Signal voice note (.helper) should be blocked: got {:?}",
+        result
+    );
+}
+
+#[test]
+fn signal_call_passes_renderer_gate() {
+    // Signal calls use the .helper.Renderer subprocess.
+    // The bundle-based gate should allow them as Native.
+    let profiles = load_detection_profiles();
+    let process = signal_process();
+    let session_key = ProcessKey::from_process(&process).unwrap();
+    let result = resolve_process_candidate(
+        session_key,
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
+    assert!(
+        matches!(result, ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "Signal"),
+        "Signal call (.helper.Renderer) should resolve as Native Signal: got {:?}",
+        result
     );
 }
 

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -1068,3 +1068,286 @@ fn ax_resolution_only_runs_before_a_meeting_is_active() {
         is_browser: true,
     }));
 }
+
+// ---------------------------------------------------------------------------
+// Call signal gate tests (#4776) — WhatsApp/Signal/Telegram voice note phantom
+// meeting prevention.
+// ---------------------------------------------------------------------------
+
+fn whatsapp_process() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("coreaudio-process:500:input:built-in-mic".to_string()),
+        audio_object_id: Some(500),
+        pid: Some(99),
+        bundle_id: Some("net.whatsapp.WhatsApp".to_string()),
+        // macOS prepends U+200E LEFT-TO-RIGHT MARK to WhatsApp's localized name.
+        process_name: Some("\u{200e}WhatsApp".to_string()),
+        owner_app_name: Some("\u{200e}WhatsApp".to_string()),
+        owner_bundle_id: Some("net.whatsapp.WhatsApp".to_string()),
+        first_seen_at_ms: None,
+    }
+}
+
+fn signal_process() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("coreaudio-process:600:input:built-in-mic".to_string()),
+        audio_object_id: Some(600),
+        pid: Some(101),
+        bundle_id: Some("org.whispersystems.signal-desktop".to_string()),
+        process_name: Some("Signal".to_string()),
+        owner_app_name: Some("Signal".to_string()),
+        owner_bundle_id: Some("org.whispersystems.signal-desktop".to_string()),
+        first_seen_at_ms: None,
+    }
+}
+
+fn telegram_process() -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: Some("coreaudio-process:700:input:built-in-mic".to_string()),
+        audio_object_id: Some(700),
+        pid: Some(102),
+        bundle_id: Some("ru.keepcoder.Telegram".to_string()),
+        process_name: Some("Telegram".to_string()),
+        owner_app_name: Some("Telegram".to_string()),
+        owner_bundle_id: Some("ru.keepcoder.Telegram".to_string()),
+        first_seen_at_ms: None,
+    }
+}
+
+#[test]
+fn unicode_ltr_mark_stripped_from_whatsapp_identity() {
+    // macOS returns "\u{200e}WhatsApp" — verify process_identity_fields strips it.
+    let process = whatsapp_process();
+    let fields = process_identity_fields(&process);
+    assert!(
+        fields.iter().any(|f| f == "whatsapp"),
+        "Unicode LTR mark should be stripped: {fields:?}"
+    );
+    assert!(
+        !fields.iter().any(|f| f.contains('\u{200e}')),
+        "No identity field should contain U+200E: {fields:?}"
+    );
+}
+
+#[test]
+fn whatsapp_resolves_to_native_with_profile_index() {
+    // WhatsApp must fall through `known_native_bundle_platform` and match via
+    // the profile loop, which returns a profile index. Without the index,
+    // `requires_call_signal` can never be consulted.
+    let profiles = load_detection_profiles();
+    let process = whatsapp_process();
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(result.is_some(), "WhatsApp should resolve as native");
+    let (platform, profile_index) = result.unwrap();
+    assert_eq!(platform, "WhatsApp");
+    assert!(
+        profile_index.is_some(),
+        "WhatsApp must have a profile index for call signal gating"
+    );
+    let profile = &profiles[profile_index.unwrap()];
+    assert!(
+        profile.requires_call_signal,
+        "WhatsApp profile must have requires_call_signal = true"
+    );
+}
+
+#[test]
+fn signal_resolves_to_native_with_profile_index() {
+    let profiles = load_detection_profiles();
+    let process = signal_process();
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(result.is_some(), "Signal should resolve as native");
+    let (platform, profile_index) = result.unwrap();
+    assert_eq!(platform, "Signal");
+    assert!(
+        profile_index.is_some(),
+        "Signal must have a profile index for call signal gating"
+    );
+    // Signal's Electron AX tree is opaque (buttons show title="-"), so
+    // requires_call_signal is false until Signal exposes call UI.
+    let profile = &profiles[profile_index.unwrap()];
+    assert!(
+        !profile.requires_call_signal,
+        "Signal profile must have requires_call_signal = false (opaque AX tree)"
+    );
+}
+
+#[test]
+fn telegram_resolves_to_native_with_profile_index() {
+    let profiles = load_detection_profiles();
+    let process = telegram_process();
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(result.is_some(), "Telegram should resolve as native");
+    let (platform, profile_index) = result.unwrap();
+    assert_eq!(platform, "Telegram");
+    assert!(
+        profile_index.is_some(),
+        "Telegram must have a profile index for call signal gating"
+    );
+    let profile = &profiles[profile_index.unwrap()];
+    assert!(
+        profile.requires_call_signal,
+        "Telegram profile must have requires_call_signal = true"
+    );
+}
+
+#[test]
+fn zoom_unaffected_by_call_signal_gate() {
+    // Call-first apps must NOT have requires_call_signal. This is a regression
+    // guard: if Zoom is accidentally flagged, every Zoom call would need AX
+    // evidence before starting.
+    let profiles = load_detection_profiles();
+    let process = zoom_process();
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(result.is_some());
+    let (platform, _) = result.unwrap();
+    assert_eq!(platform, "Zoom");
+    // Zoom resolves via known_native_bundle_platform (no profile index), which
+    // is fine — it should never be gated.
+}
+
+#[test]
+fn teams_unaffected_by_call_signal_gate() {
+    let profiles = load_detection_profiles();
+    let teams = AudioInputProcess {
+        audio_session_id: Some("coreaudio-process:800:input:built-in-mic".to_string()),
+        audio_object_id: Some(800),
+        pid: Some(103),
+        bundle_id: Some("com.microsoft.teams2".to_string()),
+        process_name: Some("Microsoft Teams".to_string()),
+        owner_app_name: Some("Microsoft Teams".to_string()),
+        owner_bundle_id: Some("com.microsoft.teams2".to_string()),
+        first_seen_at_ms: None,
+    };
+    let result = resolve_native_platform(&teams, &profiles);
+    assert!(result.is_some());
+    let (platform, _) = result.unwrap();
+    assert_eq!(platform, "Microsoft Teams");
+}
+
+#[test]
+fn whatsapp_without_call_signal_blocked_by_gate() {
+    // Voice note scenario: WhatsApp holds the mic but no Calling_Window is
+    // present. The candidate resolves to Native{WhatsApp} but the call signal
+    // gate should block it.
+    let profiles = load_detection_profiles();
+    let process = whatsapp_process();
+    let candidate = resolve_process_candidate(
+        ProcessKey::from_process(&process).unwrap(),
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
+    // Without the gate (which runs in build_candidates), resolution succeeds.
+    assert!(
+        matches!(
+            candidate,
+            ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "WhatsApp"
+        ),
+        "WhatsApp should resolve to Native before the gate: {candidate:?}"
+    );
+
+    // Simulate what build_candidates does: check call_evidence with no call signals.
+    let call_evidence = vec![CallSignalEvidence {
+        platform: "whatsapp".to_string(),
+        is_in_call: false,
+        matched_signals: vec![],
+    }];
+    let mut candidates = vec![candidate];
+    candidates.retain(|c| {
+        if let ResolvedMeetingCandidate::Native { platform, .. } = c {
+            let platform_lower = platform.to_lowercase();
+            if let Some(evidence) = call_evidence.iter().find(|e| e.platform == platform_lower) {
+                return evidence.is_in_call;
+            }
+        }
+        true
+    });
+    assert!(
+        candidates.is_empty(),
+        "WhatsApp without call signals should be blocked"
+    );
+}
+
+#[test]
+fn whatsapp_with_call_signal_passes_gate() {
+    // Real call scenario: WhatsApp holds the mic AND Calling_Window is present.
+    let profiles = load_detection_profiles();
+    let process = whatsapp_process();
+    let candidate = resolve_process_candidate(
+        ProcessKey::from_process(&process).unwrap(),
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
+    assert!(matches!(
+        candidate,
+        ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "WhatsApp"
+    ));
+
+    let call_evidence = vec![CallSignalEvidence {
+        platform: "whatsapp".to_string(),
+        is_in_call: true,
+        matched_signals: vec!["AutomationIdContains(Calling_Window)".to_string()],
+    }];
+    let mut candidates = vec![candidate];
+    candidates.retain(|c| {
+        if let ResolvedMeetingCandidate::Native { platform, .. } = c {
+            let platform_lower = platform.to_lowercase();
+            if let Some(evidence) = call_evidence.iter().find(|e| e.platform == platform_lower) {
+                return evidence.is_in_call;
+            }
+        }
+        true
+    });
+    assert_eq!(
+        candidates.len(),
+        1,
+        "WhatsApp with call signal should pass the gate"
+    );
+}
+
+#[test]
+fn zoom_not_filtered_by_call_signal_gate() {
+    // Zoom should never appear in call_evidence (requires_call_signal = false),
+    // so it must pass through the retain filter untouched.
+    let profiles = load_detection_profiles();
+    let process = zoom_process();
+    let candidate = resolve_process_candidate(
+        ProcessKey::from_process(&process).unwrap(),
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
+    assert!(matches!(
+        candidate,
+        ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "Zoom"
+    ));
+
+    // No call_evidence for Zoom (scan_messaging_call_signals skips it).
+    let call_evidence: Vec<CallSignalEvidence> = vec![];
+    let mut candidates = vec![candidate];
+    candidates.retain(|c| {
+        if let ResolvedMeetingCandidate::Native { platform, .. } = c {
+            let platform_lower = platform.to_lowercase();
+            if let Some(evidence) = call_evidence.iter().find(|e| e.platform == platform_lower) {
+                return evidence.is_in_call;
+            }
+        }
+        true
+    });
+    assert_eq!(
+        candidates.len(),
+        1,
+        "Zoom must not be affected by call signal gate"
+    );
+}

--- a/crates/screenpipe-engine/src/meeting_watcher/shared/profiles.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/shared/profiles.rs
@@ -81,6 +81,13 @@ pub struct MeetingDetectionProfile {
     /// messaging chrome (e.g. "Leave space"/"Leave team") trips the bare `leave`
     /// signal and starts a phantom meeting. See issue #4145.
     pub ignore_window_titles: &'static [&'static str],
+    /// When true, the audio-process detector must find call UI evidence in the
+    /// AX tree before starting a meeting — mic-hold + app identity alone is not
+    /// enough. This gates messaging-first platforms (WhatsApp, Signal, Telegram)
+    /// where a voice note holds the mic exactly like a call, causing phantom
+    /// meetings (#4776). Call-first platforms (Zoom, Meet, Teams, etc.) set this
+    /// to false and are completely unaffected.
+    pub requires_call_signal: bool,
 }
 
 /// Known browser app names (lowercase).
@@ -138,6 +145,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // Zoom Desktop
         // Note: Zoom on macOS does NOT expose AXWindow — only AXMenuBar.
@@ -211,6 +219,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // Google Meet (browser)
         // NOTE: "google meet" removed from url_patterns — it's too broad and matches
@@ -240,6 +249,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // Slack Huddle (browser + desktop)
         MeetingDetectionProfile {
@@ -261,6 +271,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // FaceTime
         MeetingDetectionProfile {
@@ -282,6 +293,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // Webex
         MeetingDetectionProfile {
@@ -322,6 +334,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             // title, so a window-title guard could never catch it. Kept because a
             // window titled exactly `Webex` is unambiguously the messaging shell.
             ignore_window_titles: &["webex"],
+            requires_call_signal: false,
         },
         // Discord in browser — require BOTH "Voice Connected" bar AND "Disconnect"
         // button. Either alone can appear without being in a call (e.g. seeing other
@@ -342,11 +355,13 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 2,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // Signal — voice/video calls
-        // macOS: "Signal" app with "End Call" / "Hang Up" button during active calls.
-        // Windows: "Signal.exe" Electron app, same button patterns.
-        // Signal also shows a call status bar with duration when a call is active.
+        // macOS: Signal is an Electron app whose AX tree is opaque — buttons
+        // show title="-" with no useful text, so we cannot distinguish calls
+        // from voice notes via AX scanning. requires_call_signal is false
+        // until Signal exposes call UI in its accessibility tree (#4776).
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["signal"],
@@ -377,8 +392,25 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
         // WhatsApp — voice/video calls
+        // requires_call_signal: true — WhatsApp grabs the mic for voice notes
+        // just like a call; without this gate, every voice note starts a phantom
+        // meeting (#4776).
+        //
+        // Signal selection rationale (from live AX tree investigation):
+        //   - NameContains("End call") is UNUSABLE: WhatsApp has a permanent
+        //     "End Call" AXMenuItem in its menu bar at ALL times (idle, voice
+        //     note, and call). It cannot discriminate.
+        //   - RoleWithName { AXButton, "end call" } NEVER MATCHES: WhatsApp
+        //     exposes no AXButton for call controls on macOS.
+        //   - AutomationIdContains("Calling_Window") is the PRIMARY signal:
+        //     during a real call WhatsApp opens a second AXWindow containing an
+        //     AXGroup with id="Calling_Window". This is locale-independent and
+        //     only present during active calls (voice or video).
+        //   - RoleWithName { AXButton, "leave call" } is the SECONDARY signal:
+        //     an AXButton with desc="leave call" inside the Calling_Window.
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["whatsapp"],
@@ -387,24 +419,32 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
                 browser_title_patterns: &[],
             },
             call_signals: vec![
+                // macOS: locale-independent AXGroup id, only present during
+                // active voice/video calls (never during voice notes or idle).
+                CallSignal::AutomationIdContains("Calling_Window"),
+                // macOS: AXButton inside the call window.
                 CallSignal::RoleWithName {
                     role: "AXButton",
-                    name_contains: "end call",
+                    name_contains: "leave call",
                 },
-                CallSignal::RoleWithName {
-                    role: "AXButton",
-                    name_contains: "hang up",
-                },
-                CallSignal::NameContains("End call"),
+                // Windows UIA button patterns
                 CallSignal::RoleWithName {
                     role: "Button",
                     name_contains: "End call",
                 },
+                CallSignal::RoleWithName {
+                    role: "Button",
+                    name_contains: "Hang up",
+                },
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: true,
         },
         // Telegram — voice/video calls
+        // requires_call_signal: true — Telegram grabs the mic for voice notes
+        // just like a call; without this gate, every voice note starts a phantom
+        // meeting (#4776).
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["telegram"],
@@ -430,6 +470,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: true,
         },
         // Generic fallback — catches apps like Skype, Around, Whereby, etc.
         MeetingDetectionProfile {
@@ -532,6 +573,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             ],
             min_signals_required: 1,
             ignore_window_titles: &[],
+            requires_call_signal: false,
         },
     ];
     profiles.extend(crate::meeting_watcher::ui_scan::discord_profile());

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
@@ -555,6 +555,7 @@ pub(crate) fn discord_profile() -> Option<MeetingDetectionProfile> {
         ],
         min_signals_required: 2,
         ignore_window_titles: &[],
+        requires_call_signal: false,
     })
 }
 

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
@@ -76,6 +76,7 @@ fn zoom_test_profile() -> MeetingDetectionProfile {
         call_signals: vec![],
         min_signals_required: 1,
         ignore_window_titles: &[],
+        requires_call_signal: false,
     }
 }
 

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/windows.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/windows.rs
@@ -705,6 +705,7 @@ pub(crate) fn discord_profile() -> Option<MeetingDetectionProfile> {
         ],
         min_signals_required: 1,
         ignore_window_titles: &[],
+        requires_call_signal: false,
     })
 }
 


### PR DESCRIPTION
## Summary

Fixes #4776 — WhatsApp, Telegram, and Signal voice notes hold the mic exactly like a real call, so the audio-process meeting detector was starting phantom meetings whenever a user recorded/played a voice note in these messaging apps.

- Adds a `requires_call_signal` flag to `MeetingDetectionProfile`. WhatsApp and Telegram now require AX-tree evidence of real call UI (e.g. `Calling_Window`) before a candidate is promoted to a `Native` meeting — mic-hold + app identity alone is no longer sufficient. Call-first platforms (Zoom, Meet, Teams, Slack Huddle, FaceTime) set this to `false` and are unaffected.
- Signal's Electron AX tree is opaque (can't distinguish call UI), so it instead uses a process bundle-id gate: voice notes spawn the `.helper` subprocess while real calls spawn `.helper.Renderer`. Only bundle ids containing "renderer" pass.
- Fixes a `NSRunningApplication.localizedName()` quirk where macOS prepends an invisible LTR mark (`U+200E`) to "WhatsApp", which broke profile name matching.
- Review follow-ups from the initial PR (#4998):
  - The Windows fallback path only checked `macos_app_names` when resolving native platforms, so WhatsApp/Telegram — deliberately removed from the always-native bundle list so they'd get a profile index for the new gate — could never resolve as Native on Windows at all (not just voice notes, real calls too). Now also matches `windows_process_names`.
  - The Signal bundle-id gate used `unwrap_or("")` on macOS-only fields (`bundle_id`/`owner_bundle_id`), which are always `None` on Windows. That made the gate fail closed on every Windows Signal session, including real calls. The gate now only fires when one of those fields is actually present, and fails open otherwise.

## Test plan
- [x] `cargo test -p screenpipe-engine --lib meeting_watcher::audio_process` — 44/44 passing, including new coverage for: Signal renderer gate (macOS + Windows-shaped identity), WhatsApp/Telegram call-signal gate (blocked/passed), Windows exe-name resolution fallback, and the Unicode LTR-mark stripping fix.
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)