### PR TITLE
fix(connections): bound integration HTTP requests

### DIFF
--- a/crates/screenpipe-connect/src/connections/mod.rs
+++ b/crates/screenpipe-connect/src/connections/mod.rs
@@ -247,6 +247,26 @@ pub trait Integration: Send + Sync {
 /// client when the integration uses public CAs. Centralised here so the
 /// proxy handler and `test()` callers stay in sync.
 pub fn build_client_for(integ: &dyn Integration) -> reqwest::Client {
+    build_client_for_with_timeouts(
+        integ,
+        std::time::Duration::from_secs(10),
+        std::time::Duration::from_secs(30),
+    )
+}
+
+pub fn build_default_client() -> reqwest::Client {
+    build_client_with_timeouts(
+        reqwest::Client::builder(),
+        std::time::Duration::from_secs(10),
+        std::time::Duration::from_secs(30),
+    )
+}
+
+fn build_client_for_with_timeouts(
+    integ: &dyn Integration,
+    connect_timeout: std::time::Duration,
+    request_timeout: std::time::Duration,
+) -> reqwest::Client {
     let mut builder = reqwest::Client::builder();
     if let Some(pem) = integ.extra_root_pem() {
         match reqwest::Certificate::from_pem(pem.as_bytes()) {
@@ -258,10 +278,26 @@ pub fn build_client_for(integ: &dyn Integration) -> reqwest::Client {
             ),
         }
     }
-    builder.build().unwrap_or_else(|e| {
-        tracing::warn!("custom client build failed, using default: {}", e);
-        reqwest::Client::new()
-    })
+    build_client_with_timeouts(builder, connect_timeout, request_timeout)
+}
+
+fn build_client_with_timeouts(
+    builder: reqwest::ClientBuilder,
+    connect_timeout: std::time::Duration,
+    request_timeout: std::time::Duration,
+) -> reqwest::Client {
+    builder
+        .connect_timeout(connect_timeout)
+        .timeout(request_timeout)
+        .build()
+        .unwrap_or_else(|e| {
+            tracing::warn!("custom client build failed, using default: {}", e);
+            reqwest::Client::builder()
+                .connect_timeout(connect_timeout)
+                .timeout(request_timeout)
+                .build()
+                .expect("default reqwest client should build")
+        })
 }
 
 // ---------------------------------------------------------------------------
@@ -480,7 +516,7 @@ impl ConnectionManager {
         Self {
             integrations: all_integrations(),
             screenpipe_dir,
-            client: reqwest::Client::new(),
+            client: build_default_client(),
             secret_store,
         }
     }
@@ -939,6 +975,8 @@ pub fn require_str<'a>(map: &'a Map<String, Value>, key: &str) -> Result<&'a str
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn temp_screenpipe_dir() -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
@@ -974,6 +1012,31 @@ mod tests {
             ids.contains(&"openclaw"),
             "openclaw integration must be registered"
         );
+    }
+
+    #[tokio::test]
+    async fn integration_clients_bound_request_duration() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(200).set_delay(std::time::Duration::from_millis(200)),
+            )
+            .mount(&server)
+            .await;
+        let client = build_client_for_with_timeouts(
+            &slack::Slack,
+            std::time::Duration::from_secs(1),
+            std::time::Duration::from_millis(50),
+        );
+
+        let error = client
+            .get(format!("{}/slow", server.uri()))
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(error.is_timeout());
     }
 
     #[tokio::test]

--- a/crates/screenpipe-connect/src/oauth_refresh_scheduler.rs
+++ b/crates/screenpipe-connect/src/oauth_refresh_scheduler.rs
@@ -50,7 +50,7 @@ use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use crate::connections::{all_integrations, RefreshPolicy};
+use crate::connections::{all_integrations, build_default_client, RefreshPolicy};
 use crate::oauth::{refresh_token_instance, STORE_KEY_PREFIX};
 
 // ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ pub struct ProxyRefreshRunner {
 impl Default for ProxyRefreshRunner {
     fn default() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: build_default_client(),
         }
     }
 }

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -9,7 +9,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::Html;
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use screenpipe_connect::connections::{bee, ConnectionManager};
+use screenpipe_connect::connections::{bee, build_default_client, ConnectionManager};
 use screenpipe_connect::oauth::{self as oauth_store, OAuthCallbackResult, PENDING_OAUTH};
 use screenpipe_connect::whatsapp::WhatsAppGateway;
 use screenpipe_secrets::SecretStore;
@@ -1027,7 +1027,7 @@ async fn ics_calendar_events(
         return (StatusCode::OK, Json(json!([])));
     }
 
-    let client = reqwest::Client::new();
+    let client = build_default_client();
     let events = screenpipe_connect::ics_calendar::fetch_ics_calendar_events(
         &client,
         &enabled,
@@ -1124,7 +1124,7 @@ async fn gcal_status(
     State(state): State<ConnectionsState>,
     Query(q): Query<GoogleCalendarInstanceQuery>,
 ) -> (StatusCode, Json<Value>) {
-    let client = reqwest::Client::new();
+    let client = build_default_client();
     let instance = q.instance.as_deref();
 
     // With several accounts connected, the default-slot lookup is ambiguous
@@ -1182,7 +1182,7 @@ async fn gcal_events(
     State(state): State<ConnectionsState>,
     Query(params): Query<GoogleCalendarEventsQuery>,
 ) -> (StatusCode, Json<Value>) {
-    let client = reqwest::Client::new();
+    let client = build_default_client();
     match gcal_events_inner(&client, params, &state.secret_store).await {
         Ok(events) => (StatusCode::OK, Json(json!(events))),
         Err(e) => gcal_events_error_response(&e),
@@ -1820,7 +1820,7 @@ async fn connection_proxy(
     // Before this fix the proxy would surface "no credentials found" and 401
     // for any connection with an expired token, even though the refresh was
     // a single round-trip away.
-    let http_client = reqwest::Client::new();
+    let http_client = build_default_client();
     let oauth_token = screenpipe_connect::oauth::get_valid_token_instance(
         state.secret_store.as_deref(),
         &http_client,
@@ -1937,7 +1937,7 @@ async fn connection_proxy(
                         id,
                         e
                     );
-                    reqwest::Client::new()
+                    build_default_client()
                 }),
             Err(e) => {
                 tracing::warn!(
@@ -1945,11 +1945,11 @@ async fn connection_proxy(
                     id,
                     e
                 );
-                reqwest::Client::new()
+                build_default_client()
             }
         }
     } else {
-        reqwest::Client::new()
+        build_default_client()
     };
     let mut req = client.request(
         reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET),
@@ -2186,7 +2186,7 @@ async fn slack_send(
         };
         payload.insert("channel".to_string(), Value::String(channel.clone()));
 
-        return match reqwest::Client::new()
+        return match build_default_client()
             .post("https://slack.com/api/chat.postMessage")
             .bearer_auth(user_token)
             .json(&payload)
@@ -2237,7 +2237,7 @@ async fn slack_send(
         }
     };
 
-    match reqwest::Client::new()
+    match build_default_client()
         .post(webhook_url)
         .json(&payload)
         .send()
@@ -2340,7 +2340,7 @@ async fn slack_search(
         Err(e) => return e,
     };
     let count = q.count.unwrap_or(20).to_string();
-    let resp = reqwest::Client::new()
+    let resp = build_default_client()
         .get("https://slack.com/api/search.messages")
         .bearer_auth(&token)
         .query(&[("query", q.q.as_str()), ("count", count.as_str())])
@@ -2363,7 +2363,7 @@ async fn slack_conversations(
         .types
         .unwrap_or_else(|| "public_channel,private_channel,im,mpim".to_string());
     let limit = q.limit.unwrap_or(200).to_string();
-    let resp = reqwest::Client::new()
+    let resp = build_default_client()
         .get("https://slack.com/api/conversations.list")
         .bearer_auth(&token)
         .query(&[("types", types.as_str()), ("limit", limit.as_str())])
@@ -2383,7 +2383,7 @@ async fn slack_history(
         Err(e) => return e,
     };
     let limit = q.limit.unwrap_or(50).to_string();
-    let resp = reqwest::Client::new()
+    let resp = build_default_client()
         .get("https://slack.com/api/conversations.history")
         .bearer_auth(&token)
         .query(&[("channel", q.channel.as_str()), ("limit", limit.as_str())])
@@ -2991,7 +2991,7 @@ async fn bee_pair_start() -> (StatusCode, Json<Value>) {
             )
         }
     };
-    let client = reqwest::Client::new();
+    let client = build_default_client();
     match bee::request_pairing(&client, &public_key_b64).await {
         Ok(bee::PairingOutcome::Pending {
             request_id,
@@ -3049,7 +3049,7 @@ async fn bee_pair_poll(
         }
     };
 
-    let client = reqwest::Client::new();
+    let client = build_default_client();
     match bee::request_pairing(&client, &public_key_b64).await {
         Ok(bee::PairingOutcome::Pending { .. }) => {
             (StatusCode::OK, Json(json!({ "status": "pending" })))


### PR DESCRIPTION
## description

Adds shared 10-second connect and 30-second request timeouts to integration HTTP clients. Central integration clients, the OAuth refresh scheduler, and ad-hoc connection API clients now use the same bounded client policy.

Includes a delayed-server regression test proving a slow upstream returns a reqwest timeout instead of hanging.

Related issue: #5119

## before

```text
integration task -> unresponsive upstream -> waits indefinitely
```

## after

```text
integration task -> unresponsive upstream -> bounded timeout error
                 connect: 10s       request: 30s
```

This is backend-only behavior, so there is no visual UI change to record.

## how to test

1. `cargo test -p screenpipe-connect`
2. `cargo check -p screenpipe-engine`
3. `cargo fmt --all -- --check`

Verified locally on macOS: 160 connection tests passed, 1 ignored; engine check and formatting passed. Focused Clippy with `-D warnings` is currently blocked by pre-existing deprecation and style warnings in dependency crates (`screenpipe-vault`, `screenpipe-sync`, `screenpipe-secrets`, and `screenpipe-db`).

## desktop app checklist (if applicable)

Not applicable; no Tauri command or frontend binding changes.