### PR TITLE
fix(chat): make 'Chat Always on Top' toggle work on the open window

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -267,9 +267,14 @@ export function DisplaySection() {
               </div>
               <Switch
                 checked={settings?.chatAlwaysOnTop ?? true}
-                onCheckedChange={(checked) =>
-                  handleSettingsChange({ chatAlwaysOnTop: checked })
-                }
+                onCheckedChange={async (checked) => {
+                  handleSettingsChange({ chatAlwaysOnTop: checked });
+                  // Apply live so an already-open chat window updates
+                  // immediately instead of only on next open.
+                  try {
+                    await commands.setChatAlwaysOnTop(checked);
+                  } catch (_) {}
+                }}
                 className="ml-4"
               />
             </div>

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1934,6 +1934,22 @@ async setBrowserCookieAccessState(granted: boolean, disabled: boolean) : Promise
 }
 },
 /**
+ * Apply the "Chat Always on Top" setting to the already-open chat window.
+ *
+ * The chat window's on-top level is otherwise only set at create/show time
+ * (`window::show`), so toggling the setting while the window is open had no
+ * effect until it was reopened. This lets the Display-settings toggle take
+ * effect immediately. No-op if the chat window isn't currently open.
+ */
+async setChatAlwaysOnTop(onTop: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_chat_always_on_top", { onTop }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Toggle the "Cloud audio + video + image analysis" capability
  * in the screenpipe-api skill that Pi installs on every run.
  *

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -2219,6 +2219,47 @@ pub async fn set_window_always_on_top_native(
     Ok(())
 }
 
+/// Apply the "Chat Always on Top" setting to the already-open chat window.
+///
+/// The chat window's on-top level is otherwise only set at create/show time
+/// (`window::show`), so toggling the setting while the window is open had no
+/// effect until it was reopened. This lets the Display-settings toggle take
+/// effect immediately. No-op if the chat window isn't currently open.
+#[tauri::command]
+#[specta::specta]
+pub async fn set_chat_always_on_top(
+    app_handle: tauri::AppHandle,
+    on_top: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        use crate::window::{apply_chat_panel_on_top, run_on_main_thread_safe};
+        use tauri_nspanel::ManagerExt;
+
+        let app = app_handle.clone();
+        run_on_main_thread_safe(&app_handle, move || {
+            let label = RewindWindowId::Chat.label();
+            if let Ok(panel) = app.get_webview_panel(label) {
+                apply_chat_panel_on_top(&*panel, on_top);
+                // Keep it visible; re-order so the level change is reflected now.
+                panel.order_front_regardless();
+            }
+        });
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        use tauri::Manager;
+        if let Some(window) = app_handle.get_webview_window(RewindWindowId::Chat.label()) {
+            window
+                .set_always_on_top(on_top)
+                .map_err(|e| format!("failed to set always-on-top: {}", e))?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Re-assert the WKWebView as first responder for the current key panel.
 /// Called from JS on pointer enter / window focus to ensure trackpad pinch
 /// gestures (magnifyWithEvent:) reach the WKWebView for zoom handling.

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
@@ -112,3 +112,5 @@ pub use focus::restore_frontmost_app;
 pub use panel::{reset_to_regular_and_refresh_tray, MAIN_PANEL_SHOWN};
 #[cfg(target_os = "macos")]
 pub use util::run_on_main_thread_safe;
+#[cfg(target_os = "macos")]
+pub use show::apply_chat_panel_on_top;

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -32,6 +32,35 @@ use tauri_nspanel::ManagerExt;
 #[cfg(target_os = "macos")]
 use tauri_nspanel::WebviewWindowExt;
 
+/// Apply the chat window's always-on-top panel behaviour. Single source of
+/// truth shared by the show path and the live settings toggle
+/// (`commands::set_chat_always_on_top`). When on-top, the panel sits at level
+/// 1001 with the NonActivatingPanel style bit (128) so clicking it doesn't
+/// steal focus from the frontmost app; when off, it drops to normal window
+/// level and the bit is cleared so other windows can cover it.
+///
+/// Must run on the main thread (wrap callers in `run_on_main_thread_safe`).
+#[cfg(target_os = "macos")]
+pub fn apply_chat_panel_on_top(panel: &tauri_nspanel::raw_nspanel::RawNSPanel, on_top: bool) {
+    use objc::{msg_send, sel, sel_impl};
+    if on_top {
+        panel.set_level(1001);
+        // NonActivatingPanel (128) so clicking doesn't activate app
+        unsafe {
+            let current: i32 = msg_send![panel, styleMask];
+            panel.set_style_mask(current | 128);
+        }
+    } else {
+        // Normal window level — allow it to go behind other windows
+        panel.set_level(0);
+        // Remove NonActivatingPanel bit (128) so it behaves normally
+        unsafe {
+            let current: i32 = msg_send![panel, styleMask];
+            panel.set_style_mask(current & !128);
+        }
+    }
+}
+
 #[derive(PartialEq)]
 pub enum RewindWindowId {
     Main,
@@ -617,22 +646,7 @@ impl ShowRewindWindow {
 
                         if let Ok(panel) = app_clone.get_webview_panel(RewindWindowId::Chat.label())
                         {
-                            if chat_on_top {
-                                panel.set_level(1001);
-                                // NonActivatingPanel (128) so clicking doesn't activate app
-                                unsafe {
-                                    let current: i32 = msg_send![&*panel, styleMask];
-                                    panel.set_style_mask(current | 128);
-                                }
-                            } else {
-                                // Normal window level — allow it to go behind other windows
-                                panel.set_level(0);
-                                // Remove NonActivatingPanel bit (128) so it behaves normally
-                                unsafe {
-                                    let current: i32 = msg_send![&*panel, styleMask];
-                                    panel.set_style_mask(current & !128);
-                                }
-                            }
+                            apply_chat_panel_on_top(&*panel, chat_on_top);
                             let _: () =
                                 unsafe { msg_send![&*panel, setMovableByWindowBackground: true] };
                             let sharing: u64 = if capturable { 1 } else { 0 };


### PR DESCRIPTION
### Description:

- after:


https://github.com/user-attachments/assets/e08483bb-4c4b-48b7-8cfa-09af41ffe34e



- reported by a user: turning off "Chat Always on Top" while the chat window is open did nothing, so it felt like the floating chat could never be un-pinned (kept blocking other windows during long responses)
- root cause: the panel level was only set when the window is created/re-shown, never re-applied when the setting changes
- added a `set_chat_always_on_top` command that re-levels the live chat panel, and the Display toggle now calls it so the change takes effect immediately (no need to close and reopen chat)
- pulled the on-top panel logic (level 1001 + NonActivatingPanel bit) into one shared helper so the show path and the toggle stay in sync
- default behaviour is unchanged (still on top); this just makes the existing switch actually do something live

tested locally on macOS: with chat open, toggling off drops it behind other windows instantly and toggling on brings it back on top.