### PR TITLE
ci: prevent rust cache saves on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           shared-key: ci-test-ubuntu
           cache-bin: false
 
@@ -133,6 +134,7 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           shared-key: ci-test-windows
           cache-bin: false
 
@@ -363,6 +365,7 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           shared-key: ci-test-macos
           cache-bin: false
 

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -43,6 +43,8 @@ jobs:
         # service error must never fail the job
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: false
 
       # After rust-cache on purpose — see the action's ordering note.
       - name: Setup sccache (shared R2 compile cache)

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -112,6 +112,7 @@ jobs:
       continue-on-error: true
       uses: Swatinem/rust-cache@v2
       with:
+        cache-on-failure: false
         workspaces: apps/screenpipe-app-tauri/src-tauri
         shared-key: screenpipe-tauri-e2e-windows
         cache-bin: false
@@ -492,6 +493,7 @@ jobs:
       continue-on-error: true
       uses: Swatinem/rust-cache@v2
       with:
+        cache-on-failure: false
         workspaces: apps/screenpipe-app-tauri/src-tauri
         shared-key: screenpipe-tauri-e2e
         cache-bin: false
@@ -617,6 +619,7 @@ jobs:
     - name: Rust cache
       uses: Swatinem/rust-cache@v2
       with:
+        cache-on-failure: false
         workspaces: .
         shared-key: linux-wayland-e2e
         cache-bin: false
@@ -770,6 +773,7 @@ jobs:
       continue-on-error: true
       uses: Swatinem/rust-cache@v2
       with:
+        cache-on-failure: false
         workspaces: apps/screenpipe-app-tauri/src-tauri
         shared-key: screenpipe-tauri-e2e
         cache-bin: false

--- a/.github/workflows/eval-diarization.yml
+++ b/.github/workflows/eval-diarization.yml
@@ -101,6 +101,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
+          cache-on-failure: false
           key: eval-diarization
           shared-key: screenpipe-audio-eval
 

--- a/.github/workflows/eval-meeting-detection.yml
+++ b/.github/workflows/eval-meeting-detection.yml
@@ -59,6 +59,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
+          cache-on-failure: false
           key: eval-meeting-detection
           shared-key: screenpipe-meeting-eval
 

--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           workspaces: |
             .
             apps/screenpipe-app-tauri/src-tauri

--- a/.github/workflows/macos-intel-launch-smoke.yml
+++ b/.github/workflows/macos-intel-launch-smoke.yml
@@ -132,6 +132,7 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           workspaces: apps/screenpipe-app-tauri/src-tauri
           shared-key: screenpipe-tauri-e2e-intel
           cache-bin: false

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -295,6 +295,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           # Specify custom cache key
           key: ${{ runner.os }}-rust-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           # Cache these paths

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           key: windows-enterprise-rust-x86_64-pc-windows-msvc-${{ hashFiles('**/Cargo.lock') }}
           cache-directories: |
             ~/.cargo/registry/index/
@@ -337,6 +338,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           key: linux-enterprise-rust-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}
           cache-directories: |
             ~/.cargo/registry/index/
@@ -575,6 +577,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           key: macos-enterprise-rust-aarch64-apple-darwin-${{ hashFiles('**/Cargo.lock') }}
           cache-directories: |
             ~/.cargo/registry/index/

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -135,6 +135,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           key: sdk-release-${{ matrix.settings.target }}
           workspaces: ee/sdk -> target
           cache-bin: false

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           key: sdk-cargo-test-${{ matrix.settings.target }}
           workspaces: ee/sdk -> target
           cache-bin: false
@@ -95,6 +96,7 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
+          cache-on-failure: false
           key: sdk-build-${{ matrix.settings.target }}
           workspaces: ee/sdk -> target
           cache-bin: false


### PR DESCRIPTION
## Summary

- set `cache-on-failure: false` on every `Swatinem/rust-cache` step
- cover all 19 cache steps across CI, E2E, evaluation, SDK, smoke, and release workflows
- keep successful-job cache saves unchanged

## Why

Failed builds can leave incomplete or invalid artifacts in Cargo target directories. Making the action's native failure guard explicit prevents those artifacts from being uploaded and restored by later runs.

## Behavior

```text
job succeeds ──> rust-cache post step ──> cache may be saved
job fails    ──> rust-cache post step ──> cache upload is skipped
```

## Root cause

The workflows did not explicitly declare the failure-save policy. Some also set `save-if: true`, which controls whether saving is enabled generally but does not express whether failed jobs may save. The action's dedicated `cache-on-failure` input is the correct control.

## Validation

- `actionlint -shellcheck= <11 changed workflow files>` — passed
- `git diff --check upstream/main...HEAD` — passed
- structural Ruby/YAML assertion — verified all 19 `Swatinem/rust-cache` steps set `cache-on-failure: false`

A live failed-job cache upload was not intentionally triggered locally because `act` is unavailable and the Docker daemon is not running; PR checks provide the live GitHub Actions coverage.
