### PR TITLE
fix(app): stop focus-triggered capture restart loop

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -825,6 +825,11 @@ jobs:
         projectPath: "./apps/screenpipe-app-tauri"
         tauriScript: bunx tauri -v
 
+    - name: Run microphone focus restart E2E
+      shell: bash
+      working-directory: ./apps/screenpipe-app-tauri
+      run: bun run test:e2e:mic-focus:macos
+
     - name: Run E2E Tests
       # ADVISORY (non-blocking): the full serial suite (maxInstances:1) with
       # specFileRetries:3 on the slow macos-15 image exceeds the job budget and

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -7,8 +7,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 65
-- Declared test blocks: 204
-- Weighted coverage points: 157.3
+- Declared test blocks: 206
+- Weighted coverage points: 160.8
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -19,9 +19,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 56 | 191 | 152.4 | 15 | 61 | 92% |
-| macos | 62 | 170 | 129.9 | 17 | 63 | 89% |
-| linux | 48 | 155 | 124.4 | 13 | 58 | 86% |
+| windows | 56 | 192 | 153.4 | 15 | 61 | 92% |
+| macos | 62 | 172 | 133.4 | 17 | 65 | 89% |
+| linux | 48 | 156 | 125.4 | 13 | 58 | 86% |
 
 ## Runtime Results
 
@@ -39,17 +39,17 @@ pass/fail/skip counts.
 | capture-ocr | 2 specs / 14 tests / 5.6 pts | 2 specs / 4 tests / 1.6 pts | 1 specs / 3 tests / 1.2 pts |
 | chat-ai | 14 specs / 23 tests / 14.4 pts | 17 specs / 27 tests / 15.7 pts | 13 specs / 22 tests / 13.9 pts |
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
-| local-api | 14 specs / 92 tests / 76.6 pts | 13 specs / 67 tests / 57.6 pts | 11 specs / 66 tests / 57.2 pts |
+| local-api | 14 specs / 93 tests / 77.6 pts | 13 specs / 68 tests / 58.6 pts | 11 specs / 67 tests / 58.2 pts |
 | notifications | 2 specs / 11 tests / 10.1 pts | 2 specs / 4 tests / 2.4 pts | 1 specs / 3 tests / 2.1 pts |
 | onboarding | 1 specs / 3 tests / 1.2 pts | 1 specs / 3 tests / 1.2 pts | 1 specs / 3 tests / 1.2 pts |
 | os-integration | 4 specs / 16 tests / 15.1 pts | 4 specs / 3 tests / 0.9 pts | - |
-| performance | 2 specs / 43 tests / 43.0 pts | 4 specs / 33 tests / 29.5 pts | 1 specs / 28 tests / 28.0 pts |
+| performance | 2 specs / 44 tests / 44.0 pts | 4 specs / 34 tests / 30.5 pts | 1 specs / 29 tests / 29.0 pts |
 | pipes | 2 specs / 11 tests / 11.0 pts | 2 specs / 11 tests / 11.0 pts | 2 specs / 11 tests / 11.0 pts |
-| real-ui-e2e | 35 specs / 111 tests / 88.2 pts | 36 specs / 98 tests / 77.7 pts | 32 specs / 92 tests / 75.8 pts |
+| real-ui-e2e | 35 specs / 111 tests / 88.2 pts | 36 specs / 99 tests / 80.1 pts | 32 specs / 92 tests / 75.8 pts |
 | settings | 13 specs / 31 tests / 28.6 pts | 14 specs / 25 tests / 21.9 pts | 12 specs / 23 tests / 20.6 pts |
 | storage-privacy | 6 specs / 20 tests / 19.1 pts | 5 specs / 12 tests / 11.1 pts | 4 specs / 12 tests / 11.1 pts |
-| tauri-command | 8 specs / 17 tests / 10.3 pts | 9 specs / 19 tests / 10.8 pts | 8 specs / 17 tests / 10.3 pts |
-| window-lifecycle | 17 specs / 60 tests / 51.2 pts | 17 specs / 41 tests / 29.6 pts | 12 specs / 36 tests / 28.1 pts |
+| tauri-command | 8 specs / 17 tests / 10.3 pts | 9 specs / 20 tests / 13.3 pts | 8 specs / 17 tests / 10.3 pts |
+| window-lifecycle | 17 specs / 60 tests / 51.2 pts | 17 specs / 42 tests / 32.0 pts | 12 specs / 36 tests / 28.1 pts |
 
 ## Critical Feature Matrix
 
@@ -65,7 +65,7 @@ pass/fail/skip counts.
 | Privacy API auth settings UX | settings | covered (strong; settings-sections, windows-user-journey) | covered (strong; settings-sections, privacy-api-auth) | covered (strong; settings-sections, privacy-api-auth) |
 | Notification history and viewer paths | notifications | covered (strong; windows-user-journey, notification-viewer-link) | covered (partial; notification-viewer-link, audio-fallback) | covered (partial; notification-viewer-link) |
 | Audio device health | audio-device | covered (strong; windows-system-integration, windows-core-recording) | weak (conditional; audio-fallback) | gap |
-| Window lifecycle, focus, and dedupe | window-lifecycle | covered (strong; windows-system-integration, window-lifecycle) | covered (strong; window-lifecycle, viewer-deeplink) | covered (strong; window-lifecycle, viewer-deeplink) |
+| Window lifecycle, focus, and dedupe | window-lifecycle | covered (strong; windows-system-integration, window-lifecycle) | covered (strong; window-activation, window-lifecycle) | covered (strong; window-lifecycle, viewer-deeplink) |
 | Meeting note creation and editing | real-ui-e2e | covered (strong; windows-user-journey, meeting-note-bottom-click) | covered (strong; meeting-note-bottom-click) | covered (strong; meeting-note-bottom-click) |
 | Pipes discover, install, and play | pipes | covered (strong; pipes, pipes-mcp-connections) | covered (strong; pipes, pipes-mcp-connections) | covered (strong; pipes, pipes-mcp-connections) |
 | Chat window, composer, and streaming state | chat-ai | covered (strong; chat-sidebar-groups, chat-settings-background-stream) | covered (strong; chat-sidebar-groups, chat-settings-background-stream) | covered (strong; chat-sidebar-groups, chat-settings-background-stream) |
@@ -93,7 +93,7 @@ pass/fail/skip counts.
 | Spec | Platforms | Layers | Features | Criticality | Confidence | UX | Tests | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | api-key-cold-spawn.spec.ts | windows, macos, linux | local-api, tauri-command | local-api-auth, app-launch | medium | partial | command | 3 | Cold-spawn local API config regression coverage. |
-| api-search-stress.spec.ts | windows, macos, linux | local-api, performance | local-api-auth, local-api-search, health, audio-device-health, local-api-load | high | strong | api | 28 | Broad readonly API, auth, search, and load coverage. |
+| api-search-stress.spec.ts | windows, macos, linux | local-api, performance | local-api-auth, local-api-search, health, audio-device-health, local-api-load | high | strong | api | 29 | Broad readonly API, auth, search, and load coverage. |
 | api.spec.ts | windows, macos, linux | local-api | health, audio-device-health, connections, local-api-auth | high | partial | api | 7 | Smoke coverage for local HTTP API shape and auth behavior. |
 | app-lifecycle.spec.ts | windows, macos, linux | real-ui-e2e, window-lifecycle | app-launch, home-navigation, webview-stability, route-churn, browser-storage | high | strong | mixed | 14 | Home webview, routing, reload, focus, resize, and storage stability. |
 | artifacts-api.spec.ts | windows, macos, linux | local-api | local-api-auth, artifacts | medium | strong | api | 7 | CRUD coverage for artifact registration, validation, unified listing, upsert, and delete. |
@@ -143,7 +143,7 @@ pass/fail/skip counts.
 | tray-search.spec.ts | windows, macos, linux | window-lifecycle, tauri-command, real-ui-e2e | tray-search, home-search, window-lifecycle | high | partial | command | 2 | Invokes open_search_window and verifies focused floating Search. |
 | updater-banner.spec.ts | windows, macos, linux | real-ui-e2e | update-surfacing | high | partial | synthetic | 1 | Synthetic update-available event surfaces the restart-to-update banner (no relaunch). Real check/download/install + rollback stay manual via e2e/mock-updates; the debug e2e build disables the updater check under cfg!(debug_assertions). |
 | viewer-deeplink.spec.ts | windows, macos, linux | window-lifecycle, tauri-command | viewer-deeplink, window-lifecycle | medium | partial | command | 3 | Viewer window creation and per-path dedupe. |
-| window-activation.spec.ts | macos | window-lifecycle, tauri-command, real-ui-e2e | window-lifecycle, chat | medium | conditional | real-user-flow | 2 | macOS-only show_window_activated focus coverage. |
+| window-activation.spec.ts | macos | window-lifecycle, tauri-command, real-ui-e2e | window-lifecycle, chat, microphone-permission, capture-restart | high | strong | real-user-flow | 3 | macOS activation plus a blocking focus-burst regression that rejects false microphone-grant capture restarts. |
 | window-lifecycle.spec.ts | windows, macos, linux | window-lifecycle, tauri-command, real-ui-e2e | window-lifecycle, onboarding, tray-search | high | strong | mixed | 3 | Home, Search, and onboarding window routing. |
 | windows-core-recording.spec.ts | windows | capture-ocr, local-api, audio-device, real-ui-e2e | capture-ocr, local-api-auth, local-api-search, audio-device-health, timeline | high | conditional | mixed | 11 | Windows recording-enabled lane; hosted runners can skip frame-dependent OCR assertions. |
 | windows-system-integration.spec.ts | windows | os-integration, local-api, audio-device, window-lifecycle, performance | app-launch, local-api-auth, audio-device-health, window-lifecycle, os-process-health, webview-stability | high | strong | mixed | 15 | Windows display, WebView2, loopback, process, Defender, audio, focus, and crash-report checks. |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -586,11 +586,11 @@
       "spec": "window-activation.spec.ts",
       "platforms": ["macos"],
       "layers": ["window-lifecycle", "tauri-command", "real-ui-e2e"],
-      "features": ["window-lifecycle", "chat"],
-      "criticality": "medium",
-      "confidence": "conditional",
+      "features": ["window-lifecycle", "chat", "microphone-permission", "capture-restart"],
+      "criticality": "high",
+      "confidence": "strong",
       "ux": "real-user-flow",
-      "notes": "macOS-only show_window_activated focus coverage."
+      "notes": "macOS activation plus a blocking focus-burst regression that rejects false microphone-grant capture restarts."
     },
     {
       "spec": "window-lifecycle.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/window-activation.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/window-activation.spec.ts
@@ -14,7 +14,9 @@
  * WKWebView first responder path executed.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { E2E_DATA_DIR, E2E_SEED_FLAGS } from "../helpers/app-launcher.js";
 import { saveScreenshot } from "../helpers/screenshot-utils.js";
 import { openHomeWindow, waitForAppReady, t } from "../helpers/test-utils.js";
 import {
@@ -30,6 +32,21 @@ type MainLabel = (typeof MAIN_LABELS)[number];
 
 async function showWindowActivated(window: "Main" | "Chat"): Promise<void> {
   await invokeOrThrow("show_window_activated", { window });
+}
+
+async function showHomeActivated(): Promise<void> {
+  await invokeOrThrow("show_window_activated", {
+    window: { Home: { page: null } },
+  });
+}
+
+function countAppLog(marker: string): number {
+  return readdirSync(E2E_DATA_DIR)
+    .filter((name) => name.startsWith("screenpipe-app.") && name.endsWith(".log"))
+    .reduce((count, name) => {
+      const content = readFileSync(resolve(E2E_DATA_DIR, name), "utf8");
+      return count + content.split(marker).length - 1;
+    }, 0);
 }
 
 async function waitForAnyMainHandle(timeoutMs = t(12_000)): Promise<MainLabel> {
@@ -146,6 +163,56 @@ async function waitForAnyMainHandle(timeoutMs = t(12_000)): Promise<MainLabel> {
 
       const filepath = await saveScreenshot("window-activated-chat-focused");
       expect(existsSync(filepath)).toBe(true);
+    });
+
+    it("does not mistake repeated focus for a new microphone grant", async function () {
+      if (!E2E_SEED_FLAGS.split(",").includes("mic-focus-repro")) {
+        this.skip();
+      }
+
+      const focusMarker = "e2e mic-focus observation";
+      const handledMarker = "e2e mic-focus handled";
+      const permissionGrantMarker =
+        "Microphone permission newly granted (focus return)";
+      const captureStopMarker = "Stopping capture session (server stays alive)";
+      const screenStreamMarker = "persistent SCK stream started";
+      const modelMarker = "transcription engine runtime: Parakeet";
+      const focusBefore = countAppLog(focusMarker);
+      const handledBefore = countAppLog(handledMarker);
+      const permissionGrantsBefore = countAppLog(permissionGrantMarker);
+      const captureStopsBefore = countAppLog(captureStopMarker);
+      const screenStreamsBefore = countAppLog(screenStreamMarker);
+      const modelsBefore = countAppLog(modelMarker);
+
+      for (let index = 0; index < 4; index += 1) {
+        await showWindowActivated("Chat");
+        await waitForWindowHandle("chat", t(15_000));
+        await browser.switchToWindow("chat");
+
+        await showHomeActivated();
+        await waitForWindowHandle("home", t(15_000));
+        await browser.switchToWindow("home");
+      }
+
+      await browser.waitUntil(
+        async () => {
+          const observed = countAppLog(focusMarker) - focusBefore;
+          const handled = countAppLog(handledMarker) - handledBefore;
+          return observed >= 8 && handled >= observed;
+        },
+        {
+          timeout: t(15_000),
+          interval: 250,
+          timeoutMsg: "native focus churn did not finish in the app window handler",
+        },
+      );
+
+      expect(
+        countAppLog(permissionGrantMarker) - permissionGrantsBefore,
+      ).toBe(0);
+      expect(countAppLog(captureStopMarker) - captureStopsBefore).toBe(0);
+      expect(countAppLog(screenStreamMarker) - screenStreamsBefore).toBe(0);
+      expect(countAppLog(modelMarker) - modelsBefore).toBe(0);
     });
   },
 );

--- a/apps/screenpipe-app-tauri/package.json
+++ b/apps/screenpipe-app-tauri/package.json
@@ -25,6 +25,7 @@
     "coverage:all:check": "bun run e2e:coverage:check && bun run coverage:core:check && bun ../../coverage/scripts/generate-unified-coverage-report.ts --check",
     "test:e2e:audio-fallback:macos": "SCREENPIPE_E2E_SEED=onboarding,no-recording,cloud-audio-fallback bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/audio-fallback.spec.ts",
     "test:e2e:audio-fallback-reverify:macos": "SCREENPIPE_E2E_SEED=onboarding,no-recording,cloud-audio-fallback bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/zz-audio-fallback-reverify.spec.ts",
+    "test:e2e:mic-focus:macos": "SCREENPIPE_DISABLE_TELEMETRY=1 SCREENPIPE_E2E_SEED=onboarding,no-recording,mic-focus-repro SCREENPIPE_PORT=3042 SCREENPIPE_FOCUS_PORT=11436 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/window-activation.spec.ts",
     "test:e2e:onboarding-redirect": "SCREENPIPE_E2E_SEED=no-recording bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/onboarding-redirect.spec.ts",
     "test:e2e:hd:macos": "SCREENPIPE_E2E_SEED=onboarding bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/hd-recording-pipeline.spec.ts",
     "test:e2e:search-bugs": "SCREENPIPE_E2E_SEED=onboarding,no-recording,search-fixture SCREENPIPE_PORT=3041 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/search/search-bugs-4645.spec.ts",

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -653,6 +653,8 @@ async fn main() {
     let pi_state = pi::PiState(Arc::new(tokio::sync::Mutex::new(pi::PiPool::new())));
     let suggestions_state = suggestions::SuggestionsState::new();
     let pipe_suggestions_state = pipe_suggestions_scheduler::PipeSuggestionsState::new();
+    #[cfg(target_os = "macos")]
+    permissions::initialize_mic_grant_recovery();
     #[allow(clippy::single_match)]
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -661,18 +663,23 @@ async fn main() {
         .on_window_event(|window, event| match event {
             #[cfg(target_os = "macos")]
             tauri::WindowEvent::Focused(true) => {
+                #[cfg(feature = "e2e")]
+                let mic_focus_repro = get_e2e_seed_flags()
+                    .iter()
+                    .any(|flag| flag == "mic-focus-repro");
+                #[cfg(feature = "e2e")]
+                if mic_focus_repro {
+                    info!("e2e mic-focus observation");
+                }
                 let app = window.app_handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    if !permissions::check_microphone_permission().permitted() {
-                        return;
+                    let status = permissions::check_microphone_permission_for_recovery();
+                    permissions::handle_mic_permission_observation(app, status, "focus return")
+                        .await;
+                    #[cfg(feature = "e2e")]
+                    if mic_focus_repro {
+                        info!("e2e mic-focus handled");
                     }
-                    if !health::get_audio_device_status().is_empty() {
-                        return;
-                    }
-                    info!(
-                        "Microphone permission newly granted (focus return) — restarting capture for audio reinit"
-                    );
-                    permissions::restart_capture_on_mic_grant(app).await;
                 });
             }
             tauri::WindowEvent::CloseRequested { api, .. } => {
@@ -752,10 +759,11 @@ async fn main() {
             MacosLauncher::LaunchAgent,
             None,
         ))
-        // single-instance plugin uses zbus::blocking on Linux which panics
-        // inside an existing tokio runtime (nested block_on), so skip it on Linux
-        ;
-    #[cfg(not(target_os = "linux"))]
+    // The single-instance plugin uses zbus::blocking on Linux which panics
+    // inside an existing tokio runtime (nested block_on). E2E uses its own
+    // focus port and data dir, and must coexist with a developer's app.
+    ;
+    #[cfg(all(not(target_os = "linux"), not(feature = "e2e")))]
     let app = app.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
         // Defer off event stack: plugin may invoke this from run loop (nounwind).
         let app_for_closure = app.clone();

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -5,8 +5,6 @@
 use crate::tray::QUIT_REQUESTED;
 use serde::{Deserialize, Serialize};
 use specta::Type;
-#[allow(unused_imports)] // used on macOS
-use std::sync::atomic::Ordering;
 use tracing::{debug, error, info, warn};
 
 #[derive(Serialize, Deserialize, Type, Clone)]
@@ -88,13 +86,30 @@ pub async fn request_permission(app: tauri::AppHandle, permission: OSPermission)
                 };
                 match status {
                     AVAuthorizationStatus::Authorized => {
-                        // Already granted, nothing to do
+                        handle_mic_permission_observation(
+                            app.clone(),
+                            OSPermissionStatus::Granted,
+                            "permission request",
+                        )
+                        .await;
                     }
                     AVAuthorizationStatus::NotDetermined => {
                         // First time — show the system prompt
+                        handle_mic_permission_observation(
+                            app.clone(),
+                            OSPermissionStatus::Empty,
+                            "permission request",
+                        )
+                        .await;
                         request_av_permission(app.clone(), AVMediaType::Audio);
                     }
                     _ => {
+                        handle_mic_permission_observation(
+                            app.clone(),
+                            OSPermissionStatus::Denied,
+                            "permission request",
+                        )
+                        .await;
                         open_permission_settings(OSPermission::Microphone);
                     }
                 }
@@ -136,13 +151,15 @@ fn request_av_permission(app: tauri::AppHandle, media_type: nokhwa_bindings_maco
         use tauri_nspanel::block::ConcreteBlock;
 
         let callback = move |granted: BOOL| {
-            if is_audio && granted != NO {
-                info!(
-                    "Microphone permission granted via AV callback — restarting capture for audio reinit"
-                );
+            if is_audio {
                 let app = app_for_callback.clone();
+                let status = if granted != NO {
+                    OSPermissionStatus::Granted
+                } else {
+                    OSPermissionStatus::Denied
+                };
                 tauri::async_runtime::spawn(async move {
-                    restart_capture_on_mic_grant(app).await;
+                    handle_mic_permission_observation(app, status, "AV callback").await;
                 });
             }
         };
@@ -155,24 +172,160 @@ fn request_av_permission(app: tauri::AppHandle, media_type: nokhwa_bindings_maco
     });
 }
 
-/// Guards concurrent/duplicate `restart_capture_on_mic_grant` invocations —
-/// both the window-focus handler in main.rs and the direct AVCaptureDevice
-/// grant callback in `request_av_permission` above can trigger it. Always
-/// reset on drop (success, early-return, or a give-up) so a *later* trigger
-/// (e.g. the user refocusing the window) can retry. A latch that is set once
-/// and never reset would permanently disable mic-grant recovery for the rest
-/// of the process the first time an attempt didn't land (found during the
-/// Intel-Mac CI smoke-test investigation, screenpipe#4978).
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MicGrantRecoveryPhase {
+    Unknown,
+    NotGranted,
+    Pending(u64),
+    InFlight(u64),
+    GrantedIdle,
+}
+
+/// Tracks a single microphone permission transition independently from capture
+/// health. The audio-device cache can be empty during boot or a failed health
+/// poll, so it must not be used as proof that permission was newly granted.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Debug)]
+struct MicGrantRecovery {
+    phase: MicGrantRecoveryPhase,
+    next_generation: u64,
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl MicGrantRecovery {
+    const fn new() -> Self {
+        Self {
+            phase: MicGrantRecoveryPhase::Unknown,
+            next_generation: 0,
+        }
+    }
+
+    fn prime(&mut self, granted: bool) {
+        if self.phase == MicGrantRecoveryPhase::Unknown {
+            self.phase = if granted {
+                MicGrantRecoveryPhase::GrantedIdle
+            } else {
+                MicGrantRecoveryPhase::NotGranted
+            };
+        }
+    }
+
+    /// Observe current TCC state. Returns an attempt token only for a real
+    /// not-granted -> granted edge, or for a retry of that same failed edge.
+    fn observe(&mut self, granted: bool) -> Option<u64> {
+        if !granted {
+            self.phase = MicGrantRecoveryPhase::NotGranted;
+            return None;
+        }
+
+        match self.phase {
+            MicGrantRecoveryPhase::Unknown => {
+                // The first observation establishes a baseline. An app that
+                // launches with permission already granted must not restart.
+                self.phase = MicGrantRecoveryPhase::GrantedIdle;
+                None
+            }
+            MicGrantRecoveryPhase::NotGranted => {
+                self.next_generation = self.next_generation.wrapping_add(1).max(1);
+                let token = self.next_generation;
+                self.phase = MicGrantRecoveryPhase::InFlight(token);
+                Some(token)
+            }
+            MicGrantRecoveryPhase::Pending(token) => {
+                self.phase = MicGrantRecoveryPhase::InFlight(token);
+                Some(token)
+            }
+            MicGrantRecoveryPhase::InFlight(_) | MicGrantRecoveryPhase::GrantedIdle => None,
+        }
+    }
+
+    /// Finish only the matching attempt. If permission was revoked or another
+    /// transition superseded it, a stale completion cannot mark recovery done.
+    fn finish(&mut self, token: u64, success: bool) -> bool {
+        if self.phase != MicGrantRecoveryPhase::InFlight(token) {
+            return false;
+        }
+        self.phase = if success {
+            MicGrantRecoveryPhase::GrantedIdle
+        } else {
+            MicGrantRecoveryPhase::Pending(token)
+        };
+        true
+    }
+}
+
 #[cfg(target_os = "macos")]
-static MIC_GRANT_RESTART_IN_FLIGHT: std::sync::atomic::AtomicBool =
+static MIC_GRANT_RECOVERY: std::sync::Mutex<MicGrantRecovery> =
+    std::sync::Mutex::new(MicGrantRecovery::new());
+
+#[cfg(target_os = "macos")]
+static MIC_GRANT_RESTART_WORKER_ACTIVE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 #[cfg(target_os = "macos")]
-struct ResetGuard<'a>(&'a std::sync::atomic::AtomicBool);
+fn with_mic_grant_recovery<T>(f: impl FnOnce(&mut MicGrantRecovery) -> T) -> T {
+    let mut tracker = MIC_GRANT_RECOVERY
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    f(&mut tracker)
+}
+
+/// Establish the launch-time permission baseline before any window can emit a
+/// focus event. Already-granted launches are idle, not grant transitions.
 #[cfg(target_os = "macos")]
-impl Drop for ResetGuard<'_> {
+pub(crate) fn initialize_mic_grant_recovery() {
+    let granted = matches!(
+        check_microphone_permission_for_recovery(),
+        OSPermissionStatus::Granted
+    );
+    with_mic_grant_recovery(|tracker| tracker.prime(granted));
+}
+
+#[cfg(target_os = "macos")]
+fn finish_mic_grant_attempt(token: u64, success: bool) {
+    with_mic_grant_recovery(|tracker| {
+        tracker.finish(token, success);
+    });
+}
+
+/// Defaults an interrupted or failed recovery attempt back to Pending so a
+/// later focus observation can retry the same permission edge.
+#[cfg(target_os = "macos")]
+struct MicGrantAttemptGuard {
+    token: u64,
+    finished: bool,
+}
+
+#[cfg(target_os = "macos")]
+impl MicGrantAttemptGuard {
+    fn try_new(token: u64) -> Option<Self> {
+        use std::sync::atomic::Ordering;
+
+        MIC_GRANT_RESTART_WORKER_ACTIVE
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .ok()?;
+        Some(Self {
+            token,
+            finished: false,
+        })
+    }
+
+    fn succeed(mut self) {
+        finish_mic_grant_attempt(self.token, true);
+        self.finished = true;
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Drop for MicGrantAttemptGuard {
     fn drop(&mut self) {
-        self.0.store(false, Ordering::SeqCst);
+        use std::sync::atomic::Ordering;
+
+        if !self.finished {
+            finish_mic_grant_attempt(self.token, false);
+        }
+        MIC_GRANT_RESTART_WORKER_ACTIVE.store(false, Ordering::SeqCst);
     }
 }
 
@@ -196,27 +349,36 @@ const BOOT_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30
 /// path and the auto-update restart gate already use for this exact class of
 /// race (found during the Intel-Mac CI smoke-test investigation, screenpipe#4978).
 #[cfg(target_os = "macos")]
-pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
+pub(crate) async fn handle_mic_permission_observation(
+    app: tauri::AppHandle,
+    status: OSPermissionStatus,
+    source: &'static str,
+) {
+    let granted = matches!(status, OSPermissionStatus::Granted);
+    let token = with_mic_grant_recovery(|tracker| tracker.observe(granted));
+    let Some(token) = token else {
+        return;
+    };
+
+    info!("Microphone permission newly granted ({})", source);
+    let Some(attempt) = MicGrantAttemptGuard::try_new(token) else {
+        debug!("mic-grant capture restart worker already active; leaving transition pending");
+        finish_mic_grant_attempt(token, false);
+        return;
+    };
+    if restart_capture_after_mic_grant(app).await {
+        attempt.succeed();
+    }
+}
+
+#[cfg(target_os = "macos")]
+async fn restart_capture_after_mic_grant(app: tauri::AppHandle) -> bool {
     use tauri::Manager;
 
-    if MIC_GRANT_RESTART_IN_FLIGHT
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
     {
-        debug!("start_capture after mic grant: already in flight, skipping duplicate trigger");
-        return;
-    }
-    let _guard = ResetGuard(&MIC_GRANT_RESTART_IN_FLIGHT);
-
-    let need_stop = {
         let state = app.state::<crate::recording::RecordingState>();
-        let is_running = state.capture.lock().await.is_some();
-        is_running
-    };
-    if need_stop {
-        let state = app.state::<crate::recording::RecordingState>();
-        if let Err(e) = crate::recording::stop_capture(state, app.clone()).await {
-            warn!("stop_capture before mic-grant audio reinit: {}", e);
+        if !crate::recording::mic_permission_capture_restart_needed(&state, &app) {
+            return true;
         }
     }
 
@@ -229,7 +391,7 @@ pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
                     .error
                     .unwrap_or_default()
             );
-            return;
+            return false;
         }
         crate::health::BootReadiness::Pending => {
             error!(
@@ -238,7 +400,7 @@ pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
                 BOOT_WAIT_TIMEOUT.as_secs(),
                 crate::health::get_boot_phase_snapshot().phase
             );
-            return;
+            return false;
         }
         crate::health::BootReadiness::Ready => {}
     }
@@ -252,22 +414,22 @@ pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
     let mut last_err: Option<String> = None;
     for attempt in 1..=MAX_ATTEMPTS {
         let state = app.state::<crate::recording::RecordingState>();
-        match crate::recording::start_capture(state, app.clone()).await {
+        match crate::recording::restart_capture_for_mic_permission(state, app.clone()).await {
             Ok(()) => {
                 if attempt > 1 {
                     info!(
-                        "start_capture after mic grant: succeeded on attempt {}/{}",
+                        "capture recovery after mic grant: succeeded on attempt {}/{}",
                         attempt, MAX_ATTEMPTS
                     );
                 }
-                return;
+                return true;
             }
             Err(e) => {
-                let transient = e.contains("Server not running")
-                    || e.contains("Server not responding");
+                let transient =
+                    e.contains("Server not running") || e.contains("Server not responding");
                 if !transient {
-                    warn!("start_capture after mic grant: {}", e);
-                    return;
+                    warn!("capture recovery after mic grant: {}", e);
+                    return false;
                 }
                 last_err = Some(e);
                 tokio::time::sleep(std::time::Duration::from_millis(BACKOFF_MS)).await;
@@ -275,11 +437,12 @@ pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
         }
     }
     error!(
-        "start_capture after mic grant: gave up after {} attempts post-boot-ready ({}ms): {}",
+        "capture recovery after mic grant: gave up after {} attempts post-boot-ready ({}ms): {}",
         MAX_ATTEMPTS,
         MAX_ATTEMPTS as u64 * BACKOFF_MS,
         last_err.unwrap_or_else(|| "unknown error".to_string())
     );
+    false
 }
 
 // Accessibility permission APIs using ApplicationServices framework
@@ -366,6 +529,25 @@ impl OSPermissionsCheck {
 #[specta::specta]
 pub fn check_microphone_permission() -> OSPermissionStatus {
     core_to_os_status(screenpipe_core::permissions::check_microphone())
+}
+
+/// Internal probe for mic-grant recovery. E2E can model an already-granted
+/// launch without changing the permission value exposed to the frontend.
+#[cfg(target_os = "macos")]
+pub(crate) fn check_microphone_permission_for_recovery() -> OSPermissionStatus {
+    #[cfg(all(feature = "e2e", target_os = "macos"))]
+    if std::env::var("SCREENPIPE_E2E_SEED")
+        .ok()
+        .is_some_and(|flags| {
+            flags
+                .split(',')
+                .any(|flag| flag.trim() == "mic-focus-repro")
+        })
+    {
+        return OSPermissionStatus::Granted;
+    }
+
+    check_microphone_permission()
 }
 
 /// Check only screen recording permission (no dialog trigger)
@@ -1239,53 +1421,88 @@ pub fn request_arc_automation_permission(_app: tauri::AppHandle) -> bool {
 // keeps the synchronous TCC/AV check helpers used by the onboarding UI
 // and the preflight startup check.
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(test)]
 mod mic_grant_restart_tests {
     use super::*;
-    use std::sync::atomic::AtomicBool;
 
-    // Regression for the mic-grant-restart guard: previously it was a
-    // fire-once-per-process AtomicBool (`MIC_FOCUS_CAPTURE_RESTART` in
-    // main.rs) that was set true and never reset, so if the first attempt
-    // didn't land (e.g. the boot-wait timed out), no later window-focus
-    // event could ever retry for the rest of the process's life (found during
-    // the Intel-Mac CI smoke-test investigation, screenpipe#4978).
     #[test]
-    fn guard_resets_after_scope_so_a_later_call_can_retry() {
-        let flag = AtomicBool::new(false);
+    fn already_granted_launch_is_a_baseline_not_a_transition() {
+        let mut tracker = MicGrantRecovery::new();
+        tracker.prime(true);
 
-        assert!(
-            flag.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-                .is_ok(),
-            "first entry should acquire the guard"
-        );
-        {
-            let _guard = ResetGuard(&flag);
-            assert!(flag.load(Ordering::SeqCst));
-        } // guard drops here — must release the flag
-        assert!(
-            !flag.load(Ordering::SeqCst),
-            "guard must reset the flag on drop so a later trigger (e.g. the \
-             user refocusing the window) can retry"
-        );
-
-        // A later trigger can now acquire the guard again.
-        assert!(flag
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok());
+        assert_eq!(tracker.observe(true), None);
+        assert_eq!(tracker.observe(true), None);
+        assert_eq!(tracker.phase, MicGrantRecoveryPhase::GrantedIdle);
     }
 
     #[test]
-    fn concurrent_entry_is_rejected_while_first_is_in_flight() {
-        let flag = AtomicBool::new(false);
-        flag.store(true, Ordering::SeqCst);
-        let _guard = ResetGuard(&flag);
+    fn not_granted_to_granted_starts_exactly_one_attempt() {
+        let mut tracker = MicGrantRecovery::new();
+        tracker.prime(false);
 
-        // A second caller (e.g. the direct AVCaptureDevice grant callback
-        // firing at the same time as a window-focus event) must be rejected
-        // while the first is still in flight.
-        assert!(flag
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_err());
+        let token = tracker
+            .observe(true)
+            .expect("grant edge should start recovery");
+        assert_eq!(
+            tracker.observe(true),
+            None,
+            "duplicate focus/callback must dedupe"
+        );
+        assert!(tracker.finish(token, true));
+        assert_eq!(
+            tracker.observe(true),
+            None,
+            "success must latch this grant edge"
+        );
+    }
+
+    #[test]
+    fn failed_attempt_is_retryable_without_creating_a_new_edge() {
+        let mut tracker = MicGrantRecovery::new();
+        tracker.prime(false);
+
+        let token = tracker.observe(true).unwrap();
+        assert!(tracker.finish(token, false));
+        assert_eq!(tracker.phase, MicGrantRecoveryPhase::Pending(token));
+        assert_eq!(tracker.observe(true), Some(token));
+    }
+
+    #[test]
+    fn completed_recovery_rearms_only_after_permission_is_lost() {
+        let mut tracker = MicGrantRecovery::new();
+        tracker.prime(false);
+
+        let first_token = tracker.observe(true).unwrap();
+        assert!(tracker.finish(first_token, true));
+        assert_eq!(tracker.observe(true), None);
+
+        assert_eq!(tracker.observe(false), None);
+        let second_token = tracker.observe(true).unwrap();
+        assert_ne!(first_token, second_token);
+    }
+
+    #[test]
+    fn first_unknown_observation_is_safe_even_without_explicit_priming() {
+        let mut tracker = MicGrantRecovery::new();
+
+        assert_eq!(tracker.observe(true), None);
+        assert_eq!(tracker.phase, MicGrantRecoveryPhase::GrantedIdle);
+    }
+
+    #[test]
+    fn revoke_during_attempt_invalidates_stale_completion() {
+        let mut tracker = MicGrantRecovery::new();
+        tracker.prime(false);
+        let stale_token = tracker.observe(true).unwrap();
+
+        assert_eq!(tracker.observe(false), None);
+        let current_token = tracker.observe(true).unwrap();
+        assert_ne!(stale_token, current_token);
+        assert!(!tracker.finish(stale_token, true));
+        assert_eq!(
+            tracker.phase,
+            MicGrantRecoveryPhase::InFlight(current_token)
+        );
+        assert!(tracker.finish(current_token, true));
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -210,6 +210,45 @@ fn capture_intended_now(wants_recording: &AtomicBool) -> bool {
     wants_recording.load(Ordering::SeqCst)
 }
 
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MicGrantCaptureRestartDecision {
+    Restart,
+    SkipPaused,
+    SkipAudioDisabled,
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn mic_grant_capture_restart_decision(
+    capture_intended: bool,
+    audio_disabled: bool,
+) -> MicGrantCaptureRestartDecision {
+    if !capture_intended {
+        MicGrantCaptureRestartDecision::SkipPaused
+    } else if audio_disabled {
+        MicGrantCaptureRestartDecision::SkipAudioDisabled
+    } else {
+        MicGrantCaptureRestartDecision::Restart
+    }
+}
+
+/// Cheap preflight used before waiting for the backend to finish booting.
+/// The locked recovery path re-evaluates this decision before changing capture.
+#[cfg(target_os = "macos")]
+pub(crate) fn mic_permission_capture_restart_needed(
+    state: &RecordingState,
+    app: &tauri::AppHandle,
+) -> bool {
+    let store = SettingsStore::get(app).ok().flatten().unwrap_or_default();
+    matches!(
+        mic_grant_capture_restart_decision(
+            state.capture_intended(),
+            store.recording.disable_audio,
+        ),
+        MicGrantCaptureRestartDecision::Restart
+    )
+}
+
 // ---------------------------------------------------------------------------
 // Device listing (unchanged)
 // ---------------------------------------------------------------------------
@@ -330,21 +369,41 @@ pub async fn stop_capture(
     // — which would resurrect capture the user deliberately stopped.
     state.set_capture_intent(false);
 
-    remember_active_meeting_for_capture_restart(&state).await;
+    // Serialize with permission recovery and full server restarts. Intent is
+    // cleared before waiting so an in-flight recovery sees the user's stop and
+    // never starts capture again on their behalf.
+    let _lifecycle_guard = state.server_lifecycle.lock().await;
 
-    let mut capture_guard = state.capture.lock().await;
-    if let Some(session) = capture_guard.take() {
-        session.stop().await;
-        info!("Capture session stopped");
-    } else {
-        debug!("No capture session running");
+    if state.capture_intended() {
+        info!("Capture stop was superseded by a later start request");
+        return Ok(());
     }
+
+    stop_capture_session(&state).await;
     Ok(())
 }
 
-/// Whether capture is currently paused. Reads `capture_intended` which is
-/// flipped immediately in stop_capture/start_capture — no health-monitor
-/// delay. The frontend polls this so the UI stays in sync with the tray.
+async fn stop_capture_session(state: &RecordingState) {
+    let mut capture_guard = state.capture.lock().await;
+    if capture_guard.is_none() {
+        debug!("No capture session running");
+        return;
+    }
+
+    // Keep the capture session alive until the active meeting is saved. A
+    // duplicate stop that arrives after this one will see no capture and must
+    // not clear the meeting snapshot needed by the next start.
+    remember_active_meeting_for_capture_restart(state).await;
+
+    let session = capture_guard
+        .take()
+        .expect("capture presence checked while holding the capture lock");
+    session.stop().await;
+    info!("Capture session stopped");
+}
+
+/// Whether capture is currently paused. The frontend polls this alongside
+/// per-device status so the UI stays in sync with the tray indicator.
 #[tauri::command]
 #[specta::specta]
 pub fn is_capture_paused(state: State<'_, RecordingState>) -> bool {
@@ -488,6 +547,43 @@ async fn probe_server_health(health_url: &str, api_key: Option<&str>) -> bool {
     false
 }
 
+async fn ensure_server_healthy(
+    state: &RecordingState,
+    app: &tauri::AppHandle,
+) -> Result<(), String> {
+    // `state.server.is_some()` only means ServerCore was constructed once; it
+    // does NOT mean the HTTP serve task is still alive. Long-running sessions
+    // can lose the HTTP server across sleep/wake while ServerCore stays in
+    // state. Starting capture on a corpse leaves the timeline UI showing
+    // "connection error" forever — escalate to a full restart instead.
+    let (port, api_key) = {
+        let server_guard = state.server.lock().await;
+        let Some(ref core) = *server_guard else {
+            return Err("Server not running — cannot start capture".to_string());
+        };
+        (core.port, core.local_api_key.clone())
+    };
+
+    if probe_server_health(
+        &format!("http://localhost:{}/health", port),
+        api_key.as_deref(),
+    )
+    .await
+    {
+        return Ok(());
+    }
+
+    warn!(
+        "Server unresponsive on port {} — requesting full restart",
+        port
+    );
+    let _ = app.emit("request-server-restart", ());
+    Err(format!(
+        "Server not responding on port {} — full restart requested",
+        port
+    ))
+}
+
 /// Start recording. Requires the server to be running.
 #[tauri::command]
 #[specta::specta]
@@ -503,6 +599,24 @@ pub async fn start_capture(
     // — record it so the health watchdog will respawn a crashed engine instead
     // of treating the absence of capture as a deliberate stop.
     state.set_capture_intent(true);
+
+    // Serialize with user stops, permission recovery, and full server
+    // restarts. Intent is set before waiting so an in-flight recovery can
+    // observe the latest user choice before it decides whether to restart.
+    let _lifecycle_guard = state.server_lifecycle.lock().await;
+
+    start_capture_locked(&state, &app).await
+}
+
+/// Start capture while the caller holds `server_lifecycle`.
+async fn start_capture_locked(
+    state: &RecordingState,
+    app: &tauri::AppHandle,
+) -> Result<(), String> {
+    if !state.capture_intended() {
+        info!("Capture start was superseded by a later stop request");
+        return Ok(());
+    }
 
     // Race guard: short-circuit duplicate invocations.
     //
@@ -535,50 +649,75 @@ pub async fn start_capture(
         return Ok(());
     }
 
-    // `state.server.is_some()` only means ServerCore was constructed once; it
-    // does NOT mean the HTTP serve task is still alive. Long-running sessions
-    // can lose the HTTP server across sleep/wake while ServerCore stays in
-    // state. Starting capture on a corpse leaves the timeline UI showing
-    // "connection error" forever — escalate to a full restart instead.
-    let (port, api_key) = {
-        let server_guard = state.server.lock().await;
-        let Some(ref core) = *server_guard else {
-            return Err("Server not running — cannot start capture".to_string());
-        };
-        (core.port, core.local_api_key.clone())
-    };
+    ensure_server_healthy(state, app).await?;
 
-    let healthy = probe_server_health(
-        &format!("http://localhost:{}/health", port),
-        api_key.as_deref(),
-    )
-    .await;
-    if !healthy {
-        warn!(
-            "Server unresponsive on port {} — requesting full restart",
-            port
-        );
-        let _ = app.emit("request-server-restart", ());
-        return Err(format!(
-            "Server not responding on port {} — full restart requested",
-            port
-        ));
-    }
-
-    restore_interrupted_meeting_for_capture_restart(&state).await?;
+    restore_interrupted_meeting_for_capture_restart(state).await?;
 
     let server_guard = state.server.lock().await;
     let server = server_guard
         .as_ref()
         .ok_or_else(|| "Server not running — cannot start capture".to_string())?;
-    let config = build_config(&app)?;
+    let config = build_config(app)?;
     let session = CaptureSession::start(server, &config, false).await?;
     drop(server_guard);
+
+    if !state.capture_intended() {
+        info!("Capture was paused while startup was in flight; discarding the new session");
+        session.stop().await;
+        return Ok(());
+    }
 
     *capture_guard = Some(session);
 
     info!("Capture session started");
     Ok(())
+}
+
+/// Rebuild capture after a real macOS microphone permission grant without
+/// changing the user's recording intent. The full stop/start is serialized
+/// with explicit tray commands, and a stop that arrives while recovery is in
+/// flight wins before capture can be started again.
+#[cfg(target_os = "macos")]
+pub(crate) async fn restart_capture_for_mic_permission(
+    state: State<'_, RecordingState>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    let _lifecycle_guard = state.server_lifecycle.lock().await;
+    let store = SettingsStore::get(&app).ok().flatten().unwrap_or_default();
+
+    match mic_grant_capture_restart_decision(
+        state.capture_intended(),
+        store.recording.disable_audio,
+    ) {
+        MicGrantCaptureRestartDecision::SkipPaused => {
+            info!("Microphone permission granted while capture is paused; deferring audio initialization until the next explicit start");
+            return Ok(());
+        }
+        MicGrantCaptureRestartDecision::SkipAudioDisabled => {
+            info!("Microphone permission granted while audio recording is disabled; no capture restart needed");
+            return Ok(());
+        }
+        MicGrantCaptureRestartDecision::Restart => {}
+    }
+
+    require_app_entitlement(&store)?;
+
+    // Do not tear down a healthy capture just to discover afterward that its
+    // long-lived HTTP server is already unavailable.
+    ensure_server_healthy(&state, &app).await?;
+
+    info!("Restarting capture after microphone permission grant");
+    stop_capture_session(&state).await;
+
+    // `stop_capture` and `stop_screenpipe` clear intent before waiting for the
+    // lifecycle lock. Re-read after teardown so a concurrent user stop always
+    // wins and recovery cannot silently turn recording back on.
+    if !state.capture_intended() {
+        info!("Capture was paused during microphone recovery; leaving it stopped");
+        return Ok(());
+    }
+
+    start_capture_locked(&state, &app).await
 }
 
 // ---------------------------------------------------------------------------
@@ -1343,7 +1482,9 @@ async fn kill_process_on_port(port: u16) {
 
 #[cfg(test)]
 mod capture_intent_tests {
-    use super::capture_intended_now;
+    use super::{
+        capture_intended_now, mic_grant_capture_restart_decision, MicGrantCaptureRestartDecision,
+    };
     use std::sync::atomic::{AtomicBool, Ordering};
 
     #[test]
@@ -1356,6 +1497,34 @@ mod capture_intent_tests {
         wants_recording.store(false, Ordering::SeqCst);
 
         assert!(!capture_intended_now(&wants_recording));
+    }
+
+    #[test]
+    fn mic_grant_never_restarts_capture_while_paused() {
+        assert_eq!(
+            mic_grant_capture_restart_decision(false, false),
+            MicGrantCaptureRestartDecision::SkipPaused
+        );
+        assert_eq!(
+            mic_grant_capture_restart_decision(false, true),
+            MicGrantCaptureRestartDecision::SkipPaused
+        );
+    }
+
+    #[test]
+    fn mic_grant_skips_restart_when_audio_is_disabled() {
+        assert_eq!(
+            mic_grant_capture_restart_decision(true, true),
+            MicGrantCaptureRestartDecision::SkipAudioDisabled
+        );
+    }
+
+    #[test]
+    fn mic_grant_restarts_only_active_audio_capture() {
+        assert_eq!(
+            mic_grant_capture_restart_decision(true, false),
+            MicGrantCaptureRestartDecision::Restart
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- replace the empty audio-device-cache heuristic with an explicit macOS microphone permission transition tracker
- serialize microphone recovery with capture lifecycle changes while preserving the user's recording intent
- add a blocking native macOS focus-burst regression before the advisory full E2E suite

## Root cause

Every `Focused(true)` window event treated "microphone permission is granted + cached audio device list is empty" as a new grant. That cache starts empty and can also be empty after a delayed/failed health poll, so ordinary Chat/Home focus changes repeatedly ran a full capture stop/start.

The repeated restart rebuilt the ScreenCaptureKit/graphics and transcription stack, producing the observed multi-GB memory spikes even though no permission changed.

## Fix

- prime the current TCC state at launch, then recover only on a real not-granted -> granted edge
- dedupe callback/focus observations and preserve retry behavior after a genuine failed recovery
- never mutate capture intent during permission recovery
- skip recovery when recording is paused or audio is disabled
- serialize explicit start/stop and recovery so the latest user action wins
- preserve active-meeting handoff across duplicate stop commands
- keep the focused E2E app isolated from another developer instance

## Reproduction / validation

Before the fix, the isolated desktop test produced 8 false microphone-grant recoveries from 8 focus events and restarted capture.

After the fix:

- native macOS WebDriver test: **3/3 passing**
- focus burst: **0 false grant detections, 0 capture stops, 0 new SCK streams, 0 Parakeet runtime loads**
- focused Rust permission/capture tests: **9/9 passing**
- `cargo build --features e2e`
- targeted TypeScript check and ESLint
- E2E coverage consistency check
- `git diff --check`

The focused macOS regression now runs as a blocking CI step before the longer advisory suite.
