### PR TITLE
fix(pipes): stop run-log stdout retention + reap agent process groups; track event-run concurrency

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1289,6 +1289,7 @@ impl PiExecutor {
         }
 
         let output = child.wait_with_output().await?;
+        reap_lingering_process_group(pid);
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
@@ -1493,6 +1494,9 @@ impl PiExecutor {
         }
 
         let status = child.wait().await?;
+        // Reap grandchildren before reading stderr: one holding the stderr pipe
+        // open would otherwise block read_to_end below until the timeout.
+        reap_lingering_process_group(pid);
 
         // Read remaining stderr (lossy — same reason as stdout above)
         let mut stderr = if let Some(mut stderr_handle) = child.stderr.take() {
@@ -2700,6 +2704,31 @@ fn resolve_cmd_js_entry(cmd_path: &str) -> Option<String> {
 
 /// Kill a process group (SIGTERM → 5s → SIGKILL).
 /// On Unix, kills the entire process group so child processes are also terminated.
+/// After the agent process has exited and been reaped, kill any lingering
+/// members of its process group — e.g. a stdio MCP server or bun helper that
+/// closed its inherited stdio (so the parent saw EOF and `wait()` returned) but
+/// kept running. Without this they accumulate across pipe runs and pin RAM. The
+/// group shares the parent's pid via `setsid()` at spawn. No-op when the group
+/// is already empty, so the common clean-exit case costs one `kill(pgid, 0)`
+/// probe and never spawns the escalation thread. Unix-only; a normal-completion
+/// backstop mirroring the timeout/stop kill paths.
+fn reap_lingering_process_group(pid: Option<u32>) {
+    #[cfg(unix)]
+    {
+        if let Some(p) = pid {
+            let pgid = p as i32;
+            // Only escalate if the group still has live members.
+            if unsafe { libc::kill(-pgid, 0) } == 0 {
+                let _ = kill_process_group(p);
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+    }
+}
+
 pub fn kill_process_group(pid: u32) -> Result<()> {
     #[cfg(unix)]
     {

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -44,6 +44,17 @@ const PIPE_LOG_ACTIVE_KEEP_PER_PIPE: usize = 200;
 const PIPE_LOG_ARCHIVE_AFTER_DAYS: i64 = 14;
 const PIPE_LOG_ARCHIVE_DIR: &str = "archive";
 const PIPE_EXECUTION_KEEP_PER_PIPE: i32 = 500;
+/// Max stdout/stderr bytes retained per run in the in-memory `logs` ring.
+///
+/// The full output is always persisted to the DB (`finish_execution`) and, for
+/// foreground runs, to disk (`write_log_to_disk`). The in-memory copy is only a
+/// fallback for CLI mode / DB errors (`get_logs`) and the short `last_error`
+/// snippet shown in `list_pipes`/`get_pipe`, so keeping whole (potentially
+/// MB-sized) agent transcripts here is pure RAM overhead that accumulates as
+/// pipes run and is freed only on `delete_pipe`. Bounding each entry keeps a
+/// long history of chatty pipes from pinning hundreds of MB for the whole
+/// process lifetime.
+const PIPE_LOG_INMEM_MAX_OUTPUT_BYTES: usize = 16 * 1024;
 
 // ---------------------------------------------------------------------------
 // Config & log types
@@ -3176,10 +3187,7 @@ impl PipeManager {
             let name_for_cb = log.pipe_name.clone();
             let mut l = logs_ref.lock().await;
             let entry = l.entry(log.pipe_name.clone()).or_insert_with(VecDeque::new);
-            entry.push_back(log);
-            if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-                entry.pop_front();
-            }
+            push_inmem_log(entry, log);
             drop(l);
 
             if let Some(ref cb) = on_complete {
@@ -5082,10 +5090,7 @@ impl PipeManager {
                         let name_for_cb = log.pipe_name.clone();
                         let mut l = logs_ref.lock().await;
                         let entry = l.entry(log.pipe_name.clone()).or_insert_with(VecDeque::new);
-                        entry.push_back(log);
-                        if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-                            entry.pop_front();
-                        }
+                        push_inmem_log(entry, log);
                         drop(l);
 
                         // Emit pipe_completed event so other pipes can chain
@@ -5415,10 +5420,7 @@ impl PipeManager {
     async fn append_log(&self, name: &str, log: &PipeRunLog) {
         let mut logs = self.logs.lock().await;
         let entry = logs.entry(name.to_string()).or_insert_with(VecDeque::new);
-        entry.push_back(log.clone());
-        if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-            entry.pop_front();
-        }
+        push_inmem_log(entry, log.clone());
     }
 
     fn write_log_to_disk(&self, name: &str, log: &PipeRunLog) -> Result<()> {
@@ -6362,6 +6364,35 @@ fn parse_duration_str(s: &str) -> Option<std::time::Duration> {
 // ---------------------------------------------------------------------------
 // Utility helpers
 // ---------------------------------------------------------------------------
+
+/// Truncate a string in place to at most `max_len` bytes on a UTF-8 char
+/// boundary, appending a marker when truncation occurred. Used to bound the
+/// size of log output retained in the in-memory ring buffer without ever
+/// splitting a multi-byte character (which would corrupt the `String`).
+fn truncate_utf8_in_place(s: &mut String, max_len: usize) {
+    if s.len() <= max_len {
+        return;
+    }
+    let mut end = max_len;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s.truncate(end);
+    s.push_str("…[truncated]");
+}
+
+/// Append a run log to a pipe's in-memory ring buffer, bounding both the
+/// per-entry output size (`PIPE_LOG_INMEM_MAX_OUTPUT_BYTES`) and the number of
+/// retained runs (`PIPE_LOG_ACTIVE_KEEP_PER_PIPE`). The full, untruncated
+/// output is persisted elsewhere (DB + disk) — see the constant docs.
+fn push_inmem_log(entry: &mut VecDeque<PipeRunLog>, mut log: PipeRunLog) {
+    truncate_utf8_in_place(&mut log.stdout, PIPE_LOG_INMEM_MAX_OUTPUT_BYTES);
+    truncate_utf8_in_place(&mut log.stderr, PIPE_LOG_INMEM_MAX_OUTPUT_BYTES);
+    entry.push_back(log);
+    while entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
+        entry.pop_front();
+    }
+}
 
 /// Filter NDJSON stdout to remove bulky streaming events before storage.
 /// `toolcall_delta` and `thinking_delta` events are only useful for live
@@ -8240,6 +8271,64 @@ mod tests {
         let result = truncate_string("hello world", 5);
         assert!(result.starts_with("hello"));
         assert!(result.contains("[truncated]"));
+    }
+
+    // -- in-memory log bounding (RAM leak guard) ----------------------------
+
+    #[test]
+    fn truncate_utf8_in_place_leaves_short_strings_untouched() {
+        let mut s = "hello".to_string();
+        truncate_utf8_in_place(&mut s, 16 * 1024);
+        assert_eq!(s, "hello");
+    }
+
+    #[test]
+    fn truncate_utf8_in_place_bounds_large_strings() {
+        let mut s = "a".repeat(1_000_000);
+        truncate_utf8_in_place(&mut s, 16 * 1024);
+        let marker = "…[truncated]";
+        assert!(s.ends_with(marker));
+        assert!(s.len() <= 16 * 1024 + marker.len());
+    }
+
+    #[test]
+    fn truncate_utf8_in_place_never_splits_a_char() {
+        // Each emoji is 4 bytes; cut at a non-multiple-of-4 offset.
+        let mut s = "😀".repeat(1000);
+        truncate_utf8_in_place(&mut s, 10);
+        let marker = "…[truncated]";
+        assert!(s.ends_with(marker));
+        // Body must contain only whole emoji (valid UTF-8, no split char).
+        let body = &s[..s.len() - marker.len()];
+        assert_eq!(body.len() % 4, 0);
+        assert!(body.chars().all(|c| c == '😀'));
+    }
+
+    #[test]
+    fn push_inmem_log_bounds_output_size_and_run_count() {
+        let mut dq: VecDeque<PipeRunLog> = VecDeque::new();
+        let now = Utc::now();
+        for _ in 0..(PIPE_LOG_ACTIVE_KEEP_PER_PIPE + 50) {
+            push_inmem_log(
+                &mut dq,
+                PipeRunLog {
+                    pipe_name: "p".to_string(),
+                    started_at: now,
+                    finished_at: now,
+                    success: true,
+                    stdout: "x".repeat(1_000_000),
+                    stderr: "y".repeat(1_000_000),
+                },
+            );
+        }
+        // Count is capped.
+        assert_eq!(dq.len(), PIPE_LOG_ACTIVE_KEEP_PER_PIPE);
+        // Every retained entry has bounded output — no unbounded RAM growth.
+        let marker_len = "…[truncated]".len();
+        for entry in &dq {
+            assert!(entry.stdout.len() <= PIPE_LOG_INMEM_MAX_OUTPUT_BYTES + marker_len);
+            assert!(entry.stderr.len() <= PIPE_LOG_INMEM_MAX_OUTPUT_BYTES + marker_len);
+        }
     }
 
     // -- url_to_pipe_name ---------------------------------------------------

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -51,6 +51,12 @@ const PIPE_EXECUTION_KEEP_PER_PIPE: i32 = 500;
 /// across many pipes spawns one heavy agent subprocess *each*, all at once — the
 /// RAM spike behind "many pipes → high memory". This bounds the fan-out while
 /// still allowing several to run in parallel. Tunable.
+///
+/// CURRENTLY DISABLED at the permit-acquire site in the scheduler (the
+/// semaphore and this constant are kept for re-enable): a hard cap could stall
+/// legitimately bursty workflows. `event_runs_peak` on the
+/// `pipe_scheduled_run` analytics event tracks how much concurrency real
+/// users need; re-enable (and retune) once that data is in.
 const EVENT_TRIGGERED_CONCURRENCY_LIMIT: usize = 4;
 
 // ---------------------------------------------------------------------------
@@ -2034,6 +2040,12 @@ pub struct PipeManager {
     local_api_key: Option<String>,
     /// Circuit breaker registry for AI preset fallback.
     fallback_registry: Arc<preset_fallback::PresetFallbackRegistry>,
+    /// Live count of concurrently-executing event-triggered runs.
+    event_runs_active: Arc<std::sync::atomic::AtomicUsize>,
+    /// Process-lifetime peak of `event_runs_active`. Reported to analytics —
+    /// decides whether the (currently disabled) event-run concurrency cap can
+    /// be re-enabled without hurting real workflows.
+    event_runs_peak: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl PipeManager {
@@ -2074,7 +2086,23 @@ impl PipeManager {
             connections_context: None,
             local_api_key: None,
             fallback_registry: registry,
+            event_runs_active: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            event_runs_peak: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
+    }
+
+    /// (live, peak) counters of concurrent event-triggered runs, for
+    /// analytics. Peak is process-lifetime.
+    pub fn event_run_concurrency(
+        &self,
+    ) -> (
+        Arc<std::sync::atomic::AtomicUsize>,
+        Arc<std::sync::atomic::AtomicUsize>,
+    ) {
+        (
+            self.event_runs_active.clone(),
+            self.event_runs_peak.clone(),
+        )
     }
 
     /// Returns the pipes directory (e.g. `~/.screenpipe/pipes/`).
@@ -4266,6 +4294,10 @@ impl PipeManager {
         let extra_context = self.extra_context.clone();
         let connections_context = self.connections_context.clone();
         let local_api_key = self.local_api_key.clone();
+        // Live count + process-lifetime peak of concurrent event-triggered
+        // runs, surfaced to analytics via `event_run_concurrency()`.
+        let event_runs_active = self.event_runs_active.clone();
+        let event_runs_peak = self.event_runs_peak.clone();
 
         let handle = tokio::spawn(async move {
             info!("pipe scheduler started (generation {})", generation);
@@ -4279,9 +4311,12 @@ impl PipeManager {
             // avoid rate-limit stampedes when many pipes share the same cron.
             // Event-triggered pipes bypass the queue for low-latency response.
             let execution_semaphore = Arc::new(tokio::sync::Semaphore::new(1));
-            // Event-triggered runs bypass the sequential queue above, but are
-            // capped so a burst can't spawn unbounded heavy agent subprocesses
-            // at once. See EVENT_TRIGGERED_CONCURRENCY_LIMIT.
+            // Event-triggered runs bypass the sequential queue above. They were
+            // capped via this semaphore (EVENT_TRIGGERED_CONCURRENCY_LIMIT) so a
+            // burst can't spawn unbounded heavy agent subprocesses at once, but
+            // the cap is temporarily disabled at the acquire site below — it
+            // could stall legitimately bursty user workflows. `event_runs_peak`
+            // telemetry decides whether/where to re-enable it.
             let event_semaphore =
                 Arc::new(tokio::sync::Semaphore::new(EVENT_TRIGGERED_CONCURRENCY_LIMIT));
             // Track pipes that are queued (waiting for semaphore) or running,
@@ -4746,7 +4781,9 @@ impl PipeManager {
                     let mcp_session_access_ref = mcp_session_access.clone();
                     let pipe_timeout = config.timeout.unwrap_or(DEFAULT_TIMEOUT_SECS);
                     let semaphore = execution_semaphore.clone();
-                    let event_sem = event_semaphore.clone();
+                    let _event_sem = event_semaphore.clone();
+                    let event_active = event_runs_active.clone();
+                    let event_peak = event_runs_peak.clone();
                     let pipes_dir_for_mark = pipes_dir.clone();
                     let queued_ref = queued_or_running.clone();
                     let mcp_server_allowlist = selected_mcp_server_ids(config);
@@ -4754,19 +4791,35 @@ impl PipeManager {
                     tokio::spawn(async move {
                         // Scheduled pipes wait for the previous one to finish
                         // (semaphore of 1). Event-triggered pipes skip that queue
-                        // for low latency but still take a permit from a separate,
-                        // higher-capacity semaphore so a burst can't spawn
-                        // unbounded concurrent agent subprocesses.
+                        // for low latency and currently run UNCAPPED: the
+                        // concurrency cap is disabled (not removed) until
+                        // `event_runs_peak` telemetry shows how many concurrent
+                        // event runs real workflows need. To re-enable, replace
+                        // `None` with the commented acquire.
                         let _permit = if !is_event_triggered {
-                            semaphore
-                                .acquire()
-                                .await
-                                .expect("execution semaphore closed")
+                            Some(
+                                semaphore
+                                    .acquire()
+                                    .await
+                                    .expect("execution semaphore closed"),
+                            )
                         } else {
-                            event_sem
-                                .acquire()
-                                .await
-                                .expect("event semaphore closed")
+                            // Some(
+                            //     _event_sem
+                            //         .acquire()
+                            //         .await
+                            //         .expect("event semaphore closed"),
+                            // )
+                            None
+                        };
+
+                        // Count concurrent event-triggered runs (drops on every
+                        // exit path); the peak feeds the pipe_scheduled_run
+                        // analytics event.
+                        let _concurrency_guard = if is_event_triggered {
+                            Some(EventRunGuard::enter(event_active, event_peak))
+                        } else {
+                            None
                         };
 
                         let shared_pid = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
@@ -6382,6 +6435,30 @@ fn parse_duration_str(s: &str) -> Option<std::time::Duration> {
 // ---------------------------------------------------------------------------
 // Utility helpers
 // ---------------------------------------------------------------------------
+
+/// RAII counter for concurrent event-triggered runs: increments the live count
+/// and records the process-lifetime peak on enter, decrements on drop — so the
+/// count stays accurate on every exit path (success, error, timeout, stop).
+struct EventRunGuard {
+    active: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl EventRunGuard {
+    fn enter(
+        active: Arc<std::sync::atomic::AtomicUsize>,
+        peak: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        let now = active.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        peak.fetch_max(now, std::sync::atomic::Ordering::SeqCst);
+        Self { active }
+    }
+}
+
+impl Drop for EventRunGuard {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
 
 /// Append a run to a pipe's in-memory ring, keeping only the fields the status
 /// APIs actually read (`stderr` for `last_error`, plus timestamps/success) and
@@ -8806,6 +8883,9 @@ mod tests {
         // Simulates a burst of event-triggered pipes all acquiring the event
         // semaphore. No more than EVENT_TRIGGERED_CONCURRENCY_LIMIT should run
         // at once — the guard against unbounded concurrent agent subprocesses.
+        // NOTE: the scheduler currently does NOT acquire this semaphore (cap
+        // disabled pending event_runs_peak telemetry); this test keeps the
+        // mechanism honest for when it's re-enabled.
         let event_semaphore =
             Arc::new(tokio::sync::Semaphore::new(EVENT_TRIGGERED_CONCURRENCY_LIMIT));
         let active_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
@@ -8836,6 +8916,29 @@ mod tests {
         );
         // With a burst larger than the cap, we should actually reach the cap.
         assert_eq!(peak, EVENT_TRIGGERED_CONCURRENCY_LIMIT);
+    }
+
+    #[tokio::test]
+    async fn test_event_run_guard_tracks_live_and_peak() {
+        // The telemetry counters behind event_runs_active/event_runs_peak:
+        // guard increments the live count and records the peak on enter,
+        // decrements on drop.
+        let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let peak = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        {
+            let _g1 = EventRunGuard::enter(active.clone(), peak.clone());
+            let _g2 = EventRunGuard::enter(active.clone(), peak.clone());
+            let _g3 = EventRunGuard::enter(active.clone(), peak.clone());
+            assert_eq!(active.load(std::sync::atomic::Ordering::SeqCst), 3);
+        }
+        // All guards dropped — live count returns to zero, peak sticks.
+        assert_eq!(active.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(peak.load(std::sync::atomic::Ordering::SeqCst), 3);
+
+        // Peak never decreases on later, smaller bursts.
+        let _g = EventRunGuard::enter(active.clone(), peak.clone());
+        assert_eq!(peak.load(std::sync::atomic::Ordering::SeqCst), 3);
     }
 
     #[tokio::test]

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -3176,10 +3176,7 @@ impl PipeManager {
             let name_for_cb = log.pipe_name.clone();
             let mut l = logs_ref.lock().await;
             let entry = l.entry(log.pipe_name.clone()).or_insert_with(VecDeque::new);
-            entry.push_back(log);
-            if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-                entry.pop_front();
-            }
+            push_run_log_status(entry, log);
             drop(l);
 
             if let Some(ref cb) = on_complete {
@@ -5082,10 +5079,7 @@ impl PipeManager {
                         let name_for_cb = log.pipe_name.clone();
                         let mut l = logs_ref.lock().await;
                         let entry = l.entry(log.pipe_name.clone()).or_insert_with(VecDeque::new);
-                        entry.push_back(log);
-                        if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-                            entry.pop_front();
-                        }
+                        push_run_log_status(entry, log);
                         drop(l);
 
                         // Emit pipe_completed event so other pipes can chain
@@ -5415,10 +5409,18 @@ impl PipeManager {
     async fn append_log(&self, name: &str, log: &PipeRunLog) {
         let mut logs = self.logs.lock().await;
         let entry = logs.entry(name.to_string()).or_insert_with(VecDeque::new);
-        entry.push_back(log.clone());
-        if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-            entry.pop_front();
-        }
+        // Store status only — the full stdout lives in the DB/disk, not RAM.
+        push_run_log_status(
+            entry,
+            PipeRunLog {
+                pipe_name: log.pipe_name.clone(),
+                started_at: log.started_at,
+                finished_at: log.finished_at,
+                success: log.success,
+                stdout: String::new(),
+                stderr: log.stderr.clone(),
+            },
+        );
     }
 
     fn write_log_to_disk(&self, name: &str, log: &PipeRunLog) -> Result<()> {
@@ -6362,6 +6364,23 @@ fn parse_duration_str(s: &str) -> Option<std::time::Duration> {
 // ---------------------------------------------------------------------------
 // Utility helpers
 // ---------------------------------------------------------------------------
+
+/// Append a run to a pipe's in-memory ring, keeping only the fields the status
+/// APIs actually read (`stderr` for `last_error`, plus timestamps/success) and
+/// dropping the potentially MB-sized `stdout` transcript.
+///
+/// The full output is the DB's job (`finish_execution`) — and disk's for
+/// foreground runs (`write_log_to_disk`); `get_logs` reads history from the DB.
+/// Keeping the whole transcript here too, up to 200 runs per pipe for the
+/// entire process lifetime, was pure RAM overhead that never freed after a run
+/// finished. This drops it without touching the persisted copies.
+fn push_run_log_status(entry: &mut VecDeque<PipeRunLog>, mut log: PipeRunLog) {
+    log.stdout = String::new();
+    entry.push_back(log);
+    while entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
+        entry.pop_front();
+    }
+}
 
 /// Filter NDJSON stdout to remove bulky streaming events before storage.
 /// `toolcall_delta` and `thinking_delta` events are only useful for live
@@ -8240,6 +8259,33 @@ mod tests {
         let result = truncate_string("hello world", 5);
         assert!(result.starts_with("hello"));
         assert!(result.contains("[truncated]"));
+    }
+
+    // -- in-memory run-log ring (RAM footprint) -----------------------------
+
+    #[test]
+    fn push_run_log_status_drops_stdout_keeps_stderr_and_caps_count() {
+        let mut dq: VecDeque<PipeRunLog> = VecDeque::new();
+        let now = Utc::now();
+        for _ in 0..(PIPE_LOG_ACTIVE_KEEP_PER_PIPE + 50) {
+            push_run_log_status(
+                &mut dq,
+                PipeRunLog {
+                    pipe_name: "p".to_string(),
+                    started_at: now,
+                    finished_at: now,
+                    success: false,
+                    stdout: "x".repeat(1_000_000),
+                    stderr: "boom".to_string(),
+                },
+            );
+        }
+        // Run count is capped.
+        assert_eq!(dq.len(), PIPE_LOG_ACTIVE_KEEP_PER_PIPE);
+        // The heavy stdout transcript is not retained in memory at all…
+        assert!(dq.iter().all(|l| l.stdout.is_empty()));
+        // …but stderr (needed for `last_error`) is kept verbatim, untruncated.
+        assert!(dq.iter().all(|l| l.stderr == "boom"));
     }
 
     // -- url_to_pipe_name ---------------------------------------------------

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -44,6 +44,14 @@ const PIPE_LOG_ACTIVE_KEEP_PER_PIPE: usize = 200;
 const PIPE_LOG_ARCHIVE_AFTER_DAYS: i64 = 14;
 const PIPE_LOG_ARCHIVE_DIR: &str = "archive";
 const PIPE_EXECUTION_KEEP_PER_PIPE: i32 = 500;
+/// Max event-triggered pipe runs allowed to execute concurrently.
+///
+/// Scheduled runs are already serialized (one at a time). Event-triggered runs
+/// bypass that queue for low latency, but without a ceiling a burst of triggers
+/// across many pipes spawns one heavy agent subprocess *each*, all at once — the
+/// RAM spike behind "many pipes → high memory". This bounds the fan-out while
+/// still allowing several to run in parallel. Tunable.
+const EVENT_TRIGGERED_CONCURRENCY_LIMIT: usize = 4;
 
 // ---------------------------------------------------------------------------
 // Config & log types
@@ -4271,6 +4279,11 @@ impl PipeManager {
             // avoid rate-limit stampedes when many pipes share the same cron.
             // Event-triggered pipes bypass the queue for low-latency response.
             let execution_semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+            // Event-triggered runs bypass the sequential queue above, but are
+            // capped so a burst can't spawn unbounded heavy agent subprocesses
+            // at once. See EVENT_TRIGGERED_CONCURRENCY_LIMIT.
+            let event_semaphore =
+                Arc::new(tokio::sync::Semaphore::new(EVENT_TRIGGERED_CONCURRENCY_LIMIT));
             // Track pipes that are queued (waiting for semaphore) or running,
             // so the scheduler doesn't double-queue the same pipe.
             let queued_or_running: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>> =
@@ -4733,22 +4746,27 @@ impl PipeManager {
                     let mcp_session_access_ref = mcp_session_access.clone();
                     let pipe_timeout = config.timeout.unwrap_or(DEFAULT_TIMEOUT_SECS);
                     let semaphore = execution_semaphore.clone();
+                    let event_sem = event_semaphore.clone();
                     let pipes_dir_for_mark = pipes_dir.clone();
                     let queued_ref = queued_or_running.clone();
                     let mcp_server_allowlist = selected_mcp_server_ids(config);
 
                     tokio::spawn(async move {
-                        // Event-triggered pipes skip the queue for low-latency response.
-                        // Scheduled pipes wait for the previous one to finish.
+                        // Scheduled pipes wait for the previous one to finish
+                        // (semaphore of 1). Event-triggered pipes skip that queue
+                        // for low latency but still take a permit from a separate,
+                        // higher-capacity semaphore so a burst can't spawn
+                        // unbounded concurrent agent subprocesses.
                         let _permit = if !is_event_triggered {
-                            Some(
-                                semaphore
-                                    .acquire()
-                                    .await
-                                    .expect("execution semaphore closed"),
-                            )
+                            semaphore
+                                .acquire()
+                                .await
+                                .expect("execution semaphore closed")
                         } else {
-                            None
+                            event_sem
+                                .acquire()
+                                .await
+                                .expect("event semaphore closed")
                         };
 
                         let shared_pid = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
@@ -8781,6 +8799,43 @@ mod tests {
         );
 
         scheduled.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_event_triggered_concurrency_is_capped() {
+        // Simulates a burst of event-triggered pipes all acquiring the event
+        // semaphore. No more than EVENT_TRIGGERED_CONCURRENCY_LIMIT should run
+        // at once — the guard against unbounded concurrent agent subprocesses.
+        let event_semaphore =
+            Arc::new(tokio::sync::Semaphore::new(EVENT_TRIGGERED_CONCURRENCY_LIMIT));
+        let active_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let max_concurrent = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        let burst = EVENT_TRIGGERED_CONCURRENCY_LIMIT * 3;
+        let mut handles = Vec::new();
+        for _ in 0..burst {
+            let sem = event_semaphore.clone();
+            let active = active_count.clone();
+            let max = max_concurrent.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = sem.acquire().await.unwrap();
+                let current = active.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+                max.fetch_max(current, std::sync::atomic::Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                active.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        let peak = max_concurrent.load(std::sync::atomic::Ordering::SeqCst) as usize;
+        assert!(
+            peak <= EVENT_TRIGGERED_CONCURRENCY_LIMIT,
+            "event-triggered concurrency ({peak}) exceeded cap ({EVENT_TRIGGERED_CONCURRENCY_LIMIT})"
+        );
+        // With a burst larger than the cap, we should actually reach the cap.
+        assert_eq!(peak, EVENT_TRIGGERED_CONCURRENCY_LIMIT);
     }
 
     #[tokio::test]

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -44,17 +44,6 @@ const PIPE_LOG_ACTIVE_KEEP_PER_PIPE: usize = 200;
 const PIPE_LOG_ARCHIVE_AFTER_DAYS: i64 = 14;
 const PIPE_LOG_ARCHIVE_DIR: &str = "archive";
 const PIPE_EXECUTION_KEEP_PER_PIPE: i32 = 500;
-/// Max stdout/stderr bytes retained per run in the in-memory `logs` ring.
-///
-/// The full output is always persisted to the DB (`finish_execution`) and, for
-/// foreground runs, to disk (`write_log_to_disk`). The in-memory copy is only a
-/// fallback for CLI mode / DB errors (`get_logs`) and the short `last_error`
-/// snippet shown in `list_pipes`/`get_pipe`, so keeping whole (potentially
-/// MB-sized) agent transcripts here is pure RAM overhead that accumulates as
-/// pipes run and is freed only on `delete_pipe`. Bounding each entry keeps a
-/// long history of chatty pipes from pinning hundreds of MB for the whole
-/// process lifetime.
-const PIPE_LOG_INMEM_MAX_OUTPUT_BYTES: usize = 16 * 1024;
 
 // ---------------------------------------------------------------------------
 // Config & log types
@@ -3187,7 +3176,10 @@ impl PipeManager {
             let name_for_cb = log.pipe_name.clone();
             let mut l = logs_ref.lock().await;
             let entry = l.entry(log.pipe_name.clone()).or_insert_with(VecDeque::new);
-            push_inmem_log(entry, log);
+            entry.push_back(log);
+            if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
+                entry.pop_front();
+            }
             drop(l);
 
             if let Some(ref cb) = on_complete {
@@ -5090,7 +5082,10 @@ impl PipeManager {
                         let name_for_cb = log.pipe_name.clone();
                         let mut l = logs_ref.lock().await;
                         let entry = l.entry(log.pipe_name.clone()).or_insert_with(VecDeque::new);
-                        push_inmem_log(entry, log);
+                        entry.push_back(log);
+                        if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
+                            entry.pop_front();
+                        }
                         drop(l);
 
                         // Emit pipe_completed event so other pipes can chain
@@ -5420,7 +5415,10 @@ impl PipeManager {
     async fn append_log(&self, name: &str, log: &PipeRunLog) {
         let mut logs = self.logs.lock().await;
         let entry = logs.entry(name.to_string()).or_insert_with(VecDeque::new);
-        push_inmem_log(entry, log.clone());
+        entry.push_back(log.clone());
+        if entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
+            entry.pop_front();
+        }
     }
 
     fn write_log_to_disk(&self, name: &str, log: &PipeRunLog) -> Result<()> {
@@ -6364,35 +6362,6 @@ fn parse_duration_str(s: &str) -> Option<std::time::Duration> {
 // ---------------------------------------------------------------------------
 // Utility helpers
 // ---------------------------------------------------------------------------
-
-/// Truncate a string in place to at most `max_len` bytes on a UTF-8 char
-/// boundary, appending a marker when truncation occurred. Used to bound the
-/// size of log output retained in the in-memory ring buffer without ever
-/// splitting a multi-byte character (which would corrupt the `String`).
-fn truncate_utf8_in_place(s: &mut String, max_len: usize) {
-    if s.len() <= max_len {
-        return;
-    }
-    let mut end = max_len;
-    while end > 0 && !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    s.truncate(end);
-    s.push_str("…[truncated]");
-}
-
-/// Append a run log to a pipe's in-memory ring buffer, bounding both the
-/// per-entry output size (`PIPE_LOG_INMEM_MAX_OUTPUT_BYTES`) and the number of
-/// retained runs (`PIPE_LOG_ACTIVE_KEEP_PER_PIPE`). The full, untruncated
-/// output is persisted elsewhere (DB + disk) — see the constant docs.
-fn push_inmem_log(entry: &mut VecDeque<PipeRunLog>, mut log: PipeRunLog) {
-    truncate_utf8_in_place(&mut log.stdout, PIPE_LOG_INMEM_MAX_OUTPUT_BYTES);
-    truncate_utf8_in_place(&mut log.stderr, PIPE_LOG_INMEM_MAX_OUTPUT_BYTES);
-    entry.push_back(log);
-    while entry.len() > PIPE_LOG_ACTIVE_KEEP_PER_PIPE {
-        entry.pop_front();
-    }
-}
 
 /// Filter NDJSON stdout to remove bulky streaming events before storage.
 /// `toolcall_delta` and `thinking_delta` events are only useful for live
@@ -8271,64 +8240,6 @@ mod tests {
         let result = truncate_string("hello world", 5);
         assert!(result.starts_with("hello"));
         assert!(result.contains("[truncated]"));
-    }
-
-    // -- in-memory log bounding (RAM leak guard) ----------------------------
-
-    #[test]
-    fn truncate_utf8_in_place_leaves_short_strings_untouched() {
-        let mut s = "hello".to_string();
-        truncate_utf8_in_place(&mut s, 16 * 1024);
-        assert_eq!(s, "hello");
-    }
-
-    #[test]
-    fn truncate_utf8_in_place_bounds_large_strings() {
-        let mut s = "a".repeat(1_000_000);
-        truncate_utf8_in_place(&mut s, 16 * 1024);
-        let marker = "…[truncated]";
-        assert!(s.ends_with(marker));
-        assert!(s.len() <= 16 * 1024 + marker.len());
-    }
-
-    #[test]
-    fn truncate_utf8_in_place_never_splits_a_char() {
-        // Each emoji is 4 bytes; cut at a non-multiple-of-4 offset.
-        let mut s = "😀".repeat(1000);
-        truncate_utf8_in_place(&mut s, 10);
-        let marker = "…[truncated]";
-        assert!(s.ends_with(marker));
-        // Body must contain only whole emoji (valid UTF-8, no split char).
-        let body = &s[..s.len() - marker.len()];
-        assert_eq!(body.len() % 4, 0);
-        assert!(body.chars().all(|c| c == '😀'));
-    }
-
-    #[test]
-    fn push_inmem_log_bounds_output_size_and_run_count() {
-        let mut dq: VecDeque<PipeRunLog> = VecDeque::new();
-        let now = Utc::now();
-        for _ in 0..(PIPE_LOG_ACTIVE_KEEP_PER_PIPE + 50) {
-            push_inmem_log(
-                &mut dq,
-                PipeRunLog {
-                    pipe_name: "p".to_string(),
-                    started_at: now,
-                    finished_at: now,
-                    success: true,
-                    stdout: "x".repeat(1_000_000),
-                    stderr: "y".repeat(1_000_000),
-                },
-            );
-        }
-        // Count is capped.
-        assert_eq!(dq.len(), PIPE_LOG_ACTIVE_KEEP_PER_PIPE);
-        // Every retained entry has bounded output — no unbounded RAM growth.
-        let marker_len = "…[truncated]".len();
-        for entry in &dq {
-            assert!(entry.stdout.len() <= PIPE_LOG_INMEM_MAX_OUTPUT_BYTES + marker_len);
-            assert!(entry.stderr.len() <= PIPE_LOG_INMEM_MAX_OUTPUT_BYTES + marker_len);
-        }
     }
 
     // -- url_to_pipe_name ---------------------------------------------------

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1454,12 +1454,20 @@ async fn main() -> anyhow::Result<()> {
             server.pipe_permissions.clone(),
         ),
     ));
+    let (event_runs_active, event_runs_peak) = pipe_manager.event_run_concurrency();
     pipe_manager.set_on_run_complete(std::sync::Arc::new(
-        |pipe_name, _execution_id, success, duration_secs, error_type| {
+        move |pipe_name, _execution_id, success, duration_secs, error_type| {
             let mut props = serde_json::json!({
                 "pipe": pipe_name,
                 "success": success,
                 "duration_secs": duration_secs,
+                // Concurrency of event-triggered runs: live count as this run
+                // completes + process-lifetime peak. The peak decides whether
+                // the disabled EVENT_TRIGGERED_CONCURRENCY_LIMIT cap can be
+                // re-enabled (screenpipe-core pipes/mod.rs) without stalling
+                // real workflows.
+                "event_runs_active": event_runs_active.load(std::sync::atomic::Ordering::Relaxed),
+                "event_runs_peak": event_runs_peak.load(std::sync::atomic::Ordering::Relaxed),
             });
             if let Some(et) = error_type {
                 props["error_type"] = serde_json::Value::String(et.to_string());


### PR DESCRIPTION
## description

Heavy-pipe users leak/bloat RAM: PostHog shows leak-suspected users run ~19x more pipes (501 vs 26/wk) and hit ~3x peak tracked memory (22 vs 7 GB, engine RSS + pipe subprocess children). This PR closes the two leaks in the pipe machinery and adds telemetry for the third lever:

1. **Run-log ring no longer retains stdout** (`f122532`) — the in-memory `logs` ring kept the full stdout of up to 200 runs *per pipe* for the whole process lifetime. Only status fields (stderr / timestamps / success) are kept in RAM now; the full transcript still lands in the DB (`finish_execution`) and on disk for foreground runs. Measured: 100 runs of a 2 MB-stdout pipe grew engine RSS **95 → 346 MB** before, **flat ~146 MB** after (DB copy intact, 2,050,122 bytes per run).
2. **Agent process group reaped on normal completion** (`d682a00`) — `kill_process_group` only ran on timeout/stop, so grandchildren that outlived the agent (stray MCP servers, bun helpers) accumulated across runs. `reap_lingering_process_group` now runs after `wait()` in both spawn paths (cheap `kill(pgid, 0)` probe, escalates only if members remain). Measured: a pipe spawning a detached `sleep 600` left **1 leftover per run** before, **0** after.
3. **Event-run concurrency cap: built but disabled, telemetry first** (`ed8f99b` + `965d702`) — event-triggered runs bypass the scheduled-run queue; a burst spawns one heavy agent subprocess each, all at once (RAM spikes). A cap of 4 was implemented and validated, but is **disabled at its acquire site** for now — a hard cap could stall legitimately bursty workflows. Instead the `pipe_scheduled_run` PostHog event now carries `event_runs_active` / `event_runs_peak` (RAII-guarded live count + process-lifetime peak), so fleet data decides whether/where to re-enable the cap. Semaphore, constant, and tests are kept; re-enabling is uncommenting one acquire.

Also validated no residual leak in the pipe machinery: 35-min soak (501 chatty runs + continuous 12-pipe event bursts, ~750 agent spawns) — `leaks` reports 0 leaked bytes, the built-in leak sentinel never fired, phys_footprint flat in a 42–89 MB band.

Full illustrated validation report (before/after RSS curves, concurrency timelines, soak): https://claude.ai/code/artifact/78fc3196-3697-405a-bf90-aca72b792102

## before

Backend-only change (no UI surface). Measured behavior at base `77c2d2e00`:

```
RSS over 100 x 2MB-stdout runs :  95 MB -> 346 MB   (+2.5 MB/run, unbounded)
12-pipe event burst            :  12 agents at once
lingering grandchildren        :  +1 per run (never reaped)
```

## after

```
RSS over 100 x 2MB-stdout runs :  ~146 MB plateau   (~8 KB/run tail)
12-pipe event burst            :  12 agents (cap OFF by design; peak now in PostHog)
lingering grandchildren        :  0
```

## how to test

1. `cargo run --bin screenpipe -- record --data-dir /tmp/sp-test --port 3434 --disable-audio --disable-vision --disable-telemetry` (set `SCREENPIPE_DATA_DIR=/tmp/sp-test` too).
2. Log-ring fix: create a pipe whose agent prints a few MB to stdout, loop `curl -X POST localhost:3434/pipes/<name>/run` ~50x (auth: `screenpipe auth token`), watch `ps -o rss= -p <engine pid>` — should plateau, not climb per run. `GET /pipes/<name>/logs` still returns full stdout from the DB.
3. Group reap: make the pipe's agent spawn a detached `sleep 600` and exit; after the run completes, `pgrep -f "sleep 600"` — no survivors.
4. Telemetry: any scheduler-driven pipe run emits `pipe_scheduled_run` with `event_runs_active` / `event_runs_peak` properties.
5. Unit tests: `cargo test -p screenpipe-core pipes` (206 tests, includes the ring, cap-mechanism, and concurrency-guard tests).

## desktop app checklist (if applicable)

N/A — no `#[tauri::command]` or exported-type changes (crates/screenpipe-core + engine bin only; no `src-tauri`/`tauri.ts` files in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
