### PR TITLE
revert(audio): restore channel caps — leak was root-caused elsewhere (#5006)

### DIFF
--- a/crates/screenpipe-config/src/defaults.rs
+++ b/crates/screenpipe-config/src/defaults.rs
@@ -88,7 +88,7 @@ pub fn detect_tier() -> DeviceTier {
 /// Database configuration tuned per device tier.
 ///
 /// Controls SQLite PRAGMA values and connection pool sizes.
-/// `Default` returns the High-tier channel caps.
+/// `Default` returns the High-tier values matching the previous hardcoded settings.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DbConfig {
     /// SQLite `mmap_size` pragma in bytes.
@@ -192,7 +192,7 @@ pub const WAL_SAFETY_PRAGMAS: [(&str, &str); 4] = [
 /// Audio/transcription channel capacities tuned per device tier.
 ///
 /// Controls the `crossbeam::channel::bounded` sizes in `AudioManager`.
-/// `Default` returns the High-tier channel caps.
+/// `Default` returns the High-tier values matching the previous hardcoded settings.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ChannelConfig {
     /// Capacity for the audio recording channel.
@@ -207,26 +207,23 @@ impl ChannelConfig {
         match tier {
             DeviceTier::High => Self::default(),
             DeviceTier::Mid => Self {
-                recording_capacity: 12,
-                transcription_capacity: 12,
+                recording_capacity: 500,
+                transcription_capacity: 500,
             },
             DeviceTier::Low => Self {
-                recording_capacity: 8,
-                transcription_capacity: 8,
+                recording_capacity: 100,
+                transcription_capacity: 100,
             },
         }
     }
 }
 
 impl Default for ChannelConfig {
-    /// High-tier cap for the audio recording + transcription channels.
-    /// Items are multi-MB audio segments; the previous 1000 allowed ~24GB of
-    /// buffered audio to accumulate when transcription lagged. Bounded low so a
-    /// slow transcriber drops old audio instead of leaking memory.
+    /// High-tier defaults — identical to the previous hardcoded values (1000).
     fn default() -> Self {
         Self {
-            recording_capacity: 16,
-            transcription_capacity: 16,
+            recording_capacity: 1000,
+            transcription_capacity: 1000,
         }
     }
 }


### PR DESCRIPTION
## description

Reverts #5001.

#5001 capped the audio recording/transcription channel sizes (Low 100→8, Mid 500→12, High 1000→16) to address a reported multi-GB `phys_footprint` leak, on the theory that transcription lag was letting multi-MB audio buffers pile up in the channel.

A follow-up investigation in #5006 (merged ~3 hours later the same day) root-caused the actual leak to a different mechanism: `SegmentIterator` was creating a brand-new ONNX segmentation session on every 30s audio chunk instead of caching it (the embedding extractor was already cached; the segmentation session wasn't). That per-chunk churn is what macOS's allocator wouldn't reclaim. #5006's own writeup explicitly checked and ruled out the channel-backlog theory:

> "Ruled out along the way (each isolated + loop-tested): the bounded audio channels (PR #5001 — the reported user's channels were empty)..."

#5006's fix (cache the session) is verified with a real-pipeline benchmark — 105 MB/1k chunks climbing → 23.5 MB/1k plateaued — and is already merged to main. It's a good, well-isolated fix, and the RAM-tier-scaling observation in #5001 (bigger machines got proportionally bigger buffers, which is backwards for a queue of large items) was a reasonable thing to flag — it just turned out not to be what was producing this particular leak.

With the actual leak fixed independently, #5001's caps are now just a regression with no offsetting benefit: on Low-tier machines they cut how much backlog the pipeline tolerates before it starts silently dropping unprocessed audio (via the existing `send_timeout` fallback) from ~50 minutes down to ~4 minutes. PostHog telemetry (`audio_pipeline_health`, CI/Action-runner traffic filtered out) shows Low-tier devices already hit that drop condition more often than Mid/High tier even under the old, much larger caps — so the tier that needed backlog headroom most is the one #5001 cut the hardest.

This PR restores the pre-#5001 capacities (100 / 500 / 1000). It does not touch #5006's fix.

related issue: none — direct follow-up from reviewing #5001

## how to test

1. `cargo test -p screenpipe-config defaults::` — the tier-ordering tests (`channel_config_low_is_smaller`, `channel_config_default_matches_high`) pass unchanged with the restored values (14 passed).
2. This is a backend-only config default change (no UI surface), so no screen recording applies.
3. A dashboard is now live to catch a real regression here if one ever shows up: [Audio Pipeline: Data Loss & Retention by Device Tier](https://us.posthog.com/project/330448/dashboard/1817964) — tracks recording-channel drop rate and end-to-end retention by device tier, CI/Action-runner traffic excluded. Worth a glance before/after this merges.