### PR TITLE
fix: prevent macOS capture teardown deadlocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8095,7 +8095,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=3d035cb51f0a9f71d8b716bc67d5380557976df6#3d035cb51f0a9f71d8b716bc67d5380557976df6"
+source = "git+https://github.com/screenpipe/sck-rs?rev=4a0d05c8a177986b848aac7803670befa886f2a3#4a0d05c8a177986b848aac7803670befa886f2a3"
 dependencies = [
  "cidre 0.15.1 (git+https://github.com/yury/cidre.git)",
  "image",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=3d035cb51f0a9f71d8b716bc67d5380557976df6#3d035cb51f0a9f71d8b716bc67d5380557976df6"
+source = "git+https://github.com/screenpipe/sck-rs?rev=4a0d05c8a177986b848aac7803670befa886f2a3#4a0d05c8a177986b848aac7803670befa886f2a3"
 dependencies = [
  "cidre 0.15.1 (git+https://github.com/yury/cidre.git)",
  "image 0.25.10",

--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -77,7 +77,7 @@ harness = false
 
 # macOS: sck-rs for 12.3+ (ScreenCaptureKit), xcap as fallback for older versions
 [target.'cfg(target_os = "macos")'.dependencies]
-sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "3d035cb51f0a9f71d8b716bc67d5380557976df6"}
+sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "4a0d05c8a177986b848aac7803670befa886f2a3"}
 xcap = { workspace = true }
 libc = { workspace = true }
 cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a", features = ["vn", "cv", "cg", "app"] }


### PR DESCRIPTION
## Summary

Pins `sck-rs` to the non-blocking ScreenCaptureKit teardown fix in [screenpipe/sck-rs#14](https://github.com/screenpipe/sck-rs/pull/14).

The production hang was a lock inversion at the macOS capture boundary:

```mermaid
sequenceDiagram
    participant Recovery as Frozen-stream recovery
    participant Manager as SCK stream manager
    participant macOS as ScreenCaptureKit
    participant Tray as AppKit tray preview
    Recovery->>Manager: invalidate stream
    Manager->>macOS: stop stream
    macOS--xManager: completion never arrives
    Tray->>Manager: peek latest frame
    Note over Manager,Tray: old code blocked the main thread forever
    Note over Recovery,Tray: fixed code releases the manager lock and makes preview fail fast
```

`MonitorStream::drop` waited synchronously for `SCStream.stop()` while invalidation could still own the global stream mutex. A wedged macOS stop callback therefore froze the tray's main-thread preview read and made the entire app **Not Responding**.

The captured incident had 906 frozen-stream recoveries but only 905 completed invalidations/restarts. A process sample found AppKit's main thread waiting for this mutex in all 5,352 samples.

## What this pin provides

- asynchronous stream stop; teardown never joins on an OS callback
- stream destruction after releasing the global manager mutex
- non-blocking tray preview reads
- a cap of 8 stranded stop callbacks to bound retained resources
- regression coverage for lock contention, invalidation, `stop_all`, callback races, and pending-stop saturation
- an ignored real-hardware stress test covering repeated stream recreation, scale changes, exclusions, HD bootstrap, and multi-monitor enumeration

The dependency is macOS-only. Windows and Linux capture paths are unchanged.

## Reproduction and validation

- Deterministic old/new reproduction: the public preview call timed out under a 3-second watchdog on the old dependency (exit 142) and returned immediately with the fix.
- Real ScreenCaptureKit stress: 100 teardown/recreate cycles on the live monitor, including 10 dedicated HD stream starts/drops, passed in 11.62s; concurrent preview latency stayed below 139 microseconds.
- The same 100-cycle hardware test passed against this app lockfile's exact `cidre` revision in 11.50s, with 177 microseconds maximum preview latency.
- `cargo test -p screenpipe-screen`: all enabled tests passed (138 unit tests plus integration/doc suites; expected hardware/manual tests ignored).
- Focused desktop tray tests: 4/4 passed.
- Full debug desktop build with the `e2e` feature: passed.
- Upstream `cargo test`, `cargo check --all-targets`, Clippy, rustfmt, and diff checks: passed (existing warnings only).
- `git diff --check`: passed.

## Desktop E2E notes

- The opt-in HD recording spec launched successfully but skipped its hardware assertion because this desktop session reported the screen as locked.
- The tray-search spec did not reach assertions: the existing `no-recording` seed started the local server and immediately stopped it during focus/permission recovery, so its `before` hook could not render Home. This occurred unchanged on retries and is separate from the SCK deadlock; teardown itself returned immediately in the logs.

The real-hardware SCK stress test directly exercises the deadlocked boundary and is the primary E2E regression guard for this fix.
