### PR TITLE
fix(app): gate posthog, sentry on analytics preference

### DIFF
--- a/apps/screenpipe-app-tauri/app/providers.tsx
+++ b/apps/screenpipe-app-tauri/app/providers.tsx
@@ -17,7 +17,7 @@ import { useUpdateListener } from "@/components/update-banner";
 import { AppEntitlementGate } from "@/components/app-entitlement-gate";
 import { DeeplinkHandler } from "@/components/deeplink-handler";
 import { usePathname } from "next/navigation";
-import { readCachedAnalyticsId } from "@/lib/analytics-id";
+import { readCachedAnalyticsId, readCachedAnalyticsEnabled } from "@/lib/analytics-id";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
 
@@ -69,6 +69,12 @@ export const Providers = forwardRef<
       // plus pollute prod analytics with test traffic.
       const isE2E = process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
       if (isDebug || isE2E) return;
+      // Respect the user's analytics opt-out preference synchronously, before
+      // PostHog init. The cached value mirrors settings.analyticsEnabled (kept
+      // in sync by use-settings and privacy-section). undefined = first boot
+      // (no cached value yet) → allow init, matching the default of true.
+      const cachedEnabled = readCachedAnalyticsEnabled();
+      if (cachedEnabled === false) return;
       // Bootstrap with the stable per-install id (mirrors settings.analyticsId,
       // cached by the identify() effect in use-settings) so EVERY event — incl.
       // ones fired by overlay windows like the floating search bar before the

--- a/apps/screenpipe-app-tauri/app/providers.tsx
+++ b/apps/screenpipe-app-tauri/app/providers.tsx
@@ -69,10 +69,8 @@ export const Providers = forwardRef<
       // plus pollute prod analytics with test traffic.
       const isE2E = process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
       if (isDebug || isE2E) return;
-      // Respect the user's analytics opt-out preference synchronously, before
-      // PostHog init. The cached value mirrors settings.analyticsEnabled (kept
-      // in sync by use-settings and privacy-section). undefined = first boot
-      // (no cached value yet) → allow init, matching the default of true.
+      // Read the cached analytics preference to sync PostHog opt-in/out
+      // after init. undefined = first boot → allow capturing (default true).
       const cachedEnabled = readCachedAnalyticsEnabled();
       // Bootstrap with the stable per-install id (mirrors settings.analyticsId,
       // cached by the identify() effect in use-settings) so EVERY event — incl.

--- a/apps/screenpipe-app-tauri/app/providers.tsx
+++ b/apps/screenpipe-app-tauri/app/providers.tsx
@@ -74,7 +74,6 @@ export const Providers = forwardRef<
       // in sync by use-settings and privacy-section). undefined = first boot
       // (no cached value yet) → allow init, matching the default of true.
       const cachedEnabled = readCachedAnalyticsEnabled();
-      if (cachedEnabled === false) return;
       // Bootstrap with the stable per-install id (mirrors settings.analyticsId,
       // cached by the identify() effect in use-settings) so EVERY event — incl.
       // ones fired by overlay windows like the floating search bar before the
@@ -92,6 +91,12 @@ export const Providers = forwardRef<
           ? { bootstrap: { distinctID: cachedAnalyticsId, isIdentifiedID: true } }
           : {}),
       });
+      // sync opt-in/out with cached preference on every boot
+      if (cachedEnabled === false) {
+        posthog.opt_out_capturing();
+      } else {
+        posthog.opt_in_capturing();
+      }
     }
   }, []);
 

--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -60,6 +60,7 @@ import { commands } from "@/lib/utils/tauri";
 import posthog from "posthog-js";
 import * as Sentry from "@sentry/react";
 import { defaultOptions } from "tauri-plugin-sentry-api";
+import { cacheAnalyticsEnabled } from "@/lib/analytics-id";
 import {
   validateField,
   sanitizeValue,
@@ -499,6 +500,16 @@ export function PrivacySection() {
   const managedKeyboardCapture = getManagedValue("disableKeyboardCapture");
   const managedClickCapture = getManagedValue("disableClickCapture");
 
+  // Apply PostHog opt-out on mount when the persisted setting is false.
+  // Without this, a user who set analyticsEnabled=false in a previous session
+  // but never opens the settings save handler this session would still have
+  // PostHog capturing (if it was initialized before the cache was populated).
+  useEffect(() => {
+    if (!settings.analyticsEnabled) {
+      posthog.opt_out_capturing();
+    }
+  }, [settings.analyticsEnabled]);
+
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
@@ -589,6 +600,10 @@ export function PrivacySection() {
 
       const analyticsEnabled =
         pendingSettings.analyticsEnabled ?? settings.analyticsEnabled;
+
+      // Cache immediately so the next boot picks up the change before
+      // settings IPC resolves (see readCachedAnalyticsEnabled in providers.tsx).
+      cacheAnalyticsEnabled(analyticsEnabled);
 
       if (!analyticsEnabled) {
         posthog.capture("telemetry", { enabled: false });

--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -500,16 +500,6 @@ export function PrivacySection() {
   const managedKeyboardCapture = getManagedValue("disableKeyboardCapture");
   const managedClickCapture = getManagedValue("disableClickCapture");
 
-  // Apply PostHog opt-out on mount when the persisted setting is false.
-  // Without this, a user who set analyticsEnabled=false in a previous session
-  // but never opens the settings save handler this session would still have
-  // PostHog capturing (if it was initialized before the cache was populated).
-  useEffect(() => {
-    if (!settings.analyticsEnabled) {
-      posthog.opt_out_capturing();
-    }
-  }, [settings.analyticsEnabled]);
-
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
@@ -900,7 +890,17 @@ export function PrivacySection() {
   };
 
   const handleAnalyticsToggle = (checked: boolean) => {
-    handleSettingsChange({ analyticsEnabled: checked }, true);
+    // no restart needed — analytics is purely frontend
+    handleSettingsChange({ analyticsEnabled: checked }, false);
+    cacheAnalyticsEnabled(checked);
+    const isDebug = process.env.TAURI_ENV_DEBUG === "true";
+    if (!isDebug) {
+      if (checked) {
+        posthog.opt_in_capturing();
+      } else {
+        posthog.opt_out_capturing();
+      }
+    }
   };
 
   // Add one pattern from the WindowPicker. Reuses the MultiSelect change

--- a/apps/screenpipe-app-tauri/lib/analytics-id.ts
+++ b/apps/screenpipe-app-tauri/lib/analytics-id.ts
@@ -37,3 +37,30 @@ export function cacheAnalyticsId(id: string | undefined | null): void {
 		// best-effort and must never break app boot.
 	}
 }
+
+// Same pattern for the analytics opt-out preference: cache it in localStorage
+// so posthog.init() in providers.tsx can read it SYNCHRONOUSLY on boot —
+// before the async settings IPC resolves. Without this, users with
+// analyticsEnabled=false still get PostHog initialized (session cookie set,
+// feature flags fetched) on every cold boot.
+export const ANALYTICS_ENABLED_KEY = "screenpipe_analytics_enabled";
+
+export function readCachedAnalyticsEnabled(): boolean | undefined {
+	if (typeof window === "undefined") return undefined;
+	try {
+		const raw = localStorage.getItem(ANALYTICS_ENABLED_KEY);
+		if (raw === null) return undefined;
+		return raw === "true";
+	} catch {
+		return undefined;
+	}
+}
+
+export function cacheAnalyticsEnabled(enabled: boolean): void {
+	if (typeof window === "undefined") return;
+	try {
+		localStorage.setItem(ANALYTICS_ENABLED_KEY, String(enabled));
+	} catch {
+		// Best-effort — must never break app boot.
+	}
+}

--- a/apps/screenpipe-app-tauri/lib/analytics-id.ts
+++ b/apps/screenpipe-app-tauri/lib/analytics-id.ts
@@ -39,10 +39,8 @@ export function cacheAnalyticsId(id: string | undefined | null): void {
 }
 
 // Same pattern for the analytics opt-out preference: cache it in localStorage
-// so posthog.init() in providers.tsx can read it SYNCHRONOUSLY on boot —
-// before the async settings IPC resolves. Without this, users with
-// analyticsEnabled=false still get PostHog initialized (session cookie set,
-// feature flags fetched) on every cold boot.
+// so providers.tsx can read it SYNCHRONOUSLY on boot and sync PostHog
+// opt-in/out right after init — before the async settings IPC resolves.
 export const ANALYTICS_ENABLED_KEY = "screenpipe_analytics_enabled";
 
 export function readCachedAnalyticsEnabled(): boolean | undefined {

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -1337,8 +1337,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 		// person instead of a fresh per-webview anonymous id. See lib/analytics-id.
 		cacheAnalyticsId(settings.analyticsId);
 
-		// Cache the analytics opt-out preference so posthog.init() can skip
-		// entirely on the next boot for users who opted out. See lib/analytics-id.
+		// Cache the analytics opt-out preference so providers.tsx can sync
+		// PostHog opt-in/out on the next boot. See lib/analytics-id.
 		cacheAnalyticsEnabled(settings.analyticsEnabled);
 
 		const clerkId = settings.user?.clerk_id || undefined;

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -10,7 +10,7 @@ import { Store } from "@tauri-apps/plugin-store";
 import { emit, listen } from "@tauri-apps/api/event";
 import React, { createContext, useContext, useEffect, useRef, useState } from "react";
 import posthog from "posthog-js";
-import { cacheAnalyticsId } from "@/lib/analytics-id";
+import { cacheAnalyticsId, cacheAnalyticsEnabled } from "@/lib/analytics-id";
 import { User } from "../utils/tauri";
 import { SettingsStore } from "../utils/tauri";
 import { installAuthInterceptor, stripSessionToken } from "../auth-guard";
@@ -1336,6 +1336,10 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 		// keeping every window (esp. the floating search overlay) on one durable
 		// person instead of a fresh per-webview anonymous id. See lib/analytics-id.
 		cacheAnalyticsId(settings.analyticsId);
+
+		// Cache the analytics opt-out preference so posthog.init() can skip
+		// entirely on the next boot for users who opted out. See lib/analytics-id.
+		cacheAnalyticsEnabled(settings.analyticsEnabled);
 
 		const clerkId = settings.user?.clerk_id || undefined;
 		const distinctId = clerkId || settings.analyticsId;


### PR DESCRIPTION
This pr fixes posthog and sentry not respecting the analytics toggle. users who disabled analytics still had posthog initialized on every cold boot, and turning it back on didn't work because the restart bar covered the toggle.

Also added a localStorage cache for the analytics preference so it's available synchronously on boot. posthog always initializes now but opts in or out based on cached value. analytics toggle no  longer shows the restart bar since it's frontend-only.



Before -
<img width="929" height="644" alt="image" src="https://github.com/user-attachments/assets/9bd112b0-51d1-417c-9b29-fedc1fa4b74c" />



After -



https://github.com/user-attachments/assets/29633fbd-ef89-4fdb-847d-01c1415ce268

