### PR TITLE
feat: alert user ASAP on shortcut reminder overlay when recording is …

### DIFF
--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -12,12 +12,13 @@ import posthog from "posthog-js";
 import { usePlatform } from "@/lib/hooks/use-platform";
 import { getStore, saveAndEncrypt } from "@/lib/hooks/use-settings";
 import { commands } from "@/lib/utils/tauri";
-import { X, Phone } from "lucide-react";
+import { X, Phone, RotateCw, Loader2, CheckCircle2 } from "lucide-react";
 import { useOverlayData } from "./use-overlay-data";
 import { AudioEqualizer } from "./audio-equalizer";
 import { ScreenMatrix } from "./screen-matrix";
 import { computeMeetingActive, type MeetingStatusResponse } from "@/lib/utils/meeting-state";
 import { appendAuthToken, ensureApiReady, getApiBaseUrl } from "@/lib/api";
+import { useHealthCheck } from "@/lib/hooks/use-health-check";
 
 type ReminderSettings = {
   disabledShortcuts?: string[];
@@ -114,6 +115,9 @@ function useMeetingState() {
 
 export default function ShortcutReminderPage() {
   const { isMac, isLoading } = usePlatform();
+  const { health, isServerDown } = useHealthCheck();
+  const [recordingState, setRecordingState] = useState<"normal" | "failure" | "fixing" | "recovered">("normal");
+  const [isHovered, setIsHovered] = useState(false);
   const [overlayShortcut, setOverlayShortcut] = useState<string | null>(null);
   const [chatShortcut, setChatShortcut] = useState<string | null>(null);
   const [searchShortcut, setSearchShortcut] = useState<string | null>(null);
@@ -122,6 +126,46 @@ export default function ShortcutReminderPage() {
   const [overlayScale, setOverlayScale] = useState(1);
   const isMacRef = useRef(isMac);
   isMacRef.current = isMac;
+
+  useEffect(() => {
+    const isBroken = isServerDown || health?.status === "unhealthy" || health?.status === "error";
+    if (isBroken) {
+      if (recordingState === "normal") {
+        setRecordingState("failure");
+      }
+    } else {
+      if (recordingState === "failure" || recordingState === "fixing") {
+        setRecordingState("recovered");
+        const timer = setTimeout(() => {
+          setRecordingState("normal");
+        }, 3000);
+        return () => clearTimeout(timer);
+      }
+    }
+  }, [isServerDown, health?.status, recordingState]);
+
+  const handleRestart = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setRecordingState("fixing");
+    try {
+      try { await commands.stopScreenpipe(); } catch {}
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await commands.spawnScreenpipe(null);
+    } catch (err) {
+      console.error("Restart failed:", err);
+    }
+  }, []);
+
+  const handleCloseFailure = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    try {
+      await commands.hideShortcutReminder();
+    } catch (err) {
+      console.error("Failed to hide shortcut reminder:", err);
+    }
+  }, []);
 
   const applyReminderSettings = useCallback((settings?: ReminderSettings | null) => {
     if (!settings) return;
@@ -260,6 +304,138 @@ export default function ShortcutReminderPage() {
   const gap = 2 * overlayScale;
   const smIconPx = 10 * overlayScale;
   const dotPx = Math.max(5 * overlayScale, 5);
+
+
+  if (recordingState === "failure") {
+    return (
+      <div
+        className="w-full h-full flex items-center justify-center"
+        style={{ background: "transparent" }}
+      >
+        <div
+          onMouseDown={handleMouseDown}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          className="select-none w-full h-full border border-red-500/40"
+          style={{
+            background: "rgba(0, 0, 0, 0.88)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: `${padY}px ${padX * 2}px`,
+            cursor: "grab",
+          }}
+        >
+          <div className="flex items-center" style={{ gap: `${gap * 2}px` }}>
+            <div
+              className="rounded-full bg-red-500 animate-pulse shrink-0"
+              style={{ width: `${dotPx}px`, height: `${dotPx}px` }}
+            />
+            <span
+              className="font-mono text-white/90 whitespace-nowrap"
+              style={{ fontSize: `${fontPx}px` }}
+            >
+              recording stopped
+            </span>
+          </div>
+
+          {isHovered && (
+            <div className="flex items-center shrink-0" style={{ gap: `${gap * 2}px`, WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+              <div className="bg-white/20" style={{ width: "1px", height: `${12 * overlayScale}px` }} />
+              <button
+                onClick={handleRestart}
+                onMouseDown={(e) => e.stopPropagation()}
+                className="flex items-center hover:bg-white/10 transition-colors cursor-pointer text-white/90"
+                style={{ gap: `${gap}px`, padding: `${padY}px ${padX}px` }}
+              >
+                <RotateCw style={{ width: `${smIconPx}px`, height: `${smIconPx}px` }} className="shrink-0" />
+                <span className="font-mono font-bold uppercase" style={{ fontSize: `${fontPx}px` }}>
+                  restart
+                </span>
+              </button>
+              <div className="bg-white/20" style={{ width: "1px", height: `${12 * overlayScale}px` }} />
+              <button
+                onClick={handleCloseFailure}
+                onMouseDown={(e) => e.stopPropagation()}
+                className="flex items-center justify-center hover:bg-white/10 transition-colors cursor-pointer text-white/60 hover:text-white"
+                style={{ padding: `${padY}px` }}
+              >
+                <X style={{ width: `${smIconPx}px`, height: `${smIconPx}px` }} />
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (recordingState === "fixing") {
+    return (
+      <div
+        className="w-full h-full flex items-center justify-center"
+        style={{ background: "transparent" }}
+      >
+        <div
+          onMouseDown={handleMouseDown}
+          className="select-none w-full h-full border border-white/25"
+          style={{
+            background: "rgba(0, 0, 0, 0.88)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            padding: `${padY}px ${padX * 2}px`,
+            cursor: "grab",
+            gap: `${gap * 2}px`,
+          }}
+        >
+          <Loader2
+            className="animate-spin text-white/70 shrink-0"
+            style={{ width: `${smIconPx}px`, height: `${smIconPx}px` }}
+          />
+          <span
+            className="font-mono text-white/90 whitespace-nowrap"
+            style={{ fontSize: `${fontPx}px` }}
+          >
+            fixing recording...
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (recordingState === "recovered") {
+    return (
+      <div
+        className="w-full h-full flex items-center justify-center"
+        style={{ background: "transparent" }}
+      >
+        <div
+          onMouseDown={handleMouseDown}
+          className="select-none w-full h-full border border-green-500/40"
+          style={{
+            background: "rgba(0, 0, 0, 0.88)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            padding: `${padY}px ${padX * 2}px`,
+            cursor: "grab",
+            gap: `${gap * 2}px`,
+          }}
+        >
+          <CheckCircle2
+            className="text-green-500 shrink-0"
+            style={{ width: `${smIconPx}px`, height: `${smIconPx}px` }}
+          />
+          <span
+            className="font-mono text-white/90 whitespace-nowrap"
+            style={{ fontSize: `${fontPx}px` }}
+          >
+            recording again
+          </span>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -2379,10 +2379,12 @@ pub async fn show_shortcut_reminder(
                     let mut metrics_ws_url = format!("ws://127.0.0.1:{}/ws/metrics", core.port);
                     let mut events_ws_url =
                         format!("ws://127.0.0.1:{}/ws/meeting-status", core.port);
+                    let mut health_ws_url = format!("ws://127.0.0.1:{}/ws/health", core.port);
                     if let Some(ref key) = core.local_api_key {
                         let enc = urlencoding::encode(key);
                         metrics_ws_url = format!("{}?token={}", metrics_ws_url, enc);
                         events_ws_url = format!("{}?token={}", events_ws_url, enc);
+                        health_ws_url = format!("{}?token={}", health_ws_url, enc);
                     }
                     map.insert(
                         "metrics_ws_url".to_string(),
@@ -2391,6 +2393,10 @@ pub async fn show_shortcut_reminder(
                     map.insert(
                         "events_ws_url".to_string(),
                         serde_json::json!(events_ws_url),
+                    );
+                    map.insert(
+                        "health_ws_url".to_string(),
+                        serde_json::json!(health_ws_url),
                     );
                 }
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -427,7 +427,7 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
                                         "stoppableMeetingId": serde_json::Value::Null,
                                         "meetingApp": serde_json::Value::Null,
                                         "detectionSource": serde_json::Value::Null,
-                                    }),
+                                     }),
                                 );
                             }
                         }
@@ -458,6 +458,16 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
                             warn!("failed to check meeting status");
                         }
                     }
+                }
+                "restart_recording" => {
+                    let app_clone = app_clone.clone();
+                    tauri::async_runtime::spawn(async move {
+                        info!("native shortcut action: restarting recording...");
+                        let _ = crate::recording::stop_screenpipe(&app_clone).await;
+                        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                        let _ = crate::recording::spawn_screenpipe(&app_clone, None).await;
+                        info!("native shortcut action: restart recording complete");
+                    });
                 }
                 _ => {}
             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -1328,6 +1328,17 @@ async fn show_capture_stall_notification(app: &tauri::AppHandle, system: &str) -
             return Ok(());
         }
     }
+    
+    // Automatically reveal the shortcut reminder overlay for the incident
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let store = crate::store::SettingsStore::get(&app_clone)
+            .unwrap_or_default()
+            .unwrap_or_default();
+        let shortcut = store.show_screenpipe_shortcut.clone();
+        let _ = crate::commands::show_shortcut_reminder(app_clone, shortcut).await;
+    });
+
     let payload = serde_json::json!({
         "id": format!("capture_stall_{}", system),
         "type": "capture_stall",

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -30,6 +30,9 @@ final class OverlayMetrics: ObservableObject {
     @Published var screenActive: Bool = false
     @Published var captureFps: Double = 0
     @Published var meetingActive: Bool = false
+    @Published var isServerDown: Bool = false
+    @Published var isUnhealthy: Bool = false
+    @Published var fixingState: String = "normal" // "normal" | "failure" | "fixing" | "recovered"
 }
 
 // MARK: - Font helper (same as notification panel)
@@ -239,7 +242,13 @@ struct ShortcutReminderView: View {
 
     var body: some View {
         ZStack {
-            if isExpanded {
+            if metrics.fixingState == "failure" {
+                failureView
+            } else if metrics.fixingState == "fixing" {
+                fixingView
+            } else if metrics.fixingState == "recovered" {
+                recoveredView
+            } else if isExpanded {
                 // Once expanded, collapse only when the mouse leaves the
                 // entire expanded bar (so hovering individual buttons inside
                 // doesn't bounce us back).
@@ -256,7 +265,102 @@ struct ShortcutReminderView: View {
         .fixedSize()
         .accessibilityHidden(true)
         .animation(.easeInOut(duration: kAnimDur), value: isExpanded)
+        .animation(.easeInOut(duration: kAnimDur), value: metrics.fixingState)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+
+    // MARK: - Failure State View
+    private var failureView: some View {
+        HStack(spacing: 0) {
+            Circle()
+                .fill(Color.red)
+                .frame(width: s(6), height: s(6))
+                .padding(.leading, s(8))
+                .padding(.trailing, s(4))
+            
+            Text("recording stopped")
+                .font(Brand.swiftUIMonoFont(size: 8 * scale, weight: .regular))
+                .foregroundColor(.white.opacity(0.85))
+                .padding(.trailing, s(8))
+            
+            if isExpanded {
+                Rectangle().fill(.white.opacity(0.15)).frame(width: 0.5).frame(height: s(12))
+                
+                Button(action: {
+                    onAction("restart_recording")
+                }) {
+                    HStack(spacing: s(2)) {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.system(size: 6 * scale, weight: .bold))
+                            .foregroundColor(.white.opacity(0.95))
+                        Text("restart")
+                            .font(Brand.swiftUIMonoFont(size: 8 * scale, weight: .bold))
+                            .foregroundColor(.white.opacity(0.95))
+                    }
+                    .padding(.horizontal, s(8))
+                    .frame(maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                
+                Rectangle().fill(.white.opacity(0.15)).frame(width: 0.5).frame(height: s(12))
+                
+                Button(action: {
+                    onAction("close")
+                }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 6 * scale, weight: .medium))
+                        .foregroundColor(.white.opacity(0.6))
+                        .padding(.horizontal, s(8))
+                        .frame(maxHeight: .infinity)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(height: kBaseCollapsedH * scale)
+        .background(Capsule().fill(Color.black.opacity(0.85)))
+        .overlay(Capsule().stroke(Color.red.opacity(0.4), lineWidth: 0.5))
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isExpanded = hovering
+        }
+    }
+
+    // MARK: - Fixing State View
+    private var fixingView: some View {
+        HStack(spacing: s(4)) {
+            ProgressView()
+                .scaleEffect(0.45)
+                .frame(width: s(12), height: s(12))
+                .padding(.leading, s(8))
+            
+            Text("fixing recording...")
+                .font(Brand.swiftUIMonoFont(size: 8 * scale, weight: .regular))
+                .foregroundColor(.white.opacity(0.85))
+                .padding(.trailing, s(8))
+        }
+        .frame(height: kBaseCollapsedH * scale)
+        .background(Capsule().fill(Color.black.opacity(0.85)))
+        .overlay(Capsule().stroke(.white.opacity(0.15), lineWidth: 0.5))
+    }
+
+    // MARK: - Recovered State View
+    private var recoveredView: some View {
+        HStack(spacing: s(4)) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 8 * scale))
+                .foregroundColor(.green)
+                .padding(.leading, s(8))
+            
+            Text("recording again")
+                .font(Brand.swiftUIMonoFont(size: 8 * scale, weight: .regular))
+                .foregroundColor(.white.opacity(0.85))
+                .padding(.trailing, s(8))
+        }
+        .frame(height: kBaseCollapsedH * scale)
+        .background(Capsule().fill(Color.black.opacity(0.85)))
+        .overlay(Capsule().stroke(Color.green.opacity(0.4), lineWidth: 0.5))
     }
 
     // MARK: - Collapsed pill
@@ -494,11 +598,14 @@ class ShortcutReminderController: NSObject {
     private var wsRetryTimer: Timer?
     private var meetingWsTask: URLSessionWebSocketTask?
     private var meetingWsRetryTimer: Timer?
+    private var healthWsTask: URLSessionWebSocketTask?
+    private var healthWsRetryTimer: Timer?
     private var prevFramesCaptured: Int?
     private var prevOcrCompleted: Int?
     /// Set from Rust `show_shortcut_reminder` when API auth is enabled (includes ?token=).
     private var metricsWsUrl = "ws://127.0.0.1:3030/ws/metrics"
     private var eventsWsUrl = "ws://127.0.0.1:3030/ws/meeting-status"
+    private var healthWsUrl = "ws://127.0.0.1:3030/ws/health"
     private var isVisible = false
 
     func show(shortcuts: String?) {
@@ -524,6 +631,7 @@ class ShortcutReminderController: NSObject {
             )
             connectWebSocket()
             connectMeetingEventsWebSocket()
+            connectHealthWebSocket()
         }
     }
 
@@ -533,6 +641,7 @@ class ShortcutReminderController: NSObject {
             AnimationTick.shared.setVisible(false, hasActiveSignal: false)
             disconnectWebSocket()
             disconnectMeetingEventsWebSocket()
+            disconnectHealthWebSocket()
             panel?.orderOut(nil)
         }
     }
@@ -677,6 +786,99 @@ class ShortcutReminderController: NSObject {
         }
     }
 
+    // MARK: - Health status connection
+
+    private func connectHealthWebSocket() {
+        disconnectHealthWebSocket()
+        guard isVisible else { return }
+        guard let url = URL(string: healthWsUrl) else { return }
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: url)
+        self.healthWsTask = task
+        task.resume()
+        receiveHealthMessage()
+    }
+
+    private func disconnectHealthWebSocket() {
+        healthWsRetryTimer?.invalidate()
+        healthWsRetryTimer = nil
+        healthWsTask?.cancel(with: .goingAway, reason: nil)
+        healthWsTask = nil
+    }
+
+    private func receiveHealthMessage() {
+        healthWsTask?.receive { [weak self] result in
+            guard let self = self else { return }
+            switch result {
+            case .success(let message):
+                if case .string(let text) = message {
+                    self.processHealthMessage(text)
+                }
+                self.receiveHealthMessage()
+            case .failure:
+                DispatchQueue.main.async {
+                    self.setServerDown(true)
+                    guard self.isVisible else { return }
+                    self.healthWsRetryTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { [weak self] _ in
+                        self?.connectHealthWebSocket()
+                    }
+                }
+            }
+        }
+    }
+
+    private func processHealthMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
+        let status = json["status"] as? String ?? ""
+        let isUnhealthy = status == "unhealthy" || status == "error"
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.setServerDown(false)
+            self.setUnhealthy(isUnhealthy)
+        }
+    }
+
+    func setServerDown(_ down: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if self.metrics.isServerDown != down {
+                self.metrics.isServerDown = down
+                self.updateFixingState()
+            }
+        }
+    }
+
+    func setUnhealthy(_ unhealthy: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if self.metrics.isUnhealthy != unhealthy {
+                self.metrics.isUnhealthy = unhealthy
+                self.updateFixingState()
+            }
+        }
+    }
+
+    func updateFixingState() {
+        let isBroken = metrics.isServerDown || metrics.isUnhealthy
+        if isBroken {
+            if metrics.fixingState == "normal" {
+                metrics.fixingState = "failure"
+            }
+        } else {
+            if metrics.fixingState == "failure" || metrics.fixingState == "fixing" {
+                metrics.fixingState = "recovered"
+                Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] _ in
+                    DispatchQueue.main.async {
+                        if self?.metrics.fixingState == "recovered" {
+                            self?.metrics.fixingState = "normal"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private func parseShortcuts(_ json: String) {
         // Expects shortcut labels, size, and optional authenticated API URLs from Rust.
         guard let data = json.data(using: .utf8),
@@ -687,6 +889,7 @@ class ShortcutReminderController: NSObject {
         if let s = dict["shortcutOverlaySize"] { setOverlayScale(s) }
         if let s = dict["metrics_ws_url"] { metricsWsUrl = s }
         if let s = dict["events_ws_url"] { eventsWsUrl = s }
+        if let s = dict["health_ws_url"] { healthWsUrl = s }
     }
 
     /// Convert "Super+Ctrl+S" → "⌘⌃S" for compact overlay display.


### PR DESCRIPTION
## Description

This PR implements recording health indicators and a background restart action directly inside the always-on-top shortcut reminder overlay (addressing #5127). 

Previously, when the recording engine stalled, crashed, or became unhealthy, the user had to open the main app window or click the tray menu to notice the failure. With this change, the shortcut overlay automatically transitions to a failure state to alert the user and lets them restart the engine in place without leaving their active application.

## UI State Transitions (ASCII Mockups)

```text
1. Normal (Collapsed View)
   [ AppIcon | AudioEqualizer | ScreenMatrix | Phone ]

2. Confirmed Failure (Collapsed View)
   [ ● recording stopped ]

3. Confirmed Failure (Hovered / Expanded View)
   [ ● recording stopped | ↻ restart | X ]

4. Fixing State (Clicking "restart")
   [ ⟳ fixing recording... ]

5. Recovered State (Server starts back up and becomes healthy)
   [ ✓ recording again ]  --> (Collapses back to Normal after 3s)