### PR TITLE
feat(onboarding): ask for browser URL permission right after microphone

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx
@@ -107,6 +107,21 @@ export default function PermissionsStep({
       request: () => commands.requestPermission("microphone"),
     },
     {
+      id: "browsers",
+      icon: <Globe className="w-3.5 h-3.5" strokeWidth={1.5} />,
+      title: "Capture browser URLs",
+      subtitle: "So Screenpipe knows what you were reading, not just what the pixels say",
+      check: async () => {
+        const granted = await commands.checkBrowsersAutomationPermission();
+        return granted ? "granted" : "denied";
+      },
+      request: async () => {
+        await commands.requestBrowsersAutomationPermission();
+      },
+      macOnly: true,
+      optional: true,
+    },
+    {
       id: "accessibility",
       icon: <Keyboard className="w-3.5 h-3.5" strokeWidth={1.5} />,
       title: "Read on-screen text",
@@ -124,21 +139,6 @@ export default function PermissionsStep({
       // so asking earlier just sends the user back into settings again mid-flow
       check: () => commands.checkScreenRecordingPermission(),
       request: () => requestPermissionWithFlow("screenRecording"),
-    },
-    {
-      id: "browsers",
-      icon: <Globe className="w-3.5 h-3.5" strokeWidth={1.5} />,
-      title: "Capture browser URLs",
-      subtitle: "So Screenpipe knows what you were reading, not just what the pixels say",
-      check: async () => {
-        const granted = await commands.checkBrowsersAutomationPermission();
-        return granted ? "granted" : "denied";
-      },
-      request: async () => {
-        await commands.requestBrowsersAutomationPermission();
-      },
-      macOnly: true,
-      optional: true,
     },
   ];
 


### PR DESCRIPTION
## What

Reorders the onboarding permission list so the **browser URL** (automation) prompt appears immediately after the **microphone** prompt.

New order: `microphone → browser URLs → accessibility → screen recording`.

Screen recording stays last on purpose — granting it requires an app restart to take effect, so asking earlier bounces the user back into settings mid-flow.

## Why

Browser URL capture is what makes on-screen context useful ("what you were reading, not just what the pixels say"). Surfacing it right after mic — while the user is still in permission-granting mode — should lift its opt-in rate. It stays `optional`, so it never blocks auto-advance.

## Notes

Single-file change in [permissions-step.tsx](apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx). No logic changes — only array ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)