### PR TITLE
fix(app): backfill disabledShortcuts to prevent app-wide crash

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -1045,6 +1045,14 @@ function createSettingsStore() {
 			}
 		}
 
+		// Migration: backfill disabledShortcuts for installs that predate the
+		// field. Several call sites assume it's always an array (`.includes(...)`)
+		// and crash with "Cannot read properties of undefined" when it's missing.
+		if (!Array.isArray(settings.disabledShortcuts)) {
+			settings.disabledShortcuts = [];
+			needsUpdate = true;
+		}
+
 		// Save migrations if needed
 		if (needsUpdate) {
 			await setSettingsStripped(store, settings);


### PR DESCRIPTION
## Summary
- Windows user on v2.5.98 hit a full app-shell crash (`Cannot read properties of undefined (reading 'includes')`) on every launch, because `settings.disabledShortcuts` was `undefined` on their install (predates this field) while several call sites assume it's always an array — e.g. the unconditional `useMemo` in `TimelineControls` that renders on Home's default section.
- Adds a one-time migration in `use-settings.tsx`'s settings loader (same pattern as the other backfill migrations already there) that defaults `disabledShortcuts` to `[]` when it isn't an array. Runs once, persists, never touches any other field.

## Test plan
- [x] `bunx tsc --noEmit` shows no new errors introduced by this change
- [ ] Repro locally: manually strip `disabledShortcuts` from a dev `store.bin`, relaunch, confirm the crash reproduces on `main` and is fixed on this branch
- [ ] Confirm existing settings (shortcuts, AI presets, etc.) are untouched after the migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)