### PR TITLE
Avoid retaining raw audio in reconciliation diarization

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
+++ b/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
@@ -36,7 +36,7 @@ const RECONCILIATION_CHUNKS_PER_SWEEP: i64 = 50;
 use crate::core::engine::AudioTranscriptionEngine;
 use crate::metrics::AudioPipelineMetrics;
 use crate::segmentation::segmentation_manager::SegmentationManager;
-use crate::speaker::segment::{get_segments, SpeechSegment};
+use crate::speaker::segment::{get_segments_without_samples, SpeechSegment};
 use crate::transcription::engine::{TranscriptionEngine, TranscriptionSession};
 use crate::transcription::get_or_create_speaker_from_embedding;
 use crate::transcription::{AudioInsertCallback, AudioInsertInfo, TranscriptionDiarizationSegment};
@@ -1275,7 +1275,7 @@ async fn extract_local_diarization_segments(
         }
     };
 
-    let segments = match get_segments(
+    let segments = match get_segments_without_samples(
         samples,
         sample_rate,
         segmentation_model_path,
@@ -1405,7 +1405,7 @@ async fn extract_speaker_id(
         }
     };
 
-    let segments = match get_segments(
+    let segments = match get_segments_without_samples(
         samples,
         sample_rate,
         segmentation_model_path,

--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -17,6 +17,7 @@ use super::{embedding::EmbeddingExtractor, embedding_manager::EmbeddingManager};
 const MIN_EMBEDDING_SAMPLES: usize = 1600;
 const MAX_EMBEDDING_SEGMENT_SECONDS: f64 = 2.0;
 const MAX_SAME_SPEAKER_MERGE_GAP_SECONDS: f64 = 0.75;
+const MAX_MERGED_SPEECH_SEGMENT_SECONDS: f64 = 30.0;
 
 // pyannote segmentation 3.0 uses powerset classes: 0 is silence, 1..=3 are
 // single-speaker speech, and higher classes represent overlapping speakers.
@@ -57,6 +58,7 @@ fn create_speech_segment_from_range(
     padded_samples: &[f32],
     embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
     embedding_manager: &Arc<Mutex<EmbeddingManager>>,
+    retain_samples: bool,
 ) -> Result<SpeechSegment> {
     let mut segment_vec;
 
@@ -98,7 +100,11 @@ fn create_speech_segment_from_range(
     Ok(SpeechSegment {
         start: start_idx as f64 / sample_rate as f64,
         end: end_idx as f64 / sample_rate as f64,
-        samples: segment_samples.to_vec(),
+        samples: if retain_samples {
+            segment_samples.to_vec()
+        } else {
+            Vec::new()
+        },
         speaker,
         embedding,
         sample_rate,
@@ -109,16 +115,17 @@ fn create_speech_segments(
     start_offset: f64,
     offset: i32,
     sample_rate: u32,
-    samples: &[f32],
+    sample_len: usize,
     padded_samples: &[f32],
     embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
     embedding_manager: &Arc<Mutex<EmbeddingManager>>,
+    retain_samples: bool,
 ) -> Result<Vec<SpeechSegment>> {
     let max_segment_samples = ((sample_rate as f64) * MAX_EMBEDDING_SEGMENT_SECONDS) as usize;
     let mut start_idx = start_offset
         .max(0.0)
-        .min((samples.len().saturating_sub(1)) as f64) as usize;
-    let end_idx = (offset.max(0) as usize).min(samples.len());
+        .min((sample_len.saturating_sub(1)) as f64) as usize;
+    let end_idx = (offset.max(0) as usize).min(sample_len);
     let mut segments = Vec::new();
 
     while start_idx < end_idx {
@@ -140,11 +147,27 @@ fn create_speech_segments(
             padded_samples,
             embedding_extractor.clone(),
             embedding_manager,
+            retain_samples,
         )?);
         start_idx = split_end_idx;
     }
 
     Ok(segments)
+}
+
+fn merged_samples_within_cap(prev_segment: &SpeechSegment, new_segment: &SpeechSegment) -> bool {
+    let merged_samples = prev_segment
+        .samples
+        .len()
+        .saturating_add(new_segment.samples.len());
+
+    if merged_samples == 0 {
+        return true;
+    }
+
+    let sample_rate = prev_segment.sample_rate.max(new_segment.sample_rate).max(1);
+    let max_samples = ((sample_rate as f64) * MAX_MERGED_SPEECH_SEGMENT_SECONDS).ceil() as usize;
+    merged_samples <= max_samples
 }
 
 fn handle_new_segment(
@@ -156,6 +179,7 @@ fn handle_new_segment(
         let gap_seconds = new_segment.start - prev_segment.end;
         if prev_segment.speaker == new_segment.speaker
             && gap_seconds <= MAX_SAME_SPEAKER_MERGE_GAP_SECONDS
+            && merged_samples_within_cap(&prev_segment, &new_segment)
         {
             // Merge segments
             prev_segment.end = new_segment.end;
@@ -210,7 +234,7 @@ fn cached_seg_session(model_path: &Path) -> Result<Arc<SegSession>> {
 }
 
 pub struct SegmentIterator {
-    samples: Vec<f32>,
+    sample_len: usize,
     sample_rate: u32,
     /// Shared, cached segmentation session (see `cached_seg_session`).
     seg: Arc<SegSession>,
@@ -226,6 +250,7 @@ pub struct SegmentIterator {
     current_segment: Option<SpeechSegment>,
     pending_segments: VecDeque<SpeechSegment>,
     padded_samples: Vec<f32>,
+    retain_samples: bool,
 }
 
 impl SegmentIterator {
@@ -236,17 +261,32 @@ impl SegmentIterator {
         embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
         embedding_manager: Arc<Mutex<EmbeddingManager>>,
     ) -> Result<Self> {
+        Self::new_with_sample_payload(
+            samples,
+            sample_rate,
+            model_path,
+            embedding_extractor,
+            embedding_manager,
+            true,
+        )
+    }
+
+    fn new_with_sample_payload<P: AsRef<Path>>(
+        mut samples: Vec<f32>,
+        sample_rate: u32,
+        model_path: P,
+        embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
+        embedding_manager: Arc<Mutex<EmbeddingManager>>,
+        retain_samples: bool,
+    ) -> Result<Self> {
         let seg = cached_seg_session(model_path.as_ref())?;
         let window_size = (sample_rate * 10) as usize;
+        let sample_len = samples.len();
 
-        let padded_samples = {
-            let mut padded = samples.clone();
-            padded.extend(vec![0.0; window_size - (samples.len() % window_size)]);
-            padded
-        };
+        samples.extend(vec![0.0; window_size - (sample_len % window_size)]);
 
         Ok(Self {
-            samples,
+            sample_len,
             sample_rate,
             seg,
             embedding_extractor,
@@ -260,7 +300,8 @@ impl SegmentIterator {
             active_overlap: None,
             current_segment: None,
             pending_segments: VecDeque::new(),
-            padded_samples,
+            padded_samples: samples,
+            retain_samples,
         })
     }
 
@@ -269,10 +310,11 @@ impl SegmentIterator {
             self.start_offset,
             self.offset,
             self.sample_rate,
-            &self.samples,
+            self.sample_len,
             &self.padded_samples,
             self.embedding_extractor.clone(),
             &self.embedding_manager,
+            self.retain_samples,
         )?;
 
         for new_segment in new_segments {
@@ -408,6 +450,23 @@ pub fn get_segments<P: AsRef<Path>>(
     )
 }
 
+pub(crate) fn get_segments_without_samples<P: AsRef<Path>>(
+    samples: &[f32],
+    sample_rate: u32,
+    model_path: P,
+    embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
+    embedding_manager: Arc<Mutex<EmbeddingManager>>,
+) -> Result<SegmentIterator> {
+    SegmentIterator::new_with_sample_payload(
+        samples.to_vec(),
+        sample_rate,
+        model_path,
+        embedding_extractor,
+        embedding_manager,
+        false,
+    )
+}
+
 fn get_speaker_embedding(
     embedding_extractor: Arc<Mutex<EmbeddingExtractor>>,
     samples: &[f32],
@@ -433,7 +492,21 @@ pub fn get_speaker_from_embedding(
 
 #[cfg(test)]
 mod tests {
-    use super::is_overlap_class;
+    use super::{
+        handle_new_segment, is_overlap_class, SpeechSegment, MAX_EMBEDDING_SEGMENT_SECONDS,
+        MAX_MERGED_SPEECH_SEGMENT_SECONDS,
+    };
+
+    fn test_segment(start: f64, end: f64, sample_count: usize, speaker: &str) -> SpeechSegment {
+        SpeechSegment {
+            start,
+            end,
+            samples: vec![0.25; sample_count],
+            speaker: speaker.to_string(),
+            embedding: vec![0.0; 192],
+            sample_rate: 16_000,
+        }
+    }
 
     #[test]
     fn pyannote_powerset_overlap_classes_start_after_single_speaker_classes() {
@@ -444,5 +517,43 @@ mod tests {
         assert!(is_overlap_class(4));
         assert!(is_overlap_class(5));
         assert!(is_overlap_class(6));
+    }
+
+    #[test]
+    fn same_speaker_merge_flushes_before_audio_payload_grows_unbounded() {
+        let sample_rate = 16_000usize;
+        let samples_per_segment = (sample_rate as f64 * MAX_EMBEDDING_SEGMENT_SECONDS) as usize;
+        let max_retained_samples =
+            (sample_rate as f64 * MAX_MERGED_SPEECH_SEGMENT_SECONDS) as usize;
+        let segment_count = 50usize;
+
+        let mut current_segment = None;
+        let mut flushed_segments = Vec::new();
+        let mut start = 0.0;
+
+        for _ in 0..segment_count {
+            let end = start + MAX_EMBEDDING_SEGMENT_SECONDS;
+            let segment = test_segment(start, end, samples_per_segment, "speaker-1");
+            current_segment = handle_new_segment(current_segment, segment, &mut flushed_segments);
+
+            let current_samples = current_segment
+                .as_ref()
+                .map(|segment| segment.samples.len())
+                .unwrap_or_default();
+            assert!(
+                current_samples <= max_retained_samples,
+                "same-speaker merge retained {current_samples} samples in the active segment; cap is {max_retained_samples}"
+            );
+
+            start = end + 0.01;
+        }
+
+        assert!(
+            !flushed_segments.is_empty(),
+            "long same-speaker runs should flush bounded segments instead of growing one retained audio buffer"
+        );
+        assert!(flushed_segments
+            .iter()
+            .all(|segment| segment.samples.len() <= max_retained_samples));
     }
 }

--- a/crates/screenpipe-audio/src/speaker/segment.rs
+++ b/crates/screenpipe-audio/src/speaker/segment.rs
@@ -17,7 +17,6 @@ use super::{embedding::EmbeddingExtractor, embedding_manager::EmbeddingManager};
 const MIN_EMBEDDING_SAMPLES: usize = 1600;
 const MAX_EMBEDDING_SEGMENT_SECONDS: f64 = 2.0;
 const MAX_SAME_SPEAKER_MERGE_GAP_SECONDS: f64 = 0.75;
-const MAX_MERGED_SPEECH_SEGMENT_SECONDS: f64 = 30.0;
 
 // pyannote segmentation 3.0 uses powerset classes: 0 is silence, 1..=3 are
 // single-speaker speech, and higher classes represent overlapping speakers.
@@ -155,21 +154,6 @@ fn create_speech_segments(
     Ok(segments)
 }
 
-fn merged_samples_within_cap(prev_segment: &SpeechSegment, new_segment: &SpeechSegment) -> bool {
-    let merged_samples = prev_segment
-        .samples
-        .len()
-        .saturating_add(new_segment.samples.len());
-
-    if merged_samples == 0 {
-        return true;
-    }
-
-    let sample_rate = prev_segment.sample_rate.max(new_segment.sample_rate).max(1);
-    let max_samples = ((sample_rate as f64) * MAX_MERGED_SPEECH_SEGMENT_SECONDS).ceil() as usize;
-    merged_samples <= max_samples
-}
-
 fn handle_new_segment(
     current_segment: Option<SpeechSegment>,
     new_segment: SpeechSegment,
@@ -179,7 +163,6 @@ fn handle_new_segment(
         let gap_seconds = new_segment.start - prev_segment.end;
         if prev_segment.speaker == new_segment.speaker
             && gap_seconds <= MAX_SAME_SPEAKER_MERGE_GAP_SECONDS
-            && merged_samples_within_cap(&prev_segment, &new_segment)
         {
             // Merge segments
             prev_segment.end = new_segment.end;
@@ -492,10 +475,7 @@ pub fn get_speaker_from_embedding(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        handle_new_segment, is_overlap_class, SpeechSegment, MAX_EMBEDDING_SEGMENT_SECONDS,
-        MAX_MERGED_SPEECH_SEGMENT_SECONDS,
-    };
+    use super::{handle_new_segment, is_overlap_class, SpeechSegment};
 
     fn test_segment(start: f64, end: f64, sample_count: usize, speaker: &str) -> SpeechSegment {
         SpeechSegment {
@@ -520,11 +500,7 @@ mod tests {
     }
 
     #[test]
-    fn same_speaker_merge_flushes_before_audio_payload_grows_unbounded() {
-        let sample_rate = 16_000usize;
-        let samples_per_segment = (sample_rate as f64 * MAX_EMBEDDING_SEGMENT_SECONDS) as usize;
-        let max_retained_samples =
-            (sample_rate as f64 * MAX_MERGED_SPEECH_SEGMENT_SECONDS) as usize;
+    fn metadata_only_same_speaker_merge_retains_no_audio_payload() {
         let segment_count = 50usize;
 
         let mut current_segment = None;
@@ -532,28 +508,20 @@ mod tests {
         let mut start = 0.0;
 
         for _ in 0..segment_count {
-            let end = start + MAX_EMBEDDING_SEGMENT_SECONDS;
-            let segment = test_segment(start, end, samples_per_segment, "speaker-1");
+            let end = start + 2.0;
+            let segment = test_segment(start, end, 0, "speaker-1");
             current_segment = handle_new_segment(current_segment, segment, &mut flushed_segments);
 
             let current_samples = current_segment
                 .as_ref()
                 .map(|segment| segment.samples.len())
                 .unwrap_or_default();
-            assert!(
-                current_samples <= max_retained_samples,
-                "same-speaker merge retained {current_samples} samples in the active segment; cap is {max_retained_samples}"
-            );
+            assert_eq!(current_samples, 0);
 
             start = end + 0.01;
         }
 
-        assert!(
-            !flushed_segments.is_empty(),
-            "long same-speaker runs should flush bounded segments instead of growing one retained audio buffer"
-        );
-        assert!(flushed_segments
-            .iter()
-            .all(|segment| segment.samples.len() <= max_retained_samples));
+        assert!(flushed_segments.is_empty());
+        assert_eq!(current_segment.unwrap().samples.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the audio reconciliation memory spike by making the reconciliation-only speaker segmentation path produce metadata-only `SpeechSegment`s after embeddings are computed.

## Root Cause

The reconciliation path runs local speaker segmentation over batched orphaned audio. `handle_new_segment` normally keeps raw segment samples because live transcription later needs that audio for STT. Reconciliation does not need those samples after speaker embedding and timing metadata are computed, but it was using the same sample-retaining iterator, so a backlog sweep could retain large raw audio payloads while building local diarization/speaker metadata.

## Changes

- Add a metadata-only `get_segments_without_samples` path for reconciliation diarization/speaker-id extraction.
- Keep normal live/transcription segment merging behavior unchanged to avoid changing transcript chunking or cloud STT call patterns.
- Remove one full-buffer clone inside `SegmentIterator` by padding the owned sample buffer in place and tracking the original sample length separately.
- Add a regression test proving metadata-only same-speaker merges retain no raw audio payload.

## Validation

- `cargo test -p screenpipe-audio metadata_only_same_speaker_merge_retains_no_audio_payload -- --nocapture`
- `cargo test -p screenpipe-audio reconciliation --lib -- --nocapture`
- `cargo test -p screenpipe-audio --lib`
- `git diff --check`