### PR TITLE
fix(updater): apply tray restart-to-update in backend, dedupe restarts

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -331,11 +331,10 @@ interface PendingUpdateSnapshot {
 // state from Rust so it can recover if the event fired before this hook
 // registered (boot-time webview race).
 export function useUpdateListener() {
-  const { setIsVisible, setUpdateInfo, setAuthRequired, resetDismissed } = useUpdateBanner();
+  const { setIsVisible, setUpdateInfo, setAuthRequired } = useUpdateBanner();
 
   useEffect(() => {
     let unlistenAvailable: (() => void) | undefined;
-    let unlistenClick: (() => void) | undefined;
     let unlistenAuth: (() => void) | undefined;
 
     // Rust re-emits update-available on every periodic check, and providers
@@ -359,13 +358,6 @@ export function useUpdateListener() {
       // when the download is complete and the app is ready to restart.
       unlistenAvailable = await listen<UpdateInfo>("update-available", (event) => {
         showIfNotDismissed(event.payload);
-      });
-
-      // Tray click is an explicit user request — clear any prior dismissal
-      // so the banner reappears even if they X'd it earlier this session.
-      unlistenClick = await listen("update-now-clicked", () => {
-        resetDismissed();
-        setIsVisible(true);
       });
 
       // Listen for auth-required (user needs to sign in to download update)
@@ -394,8 +386,7 @@ export function useUpdateListener() {
 
     return () => {
       unlistenAvailable?.();
-      unlistenClick?.();
       unlistenAuth?.();
     };
-  }, [setIsVisible, setUpdateInfo, setAuthRequired, resetDismissed]);
+  }, [setIsVisible, setUpdateInfo, setAuthRequired]);
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -1566,7 +1566,12 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                     tauri::async_runtime::spawn(async move {
                         let state = app.state::<std::sync::Arc<crate::updates::UpdatesManager>>();
                         if state.has_update_installed().await {
-                            let _ = app.emit("update-now-clicked", ());
+                            // apply via the same backend path as the banner instead
+                            // of round-tripping through the frontend.
+                            if let Err(e) = crate::updates::restart_for_update(app.clone(), None).await
+                            {
+                                tracing::error!("tray menu: restart for update failed: {}", e);
+                            }
                         } else if let Err(e) = state.check_for_updates(true, true).await {
                             tracing::error!("tray menu: check for updates failed: {}", e);
                         }

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -290,6 +290,10 @@ pub async fn await_safe_restart(timeout_secs: Option<u64>) -> String {
     }
 }
 
+/// True once a surface has committed to applying a staged update; keeps a
+/// second trigger from starting a parallel teardown+relaunch.
+static UPDATE_RESTART_STARTED: AtomicBool = AtomicBool::new(false);
+
 /// Banner-click restart. Mirror the auto-update path: gate, stop server, then
 /// spawn the replacement app and `_exit` the old process so C/C++ atexit
 /// handlers cannot abort during restart. See 2026-06-10 and 2026-07-02 reports.
@@ -303,6 +307,12 @@ pub async fn restart_for_update(
     let gate = await_restart_gate(cap, "banner-triggered restart").await;
     if !gate.should_restart() {
         return Ok(gate.as_str().to_string());
+    }
+
+    // Only the first trigger applies; later ones ride the in-flight restart.
+    if UPDATE_RESTART_STARTED.swap(true, Ordering::SeqCst) {
+        info!("banner restart: update-restart already in progress, ignoring");
+        return Ok("proceed".to_string());
     }
 
     info!("banner restart: gate passed, shutting down for update");
@@ -938,6 +948,12 @@ impl UpdatesManager {
                     .await
                     .should_restart()
                 {
+                    return Result::Ok(true);
+                }
+
+                // Only the first trigger applies; defer to an in-flight restart.
+                if UPDATE_RESTART_STARTED.swap(true, Ordering::SeqCst) {
+                    info!("auto-update: update-restart already in progress, deferring");
                     return Result::Ok(true);
                 }
 


### PR DESCRIPTION
## Problem

On macOS, applying an update behaves differently depending on where the user clicks "restart to update". From the in-app banner it applies cleanly; from the system tray menu the same action degenerates into a process kill loop that thrashes the whole session.

## Before

- tray "restart to update": the server stops and is immediately respawned, the orphaned process holding port 3030 gets force-killed, WKWebView's content process dies and the handler reloads the webview, permissions recovery windows keep popping up, and the whole cycle repeats
- banner "restart to update": one clean restart, app comes back in a sane state

## After

- tray and banner apply the update the same way: a single stop-then-relaunch, no respawn race, no port 3030 churn, no webview thrash, no permissions spam

## Root cause

- the banner applies via one backend call, `restart_for_update` (stop the server, then relaunch)
- the tray instead emitted `update-now-clicked` to the frontend banner to run the restart, so a tray click or the auto-update timer could start a second restart in parallel
- the two teardown+relaunch sequences raced: one stopped the server while the other, plus the health watchdog, respawned it, which is the loop

## Fix

- tray calls `restart_for_update` directly instead of round-tripping through the frontend
- added an `UPDATE_RESTART_STARTED` latch so banner, tray, and auto-update converge on a single restart
- removed the now-dead `update-now-clicked` frontend listener
- cargo check and tsc pass; a real signed-update relaunch was not exercised, so a manual tray restart-to-update test is worth doing before merge
