### PR TITLE
fix(app): make cmd-w close windows on macOS

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -881,9 +881,22 @@ async fn main() {
                     .item(&PredefinedMenuItem::select_all(app, None)?)
                     .build()?;
 
+                // Standard Window menu so macOS key equivalents (Cmd-W close,
+                // Cmd-M minimize) work — without a menu item carrying the
+                // accelerator, AppKit silently swallows the keystroke. Close
+                // goes through the CloseRequested handler above, so Cmd-W
+                // hides to tray exactly like the red traffic-light button.
+                let window_submenu = SubmenuBuilder::new(app, "Window")
+                    .item(&PredefinedMenuItem::minimize(app, None)?)
+                    .item(&PredefinedMenuItem::maximize(app, None)?)
+                    .separator()
+                    .item(&PredefinedMenuItem::close_window(app, None)?)
+                    .build()?;
+
                 let menu = MenuBuilder::new(app)
                     .item(&app_submenu)
                     .item(&edit_submenu)
+                    .item(&window_submenu)
                     .build()?;
 
                 app.set_menu(menu)?;


### PR DESCRIPTION
### Description:

* before:

https://github.com/user-attachments/assets/5fbabbdd-3b25-448c-b4e3-751ec4aeb2cd

* after:

https://github.com/user-attachments/assets/d6175a35-5263-4971-928c-b5e4a4e8e620

Fixes screenpipe/screenpipe#5143

* Cmd-W (and Cmd-M) did nothing on macOS because our custom menu bar had no Window submenu — AppKit only dispatches these key equivalents through a menu item carrying the accelerator.
* Adds a standard Window menu (Minimize, Zoom, Close Window) using Tauri's predefined items.
* Close routes through the existing `CloseRequested` handler, so Cmd-W hides to tray exactly like clicking the red traffic-light button — no change to close semantics.