### PR TITLE
feat(overlay): add pin/lock toggle to keep timeline overlay open on focus loss

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline.tsx
@@ -387,8 +387,12 @@ export default function Timeline({ embedded = false }: { embedded?: boolean }) {
 				// Debounce: ignore duplicate focus events within 500ms
 				// macOS fires multiple focus events rapidly (3 in 62ms observed)
 				if (debounceTimer) clearTimeout(debounceTimer);
-				debounceTimer = setTimeout(() => {
+				debounceTimer = setTimeout(async () => {
 					debounceTimer = null;
+
+					// PERSONAL-FORK: when the overlay is pinned the user asked it to
+					// stay put — skip the position/filter/date reset entirely.
+					if (await commands.getOverlayPin().catch(() => false)) return;
 
 					// Don't reset if a search/calendar navigation is in progress —
 					// onWindowFocus resets currentDate to today, which cancels the

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/timeline-controls.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/timeline-controls.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight, ChevronDown, RefreshCw, CalendarIcon, Search, Play, Pause, Loader2, Mic, Volume2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, RefreshCw, CalendarIcon, Search, Play, Pause, Loader2, Mic, Volume2, Pin, PinOff } from "lucide-react";
 import {
 	format,
 	isAfter,
@@ -15,6 +15,7 @@ import {
 } from "date-fns";
 import { cn } from "@/lib/utils";
 import { useEffect, useMemo, useState } from "react";
+import { commands } from "@/lib/utils/tauri";
 import { usePlatform } from "@/lib/hooks/use-platform";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { Calendar } from "@/components/ui/calendar";
@@ -78,6 +79,28 @@ export function TimelineControls({
 	const { isMac } = usePlatform();
 	const { settings } = useSettings();
 	const [calendarOpen, setCalendarOpen] = useState(false);
+
+	// PERSONAL-FORK: overlay pin state. When pinned, the Rust side suppresses
+	// the focus-loss auto-hide so the overlay stays open when clicking away.
+	// Self-contained: reads the current state on mount and toggles via command.
+	const [pinned, setPinned] = useState(false);
+	useEffect(() => {
+		let cancelled = false;
+		commands.getOverlayPin().then((v) => {
+			if (!cancelled) setPinned(v);
+		}).catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+	const togglePin = async () => {
+		try {
+			const next = await commands.toggleOverlayPin();
+			setPinned(next);
+		} catch {
+			// command unavailable (older binary) — ignore
+		}
+	};
 
 	// Set of "YYYY-MM-DD" local-day strings that have at least one frame.
 	// Used to grey out empty days in the calendar picker so users don't
@@ -233,6 +256,22 @@ export function TimelineControls({
 						title="Jump to now"
 					>
 						<RefreshCw className="h-4 w-4" />
+					</Button>
+
+					{/* PERSONAL-FORK: pin toggle — keeps the overlay open on focus loss */}
+					<Button
+						variant="ghost"
+						size="icon"
+						onClick={togglePin}
+						className={cn(
+							"h-8 w-8 transition-colors duration-150",
+							pinned
+								? "bg-foreground text-background hover:bg-foreground/90"
+								: "text-foreground hover:bg-foreground hover:text-background",
+						)}
+						title={pinned ? "Unpin overlay (auto-hide on focus loss)" : "Pin overlay (stay open when clicking away)"}
+					>
+						{pinned ? <Pin className="h-4 w-4" /> : <PinOff className="h-4 w-4" />}
 					</Button>
 				</div>
 

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -704,6 +704,9 @@ async getOnboardingStatus() : Promise<Result<OnboardingStore, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async getOverlayPin() : Promise<boolean> {
+    return await TAURI_INVOKE("get_overlay_pin");
+},
 /**
  * Hydrate the frontend banner state on mount. The `update-available` event
  * is broadcast once when the download completes — if the React app isn't
@@ -2272,6 +2275,9 @@ async triggerUpdateCheck() : Promise<Result<boolean, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async toggleOverlayPin() : Promise<boolean> {
+    return await TAURI_INVOKE("toggle_overlay_pin");
 },
 /**
  * Unregister window-specific shortcuts when main window is hidden.

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -116,6 +116,27 @@ pub fn is_enterprise_build_cmd(app_handle: tauri::AppHandle) -> bool {
     is_enterprise_build(&app_handle)
 }
 
+/// PERSONAL-FORK: toggle the main overlay "pin" state. When pinned, the
+/// overlay's focus-loss auto-hide is suppressed (it stays visible when the
+/// user clicks away) and the TS timeline skips its `window-focused: true`
+/// state reset. Returns the new pinned state so the UI can reflect it.
+#[tauri::command]
+#[specta::specta]
+pub fn toggle_overlay_pin() -> bool {
+    use std::sync::atomic::Ordering;
+    let pinned = &crate::window::MAIN_PANEL_PINNED;
+    // fetch_xor(true) flips the flag and returns the PREVIOUS value, so the
+    // new state is its negation.
+    !pinned.fetch_xor(true, Ordering::SeqCst)
+}
+
+/// PERSONAL-FORK: read the current main-overlay pin state without changing it.
+#[tauri::command]
+#[specta::specta]
+pub fn get_overlay_pin() -> bool {
+    crate::window::MAIN_PANEL_PINNED.load(std::sync::atomic::Ordering::SeqCst)
+}
+
 /// Return the macOS bundle identifier of the running app
 /// (e.g. `screenpi.pe`, `screenpi.pe.beta`, `screenpi.pe.dev`,
 /// `screenpi.pe.enterprise`). The onboarding stuck-screen surfaces this so

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
@@ -110,6 +110,9 @@ pub use focus::clear_frontmost_app;
 pub use focus::restore_frontmost_app;
 #[cfg(target_os = "macos")]
 pub use panel::{reset_to_regular_and_refresh_tray, MAIN_PANEL_SHOWN};
+// PERSONAL-FORK: overlay pin flag — unconditional (used on all platforms by
+// the focus-loss guards and the toggle command).
+pub use panel::MAIN_PANEL_PINNED;
 #[cfg(target_os = "macos")]
 pub use util::run_on_main_thread_safe;
 #[cfg(target_os = "macos")]

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/panel.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/panel.rs
@@ -64,6 +64,15 @@ pub(crate) unsafe fn show_panel_visible(
 pub static MAIN_PANEL_SHOWN: Lazy<std::sync::atomic::AtomicBool> =
     Lazy::new(|| std::sync::atomic::AtomicBool::new(false));
 
+/// PERSONAL-FORK: when `true`, the main overlay panel is "pinned" and its
+/// focus-loss auto-hide is suppressed (the panel stays visible when the user
+/// clicks away). Toggled by the `toggle_overlay_pin` command; read by the
+/// focus-loss handlers in `show.rs`. Unconditional (not macOS-gated) so the
+/// guard and command compile on every platform. Defaults to unpinned, so
+/// behaviour is unchanged unless the user explicitly pins the overlay.
+pub static MAIN_PANEL_PINNED: Lazy<std::sync::atomic::AtomicBool> =
+    Lazy::new(|| std::sync::atomic::AtomicBool::new(false));
+
 /// Tracks which overlay mode the current Main window was created for.
 /// When the mode changes, show() hides the old panel and creates a fresh one
 /// under a different label to avoid NSPanel reconfiguration crashes.

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -848,6 +848,13 @@ impl ShowRewindWindow {
                         match event {
                             tauri::WindowEvent::Focused(is_focused) => {
                                 if !is_focused {
+                                    // PERSONAL-FORK: pinned overlay stays visible
+                                    // on focus loss — skip the auto-hide entirely.
+                                    if crate::window::MAIN_PANEL_PINNED
+                                        .load(std::sync::atomic::Ordering::SeqCst)
+                                    {
+                                        return;
+                                    }
                                     // Synchronous alpha=0 — no order_out (which
                                     // causes focus-fight loops when restored).
                                     #[cfg(target_os = "macos")]
@@ -1248,6 +1255,13 @@ impl ShowRewindWindow {
                         #[cfg(not(target_os = "linux"))]
                         tauri::WindowEvent::Focused(is_focused) => {
                             if !is_focused {
+                                // PERSONAL-FORK: pinned overlay stays visible on
+                                // focus loss — skip the debounced auto-hide.
+                                if crate::window::MAIN_PANEL_PINNED
+                                    .load(std::sync::atomic::Ordering::SeqCst)
+                                {
+                                    return;
+                                }
                                 info!("Main window lost focus, scheduling hide (300ms debounce)");
                                 // Synchronous alpha=0 — panel stays in window list
                                 // but is invisible. No order_out (causes focus loops).


### PR DESCRIPTION
## What

Adds a pin/lock toggle to the timeline overlay so it stays open when it loses focus, instead of auto-dismissing. Closes #4293.

- `window/panel.rs`: `MAIN_PANEL_PINNED` atomic flag
- `window/show.rs`: both focus-loss handlers early-return when pinned (no auto-hide)
- `commands.rs`: `toggle_overlay_pin` / `get_overlay_pin` commands (`#[tauri::command] #[specta::specta]`)
- `timeline-controls.tsx`: pin button (lucide `Pin`/`PinOff`)
- `timeline.tsx`: suppress the refocus state-reset when pinned

## Note for reviewers

`lib/utils/tauri.ts` bindings were **hand-added** (my local `bun run bindings:generate` was blocked by an environment issue). Please regenerate with `bun run bindings:generate` to confirm they match — the Rust commands carry both `#[tauri::command]` and `#[specta::specta]` so they should collect correctly. CI is the first clean build of this branch; happy to fix-forward on any failure. No visuals yet — can add a screen recording if wanted.

Thanks!
