### PR TITLE
fix: drag label renders raw localization key in floating panel

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -48,7 +48,7 @@ tauri-plugin-autostart = "=2.5.1"
 tauri-plugin-shell = "=2.3.5"
 tauri-plugin-store = "=2.4.2"
 tauri-plugin-http = "=2.5.7"
-tauri-plugin-permission-flow = { git = "https://github.com/divanshu-go/permission-flow", rev = "38a64e3704aa32e692bab95cffe704859e191a51", package = "tauri-plugin-permission-flow" }
+tauri-plugin-permission-flow = { git = "https://github.com/divanshu-go/permission-flow", rev = "f3fb7a5ab2f551ac2392c18749b70c9976f56f4d", package = "tauri-plugin-permission-flow" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Problem

the floating drag panel shows the **raw key** `permission_flow.drag.label` instead of the localized "Drag" string:

## Before
<img width="504" alt="before" src="https://github.com/user-attachments/assets/1bedc82c-1cd7-4c77-97ba-4a991ce10cb7" />

## After
<img width="517" alt="after" src="https://github.com/user-attachments/assets/62a6e035-d827-4f18-a2f6-0f1d150f1100" />

## Root cause

`AppDropArea.swift` in permission-flow was the **only** localized string using SwiftUI's implicit `Text(LocalizedStringKey, bundle:)` lookup. That path fails to resolve against the swift-rs resource bundle (`PermissionFlow_PermissionFlow.bundle`) when the bundle lives at a non-standard URL inside a host `.app`, which is exactly how screenpipe vendors it. SwiftUI then falls back to rendering the literal key.

Every other string resolves correctly because it uses one of the two working patterns:
- `PermissionFlowLocalizer.string(...)` → `Bundle.permissionFlow.localizedString(forKey:value:table:)` (the formatted description)
- `LocalizedStringResource(..., bundle: .atURL(Bundle.permissionFlow.bundleURL))` (the button title)

## Fix

Bump `tauri-plugin-permission-flow` to `f3fb7a5`, which routes the drag label through `PermissionFlowLocalizer` and threads the flow's `localeIdentifier` through `AppDragItemView` → `AppDragSourceView` → `AppDragCardContent`, so it honors the injected locale like the rest of the panel.

Upstream fix: divanshu-go/permission-flow#2
