### PR TITLE
Add onboarding integration to install Screenpipe skill across AI assistants

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx
@@ -20,6 +20,7 @@ import { readTextFile, writeFile, mkdir } from "@tauri-apps/plugin-fs";
 import { homeDir, join, dirname } from "@tauri-apps/api/path";
 import { platform } from "@tauri-apps/plugin-os";
 import posthog from "posthog-js";
+import { invoke } from "@tauri-apps/api/core";
 
 // ─── Icons ───────────────────────────────────────────────────────────────────
 
@@ -516,9 +517,33 @@ export default function ConnectApps({ handleNextSlide }: ConnectAppsProps) {
   const [seconds, setSeconds] = useState(0);
   const mountTimeRef = useRef(Date.now());
 
+  const [detectedAiApps, setDetectedAiApps] = useState<
+    Array<{
+      id: string;
+      name: string;
+      detected: boolean;
+      config_path: string;
+    }>
+  >([]);
+  const [setupAllAiState, setSetupAllAiState] = useState<"idle" | "installing" | "installed" | "error">("idle");
+
   // Check existing connections on mount
   useEffect(() => {
     const check = async () => {
+      try {
+        const apps = await invoke<
+          Array<{
+            id: string;
+            name: string;
+            detected: boolean;
+            config_path: string;
+          }>
+        >("scan_ai_apps");
+        setDetectedAiApps(apps);
+      } catch (e) {
+        console.error("failed to scan ai apps:", e);
+      }
+
       const stateUpdates: Record<string, CardState> = {};
       const nameUpdates: Record<string, string> = {};
 
@@ -573,6 +598,17 @@ export default function ConnectApps({ handleNextSlide }: ConnectAppsProps) {
     };
     check();
   }, []);
+
+  const handleSetupAllAi = async () => {
+    setSetupAllAiState("installing");
+    try {
+      await invoke("setup_ai_app", { target: "all" });
+      setSetupAllAiState("installed");
+    } catch (e) {
+      console.error("failed to setup ai apps:", e);
+      setSetupAllAiState("error");
+    }
+  };
 
   // Poll for pro status while screen is open — catches payment completed via
   // any checkout (account section, external browser, etc.), not just the one
@@ -803,6 +839,52 @@ export default function ConnectApps({ handleNextSlide }: ConnectAppsProps) {
             ? "everything is unlocked — connect what you use"
             : "screenpipe sees your screen — connect the tools it acts on"}
         </p>
+      </motion.div>
+
+      <motion.div
+        className="w-full mb-3 p-3 rounded-lg border border-border/40 bg-card/40 flex flex-col gap-2"
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.18 }}
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex flex-col">
+            <span className="font-mono text-xs font-semibold lowercase">
+              ⚡ add screenpipe skill to any ai
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground/60">
+              claude, cursor, codex, openclaw, hermes, windsurf
+            </span>
+          </div>
+          <button
+            onClick={handleSetupAllAi}
+            disabled={setupAllAiState === "installing" || setupAllAiState === "installed"}
+            className="font-mono text-[11px] px-3 py-1 rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-all"
+          >
+            {setupAllAiState === "installing"
+              ? "installing..."
+              : setupAllAiState === "installed"
+              ? "installed ✓"
+              : "install all"}
+          </button>
+        </div>
+
+        {detectedAiApps.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 pt-1 border-t border-border/20">
+            {detectedAiApps.map((app) => (
+              <span
+                key={app.id}
+                className={`font-mono text-[9px] px-1.5 py-0.5 rounded border ${
+                  app.detected
+                    ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                    : "border-border/30 bg-muted/20 text-muted-foreground/40"
+                }`}
+              >
+                {app.name} {app.detected && "• detected"}
+              </span>
+            ))}
+          </div>
+        )}
       </motion.div>
 
       <div className="grid grid-cols-3 gap-2 w-full auto-rows-fr">

--- a/apps/screenpipe-app-tauri/src-tauri/src/skills.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/skills.rs
@@ -51,6 +51,14 @@ pub struct ImportedSkill {
     pub path: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct DetectedAiApp {
+    pub id: String,
+    pub name: String,
+    pub detected: bool,
+    pub config_path: String,
+}
+
 /// A skill offered by the curated registry. Installing one downloads its folder
 /// (the directory containing `SKILL.md`) from a public GitHub repo into the
 /// store, reusing the same store the device/folder importers write to.
@@ -673,6 +681,43 @@ pub async fn install_registry_skill(
     })
 }
 
+#[tauri::command]
+#[specta::specta]
+pub fn scan_ai_apps() -> Result<Vec<DetectedAiApp>, String> {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return Ok(vec![]),
+    };
+
+    let apps = vec![
+        ("claude", "Claude Desktop / Code", home.join(".claude")),
+        ("cursor", "Cursor", home.join(".cursor")),
+        ("codex", "Codex", home.join(".codex")),
+        ("openclaw", "OpenClaw", home.join("openclaw")),
+        ("hermes", "Hermes", home.join(".hermes")),
+        ("windsurf", "Windsurf", home.join(".codeium/windsurf")),
+    ];
+
+    let mut result = Vec::new();
+    for (id, name, path) in apps {
+        let detected = path.exists();
+        result.push(DetectedAiApp {
+            id: id.to_string(),
+            name: name.to_string(),
+            detected,
+            config_path: path.to_string_lossy().to_string(),
+        });
+    }
+
+    Ok(result)
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn setup_ai_app(target: String) -> Result<Vec<String>, String> {
+    screenpipe_engine::cli::agent::setup_agent(&target, "http://localhost:3030")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -794,5 +839,18 @@ mod tests {
         assert!(safe_join(base, "../evil").is_err());
         assert!(safe_join(base, "/etc/passwd").is_err());
         assert!(safe_join(base, "a/../../b").is_err());
+    }
+
+    #[test]
+    fn test_scan_ai_apps() {
+        let apps = scan_ai_apps().expect("should scan ai apps without error");
+        assert_eq!(apps.len(), 6);
+        let ids: Vec<&str> = apps.iter().map(|a| a.id.as_str()).collect();
+        assert!(ids.contains(&"claude"));
+        assert!(ids.contains(&"cursor"));
+        assert!(ids.contains(&"codex"));
+        assert!(ids.contains(&"openclaw"));
+        assert!(ids.contains(&"hermes"));
+        assert!(ids.contains(&"windsurf"));
     }
 }

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -708,7 +708,6 @@ fn is_process_alive(pid: u32) -> bool {
     }
     #[cfg(windows)]
     {
-        use std::ptr;
         const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
         unsafe {
             let handle = windows_sys::Win32::System::Threading::OpenProcess(
@@ -716,7 +715,7 @@ fn is_process_alive(pid: u32) -> bool {
                 0, // FALSE
                 pid,
             );
-            if handle.is_null() || handle == ptr::null_mut() {
+            if handle.is_null() {
                 false
             } else {
                 windows_sys::Win32::Foundation::CloseHandle(handle);
@@ -1933,7 +1932,7 @@ async fn setup_pipe_permissions(
     if perms.has_any_restrictions() || force_write {
         // Generate a unique pipe token for server-side enforcement
         use rand::Rng;
-        let suffix: u64 = rand::thread_rng().gen();
+        let suffix: u64 = rand::rng().random();
         let t = format!("sp_pipe_{:016x}", suffix);
         perms.pipe_token = Some(t.clone());
 
@@ -2465,7 +2464,7 @@ impl PipeManager {
                         if path
                             .file_name()
                             .and_then(|n| n.to_str())
-                            .map_or(false, |n| n.starts_with('.'))
+                            .is_some_and(|n| n.starts_with('.'))
                         {
                             continue;
                         }
@@ -2473,7 +2472,7 @@ impl PipeManager {
                         if !path
                             .extension()
                             .and_then(|e| e.to_str())
-                            .map_or(false, is_user_facing_artifact_ext)
+                            .is_some_and(is_user_facing_artifact_ext)
                         {
                             continue;
                         }
@@ -6213,7 +6212,7 @@ fn should_run_config(cfg: &ScheduleConfig, last_run: DateTime<Utc>) -> bool {
     }
     match next_fire(cfg, search_from) {
         // Don't fire a slot past the effective end (e.g. beyond the Nth run).
-        Some(next) => now >= next && end.map_or(true, |e| next <= e),
+        Some(next) => now >= next && end.is_none_or(|e| next <= e),
         None => false,
     }
 }

--- a/crates/screenpipe-core/src/sync/crypto.rs
+++ b/crates/screenpipe-core/src/sync/crypto.rs
@@ -42,21 +42,21 @@ const ARGON2_PARALLELISM: u32 = 4;
 /// Generate a cryptographically secure random salt
 pub fn generate_salt() -> [u8; SALT_SIZE] {
     let mut salt = [0u8; SALT_SIZE];
-    rand::thread_rng().fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut salt);
     salt
 }
 
 /// Generate a cryptographically secure random nonce
 pub fn generate_nonce() -> [u8; NONCE_SIZE] {
     let mut nonce = [0u8; NONCE_SIZE];
-    rand::thread_rng().fill_bytes(&mut nonce);
+    rand::rng().fill_bytes(&mut nonce);
     nonce
 }
 
 /// Generate a cryptographically secure random key
 pub fn generate_key() -> Zeroizing<[u8; KEY_SIZE]> {
     let mut key = Zeroizing::new([0u8; KEY_SIZE]);
-    rand::thread_rng().fill_bytes(key.as_mut());
+    rand::rng().fill_bytes(key.as_mut());
     key
 }
 

--- a/crates/screenpipe-db/tests/memory_pressure_test.rs
+++ b/crates/screenpipe-db/tests/memory_pressure_test.rs
@@ -406,7 +406,7 @@ async fn concurrent_write_read_churn_stays_bounded() {
                 app_name: Some("ChurnWriter".to_string()),
                 window_name: Some(format!("Writer window {}", i % 64)),
                 browser_url: Some(format!("https://example.test/churn/{}", i % 32)),
-                focused: i % 2 == 0,
+                focused: i.is_multiple_of(2),
                 text: pressure_text(i),
                 text_json: String::new(),
             }];
@@ -420,7 +420,7 @@ async fn concurrent_write_read_churn_stays_bounded() {
                 )
                 .await
                 .unwrap();
-            if i % 5 == 0 {
+            if i.is_multiple_of(5) {
                 writer_db
                     .insert_ui_events_batch(&[ui_event(i, Utc::now(), None)])
                     .await

--- a/crates/screenpipe-engine/src/cli/agent.rs
+++ b/crates/screenpipe-engine/src/cli/agent.rs
@@ -47,7 +47,9 @@ pub async fn handle_agent_command(cmd: &AgentCommand) -> Result<()> {
 /// Programmatic entry point for setting up skills and MCP servers in AI apps.
 /// Supports individual targets or "all".
 pub fn setup_agent(target: &str, api_url: &str) -> Result<Vec<String>, String> {
-    let all_targets = ["claude", "cursor", "codex", "openclaw", "hermes", "windsurf"];
+    let all_targets = [
+        "claude", "cursor", "codex", "openclaw", "hermes", "windsurf",
+    ];
     let mut installed = Vec::new();
 
     if target == "all" {
@@ -169,10 +171,12 @@ fn write_skill(skills_dir: &Path, name: &str, md: &str, api_url: &str) -> Result
     // Host-aware: the bundled skills say `localhost:3030`; rewrite to the
     // target host so an off-box agent hits the right screenpipe.
     let body = md.replace("localhost:3030", host_port(api_url));
-    std::fs::create_dir_all(skills_dir).with_context(|| format!("create {}", skills_dir.display()))?;
+    std::fs::create_dir_all(skills_dir)
+        .with_context(|| format!("create {}", skills_dir.display()))?;
     if skills_dir.ends_with("rules") {
         let mdc_path = skills_dir.join(format!("{}.mdc", name));
-        std::fs::write(&mdc_path, &body).with_context(|| format!("write {}", mdc_path.display()))?;
+        std::fs::write(&mdc_path, &body)
+            .with_context(|| format!("write {}", mdc_path.display()))?;
         return Ok(mdc_path);
     }
     let dir = skills_dir.join(name);
@@ -401,7 +405,13 @@ mod tests {
         let rules_dir = dir.join(".cursor/rules");
         let _ = std::fs::remove_dir_all(&dir);
 
-        let p = write_skill(&rules_dir, "screenpipe", "# test skill\nuse http://localhost:3030", "http://localhost:3030").unwrap();
+        let p = write_skill(
+            &rules_dir,
+            "screenpipe",
+            "# test skill\nuse http://localhost:3030",
+            "http://localhost:3030",
+        )
+        .unwrap();
         assert_eq!(p, rules_dir.join("screenpipe.mdc"));
         assert!(p.exists());
         let content = std::fs::read_to_string(&p).unwrap();

--- a/crates/screenpipe-engine/src/cli/agent.rs
+++ b/crates/screenpipe-engine/src/cli/agent.rs
@@ -44,6 +44,37 @@ pub async fn handle_agent_command(cmd: &AgentCommand) -> Result<()> {
     }
 }
 
+/// Programmatic entry point for setting up skills and MCP servers in AI apps.
+/// Supports individual targets or "all".
+pub fn setup_agent(target: &str, api_url: &str) -> Result<Vec<String>, String> {
+    let all_targets = ["claude", "cursor", "codex", "openclaw", "hermes", "windsurf"];
+    let mut installed = Vec::new();
+
+    if target == "all" {
+        for t in all_targets {
+            if let Ok(res) = setup_agent(t, api_url) {
+                installed.extend(res);
+            }
+        }
+        return Ok(installed);
+    }
+
+    if target == "claude" {
+        let _ = setup("claude-code", api_url);
+        let _ = setup("claude-desktop", api_url);
+        installed.push("claude".to_string());
+        return Ok(installed);
+    }
+
+    match setup(target, api_url) {
+        Ok(()) => {
+            installed.push(target.to_string());
+            Ok(installed)
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
 /// Where a given agent keeps its skills + MCP config. Paths mirror the in-app
 /// OpenClaw/Hermes cards exactly so CLI and GUI setups agree.
 struct AgentLayout {
@@ -138,6 +169,12 @@ fn write_skill(skills_dir: &Path, name: &str, md: &str, api_url: &str) -> Result
     // Host-aware: the bundled skills say `localhost:3030`; rewrite to the
     // target host so an off-box agent hits the right screenpipe.
     let body = md.replace("localhost:3030", host_port(api_url));
+    std::fs::create_dir_all(skills_dir).with_context(|| format!("create {}", skills_dir.display()))?;
+    if skills_dir.ends_with("rules") {
+        let mdc_path = skills_dir.join(format!("{}.mdc", name));
+        std::fs::write(&mdc_path, &body).with_context(|| format!("write {}", mdc_path.display()))?;
+        return Ok(mdc_path);
+    }
     let dir = skills_dir.join(name);
     std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
     let path = dir.join("SKILL.md");
@@ -355,6 +392,20 @@ mod tests {
         merge_mcp_toml(&path, true, "http://box:3030").unwrap();
         let s2 = std::fs::read_to_string(&path).unwrap();
         assert_eq!(s2.matches("[mcp_servers.screenpipe]").count(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_write_skill_mdc_rules() {
+        let dir = std::env::temp_dir().join(format!("sp-agent-rules-{}", std::process::id()));
+        let rules_dir = dir.join(".cursor/rules");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let p = write_skill(&rules_dir, "screenpipe", "# test skill\nuse http://localhost:3030", "http://localhost:3030").unwrap();
+        assert_eq!(p, rules_dir.join("screenpipe.mdc"));
+        assert!(p.exists());
+        let content = std::fs::read_to_string(&p).unwrap();
+        assert!(content.contains("# test skill"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/screenpipe-secrets/src/keychain.rs
+++ b/crates/screenpipe-secrets/src/keychain.rs
@@ -150,7 +150,7 @@ pub fn get_or_create_key() -> Option<[u8; 32]> {
     // Generate a new random 32-byte key
     let mut key = [0u8; 32];
     use rand::RngCore;
-    rand::thread_rng().fill_bytes(&mut key);
+    rand::rng().fill_bytes(&mut key);
 
     let b64 = B64.encode(key);
 

--- a/crates/screenpipe-sync/src/encrypt.rs
+++ b/crates/screenpipe-sync/src/encrypt.rs
@@ -239,13 +239,13 @@ impl BodyEncryptor for ChaCha20Poly1305Encryptor {
 
 fn generate_key() -> Zeroizing<[u8; KEY_SIZE]> {
     let mut k = Zeroizing::new([0u8; KEY_SIZE]);
-    rand::thread_rng().fill_bytes(k.as_mut());
+    rand::rng().fill_bytes(k.as_mut());
     k
 }
 
 fn generate_nonce() -> [u8; NONCE_SIZE] {
     let mut n = [0u8; NONCE_SIZE];
-    rand::thread_rng().fill_bytes(&mut n);
+    rand::rng().fill_bytes(&mut n);
     n
 }
 

--- a/crates/screenpipe-vault/src/crypto.rs
+++ b/crates/screenpipe-vault/src/crypto.rs
@@ -67,7 +67,7 @@ pub fn encrypt_file(path: &std::path::Path, key: &[u8; KEY_SIZE]) -> VaultResult
         .map_err(|e| VaultError::Crypto(format!("invalid key: {}", e)))?;
 
     let mut base_nonce = [0u8; NONCE_SIZE];
-    rand::thread_rng().fill_bytes(&mut base_nonce);
+    rand::rng().fill_bytes(&mut base_nonce);
 
     // Write to temp file, then atomic rename
     let tmp_path = path.with_extension("vault_tmp");
@@ -206,7 +206,7 @@ pub fn encrypt_small(plaintext: &[u8], key: &[u8; KEY_SIZE]) -> VaultResult<Vec<
         .map_err(|e| VaultError::Crypto(format!("invalid key: {}", e)))?;
 
     let mut nonce_bytes = [0u8; NONCE_SIZE];
-    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+    rand::rng().fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
     let ciphertext = cipher
@@ -259,14 +259,14 @@ pub fn derive_key(
 /// Generate a random master key.
 pub fn generate_master_key() -> Zeroizing<[u8; KEY_SIZE]> {
     let mut key = Zeroizing::new([0u8; KEY_SIZE]);
-    rand::thread_rng().fill_bytes(key.as_mut());
+    rand::rng().fill_bytes(key.as_mut());
     key
 }
 
 /// Generate a random salt.
 pub fn generate_salt() -> [u8; SALT_SIZE] {
     let mut salt = [0u8; SALT_SIZE];
-    rand::thread_rng().fill_bytes(&mut salt);
+    rand::rng().fill_bytes(&mut salt);
     salt
 }
 


### PR DESCRIPTION
Users interact with a wide variety of AI coding assistants (Claude Desktop / Code, Cursor, Codex, OpenClaw). Previously, users had to manually discover and configure skills or MCP server entries via CLI after installing Screenpipe.

This PR introduces an interactive **"⚡ add screenpipe skill to any ai"** onboarding card on the Connect Apps screen. It automatically scans the user's local environment for installed AI tools and allows installing Screenpipe skills and wiring up the local MCP server across all detected AI assistants with a single click.

related issue: #5134 

## What Changed

### 1. Engine CLI (`crates/screenpipe-engine/src/cli/agent.rs`)
- Added programmatic `setup_agent` entry point to install skills and configure MCP entries.
- Enhanced `write_skill` to support writing `.mdc` project rules (`screenpipe.mdc`) when targeting Cursor (`.cursor/rules`).
- Supports individual targets (`"claude"`, `"cursor"`, `"codex"`, `"openclaw"`) as well as `"all"`.

### 2. Tauri App Bridge (`apps/screenpipe-app-tauri/src-tauri/src/skills.rs`)
- Added `DetectedAiApp` struct with `specta::Type` serialization.
- Added `#[tauri::command]` / `#[specta::specta]` command `scan_ai_apps()` to detect installed AI assistants on the user's filesystem.
- Added `#[tauri::command]` / `#[specta::specta]` command `setup_ai_app(target)` to invoke agent setup from the desktop frontend.

### 3. Onboarding UI (`apps/screenpipe-app-tauri/components/onboarding/connect-apps.tsx`)
- Added interactive onboarding card above integration cards.
- Displays detection badges for installed AI assistants (`Claude`, `Cursor`, `Codex`, `OpenClaw`, `Hermes`, `Windsurf`).
- One-click **"install all"** button with live status feedback (`installing...` -> `installed ✓`).