### PR TITLE
Fix Linux E2E entitlement state leak

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/zz-account-basic-upgrade-billing.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-account-basic-upgrade-billing.spec.ts
@@ -14,6 +14,7 @@ import {
   waitForTestId,
   t,
 } from "../helpers/test-utils.js";
+import { invoke } from "../helpers/tauri.js";
 
 const FAKE_TOKEN = "e2e-fake-token-basic-upgrade";
 const FAKE_EMAIL = "e2e-basic-upgrade@screenpipe.test";
@@ -211,6 +212,25 @@ async function restoreMocks(): Promise<void> {
   }).catch(() => {});
 }
 
+async function clearBasicAccountUser(): Promise<void> {
+  const logout = await $('[data-testid="account-logout-button"]');
+  if (await logout.isExisting()) {
+    await logout.click();
+  }
+
+  // Keep this spec isolated even if the UI logout is interrupted by a reload.
+  const result = await invoke("set_cloud_token", { token: null });
+  expect(result.ok).toBe(true);
+  await browser.waitUntil(
+    async () => (await loginStatusText()).includes("not logged in"),
+    {
+      timeout: t(8_000),
+      interval: 200,
+      timeoutMsg: "Basic billing test did not clear its fake account",
+    },
+  );
+}
+
 async function forEachWindow(fn: () => Promise<void>): Promise<void> {
   const start = await browser.getWindowHandle().catch(() => null);
   for (const handle of await browser.getWindowHandles().catch(() => [] as string[])) {
@@ -259,7 +279,11 @@ describe("Basic subscriber upgrade uses billing, not fresh checkout", function (
   });
 
   after(async () => {
-    await forEachWindow(() => restoreMocks()).catch(() => {});
+    try {
+      await clearBasicAccountUser();
+    } finally {
+      await forEachWindow(() => restoreMocks()).catch(() => {});
+    }
   });
 
   it("does not hit /api/subscription/checkout when upgrading an existing Basic plan", async () => {

--- a/apps/screenpipe-app-tauri/e2e/specs/zz-app-entitlement-gate.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/zz-app-entitlement-gate.spec.ts
@@ -22,8 +22,25 @@ import { invoke } from '../helpers/tauri.js';
 import { getLocalApiConfig, waitForLocalApi } from '../helpers/api-utils.js';
 
 const FORCE_KEY = 'screenpipe_e2e_force_billing_gate';
+const E2E_ACCOUNT_USER_KEY = 'screenpipe_e2e_account_user';
+const E2E_ACCOUNT_USER_EVENT = 'screenpipe-e2e-seed-account-user';
 const FAKE_DENIED_TOKEN = 'e2e-fake-token-cloud-sub-app-denied';
 const FAKE_DENIED_EMAIL = 'e2e-cloud-sub-app-denied@screenpipe.test';
+
+async function clearAccountState(): Promise<void> {
+  await browser.execute(
+    (key: string, eventName: string) => {
+      window.localStorage.setItem(key, 'null');
+      window.dispatchEvent(new Event(eventName));
+    },
+    E2E_ACCOUNT_USER_KEY,
+    E2E_ACCOUNT_USER_EVENT,
+  );
+
+  const result = await invoke('set_cloud_token', { token: null });
+  expect(result.ok).toBe(true);
+  await browser.pause(t(500));
+}
 
 /** Forcing the gate on drives the entitlement gate to stop the engine
  *  (components/app-entitlement-gate.tsx calls stopScreenpipe for an unentitled
@@ -148,6 +165,10 @@ describe('App entitlement gate', () => {
   before(async () => {
     await waitForAppReady();
     await openHomeWindow();
+    // The preceding Basic billing spec intentionally seeds an entitled user.
+    // Start from an explicit signed-out state instead of depending on spec order
+    // or an eventual real-network 401 to clear that synthetic account.
+    await clearAccountState();
   });
 
   after(async () => {


### PR DESCRIPTION
## What failed

Current main failed Linux E2E twice in `zz-app-entitlement-gate.spec.ts`. The preceding Basic billing spec seeded an entitled fake user but only restored network mocks; because the skipped stale-subscription suite does not run its cleanup hooks, the entitlement suite inherited that user. Its paywall assertions failed, restarted the app repeatedly, and six trailing specs then lost their WebDriver session.

## Fix

- sign out and clear the native cloud token after the Basic billing spec
- defensively clear account state before the entitlement-gate suite
- keep product behavior unchanged; this is E2E isolation only

## Validation

- `bun run typecheck`
- `git diff --check`
- local native UI attempt was inconclusive because the reused debug binary lacked the WebDriver feature; GitHub Linux E2E is the authoritative clean run

Failing main runs: 29275627355 and 29275728109.