### PR TITLE
fix(meeting-notes): resume mic during global capture pause

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -987,11 +987,34 @@ export function NoteView({
   );
 
   const handleResumeInputCapture = async () => {
-    if (pausedInputDevices.length === 0) return;
+    const activeInputDevices = captureDevices.filter(
+      (device) => device.kind === "input" && device.active,
+    );
+    const devicesToResume =
+      pausedInputDevices.length > 0 ? pausedInputDevices : activeInputDevices;
+    if (devicesToResume.length === 0) return;
     setResumingCapture(true);
     try {
+      // If devices appear active but audio is stalled, stop first so the
+      // restart actually re-creates the audio stream.
+      if (pausedInputDevices.length === 0 && activeInputDevices.length > 0) {
+        await Promise.all(
+          activeInputDevices.map((device) =>
+            localFetch("/audio/device/stop", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                device_name: device.fullName ?? `${device.name} (input)`,
+              }),
+            }).catch(() => {
+              // ignore stop errors
+            }),
+          ),
+        );
+        await new Promise((r) => setTimeout(r, 500));
+      }
       await Promise.all(
-        pausedInputDevices.map((device) =>
+        devicesToResume.map((device) =>
           localFetch("/audio/device/start", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -1225,7 +1248,11 @@ export function NoteView({
           {isLive && captureState && isLiveCaptureDegraded(captureState) && (
             <LiveCaptureIssueBanner
               state={captureState}
-              canResumeInput={pausedInputDevices.length > 0}
+              canResumeInput={
+                pausedInputDevices.length > 0 ||
+                captureState.kind === "audio-stalled" ||
+                captureState.kind === "audio-not-started"
+              }
               resuming={resumingCapture}
               onResumeInput={() => void handleResumeInputCapture()}
             />

--- a/crates/screenpipe-audio/src/audio_manager/manager.rs
+++ b/crates/screenpipe-audio/src/audio_manager/manager.rs
@@ -730,12 +730,15 @@ impl AudioManager {
         // Remove from disabled FIRST so start_device gate allows it
         self.user_disabled_devices.write().await.remove(device_name);
 
+        // If the audio manager was fully stopped (e.g. global capture pause),
+        // restart the pipeline so this device can actually produce data.
+        // start() is idempotent — no-op if already Running.
         if self.status().await != AudioManagerStatus::Running {
             info!(
-                "user re-enabled audio device while audio manager is stopped: {}",
+                "audio manager stopped, restarting pipeline to resume device: {}",
                 device_name
             );
-            return Ok(());
+            self.start().await?;
         }
 
         let device = match parse_audio_device(device_name) {


### PR DESCRIPTION
This pr fixes the resume mic button in meeting notes being a silent no-op when recording is globally paused from the tray or shortcut.


Before -


https://github.com/user-attachments/assets/04ee97b6-fc3a-4f13-9395-e0334493792d



After -

https://github.com/user-attachments/assets/25acdd78-a8aa-4807-860c-bb530eb43207

