### PR TITLE
a11y(onboarding): label the watching indicator for screen readers

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -928,13 +928,19 @@ if the input is sparse, just describe what little you have warmly. don't apologi
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.1 }}
+          role="status"
+          aria-label="screenpipe is watching your screen"
         >
           <motion.div
             className="w-1.5 h-1.5 rounded-full bg-foreground"
             animate={{ opacity: [1, 0.3, 1] }}
             transition={{ duration: 1.5, repeat: Infinity }}
+            aria-hidden="true"
           />
-          <span className="font-mono text-[10px] tracking-wider lowercase text-muted-foreground/70">
+          <span
+            className="font-mono text-[10px] tracking-wider lowercase text-muted-foreground/70"
+            aria-hidden="true"
+          >
             watching · {feedSeconds}s
           </span>
         </motion.div>


### PR DESCRIPTION
## description

The onboarding "watching · {n}s" indicator was announced to assistive tech as a raw, ever-incrementing counter with a decorative pulse dot — noisy and meaningless to a screen-reader user. This gives the container a stable `role="status"` with `aria-label="screenpipe is watching your screen"`, and marks the animated dot and the ticking `watching · Ns` text `aria-hidden="true"` so AT reads one clear label instead of a counter that updates every second.

related issue: #4871

## why

A live-updating second counter fires constant screen-reader announcements and conveys no useful state; the pulse dot is purely decorative. One static, descriptive label communicates the actual state ("watching your screen") without the noise.

## how to test

1. Open the onboarding engine-startup screen with a screen reader (VoiceOver / NVDA) active.
2. Confirm it announces "screenpipe is watching your screen" once, rather than reading the incrementing "watching · Ns" counter repeatedly.

## desktop app checklist

TS/markup-only; no `#[tauri::command]` handlers or exported Rust types changed — no bindings regen needed.

Thanks for maintaining screenpipe.