### PR TITLE
add autofix.ci for Rust formatting

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,29 @@
+name: autofix.ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  GIT_LFS_SKIP_SMUDGE: 1
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+          rustflags: ""
+
+      - name: Format Rust
+        run: cargo fmt --all
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a


### PR DESCRIPTION
## What changed

- add a dedicated `autofix.ci` workflow for pull requests and pushes to `main`
- run `cargo fmt --all` with the repository's pinned Rust toolchain
- upload formatter changes through the SHA-pinned autofix.ci action
- keep the workflow token read-only and skip Git LFS downloads

## Why

Rust formatting drift currently blocks pull requests and requires a manual formatting commit. This lets autofix.ci apply those mechanical changes automatically, including for forked pull requests once the GitHub App installation is confirmed.

## Validation

- `cargo fmt --all -- --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/autofix.yml`
- `git diff --check`
