### PR TITLE
fix(app): start in background on login autostart

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -160,7 +160,7 @@ export default function GeneralSettings() {
       toast({
         title: checked ? "auto-start enabled" : "auto-start disabled",
         description: checked
-          ? "screenpipe will launch when your computer starts"
+          ? "screenpipe will start in the background when you log in"
           : "screenpipe won't launch at startup",
       });
     } catch (e: any) {
@@ -231,7 +231,7 @@ export default function GeneralSettings() {
                 <Rocket className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
                   <h3 className="text-sm font-medium text-foreground">Auto-start</h3>
-                  <p className="text-xs text-muted-foreground">Launch when your computer starts</p>
+                  <p className="text-xs text-muted-foreground">Start in the background when you log in</p>
                 </div>
               </div>
               <Switch

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -220,7 +220,7 @@ fn should_skip_onboarding() -> bool {
 }
 
 /// Flag passed by tauri-plugin-autostart when the OS launches us at login.
-/// Used to skip Home / shortcut reminder so login starts stay in the tray.
+/// Used to skip Home so login starts stay in the tray.
 const AUTOSTART_ARG: &str = "--autostart";
 
 /// True when this process was started by the OS login/autostart entry
@@ -1387,7 +1387,6 @@ async fn main() {
             if store.show_shortcut_overlay
                 && onboarding_store.is_completed
                 && !app_ui_hidden
-                && !from_autostart
                 && !store.recording.disable_timeline
             {
                 let shortcut = store.show_screenpipe_shortcut.clone();

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tauri::Emitter;
 use tauri::Manager;
+#[cfg(target_os = "macos")]
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_autostart::ManagerExt as AutostartManagerExt;
 #[allow(unused_imports)]
@@ -216,6 +217,24 @@ fn should_skip_onboarding() -> bool {
         .ok()
         .map(|s| matches!(s.trim().to_lowercase().as_str(), "1" | "true" | "yes"))
         .unwrap_or(false)
+}
+
+/// Flag passed by tauri-plugin-autostart when the OS launches us at login.
+/// Used to skip Home / shortcut reminder so login starts stay in the tray.
+const AUTOSTART_ARG: &str = "--autostart";
+
+/// True when this process was started by the OS login/autostart entry
+/// (LaunchAgent / Run registry), not a manual user launch.
+fn launched_from_autostart() -> bool {
+    args_contain_autostart(std::env::args())
+}
+
+fn args_contain_autostart<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    args.into_iter().any(|a| a.as_ref() == AUTOSTART_ARG)
 }
 
 // check if the server is running
@@ -777,10 +796,14 @@ async fn main() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_permission_flow::init())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::LaunchAgent,
-            None,
-        ))
+        .plugin({
+            // LaunchAgent on macOS so ProgramArguments can include --autostart
+            // (SMAppService MainApp cannot pass custom args).
+            let builder = tauri_plugin_autostart::Builder::new().args([AUTOSTART_ARG]);
+            #[cfg(target_os = "macos")]
+            let builder = builder.macos_launcher(MacosLauncher::LaunchAgent);
+            builder.build()
+        })
         // single-instance plugin uses zbus::blocking on Linux which panics
         // inside an existing tokio runtime (nested block_on), so skip it on Linux
         ;
@@ -1286,13 +1309,20 @@ async fn main() {
             }
 
             let app_ui_hidden = crate::enterprise_policy::is_app_ui_hidden();
+            let from_autostart = launched_from_autostart();
+            if from_autostart {
+                info!("launched from OS autostart (--autostart); starting in background");
+            }
 
-            // Show onboarding/home unless this device is deployed as a managed
-            // background agent. Permission recovery is handled separately below.
+            // Show onboarding/home unless managed background agent, or login
+            // autostart (tray + server only; UI via tray/dock/shortcut).
+            // Incomplete onboarding still shows so setup can finish.
             if app_ui_hidden {
                 info!("enterprise: hidden UI mode active, skipping startup app windows");
             } else if !onboarding_store.is_completed {
                 let _ = ShowRewindWindow::Onboarding.show(&app.handle());
+            } else if from_autostart {
+                info!("autostart: skipping Home window (background login launch)");
             } else {
                 let _ = ShowRewindWindow::Home { page: None }.show(&app.handle());
             }
@@ -1357,6 +1387,7 @@ async fn main() {
             if store.show_shortcut_overlay
                 && onboarding_store.is_completed
                 && !app_ui_hidden
+                && !from_autostart
                 && !store.recording.disable_timeline
             {
                 let shortcut = store.show_screenpipe_shortcut.clone();
@@ -2068,6 +2099,24 @@ async fn main() {
             error!("panic in run event handler: {:?}", e);
         }
     });
+}
+
+#[cfg(test)]
+mod autostart_arg_tests {
+    use super::{args_contain_autostart, AUTOSTART_ARG};
+
+    #[test]
+    fn detects_autostart_flag() {
+        assert!(args_contain_autostart(["screenpipe", AUTOSTART_ARG]));
+        assert!(args_contain_autostart([AUTOSTART_ARG]));
+    }
+
+    #[test]
+    fn ignores_unrelated_args() {
+        assert!(!args_contain_autostart(["screenpipe"]));
+        assert!(!args_contain_autostart(["screenpipe", "--check-arc-automation"]));
+        assert!(!args_contain_autostart(["screenpipe", "--autostarted"]));
+    }
 }
 
 #[cfg(all(test, target_os = "macos"))]


### PR DESCRIPTION
## Problem

With Auto-start enabled, logging in launches screenpipe and immediately opens the Home window. Users expect login start to stay in the background like Discord/Slack: tray + recording up, no Home flash.

## Before

* OS login starts the app with no distinguishing flag
* setup always shows Home once onboarding is done
* Auto-start toggle copy only said "launch when your computer starts"

https://github.com/user-attachments/assets/593d9962-41dd-4452-9c19-69a88b8c74d4

## After

* login launches pass `--autostart` via LaunchAgent (macOS) / Run registry (Windows)
* when that flag is present and onboarding is done: tray + server + recording start, Home is skipped
* shortcut reminder still shows when enabled
* incomplete onboarding still shows Onboarding; permission recovery still shows if needed
* manual open, tray, dock reopen, and second-instance still open Home as before
* settings copy says it starts in the background on login

https://github.com/user-attachments/assets/02f4d1a3-2b33-466b-a5ae-609226c7d129

## Root cause

* `tauri-plugin-autostart` was initialized with `args: None`, so the OS entry could not tell login launches apart from manual ones
* startup UI always opened Home after onboarding, with no path for "background login"

## Fix

* register autostart with `Builder::new().args(["--autostart"])` (LaunchAgent on macOS so args stick)
* detect `--autostart` early and skip Home on that path
* update Auto-start settings subtitle and enable toast
* unit tests cover the arg helper (`autostart_arg_tests`)