### PR TITLE
perf(engine): make background loop intervals env-overridable

### DIFF
--- a/crates/screenpipe-db/src/db/maintenance.rs
+++ b/crates/screenpipe-db/src/db/maintenance.rs
@@ -1376,12 +1376,18 @@ impl DatabaseManager {
         tokio::spawn(async move {
             // 60s (not 300s): with inline auto-checkpoint off, the WAL grows for
             // the whole interval between ticks, so check more often to keep it
-            // small under sustained write load.
-            const INTERVAL: Duration = Duration::from_secs(60);
+            // small under sustained write load. Overridable via
+            // SCREENPIPE_WAL_INTERVAL_SECS for tuning on unusual workloads.
+            let interval_secs = std::env::var("SCREENPIPE_WAL_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|&v| v > 0)
+                .unwrap_or(60);
+            let interval_dur = Duration::from_secs(interval_secs);
             // ~40k pages * 4KB ≈ 160MB. Above this we force the checkpoint
             // through rather than tolerate more growth.
             const WAL_HARD_CAP_PAGES: i32 = 40_000;
-            let mut interval = tokio::time::interval(INTERVAL);
+            let mut interval = tokio::time::interval(interval_dur);
             loop {
                 tokio::select! {
                     _ = interval.tick() => {}

--- a/crates/screenpipe-engine/src/archive.rs
+++ b/crates/screenpipe-engine/src/archive.rs
@@ -806,7 +806,16 @@ fn spawn_archive_loop(
         // Short initial delay, then run immediately
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+        // Interval overridable via SCREENPIPE_ARCHIVE_INTERVAL_SECS (default
+        // 300s). Lets low-power / metered devices back the cloud sweep off
+        // without a rebuild.
+        let interval_secs = std::env::var("SCREENPIPE_ARCHIVE_INTERVAL_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(300);
+        let mut interval =
+            tokio::time::interval(std::time::Duration::from_secs(interval_secs));
         interval.tick().await; // consume immediate tick
 
         let mut quota_backoff = QuotaBackoff::new();

--- a/crates/screenpipe-engine/src/auto_destruct.rs
+++ b/crates/screenpipe-engine/src/auto_destruct.rs
@@ -41,6 +41,15 @@ fn is_process_alive(pid: u32) -> bool {
 pub async fn watch_pid(pid: u32) -> bool {
     info!("starting to watch for app termination (pid: {})", pid);
 
+    // Poll interval overridable via SCREENPIPE_AUTODESTRUCT_INTERVAL_SECS
+    // (default 5s). Raising it cuts battery wake-ups on laptops that don't
+    // need sub-5s teardown latency.
+    let poll_secs = std::env::var("SCREENPIPE_AUTODESTRUCT_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(5);
+
     loop {
         #[cfg(target_os = "windows")]
         {
@@ -66,6 +75,6 @@ pub async fn watch_pid(pid: u32) -> bool {
             }
         }
 
-        sleep(Duration::from_secs(5)).await;
+        sleep(Duration::from_secs(poll_secs)).await;
     }
 }

--- a/crates/screenpipe-engine/src/calendar_speaker_id.rs
+++ b/crates/screenpipe-engine/src/calendar_speaker_id.rs
@@ -568,7 +568,14 @@ async fn auto_name_input_speaker(db: Arc<screenpipe_db::DatabaseManager>, user_n
     // Wait a bit for initial audio to accumulate
     tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
 
-    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(120));
+    // Poll interval overridable via SCREENPIPE_CALENDAR_INTERVAL_SECS
+    // (default 120s) so low-power devices can slow the speaker sweep.
+    let interval_secs = std::env::var("SCREENPIPE_CALENDAR_INTERVAL_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(120);
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(interval_secs));
     let min_transcriptions = 10; // need enough data to be confident
 
     loop {


### PR DESCRIPTION
## describe the feature

Makes the four background-loop poll intervals overridable via env vars, each defaulting to the current hardcoded value:

- `SCREENPIPE_WAL_INTERVAL_SECS` — WAL checkpoint sweep (default 60s)
- `SCREENPIPE_ARCHIVE_INTERVAL_SECS` — cloud archive sweep (default 300s)
- `SCREENPIPE_AUTODESTRUCT_INTERVAL_SECS` — parent-pid watch poll (default 5s)
- `SCREENPIPE_CALENDAR_INTERVAL_SECS` — calendar speaker-id sweep (default 120s)

Each parses the env var, ignores non-numeric / zero values, and falls back to the existing constant, so behaviour is unchanged unless a var is set.

related issue: #4880

## why is this needed?

On low-power, battery, or metered devices these fixed intervals cause avoidable wake-ups and cloud/CPU work. The 5s auto-destruct poll in particular is a frequent battery wake-up on laptops that don't need sub-5s teardown latency. Letting users tune the cadence without a rebuild is the smallest useful knob.

## alternatives considered

- A single config-file setting — heavier; these are engine-internal loops and env vars match how the rest of the engine is already tuned.
- Leaving them hardcoded — forces a rebuild to adjust, which is what motivated the issue.

## additional context

Additive only; no default changes. Each override is guarded by `.filter(|&v| v > 0)` so a bad value can't disable a loop by setting a 0 interval.

Thanks for maintaining screenpipe.