### PR TITLE
fix(ci): bust poisoned rust-cache key so test-windows ONNX DLL test passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,15 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-test-windows
+          # -v2 suffix busts a poisoned cache: the green run at 9f820f26e
+          # (7/14 19:38 UTC) saved a `ci-test-windows` cache whose restored
+          # target/.../release-dev/deps was missing onnxruntime.dll. ort's
+          # `copy-dylibs` only re-stages that DLL when ort-sys's build script
+          # re-runs, which it doesn't on a cache hit — so every run after that
+          # restored the incomplete deps/ and the screenpipe-engine
+          # pii_redaction_tests binary died at load with STATUS_DLL_NOT_FOUND
+          # (0xc0000135). Bump the key to force one cold, clean build.
+          shared-key: ci-test-windows-v2
           cache-bin: false
 
       # After rust-cache on purpose — see the action's ordering note.


### PR DESCRIPTION
## Problem

The **Rust CI** \`test-windows\` job has failed on **every push to \`main\` since \`9f820f26e\` (2026-07-14 19:38 UTC)**. It dies at the **Run PII redaction tests** step:

\`\`\`
process didn't exit successfully: screenpipe_engine-c29f8ef02e71b995.exe pii_redaction_tests
(exit code: 0xc0000135, STATUS_DLL_NOT_FOUND)
\`\`\`

The binary crashes at **load time**, before any test runs.

## Root cause — poisoned \`Swatinem/rust-cache\`

- In the same job, **Run specific Windows OCR cargo test** (\`screenpipe-screen\`, uses WinRT \`Windows.Media.Ocr\` — no ONNX) and **Run PII removal tests** (\`screenpipe-core\`, pure regex) both pass. Neither imports \`onnxruntime.dll\`.
- **\`screenpipe-engine\` is the only one of the three test binaries that imports \`onnxruntime.dll\`** (via \`screenpipe-audio\` + \`screenpipe-redact\`, \`ort 2.0.0-rc.12\`).
- The engine test binary is **byte-identical green↔red** (same \`-C metadata\` hash \`c29f8ef02e71b995\`), \`Cargo.lock\` unchanged, **same runner image**, and the staged \`onnxruntime.dll\`/VC-runtime DLLs are byte-identical between the last green and the red runs.
- With binary + environment + staging all identical, the only variable is the \`target/x86_64-pc-windows-msvc/release-dev/deps\` state **restored from the \`ci-test-windows\` cache**. \`ort\`'s \`copy-dylibs\` only re-places \`onnxruntime.dll\` when \`ort-sys\`'s build script actually re-runs — on a cache hit it doesn't, so the restored \`deps/\` is missing the DLL and every subsequent run inherits it.

Failure became deterministic immediately after the last green run saved a fresh \`ci-test-windows\` cache.

## Fix

Bump the cache \`shared-key\` (\`ci-test-windows\` → \`ci-test-windows-v2\`). This forces **one cold build** that regenerates a clean \`deps/\` (the state that was green); future runs cache from that. One line, fully reversible.

If it ever recurs, the targeted follow-up is to duplicate the "Stage ONNX Runtime DLLs" step so it runs immediately before "Run PII redaction tests".

## Blast radius

- **Release builds unaffected.** \`release-app.yml\` uses a different cache key (\`rust-cache-\${{ matrix.target }}\`) and **bundles** \`onnxruntime.dll\` into the app via \`tauri.windows.conf.json\` resources. This is purely a CI-test issue.
- Verification: this PR's own \`test-windows\` run is the test — it should go green on the cold rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)