### PR TITLE
Fix v2.5.108 code quality formatting failure

### DIFF
--- a/crates/screenpipe-redact/src/adapters/onnx.rs
+++ b/crates/screenpipe-redact/src/adapters/onnx.rs
@@ -87,11 +87,7 @@ impl OnnxConfig {
     /// `~/.screenpipe/models/v49_distilled6l/` by convention.
     pub fn default_model_dir() -> PathBuf {
         dirs::home_dir()
-            .map(|h| {
-                h.join(".screenpipe")
-                    .join("models")
-                    .join("v49_distilled6l")
-            })
+            .map(|h| h.join(".screenpipe").join("models").join("v49_distilled6l"))
             .unwrap_or_else(|| PathBuf::from(".screenpipe/models/v49_distilled6l"))
     }
 


### PR DESCRIPTION
## Summary

- apply the exact `cargo fmt` output for the v49 ONNX redactor model path
- restore the Code Quality & Optimization formatting gate on main

## Root cause

The v2.5.108 bump exposed an unformatted expression introduced by the v49 redactor change. The other red workflows on the same SHA failed before repository code ran while GitHub Actions was resolving/downloading actions.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p screenpipe-redact`
- `cargo clippy -p screenpipe-redact --all-targets -- -W clippy::all`
- `cargo test -p screenpipe-redact --lib` (181 passed)
- `git diff --check`