### PR TITLE
feat(macos): quit confirmation dialog

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1047,7 +1047,7 @@ async fn main() {
                             });
                         }
                         "quit_app" => {
-                            process_exit::request_app_quit(app_handle.clone());
+                            process_exit::confirm_and_request_app_quit(app_handle.clone());
                         }
                         _ => {}
                     }

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -2052,8 +2052,25 @@ async fn main() {
                     } else if process_exit::QUIT_REQUESTED.load(std::sync::atomic::Ordering::SeqCst) {
                         info!("ExitRequested event — quit was requested, allowing exit");
                     } else {
-                        info!("ExitRequested event — preventing (app stays in tray)");
-                        api.prevent_exit();
+                        // Native terminate: (dock right-click → Quit, AppleScript
+                        // quit, OS shutdown). During shutdown/logout a dialog
+                        // would invisibly block the session, so let those exit
+                        // cleanly (RunEvent::Exit still runs teardown).
+                        #[cfg(target_os = "macos")]
+                        {
+                            if process_exit::os_session_is_ending() {
+                                info!("ExitRequested event — OS session ending, allowing exit");
+                            } else {
+                                info!("ExitRequested event — preventing, showing quit confirmation");
+                                api.prevent_exit();
+                                process_exit::confirm_and_request_app_quit(app_handle.app_handle().clone());
+                            }
+                        }
+                        #[cfg(not(target_os = "macos"))]
+                        {
+                            info!("ExitRequested event — preventing (app stays in tray)");
+                            api.prevent_exit();
+                        }
                     }
                 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -2019,6 +2019,10 @@ async fn main() {
             let app_handle_dock = app.app_handle().clone();
             dock_menu::setup_dock_menu(app_handle_dock);
         }
+
+        // Route native terminate: (dock Quit, AppleScript quit) through the
+        // quit confirmation — tao never surfaces it as ExitRequested.
+        process_exit::setup_terminate_interceptor(app.app_handle().clone());
     }
 
     app.run(|app_handle, event| {
@@ -2052,19 +2056,17 @@ async fn main() {
                     } else if process_exit::QUIT_REQUESTED.load(std::sync::atomic::Ordering::SeqCst) {
                         info!("ExitRequested event — quit was requested, allowing exit");
                     } else {
-                        // Native terminate: (dock right-click → Quit, AppleScript
-                        // quit, OS shutdown). During shutdown/logout a dialog
-                        // would invisibly block the session, so let those exit
-                        // cleanly (RunEvent::Exit still runs teardown).
+                        // Note: native terminate: (dock Quit, AppleScript quit)
+                        // never reaches this event on tao 0.35 — it is
+                        // intercepted by process_exit::setup_terminate_interceptor.
+                        // This branch only fires for unexpected programmatic
+                        // exits (e.g. a stray app.exit()), so ask instead of
+                        // silently dying or silently staying alive.
                         #[cfg(target_os = "macos")]
                         {
-                            if process_exit::os_session_is_ending() {
-                                info!("ExitRequested event — OS session ending, allowing exit");
-                            } else {
-                                info!("ExitRequested event — preventing, showing quit confirmation");
-                                api.prevent_exit();
-                                process_exit::confirm_and_request_app_quit(app_handle.app_handle().clone());
-                            }
+                            info!("ExitRequested event — preventing, showing quit confirmation");
+                            api.prevent_exit();
+                            process_exit::confirm_and_request_app_quit(app_handle.app_handle().clone());
                         }
                         #[cfg(not(target_os = "macos"))]
                         {

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -330,17 +330,48 @@ pub fn setup_terminate_interceptor(app_handle: AppHandle) {
     }
 }
 
-/// Hide the whole app (all windows) and return focus to the previous app —
-/// the "Minimize to Tray" choice in the quit dialog. The tray icon stays.
+/// True when any screenpipe window is showing. Decides whether the quit
+/// dialog offers "Minimize to Tray" — pointless when everything is already
+/// hidden (e.g. quitting from the tray with no windows open).
+///
+/// The main overlay panel is checked via the logical [`MAIN_PANEL_SHOWN`]
+/// flag because `is_visible()` returns true even at alpha 0 (see panel.rs).
+#[cfg(target_os = "macos")]
+fn any_window_visible(app: &AppHandle) -> bool {
+    if crate::window::MAIN_PANEL_SHOWN.load(Ordering::SeqCst) {
+        return true;
+    }
+    app.webview_windows().iter().any(|(label, window)| {
+        !matches!(label.as_str(), "main" | "main-window")
+            && window.is_visible().unwrap_or(false)
+    })
+}
+
+/// Hide every window — the "Minimize to Tray" choice in the quit dialog.
+/// The tray icon stays and recording keeps running.
+///
+/// Mirrors the window-close (X) path in main.rs rather than `[NSApp hide:]`:
+/// the main overlay is a tauri_nspanel NSPanel (alpha/ordering semantics)
+/// that does not participate in app-hide, so it must go through its own
+/// close machinery.
 #[cfg(target_os = "macos")]
 fn hide_app_to_tray(app: &AppHandle) {
-    let _ = app.run_on_main_thread(|| {
-        use objc::{msg_send, sel, sel_impl};
-        use tauri_nspanel::cocoa::base::{id, nil};
-        unsafe {
-            let ns_app: id = msg_send![objc::class!(NSApplication), sharedApplication];
-            let _: () = msg_send![ns_app, hide: nil];
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        crate::commands::hide_main_window(app.clone());
+
+        for (label, window) in app.webview_windows() {
+            if matches!(label.as_str(), "main" | "main-window") {
+                continue; // handled by hide_main_window above
+            }
+            if window.is_visible().unwrap_or(false) {
+                let _ = window.set_always_on_top(false);
+                let _ = window.set_visible_on_all_workspaces(false);
+                let _ = window.hide();
+            }
         }
+
+        crate::window::reset_to_regular_and_refresh_tray(&app);
     });
 }
 
@@ -366,6 +397,9 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
         DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
     };
 
+    // NSAlert binds Return to the first button and Escape only to a button
+    // titled exactly "Cancel" (rfd sets no key equivalents of its own) —
+    // renaming/localizing the cancel label would silently drop Escape.
     const QUIT_BUTTON: &str = "Quit screenpipe";
     const MINIMIZE_BUTTON: &str = "Minimize to Tray";
     const CANCEL_BUTTON: &str = "Cancel";
@@ -400,16 +434,24 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
         }
     });
 
+    // Offer "Minimize to Tray" only when there is something to minimize;
+    // with all windows already hidden it would be a dead button.
+    let buttons = if any_window_visible(&app) {
+        MessageDialogButtons::YesNoCancelCustom(
+            QUIT_BUTTON.to_string(),
+            MINIMIZE_BUTTON.to_string(),
+            CANCEL_BUTTON.to_string(),
+        )
+    } else {
+        MessageDialogButtons::OkCancelCustom(QUIT_BUTTON.to_string(), CANCEL_BUTTON.to_string())
+    };
+
     app.clone()
         .dialog()
         .message("Screen and audio recording will stop.")
         .title("Quit screenpipe?")
         .kind(MessageDialogKind::Warning)
-        .buttons(MessageDialogButtons::YesNoCancelCustom(
-            QUIT_BUTTON.to_string(),
-            MINIMIZE_BUTTON.to_string(),
-            CANCEL_BUTTON.to_string(),
-        ))
+        .buttons(buttons)
         .show_with_result(move |result| {
             QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
             match result {

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -393,17 +393,6 @@ fn hide_app_to_tray(app: &AppHandle) {
 /// they never block on a dialog.
 #[cfg(target_os = "macos")]
 pub fn confirm_and_request_app_quit(app: AppHandle) {
-    use tauri_plugin_dialog::{
-        DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
-    };
-
-    // NSAlert binds Return to the first button and Escape only to a button
-    // titled exactly "Cancel" (rfd sets no key equivalents of its own) —
-    // renaming/localizing the cancel label would silently drop Escape.
-    const QUIT_BUTTON: &str = "Quit screenpipe";
-    const MINIMIZE_BUTTON: &str = "Minimize to Tray";
-    const CANCEL_BUTTON: &str = "Cancel";
-
     if QUIT_TEARDOWN_STARTED.load(Ordering::SeqCst) {
         return;
     }
@@ -422,49 +411,95 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
         return;
     }
 
+    // Offer "Minimize to Tray" only when there is something to minimize;
+    // with all windows already hidden it would be a dead button.
+    let show_minimize = any_window_visible(&app);
+
     // Tray quit can fire while the app is inactive (or Accessory / tray-only),
     // which would leave the alert buried behind other apps.
     crate::space_monitor::suppress_space_monitor(500);
-    let _ = app.run_on_main_thread(|| {
-        use objc::{msg_send, sel, sel_impl};
-        use tauri_nspanel::cocoa::base::id;
-        unsafe {
-            let ns_app: id = msg_send![objc::class!(NSApplication), sharedApplication];
-            let _: () = msg_send![ns_app, activateIgnoringOtherApps: true];
-        }
+
+    let app_for_closure = app.clone();
+    let dispatched = app.run_on_main_thread(move || {
+        // A hand-rolled NSAlert, not tauri_plugin_dialog: a parentless plugin
+        // dialog routes through rfd's CFUserNotificationDisplayAlert, which
+        // ignores the app icon and renders a generic caution triangle. NSAlert
+        // uses the app icon and gives the centered, app-modal look.
+        show_quit_alert(&app_for_closure, show_minimize);
     });
+    if dispatched.is_err() {
+        QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
+    }
+}
 
-    // Offer "Minimize to Tray" only when there is something to minimize;
-    // with all windows already hidden it would be a dead button.
-    let buttons = if any_window_visible(&app) {
-        MessageDialogButtons::YesNoCancelCustom(
-            QUIT_BUTTON.to_string(),
-            MINIMIZE_BUTTON.to_string(),
-            CANCEL_BUTTON.to_string(),
-        )
-    } else {
-        MessageDialogButtons::OkCancelCustom(QUIT_BUTTON.to_string(), CANCEL_BUTTON.to_string())
-    };
+/// Build and run the quit-confirmation NSAlert on the main thread, then act on
+/// the choice. Must be called on the main thread (via `run_on_main_thread`);
+/// `runModal` spins a nested modal loop until the user responds.
+#[cfg(target_os = "macos")]
+fn show_quit_alert(app: &AppHandle, show_minimize: bool) {
+    use objc::{class, msg_send, sel, sel_impl};
+    use tauri_nspanel::cocoa::base::{id, nil};
+    use tauri_nspanel::cocoa::foundation::NSString;
 
-    app.clone()
-        .dialog()
-        .message("Screen and audio recording will stop.")
-        .title("Quit screenpipe?")
-        .kind(MessageDialogKind::Warning)
-        .buttons(buttons)
-        .show_with_result(move |result| {
-            QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
-            match result {
-                MessageDialogResult::Custom(label) if label == QUIT_BUTTON => {
-                    request_app_quit(app);
+    // NSAlert binds Return to the first button and Escape only to a button
+    // titled exactly "Cancel", so the order and the literal label matter.
+    const QUIT_BUTTON: &str = "Quit screenpipe";
+    const MINIMIZE_BUTTON: &str = "Minimize to Tray";
+    const CANCEL_BUTTON: &str = "Cancel";
+
+    // NSModalResponse for the first/second added button.
+    const FIRST_BUTTON: i64 = 1000;
+    const SECOND_BUTTON: i64 = 1001;
+
+    unsafe {
+        let ns_app: id = msg_send![class!(NSApplication), sharedApplication];
+        let _: () = msg_send![ns_app, activateIgnoringOtherApps: true];
+
+        let alert: id = msg_send![class!(NSAlert), new];
+        // NSAlertStyleInformational — app icon, never a caution-triangle badge.
+        let _: () = msg_send![alert, setAlertStyle: 1i64];
+
+        let title = NSString::alloc(nil).init_str("Quit screenpipe?");
+        let _: () = msg_send![alert, setMessageText: title];
+        let message = NSString::alloc(nil).init_str("Screen and audio recording will stop.");
+        let _: () = msg_send![alert, setInformativeText: message];
+
+        let quit = NSString::alloc(nil).init_str(QUIT_BUTTON);
+        let _: id = msg_send![alert, addButtonWithTitle: quit];
+        if show_minimize {
+            let minimize = NSString::alloc(nil).init_str(MINIMIZE_BUTTON);
+            let _: id = msg_send![alert, addButtonWithTitle: minimize];
+        }
+        let cancel = NSString::alloc(nil).init_str(CANCEL_BUTTON);
+        let _: id = msg_send![alert, addButtonWithTitle: cancel];
+
+        // Packaged builds inherit the bundle icon automatically; a bare dev
+        // binary has none, so load the repo icon explicitly.
+        #[cfg(debug_assertions)]
+        {
+            let icns = concat!(env!("CARGO_MANIFEST_DIR"), "/icons/dev/icon.icns");
+            if std::path::Path::new(icns).exists() {
+                let path = NSString::alloc(nil).init_str(icns);
+                let image: id = msg_send![class!(NSImage), alloc];
+                let image: id = msg_send![image, initWithContentsOfFile: path];
+                if image != nil {
+                    let _: () = msg_send![alert, setIcon: image];
                 }
-                MessageDialogResult::Custom(label) if label == MINIMIZE_BUTTON => {
-                    info!("Quit dialog: minimizing to tray instead");
-                    hide_app_to_tray(&app);
-                }
-                _ => info!("Quit cancelled by user"),
             }
-        });
+        }
+
+        let response: i64 = msg_send![alert, runModal];
+        QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
+
+        match response {
+            FIRST_BUTTON => request_app_quit(app.clone()),
+            SECOND_BUTTON if show_minimize => {
+                info!("Quit dialog: minimizing to tray instead");
+                hide_app_to_tray(app);
+            }
+            _ => info!("Quit cancelled by user"),
+        }
+    }
 }
 
 #[cfg(not(target_os = "macos"))]

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -414,6 +414,7 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
     // Offer "Minimize to Tray" only when there is something to minimize;
     // with all windows already hidden it would be a dead button.
     let show_minimize = any_window_visible(&app);
+    let message = quit_message(&app, show_minimize);
 
     // Tray quit can fire while the app is inactive (or Accessory / tray-only),
     // which would leave the alert buried behind other apps.
@@ -425,10 +426,36 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
         // dialog routes through rfd's CFUserNotificationDisplayAlert, which
         // ignores the app icon and renders a generic caution triangle. NSAlert
         // uses the app icon and gives the centered, app-modal look.
-        show_quit_alert(&app_for_closure, show_minimize);
+        show_quit_alert(&app_for_closure, show_minimize, &message);
     });
     if dispatched.is_err() {
         QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Informative text for the quit dialog. Names exactly what stops (so the user
+/// is not warned about recording they turned off), then nudges toward Minimize
+/// to Tray as the keep-recording option when that button is offered. Falls back
+/// to the both-on wording when settings can't be read.
+#[cfg(target_os = "macos")]
+fn quit_message(app: &AppHandle, show_minimize: bool) -> String {
+    let (audio_on, vision_on) = crate::store::SettingsStore::get(app)
+        .ok()
+        .flatten()
+        .map(|s| (!s.recording.disable_audio, !s.recording.disable_vision))
+        .unwrap_or((true, true));
+
+    let stops = match (vision_on, audio_on) {
+        (true, true) => "Screen and audio recording will stop",
+        (true, false) => "Screen recording will stop",
+        (false, true) => "Audio recording will stop",
+        (false, false) => "All recording will stop",
+    };
+
+    if show_minimize {
+        format!("{stops}. Minimize to Tray to keep recording in the background.")
+    } else {
+        format!("{stops} when you quit.")
     }
 }
 
@@ -436,7 +463,7 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
 /// the choice. Must be called on the main thread (via `run_on_main_thread`);
 /// `runModal` spins a nested modal loop until the user responds.
 #[cfg(target_os = "macos")]
-fn show_quit_alert(app: &AppHandle, show_minimize: bool) {
+fn show_quit_alert(app: &AppHandle, show_minimize: bool, message: &str) {
     use objc::{class, msg_send, sel, sel_impl};
     use tauri_nspanel::cocoa::base::{id, nil};
     use tauri_nspanel::cocoa::foundation::NSString;
@@ -461,7 +488,7 @@ fn show_quit_alert(app: &AppHandle, show_minimize: bool) {
 
         let title = NSString::alloc(nil).init_str("Quit screenpipe?");
         let _: () = msg_send![alert, setMessageText: title];
-        let message = NSString::alloc(nil).init_str("Screen and audio recording will stop.");
+        let message = NSString::alloc(nil).init_str(message);
         let _: () = msg_send![alert, setInformativeText: message];
 
         let quit = NSString::alloc(nil).init_str(QUIT_BUTTON);

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -199,6 +199,50 @@ pub fn request_app_relaunch(app: AppHandle, reason: &'static str, delay: Duratio
 /// Guards against stacking confirmation dialogs on repeated Cmd+Q presses.
 static QUIT_CONFIRM_SHOWING: AtomicBool = AtomicBool::new(false);
 
+/// True when the in-flight `terminate:` request comes from OS shutdown,
+/// restart, or logout. Mirrors ghostty's `applicationShouldTerminate` check of
+/// the AppleEvent `why?` attribute (kAEShutDown / kAERestart / kAEReallyLogOut)
+/// — a confirmation dialog there would invisibly block the session from
+/// ending. Must be called on the main thread while the terminate request is
+/// being dispatched (i.e. from the `ExitRequested` handler).
+#[cfg(target_os = "macos")]
+pub fn os_session_is_ending() -> bool {
+    use objc::{class, msg_send, sel, sel_impl};
+    use tauri_nspanel::cocoa::base::id;
+    unsafe {
+        let manager: id = msg_send![class!(NSAppleEventManager), sharedAppleEventManager];
+        if manager.is_null() {
+            return false;
+        }
+        let event: id = msg_send![manager, currentAppleEvent];
+        if event.is_null() {
+            return false;
+        }
+        const WHY_KEYWORD: u32 = u32::from_be_bytes(*b"why?");
+        let descriptor: id = msg_send![event, attributeDescriptorForKeyword: WHY_KEYWORD];
+        if descriptor.is_null() {
+            return false;
+        }
+        let reason: u32 = msg_send![descriptor, typeCodeValue];
+        // kAEShutDown, kAERestart, kAEReallyLogOut, kAELogOut
+        matches!(&reason.to_be_bytes(), b"shut" | b"rest" | b"rlgo" | b"logo")
+    }
+}
+
+/// Hide the whole app (all windows) and return focus to the previous app —
+/// the "Minimize to Tray" choice in the quit dialog. The tray icon stays.
+#[cfg(target_os = "macos")]
+fn hide_app_to_tray(app: &AppHandle) {
+    let _ = app.run_on_main_thread(|| {
+        use objc::{msg_send, sel, sel_impl};
+        use tauri_nspanel::cocoa::base::{id, nil};
+        unsafe {
+            let ns_app: id = msg_send![objc::class!(NSApplication), sharedApplication];
+            let _: () = msg_send![ns_app, hide: nil];
+        }
+    });
+}
+
 /// Ask the user to confirm before quitting (native dialog), then run
 /// [`request_app_quit`] on confirm.
 ///
@@ -208,13 +252,22 @@ static QUIT_CONFIRM_SHOWING: AtomicBool = AtomicBool::new(false);
 /// command; our equivalent is an active recording (`capture_intended`). A
 /// stopped or never-started capture quits silently.
 ///
-/// Only user-initiated quit paths (app menu Cmd+Q, tray Quit) go through
-/// here — programmatic paths (updater restart, relaunch) call
-/// [`request_app_quit`] / [`request_app_relaunch`] directly so they never
-/// block on a dialog.
+/// Offers Quit / Minimize to Tray / Cancel — this is a tray app, so backing
+/// out into the tray is a first-class choice.
+///
+/// Only user-initiated quit paths (app menu Cmd+Q, tray Quit, dock Quit via
+/// `ExitRequested`) go through here — programmatic paths (updater restart,
+/// relaunch) call [`request_app_quit`] / [`request_app_relaunch`] directly so
+/// they never block on a dialog.
 #[cfg(target_os = "macos")]
 pub fn confirm_and_request_app_quit(app: AppHandle) {
-    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+    use tauri_plugin_dialog::{
+        DialogExt, MessageDialogButtons, MessageDialogKind, MessageDialogResult,
+    };
+
+    const QUIT_BUTTON: &str = "Quit screenpipe";
+    const MINIMIZE_BUTTON: &str = "Minimize to Tray";
+    const CANCEL_BUTTON: &str = "Cancel";
 
     if QUIT_TEARDOWN_STARTED.load(Ordering::SeqCst) {
         return;
@@ -251,16 +304,22 @@ pub fn confirm_and_request_app_quit(app: AppHandle) {
         .message("Screen and audio recording will stop.")
         .title("Quit screenpipe?")
         .kind(MessageDialogKind::Warning)
-        .buttons(MessageDialogButtons::OkCancelCustom(
-            "Quit screenpipe".to_string(),
-            "Cancel".to_string(),
+        .buttons(MessageDialogButtons::YesNoCancelCustom(
+            QUIT_BUTTON.to_string(),
+            MINIMIZE_BUTTON.to_string(),
+            CANCEL_BUTTON.to_string(),
         ))
-        .show(move |confirmed| {
+        .show_with_result(move |result| {
             QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
-            if confirmed {
-                request_app_quit(app);
-            } else {
-                info!("Quit cancelled by user");
+            match result {
+                MessageDialogResult::Custom(label) if label == QUIT_BUTTON => {
+                    request_app_quit(app);
+                }
+                MessageDialogResult::Custom(label) if label == MINIMIZE_BUTTON => {
+                    info!("Quit dialog: minimizing to tray instead");
+                    hide_app_to_tray(&app);
+                }
+                _ => info!("Quit cancelled by user"),
             }
         });
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -196,6 +196,80 @@ pub fn request_app_relaunch(app: AppHandle, reason: &'static str, delay: Duratio
     });
 }
 
+/// Guards against stacking confirmation dialogs on repeated Cmd+Q presses.
+static QUIT_CONFIRM_SHOWING: AtomicBool = AtomicBool::new(false);
+
+/// Ask the user to confirm before quitting (native dialog), then run
+/// [`request_app_quit`] on confirm.
+///
+/// Modeled on Ghostty's quit flow (`applicationShouldTerminate` →
+/// `needsConfirmQuit`): the dialog only appears when quitting would actually
+/// interrupt something. Ghostty confirms when a terminal still has a running
+/// command; our equivalent is an active recording (`capture_intended`). A
+/// stopped or never-started capture quits silently.
+///
+/// Only user-initiated quit paths (app menu Cmd+Q, tray Quit) go through
+/// here — programmatic paths (updater restart, relaunch) call
+/// [`request_app_quit`] / [`request_app_relaunch`] directly so they never
+/// block on a dialog.
+#[cfg(target_os = "macos")]
+pub fn confirm_and_request_app_quit(app: AppHandle) {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+
+    if QUIT_TEARDOWN_STARTED.load(Ordering::SeqCst) {
+        return;
+    }
+
+    let recording_active = app
+        .try_state::<RecordingState>()
+        .map(|state| state.capture_intended())
+        .unwrap_or(false);
+    if !recording_active {
+        info!("Quit requested with no active recording — skipping confirmation");
+        request_app_quit(app);
+        return;
+    }
+
+    if QUIT_CONFIRM_SHOWING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+
+    // Tray quit can fire while the app is inactive (or Accessory / tray-only),
+    // which would leave the alert buried behind other apps.
+    crate::space_monitor::suppress_space_monitor(500);
+    let _ = app.run_on_main_thread(|| {
+        use objc::{msg_send, sel, sel_impl};
+        use tauri_nspanel::cocoa::base::id;
+        unsafe {
+            let ns_app: id = msg_send![objc::class!(NSApplication), sharedApplication];
+            let _: () = msg_send![ns_app, activateIgnoringOtherApps: true];
+        }
+    });
+
+    app.clone()
+        .dialog()
+        .message("Screen and audio recording will stop.")
+        .title("Quit screenpipe?")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Quit screenpipe".to_string(),
+            "Cancel".to_string(),
+        ))
+        .show(move |confirmed| {
+            QUIT_CONFIRM_SHOWING.store(false, Ordering::SeqCst);
+            if confirmed {
+                request_app_quit(app);
+            } else {
+                info!("Quit cancelled by user");
+            }
+        });
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn confirm_and_request_app_quit(app: AppHandle) {
+    request_app_quit(app);
+}
+
 /// Shared quit entry point for tray menu, app menu (Cmd+Q), etc.
 pub fn request_app_quit(app: AppHandle) {
     QUIT_REQUESTED.store(true, Ordering::SeqCst);

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -229,6 +229,107 @@ pub fn os_session_is_ending() -> bool {
     }
 }
 
+/// App handle for the `applicationShouldTerminate:` override.
+#[cfg(target_os = "macos")]
+static TERMINATE_APP_HANDLE: std::sync::OnceLock<AppHandle> = std::sync::OnceLock::new();
+
+/// Intercept native app termination — dock right-click → Quit, AppleScript
+/// `quit`, `osascript` — the same way ghostty does: an
+/// `applicationShouldTerminate:` override on the app delegate
+/// (ghostty/macos/Sources/App/macOS/AppDelegate.swift). tao 0.35 does not
+/// implement this delegate method and native `terminate:` never surfaces as
+/// `RunEvent::ExitRequested`, so without this override the process dies with
+/// no confirmation and no interception point.
+///
+/// Returns `NSTerminateNow` when quit was already confirmed, a restart is in
+/// flight, or the OS session is ending (shutdown/restart/logout — blocking
+/// those with a dialog would hang the session). Otherwise cancels the
+/// termination and routes through [`confirm_and_request_app_quit`].
+///
+/// Swizzled via `class_addMethod` on the existing tao delegate — same
+/// pattern as `dock_menu::setup_dock_menu`.
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+pub fn setup_terminate_interceptor(app_handle: AppHandle) {
+    use objc::runtime::{Object, Sel};
+    use objc::{class, msg_send, sel, sel_impl};
+    use tauri_nspanel::cocoa::base::id;
+
+    let _ = TERMINATE_APP_HANDLE.set(app_handle);
+
+    // NSApplicationTerminateReply: Cancel = 0, Now = 1
+    extern "C" fn should_terminate(_this: &Object, _sel: Sel, _sender: id) -> usize {
+        // Runs inside the ObjC→Rust trampoline (nounwind) — a panic here
+        // would abort the app, so catch it and fall back to allowing exit.
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if QUIT_REQUESTED.load(Ordering::SeqCst)
+                || PENDING_RESTART.load(Ordering::SeqCst)
+            {
+                return 1;
+            }
+            if os_session_is_ending() {
+                info!("terminate: OS session ending — allowing exit without confirmation");
+                QUIT_REQUESTED.store(true, Ordering::SeqCst);
+                return 1;
+            }
+            let Some(app) = TERMINATE_APP_HANDLE.get() else {
+                return 1;
+            };
+            info!("terminate: intercepted — routing through quit confirmation");
+            confirm_and_request_app_quit(app.clone());
+            0
+        }))
+        .unwrap_or(1)
+    }
+
+    unsafe {
+        // Register a scratch class to obtain a typed IMP without transmute,
+        // then copy it onto the real tao delegate (dock_menu.rs pattern).
+        let superclass = class!(NSObject);
+        let Some(mut decl) =
+            objc::declare::ClassDecl::new("ScreenpipeTerminateDelegate", superclass)
+        else {
+            warn!("terminate interceptor: scratch class registration failed");
+            return;
+        };
+        decl.add_method(
+            sel!(applicationShouldTerminate:),
+            should_terminate as extern "C" fn(&Object, Sel, id) -> usize,
+        );
+        let scratch_class = decl.register();
+        let scratch: id = msg_send![scratch_class, new];
+
+        let ns_app: id = msg_send![class!(NSApplication), sharedApplication];
+        let delegate: id = msg_send![ns_app, delegate];
+        if delegate.is_null() {
+            warn!("terminate interceptor: no app delegate to attach to");
+            return;
+        }
+
+        let terminate_sel = sel!(applicationShouldTerminate:);
+        let scratch_cls: *const objc::runtime::Class = msg_send![scratch, class];
+        let method = objc::runtime::class_getInstanceMethod(scratch_cls, terminate_sel);
+        if method.is_null() {
+            warn!("terminate interceptor: scratch method lookup failed");
+            return;
+        }
+        let imp = objc::runtime::method_getImplementation(method);
+        let encoding = b"Q@:@\0".as_ptr() as *const std::ffi::c_char;
+        let delegate_cls: *const objc::runtime::Class = msg_send![delegate, class];
+        let added = objc::runtime::class_addMethod(
+            delegate_cls as *mut _,
+            terminate_sel,
+            imp,
+            encoding,
+        );
+        if added == objc::runtime::YES {
+            info!("terminate interceptor installed (applicationShouldTerminate:)");
+        } else {
+            warn!("terminate interceptor: delegate already implements applicationShouldTerminate:");
+        }
+    }
+}
+
 /// Hide the whole app (all windows) and return focus to the previous app —
 /// the "Minimize to Tray" choice in the quit dialog. The tray icon stays.
 #[cfg(target_os = "macos")]

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -1600,7 +1600,7 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
         }
         "quit" => {
             debug!("Quit requested");
-            process_exit::request_app_quit(app_handle.clone());
+            process_exit::confirm_and_request_app_quit(app_handle.clone());
         }
         _ => debug!("Unhandled menu event: {:?}", event.id()),
     }


### PR DESCRIPTION
## What

1. Native quit confirmation on macOS: **Quit screenpipe / Minimize to Tray / Cancel** dialog instead of exiting silently, shown from Cmd+Q, tray Quit, and dock right-click Quit
2. Dialog only appears while recording is active; with recording off the app quits directly
3. With all windows already hidden the dialog drops to 2 buttons (Quit / Cancel), no dead Minimize option
4. Minimize to Tray hides every window via the normal close path; tray icon and recording keep running
5. OS shutdown/restart/logout skips the dialog so the app never blocks the session; updater restart and programmatic quits are also unaffected
6. Dock quit needed `applicationShouldTerminate:` added to the app delegate at runtime (same pattern as dock_menu.rs) since tao never surfaces native `terminate:` as `RunEvent::ExitRequested`

## Demo

https://github.com/user-attachments/assets/02600edd-b925-4b0c-b7c5-f6aec19d2c24

### Quit dialog while recording 
<img width="306" height="332" alt="image" src="https://github.com/user-attachments/assets/9f30c604-458e-4dd5-8fd3-94ac783c31c6" />





### Quit dialog while all windows are minimised
<img width="291" height="300" alt="image" src="https://github.com/user-attachments/assets/ca979ba6-bbca-4b9f-8c86-451b7c767b1c" />



