### PR TITLE
fix(audio): stop forcing shared mic sample rate + delay piggyback tap rebuilds

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/meeting_piggyback.rs
+++ b/crates/screenpipe-audio/src/audio_manager/meeting_piggyback.rs
@@ -70,6 +70,14 @@ use std::collections::HashSet;
 
 pub(crate) const MAX_TAP_STRIKES: u32 = 3;
 pub(crate) const TAP_RETRY_COOLDOWN_SECS: u64 = 60;
+/// Delay before the far end rebuilds a live tap over a changed mic-holder pid
+/// set. Observed live (2026-07-08, Zoom join): rebuilding screenpipe's own
+/// CoreAudio process tap the instant the OS reports a holder-set change
+/// competes with the other app for the same mic right when it's trying to
+/// acquire it. This delay gives that app a couple of quiet seconds to finish
+/// grabbing the mic before screenpipe reacts. Cancelled outright (not just
+/// paused) the moment the pid set reverts to what the tap already has.
+pub(crate) const RETAP_DELAY_MS: u64 = 2_000;
 
 // NOTE: the piggyback deliberately has NO mic capture-health / silence
 // machinery (removed by product decision). We track the meeting app's own
@@ -494,6 +502,14 @@ pub(crate) struct PiggybackObservation {
     /// mic-holder set changing mid-meeting (manual meetings track it live)
     /// and rebuild the tap over the new set.
     pub tap_built_pids: Vec<i32>,
+    /// Delayed view of the mic-holder pid set for the far-end rebuild
+    /// decision only (see [`RETAP_DELAY_MS`]). Equal to `tap_built_pids`
+    /// while a change is still within its delay — so the decider sees no
+    /// move and leaves the live tap alone — and equal to the fresh pid set
+    /// once the delay has elapsed. Distinct from `meeting` (used for the
+    /// piggybacking gate, cold-start `StartTap`, and mic resolution, none of
+    /// which should be delayed) so only the disruptive rebuild waits.
+    pub retap_target_pids: Vec<i32>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -524,6 +540,18 @@ pub(crate) fn decide_piggyback(obs: &PiggybackObservation) -> Vec<PiggybackActio
     // session stream and lift every suspension → exactly today's stable path.
     let piggybacking = engaged && obs.tap_available && !meeting_pids.is_empty();
     if !piggybacking {
+        // Only the "flag on, tap available, but this tick's pid went empty"
+        // case is a surprise — flag-off and no-meeting are the normal quiet
+        // paths. This is the OTHER silent teardown site (RetapForPidChange
+        // and the "not streaming" branch below both log; this one never
+        // did), and it fires on a single empty-pid tick with no persistence
+        // gate at all, unlike the manual-meeting holder-set adoption.
+        if engaged && obs.tap_available && !obs.session_devices.is_empty() {
+            tracing::info!(
+                "[MEETING_PIGGYBACK] meeting pid went empty this tick, tearing down session devices {:?}",
+                obs.session_devices
+            );
+        }
         for dev in &obs.session_devices {
             actions.push(PiggybackAction::StopSessionDevice(dev.clone()));
         }
@@ -542,6 +570,14 @@ pub(crate) fn decide_piggyback(obs: &PiggybackObservation) -> Vec<PiggybackActio
     let tap_streaming = obs.session_streaming.contains(&tap);
     if tap_registered && !tap_streaming {
         // Tap died (app-quit exit sets is_disconnected; supervisor gave up).
+        // Logged here (not just at the StartTap/Retap sites) because this is
+        // the ONLY branch that silently tears the tap down — the generic
+        // StopSessionDevice dispatch has no reason string, so without this
+        // line the far-end death is invisible in the logs.
+        tracing::info!(
+            "[MEETING_PIGGYBACK] tap over {:?} registered but not streaming, tearing down",
+            obs.tap_built_pids
+        );
         actions.push(PiggybackAction::StopSessionDevice(tap.clone()));
         for dev in &obs.suspended {
             if dev.ends_with("(output)") {
@@ -561,13 +597,14 @@ pub(crate) fn decide_piggyback(obs: &PiggybackObservation) -> Vec<PiggybackActio
                 actions.push(PiggybackAction::Resume(dev.clone()));
             }
         }
-    } else if !obs.tap_built_pids.is_empty() && obs.tap_built_pids != meeting_pids {
+    } else if !obs.tap_built_pids.is_empty() && obs.tap_built_pids != obs.retap_target_pids {
         // Tap is healthy but the pid set moved under it (a mic-holding app
         // joined or left a MANUAL meeting; the sweep already damped the set
-        // with persistence-gated adoption). Deliberate rebuild over the new set —
-        // suspensions stay, no failure strike, no cooldown gap.
+        // with persistence-gated adoption, and delayed the rebuild itself by
+        // `RETAP_DELAY_MS` — see `retap_target_pids`). Deliberate rebuild over
+        // the new set — suspensions stay, no failure strike, no cooldown gap.
         actions.push(PiggybackAction::RetapForPidChange {
-            pids: meeting_pids.to_vec(),
+            pids: obs.retap_target_pids.clone(),
         });
     } else {
         // Tap is streaming: the stable global capture is redundant (double
@@ -630,6 +667,12 @@ pub(crate) struct PiggybackState {
     /// streams costs a rebuild. Reset on meeting end.
     pub manual_pids_adopted: Vec<i32>,
     pub manual_pids_candidate: Option<(Vec<i32>, u64)>,
+    /// The mic-holder pid set currently waiting out [`RETAP_DELAY_MS`] before
+    /// the live tap is rebuilt over it (target set, wall ms first seen).
+    /// `None` when the tap already matches the current pid set. Cleared
+    /// outright (not just paused) the instant the pid set reverts back to
+    /// the tap's current set, or on meeting end.
+    pub retap_delay_candidate: Option<(Vec<i32>, u64)>,
     /// One-shot per meeting: the MANUAL-meeting mic-holder enumeration
     /// returned an error (or reported unsupported) and the sweep logged it.
     /// Errored ticks keep the previously adopted pid set in force instead of
@@ -646,6 +689,41 @@ pub(crate) struct PiggybackState {
     /// `Drop` also clears, so listeners cannot outlive the monitor task.
     #[cfg(target_os = "macos")]
     pub listeners: super::piggyback_listeners::PiggybackListenerGuard,
+}
+
+/// Delays the far-end tap rebuild by [`RETAP_DELAY_MS`] when the mic-holder
+/// pid set moves under a live tap: returns `tap_built_pids` unchanged while
+/// the fresh set is still within its delay (so the decider sees no move and
+/// leaves the live tap alone), and returns `fresh` once the delay has
+/// elapsed. If the fresh set reverts back to `tap_built_pids` before the
+/// delay is up, the pending candidate is cleared outright — there is nothing
+/// left to delay. Time-based rather than tick-counted for the same reason as
+/// [`MANUAL_PID_ADOPT_HOLDOFF_MS`]. Pure state transition — unit-tested
+/// directly.
+pub(crate) fn delay_retap_pids(
+    candidate: &mut Option<(Vec<i32>, u64)>,
+    tap_built_pids: &[i32],
+    fresh: Vec<i32>,
+    now_ms: u64,
+) -> Vec<i32> {
+    if fresh == tap_built_pids {
+        *candidate = None;
+        return fresh;
+    }
+    match candidate {
+        Some((c, first_seen_ms)) if *c == fresh => {
+            if now_ms.saturating_sub(*first_seen_ms) >= RETAP_DELAY_MS {
+                *candidate = None;
+                fresh
+            } else {
+                tap_built_pids.to_vec()
+            }
+        }
+        _ => {
+            *candidate = Some((fresh, now_ms));
+            tap_built_pids.to_vec()
+        }
+    }
 }
 
 /// Persistence-damped adoption for a MANUAL meeting's mic-holder pid set: a
@@ -1053,6 +1131,19 @@ pub(crate) async fn run_meeting_piggyback_sweep(
     let cooldown_elapsed = state
         .last_tap_attempt
         .is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(TAP_RETRY_COOLDOWN_SECS));
+    // Far-end rebuild delay: while a tap is already live, hold a changed pid
+    // set for RETAP_DELAY_MS before handing it to the decider as a rebuild
+    // target — no tap yet (cold start) skips the delay entirely.
+    let retap_target_pids = if state.tap_pids.is_empty() {
+        meeting_pids.clone()
+    } else {
+        delay_retap_pids(
+            &mut state.retap_delay_candidate,
+            &state.tap_pids,
+            meeting_pids.clone(),
+            now_ms(),
+        )
+    };
     let stable_outputs = stable_output_names(audio_manager, &session_devices);
     // A meeting is "seen" whenever the detector reports one, pid set or not —
     // the telemetry gate and the meeting-end edge below key off this, and
@@ -1070,6 +1161,7 @@ pub(crate) async fn run_meeting_piggyback_sweep(
         tap_strikes: state.tap_strikes,
         tap_cooldown_elapsed: cooldown_elapsed,
         tap_built_pids: state.tap_pids.clone(),
+        retap_target_pids,
     };
 
     let tap_device_str = format!("{} (output)", MEETING_TAP_DEVICE_NAME);
@@ -1363,6 +1455,7 @@ pub(crate) async fn run_meeting_piggyback_sweep(
         state.manual_pids_adopted = Vec::new();
         state.manual_pids_candidate = None;
         state.manual_enum_error_logged = false;
+        state.retap_delay_candidate = None;
     }
     state.last_meeting_seen = meeting_now;
 
@@ -1449,13 +1542,16 @@ mod tests {
     #[test]
     fn pid_set_change_rebuilds_live_tap_without_strike() {
         // The mic-holder set moved under a healthy tap (an app joined a
-        // manual meeting): rebuild deliberately — no failure strike, no
-        // teardown of suspensions.
+        // manual meeting) and the rebuild delay has already elapsed (the
+        // sweep only hands the decider a changed `retap_target_pids` once
+        // RETAP_DELAY_MS has passed): rebuild deliberately — no failure
+        // strike, no teardown of suspensions.
         let mut obs = base();
         obs.meeting = Some(vec![100, 200]);
         obs.session_devices = [tap_name()].into();
         obs.session_streaming = [tap_name()].into();
         obs.tap_built_pids = vec![100];
+        obs.retap_target_pids = vec![100, 200];
         let actions = decide_piggyback(&obs);
         assert!(actions.contains(&PiggybackAction::RetapForPidChange {
             pids: vec![100, 200]
@@ -1465,12 +1561,30 @@ mod tests {
     }
 
     #[test]
+    fn pid_set_change_within_delay_does_not_retap_yet() {
+        // The mic-holder set just moved under a healthy tap, but the rebuild
+        // delay hasn't elapsed — the sweep still hands the decider the OLD
+        // pid set as `retap_target_pids`, so it must see no move at all.
+        let mut obs = base();
+        obs.meeting = Some(vec![100, 200]);
+        obs.session_devices = [tap_name()].into();
+        obs.session_streaming = [tap_name()].into();
+        obs.tap_built_pids = vec![100];
+        obs.retap_target_pids = vec![100];
+        let actions = decide_piggyback(&obs);
+        assert!(!actions
+            .iter()
+            .any(|a| matches!(a, PiggybackAction::RetapForPidChange { .. })));
+    }
+
+    #[test]
     fn unchanged_pid_set_never_retaps() {
         let mut obs = base();
         obs.meeting = Some(vec![100, 200]);
         obs.session_devices = [tap_name()].into();
         obs.session_streaming = [tap_name()].into();
         obs.tap_built_pids = vec![100, 200];
+        obs.retap_target_pids = vec![100, 200];
         let actions = decide_piggyback(&obs);
         assert!(!actions
             .iter()
@@ -1514,6 +1628,44 @@ mod tests {
             vec![10, 30]
         );
         assert!(state.manual_pids_candidate.is_none());
+    }
+
+    #[test]
+    fn delay_retap_pids_holds_target_until_delay_elapses() {
+        let mut candidate = None;
+        let tap_built = vec![100];
+        let t0 = 10_000u64;
+        // First sighting of the moved set: decider still sees the OLD set.
+        assert_eq!(
+            delay_retap_pids(&mut candidate, &tap_built, vec![100, 200], t0),
+            vec![100]
+        );
+        // Still within the delay.
+        assert_eq!(
+            delay_retap_pids(&mut candidate, &tap_built, vec![100, 200], t0 + 1_000),
+            vec![100]
+        );
+        // Delay elapsed: decider now sees the new set.
+        assert_eq!(
+            delay_retap_pids(&mut candidate, &tap_built, vec![100, 200], t0 + RETAP_DELAY_MS),
+            vec![100, 200]
+        );
+    }
+
+    #[test]
+    fn delay_retap_pids_cancels_outright_on_revert() {
+        // The pid set flaps back to what the tap already has before the
+        // delay is up — nothing left to delay, not a reset-the-clock retry.
+        let mut candidate = None;
+        let tap_built = vec![100];
+        let t0 = 10_000u64;
+        delay_retap_pids(&mut candidate, &tap_built, vec![100, 200], t0);
+        assert!(candidate.is_some());
+        assert_eq!(
+            delay_retap_pids(&mut candidate, &tap_built, vec![100], t0 + 500),
+            vec![100]
+        );
+        assert!(candidate.is_none());
     }
 
     #[test]

--- a/crates/screenpipe-audio/src/core/device.rs
+++ b/crates/screenpipe-audio/src/core/device.rs
@@ -359,6 +359,20 @@ pub async fn get_cpal_device_and_config(
             .ok_or_else(|| anyhow!("No supported output configurations found"))?;
 
         (*best_config).with_sample_rate(best_config.max_sample_rate())
+    } else if let Ok(default_config) = cpal_audio_device.default_input_config() {
+        // Input devices are shared hardware — another app (a meeting app,
+        // for instance) can be using the SAME physical mic at the same time.
+        // On macOS, opening a stream at a rate other than the device's
+        // CURRENT nominal sample rate makes cpal write
+        // `kAudioDevicePropertyNominalSampleRate`, which is a device-wide
+        // property, not scoped to our stream — every other client sharing
+        // the device gets yanked through that reconfiguration too (observed
+        // live: a meeting app's own mic stream stalling right as screenpipe
+        // opens the shared mic). Requesting the device's own default config
+        // means the rate already matches, so cpal skips that write entirely.
+        // Output devices don't share this failure mode the same way, so they
+        // keep picking the highest-quality config below.
+        default_config
     } else {
         let configs: Vec<_> = cpal_audio_device.supported_input_configs()?.collect();
         let best_config = configs


### PR DESCRIPTION
## description

Fixes meeting apps (Zoom, etc.) being unable to acquire the microphone, or having it drop mid-call, while screenpipe is running.

Root cause: `get_cpal_device_and_config` always picked the **highest supported sample rate** for every audio device, input included. On macOS, cpal's CoreAudio backend only writes `kAudioDevicePropertyNominalSampleRate` when the requested rate differs from the device's *current* rate — but that property is device-wide, not scoped to our own stream. Every time screenpipe opened the mic at its self-chosen max rate instead of whatever rate was already active, it forced a hardware-level reconfiguration that every other client sharing that mic gets caught in. Confirmed live via macOS's ControlCenter `sensor-indicators` log: Zoom never got `mic:us.zoom.xos` attribution for an entire call while screenpipe held `mic:screenpi.pe.dev` continuously. Input devices now request the device's own `default_input_config()` (its already-active config) so opening the mic never needs to touch that shared property. Output devices are untouched — they don't share this failure mode.

Also fixes a real rebuild storm in the meeting-piggyback sweep (`crates/screenpipe-audio/src/audio_manager/meeting_piggyback.rs`): the far end rebuilt its CoreAudio process tap the instant it observed the mic-holder pid set change mid-meeting, which competes with the other app for the mic right as it's trying to acquire it. Rebuilds now wait `RETAP_DELAY_MS` (2s) before acting on a pid-set change, cancelled outright (not just paused) if the set reverts to the tap's current set before the delay elapses.

Along the way, added logging to two previously-silent tap-teardown paths in the piggyback decider — a "tap registered but not streaming" branch and the disengage-on-empty-pid branch — that made a lot of this very hard to diagnose live. Both fire legitimately during normal meeting-end/pid-loss and gave zero signal without the added log lines.

## before

Backend-only fix, no UI surface. Before: joining a Zoom call while screenpipe was running would freeze/fail to connect the mic, confirmed via macOS's ControlCenter log — Zoom's `mic:us.zoom.xos` attribution never appeared for the duration of a call while screenpipe held the mic.

```
19:04:50  mic:screenpi.pe.dev held
19:04:50  mic:us.zoom.xos appears, flaps within the same second
19:05:00  mic:us.zoom.xos gone — never returns for the rest of the call
```

## after

Same scenario after the fix — screenpipe, Zoom, and a third mic client (Wispr Flow) all hold the microphone concurrently with zero forced disconnects:

```
20:45:39  mic:screenpi.pe.dev + mic:us.zoom.xos + mic:com.electron.wispr-flow
          all held simultaneously for 23+ seconds, no drops
```

## how to test

1. Start screenpipe with continuous audio capture running (default mic capture engaged).
2. Join a Zoom (or Meet/Teams) call and confirm the mic connects normally on the first try, with audio flowing both ways.
3. Watch `~/.screenpipe/screenpipe-app.<date>.log` for `[MEETING_PIGGYBACK]` lines during the call — a legitimate pid-set change should log `mic-holder set changed ... rebuilding tap` at most once per real change, not repeatedly within a couple of seconds.
4. `cargo test -p screenpipe-audio --lib` — 362 tests pass, including new coverage for the retap delay (`delay_retap_pids_holds_target_until_delay_elapses`, `delay_retap_pids_cancels_outright_on_revert`).

## desktop app checklist (if applicable)

N/A — this PR only touches `crates/screenpipe-audio` (device config selection + the piggyback decider); no `#[tauri::command]` handlers or frontend-exported types changed.
