### PR TITLE
fix(app): stub libonnxruntime.dylib on aarch64 instead of deleting it

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -669,8 +669,10 @@ fn stage_libonnxruntime_dylib() {
             }
         }
         sign_macos_sidecar_if_needed(&dylib);
-    } else {
-        let _ = std::fs::remove_file(&dylib);
+    } else if !dylib.exists() {
+        // aarch64 doesn't load this dylib at runtime, but the bundler's
+        // macOS.files mapping references it unconditionally, so it must exist.
+        let _ = std::fs::write(&dylib, b"");
     }
 }
 


### PR DESCRIPTION
## Summary
- `tauri.macos.conf.json`'s `macOS.files` mapping copies `libonnxruntime.dylib` into `Contents/MacOS/` unconditionally, regardless of target architecture.
- `stage_libonnxruntime_dylib()` in `build.rs` deleted this file for non-x86_64 (aarch64) targets, since it isn't loaded at runtime on Apple Silicon.
- Result: `tauri build`/dev bundling failed with `Failed to copy "libonnxruntime.dylib" ... does not exist` on aarch64.

Fix: on aarch64, write an empty stub file instead of removing it, so the bundler's file mapping is satisfied. Mirrors the existing debug-build stub pattern used in the x86_64 fetch-failure path a few lines above.

## Test plan
- [x] `cargo build -p screenpipe-app-tauri` (build script) confirms stub is created instead of missing-file error
- [ ] Full `bun tauri dev` / `bun tauri build` bundling pass on aarch64 to confirm the bundler step no longer fails