### PR TITLE
fix(pi): stop chat and pipes fighting over Pi version

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -6,7 +6,9 @@
 //!
 //! Manages the pi coding agent via RPC mode (stdin/stdout JSON protocol).
 
-use screenpipe_core::agents::pi::screenpipe_cloud_models;
+use screenpipe_core::agents::pi::{
+    screenpipe_cloud_models, PI_AI_PACKAGE, PI_NAMESPACE_DIR, PI_PACKAGE, SCREENPIPE_API_URL,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use specta::Type;
@@ -292,11 +294,6 @@ fn check_package_bin(pkg_dir: std::path::PathBuf, bin_name: &str) -> Option<Stri
         None
     }
 }
-
-const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.80.6";
-const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.80.6";
-const PI_NAMESPACE_DIR: &str = "@earendil-works";
-const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
 
 /// Pool of Pi sessions — each session_id gets its own PiManager/process.
 pub struct PiPool {

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -16,9 +16,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
-const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.75.4";
-const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.75.4";
-const PI_NAMESPACE_DIR: &str = "@earendil-works";
+pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.80.6";
+pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.80.6";
+pub const PI_NAMESPACE_DIR: &str = "@earendil-works";
 pub const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
 
 /// Windows creation flags for background agent spawns: CREATE_NO_WINDOW


### PR DESCRIPTION
### Description:

- before:

https://github.com/user-attachments/assets/90b83978-726d-4b4b-9540-06963f6137a3

- after:


https://github.com/user-attachments/assets/29319972-1ccc-491c-8d1b-35770afc6490


- chat was on Pi 0.80.6, pipes/core still on 0.75.4
- both rewrite the same `~/.screenpipe/pi-agent`, so they kept upgrading/downgrading each other
- that made chat mark Pi as unhealthy / "not found"
- bump core to 0.80.6 and share one pin (plus namespace/API URL) from `screenpipe-core`