### PR TITLE
ci: add OpenBLAS runtime to Windows test PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,23 +268,23 @@ jobs:
             Write-Host "$($_.Name)  $($_.Length) bytes"
           }
 
-      # Add the ONNX lib dir to PATH for ALL cargo-test steps below.
-      # The DLL staging step above does put onnxruntime*.dll next to the
-      # test binaries (verified via Get-ChildItem), but accuracy_test
-      # still exits 0xc0000135 (STATUS_DLL_NOT_FOUND) — the loader
-      # resolves the .exe's adjacent dir BEFORE PATH only on the
-      # primary DLL; transitive deps still go through standard search,
-      # and on a sccache-restored deps/ at least one of those misses.
-      # Prepending the lib dir to PATH makes the Windows DLL loader
-      # find onnxruntime.dll + its providers via search regardless of
-      # adjacent-file presence — same approach Tauri's release bundle
-      # uses via resourcesMap on `--no-bundle`-skipped paths.
-      - name: Add ONNX lib dir to PATH for cargo tests
+      # Add native DLL dirs to PATH for ALL cargo-test steps below.
+      # screenpipe-engine directly imports both onnxruntime.dll and
+      # libopenblas.dll. pre_build.js sets OPENBLAS_PATH to the package
+      # root, but the Windows loader needs its bin/ directory on PATH.
+      - name: Add native DLL dirs to PATH for cargo tests
         shell: pwsh
         run: |
           $ortLib = "${{ github.workspace }}/apps/screenpipe-app-tauri/src-tauri/onnxruntime-win-x64-${{ env.ONNXRUNTIME_VERSION }}/lib"
+          $openblasBin = Join-Path $env:OPENBLAS_PATH "bin"
+          $openblasDll = Join-Path $openblasBin "libopenblas.dll"
+          if (-not (Test-Path $openblasDll)) {
+            throw "Required OpenBLAS runtime DLL not found: $openblasDll"
+          }
           echo $ortLib | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo $openblasBin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           Write-Host "PATH appended: $ortLib"
+          Write-Host "PATH appended: $openblasBin"
 
       - name: Run specific Windows OCR cargo test
         env:


### PR DESCRIPTION
## What changed

- add `$OPENBLAS_PATH/bin` to the Windows Rust test PATH alongside the existing ONNX Runtime directory
- fail early with a clear error if `libopenblas.dll` was not produced by `pre_build.js`
- keep the existing Rust cache key and test commands unchanged

## Root cause

[PR #5194](https://github.com/screenpipe/screenpipe/pull/5194) proved the cache was not responsible: its cold `ci-test-windows-v2` run still failed with `STATUS_DLL_NOT_FOUND`.

The diagnostic run on this PR compiled the final `screenpipe-engine` test executable and printed its PE import table. It directly imports `libopenblas.dll` in addition to ONNX Runtime and the VC++ runtime DLLs. `pre_build.js` downloads that DLL to `$OPENBLAS_PATH/bin`, but Rust CI only added the ONNX directory to PATH. The Windows loader therefore could not start the test executable.

The repository's Windows integration and release workflows already treat `openblas/bin/*.dll` as required runtime files. This PR applies the same runtime path to Rust CI.

## Impact

Only Windows Rust CI runtime resolution changes. Product code, release behavior, and cache namespaces are unchanged.

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- [diagnostic Windows run](https://github.com/screenpipe/screenpipe/actions/runs/29428375127/job/87396641413) confirmed `libopenblas.dll` is a direct import of `screenpipe_engine-c29f8ef02e71b995.exe`
- repository `setup_openblas.js` places the x64 DLL at `$OPENBLAS_PATH/bin/libopenblas.dll`
- [Rust CI run 29431262593](https://github.com/screenpipe/screenpipe/actions/runs/29431262593/job/87406563019) passed `test-windows`; the previously crashing engine executable launched and the test harness returned `test result: ok`

## Visual evidence

Not applicable: this is a Windows CI runtime-loader fix with no product UI.
