### PR TITLE
fix(app): stop repeated mic focus capture restarts

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -146,6 +146,33 @@ mod specta_bindings;
 mod vault;
 mod viewer;
 
+#[cfg(target_os = "macos")]
+/// Tracks the observed permission transition so repeated focus events cannot
+/// restart capture while the audio status cache is still empty.
+struct MicFocusRecoveryTracker {
+    permission_was_granted: AtomicBool,
+}
+
+#[cfg(target_os = "macos")]
+impl MicFocusRecoveryTracker {
+    const fn new() -> Self {
+        Self {
+            permission_was_granted: AtomicBool::new(false),
+        }
+    }
+
+    fn should_restart_capture(&self, permission_granted: bool, audio_devices_empty: bool) -> bool {
+        let permission_was_granted = self
+            .permission_was_granted
+            .swap(permission_granted, Ordering::SeqCst);
+
+        permission_granted && !permission_was_granted && audio_devices_empty
+    }
+}
+
+#[cfg(target_os = "macos")]
+static MIC_FOCUS_RECOVERY: MicFocusRecoveryTracker = MicFocusRecoveryTracker::new();
+
 use health::start_health_check;
 use log_files::{get_log_files, get_screenpipe_data_dir};
 use shortcuts::{
@@ -663,14 +690,16 @@ async fn main() {
             tauri::WindowEvent::Focused(true) => {
                 let app = window.app_handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    if !permissions::check_microphone_permission().permitted() {
-                        return;
-                    }
-                    if !health::get_audio_device_status().is_empty() {
+                    let permission_granted =
+                        permissions::check_microphone_permission().permitted();
+                    let audio_devices_empty = health::get_audio_device_status().is_empty();
+                    if !MIC_FOCUS_RECOVERY
+                        .should_restart_capture(permission_granted, audio_devices_empty)
+                    {
                         return;
                     }
                     info!(
-                        "Microphone permission newly granted (focus return) — restarting capture for audio reinit"
+                        "Microphone permission became available with no audio devices (focus return) — restarting capture once for audio reinit"
                     );
                     permissions::restart_capture_on_mic_grant(app).await;
                 });
@@ -2016,6 +2045,45 @@ async fn main() {
             error!("panic in run event handler: {:?}", e);
         }
     });
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod mic_focus_recovery_tests {
+    use super::MicFocusRecoveryTracker;
+
+    #[test]
+    fn repeated_focus_with_empty_audio_status_restarts_only_once() {
+        let tracker = MicFocusRecoveryTracker::new();
+
+        assert!(tracker.should_restart_capture(true, true));
+        assert!(!tracker.should_restart_capture(true, true));
+        assert!(!tracker.should_restart_capture(true, true));
+    }
+
+    #[test]
+    fn temporary_empty_audio_status_does_not_look_like_a_new_permission_grant() {
+        let tracker = MicFocusRecoveryTracker::new();
+
+        assert!(!tracker.should_restart_capture(true, false));
+        assert!(!tracker.should_restart_capture(true, true));
+    }
+
+    #[test]
+    fn permission_revoke_rearms_focus_recovery() {
+        let tracker = MicFocusRecoveryTracker::new();
+
+        assert!(tracker.should_restart_capture(true, true));
+        assert!(!tracker.should_restart_capture(false, true));
+        assert!(tracker.should_restart_capture(true, true));
+    }
+
+    #[test]
+    fn missing_permission_never_restarts_capture() {
+        let tracker = MicFocusRecoveryTracker::new();
+
+        assert!(!tracker.should_restart_capture(false, true));
+        assert!(!tracker.should_restart_capture(false, false));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- stop macOS window focus events from repeatedly restarting the full capture engine while the audio-device status cache is empty
- preserve the one-time recovery restart when microphone permission first becomes available
- re-arm recovery if permission is later observed as denied, so a real future grant still recovers capture

## Shipped reproduction

Tested against the published app-v2.5.105 build on macOS:

- 20 `Microphone permission newly granted (focus return)` capture restarts in about 23 minutes
- 2 `failed to persist audio before deferral: Broken pipe (os error 32)` errors during that window
- health snapshot showed 87.5% recording coverage and 150 active stalled seconds while database pools and writes remained healthy

The focus handler was stateless: every focus event with granted permission plus an empty audio status cache treated the same permission as newly granted and restarted capture again.

## Fix

Track the observed microphone permission state atomically. A restart is now allowed only on a denied/unseen -> granted transition when no audio devices are reported. Repeated focus events in the same granted state are ignored.

## Validation

- regression test failed against the previous stateless behavior, then passed with this fix
- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --no-default-features mic_focus_recovery_tests -- --nocapture` (4 passed)
- broad app suite: 428 passed, 3 pre-existing main-branch failures, 6 ignored
  - `skills::tests::validate_repo_rejects_junk`
  - `specta_bindings::tests::tauri_bindings_are_current`
  - `store::tests::screenpipe_cloud_falls_back_when_not_logged_in`
- `cargo fmt --all -- --check`
- `cargo clippy --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --no-default-features --bin screenpipe-app -- -W clippy::all`
- `git diff --check`
