### PR TITLE
fix(app): request screen recording permission last in onboarding/recovery flows

### DIFF
--- a/apps/screenpipe-app-tauri/app/permission-recovery/page.tsx
+++ b/apps/screenpipe-app-tauri/app/permission-recovery/page.tsx
@@ -200,14 +200,6 @@ export default function PermissionRecoveryPage() {
 
             <div className="space-y-2">
               <PermissionRow
-                icon={<Monitor className="w-4 h-4" strokeWidth={1.5} />}
-                label="screen"
-                description="capture display"
-                status={screenStatus}
-                onFix={() => handleFix("screenRecording")}
-                testId="permission-row-screen"
-              />
-              <PermissionRow
                 icon={<Mic className="w-4 h-4" strokeWidth={1.5} />}
                 label="microphone"
                 description="transcribe audio"
@@ -225,6 +217,14 @@ export default function PermissionRecoveryPage() {
                   testId="permission-row-accessibility"
                 />
               )}
+              <PermissionRow
+                icon={<Monitor className="w-4 h-4" strokeWidth={1.5} />}
+                label="screen"
+                description="capture display"
+                status={screenStatus}
+                onFix={() => handleFix("screenRecording")}
+                testId="permission-row-screen"
+              />
               {isMacOS && keychainStatus === "denied" && (
                 <PermissionRow
                   icon={<Lock className="w-4 h-4" strokeWidth={1.5} />}

--- a/apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx
@@ -99,14 +99,6 @@ export default function PermissionsStep({
 
   const permissions: PermissionDef[] = [
     {
-      id: "screen",
-      icon: <Monitor className="w-3.5 h-3.5" strokeWidth={1.5} />,
-      title: "Capture your screen",
-      subtitle: "Lets Screenpipe index what's on your screen — windows, docs, chats, code",
-      check: () => commands.checkScreenRecordingPermission(),
-      request: () => requestPermissionWithFlow("screenRecording"),
-    },
-    {
       id: "mic",
       icon: <Mic className="w-3.5 h-3.5" strokeWidth={1.5} />,
       title: "Capture what you say",
@@ -122,6 +114,16 @@ export default function PermissionsStep({
       check: () => commands.checkAccessibilityPermissionCmd(),
       request: () => requestPermissionWithFlow("accessibility"),
       macOnly: true,
+    },
+    {
+      id: "screen",
+      icon: <Monitor className="w-3.5 h-3.5" strokeWidth={1.5} />,
+      title: "Capture your screen",
+      subtitle: "Lets Screenpipe index what's on your screen — windows, docs, chats, code",
+      // requested last: granting this requires an app restart to take effect,
+      // so asking earlier just sends the user back into settings again mid-flow
+      check: () => commands.checkScreenRecordingPermission(),
+      request: () => requestPermissionWithFlow("screenRecording"),
     },
     {
       id: "browsers",

--- a/apps/screenpipe-app-tauri/components/status/permission-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/status/permission-banner.tsx
@@ -85,14 +85,14 @@ export function PermissionBanner() {
             // (e.g. mic prompt, accessibility prompt). If the permission was already
             // denied, it falls back to opening System Settings internally.
             try {
-              if (!permissions.screenOk) await requestPermissionWithFlow("screenRecording");
-              else if (!permissions.micOk) await commands.requestPermission("microphone");
+              if (!permissions.micOk) await commands.requestPermission("microphone");
               else if (!permissions.accessibilityOk) await requestPermissionWithFlow("accessibility");
+              else if (!permissions.screenOk) await requestPermissionWithFlow("screenRecording");
             } catch {
               // fallback to opening settings directly
-              if (!permissions.screenOk) await openPermissionSettingsWithFlow("screenRecording");
-              else if (!permissions.micOk) await commands.openPermissionSettings("microphone");
+              if (!permissions.micOk) await openPermissionSettingsWithFlow("microphone");
               else if (!permissions.accessibilityOk) await openPermissionSettingsWithFlow("accessibility");
+              else if (!permissions.screenOk) await openPermissionSettingsWithFlow("screenRecording");
             }
           }}
         >


### PR DESCRIPTION
## Summary
- Screen recording is the only permission that requires an app restart to take effect. Requesting it first meant users could grant mic/accessibility, then get bounced back into System Settings for the restart-required screen recording prompt mid-flow.
- Reordered permission requests to mic -> accessibility -> screen recording so the restart-requiring one is always last:
  - Onboarding permissions step (`components/onboarding/permissions-step.tsx`)
  - In-app "fix permissions" banner (`components/status/permission-banner.tsx`)
  - Permission recovery window (`app/permission-recovery/page.tsx`)

## Test plan
- [x] `tsc --noEmit` passes with no new errors in the three changed files
- [x] `eslint` passes clean on the three changed files
- [x] Verified `e2e/specs/permission-recovery.spec.ts` references recovery rows by `data-testid`, not position, so reordering rows doesn't break it
- [ ] Manual click-through of onboarding + recovery flow on a fresh macOS profile (recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)