### PR TITLE
fix(pi): restore verified 0.75.5 credential contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@ Use `#` for Python, `//` for Rust/TS/JS/Swift. Keep it as the first comment in t
 - Use `bun` for JS/TS (not npm or pnpm)
 - Use `cargo` for Rust
 
+## Dependency Changes
+
+- Pin the minimum dependency version that fixes the stated problem. Do not jump to a newer major or minor version without a separate, documented reason.
+- Before upgrading, read every intervening changelog and diff the dependency contracts Screenpipe relies on, including configuration formats, environment-variable resolution, persisted files, runtime requirements, and transitive dependencies.
+- Add regression tests for each relied-on contract and exercise every affected user journey before merging. A dependency upgrade is incomplete if only the original bug is tested.
+- Record the required capability, the previous version, the selected minimum version, rejected alternatives, and compatibility evidence in the pull request.
+
 ## Testing
 
 Always test your work. Verification and reviewing pull requests is the hardest thing to do for us, so you need to always make sure to do as much as possible end-to-end testing. If necessary, computer use testing and be very rigorous in your testing, and add as many visuals as possible, like screenshots or video recording, in the body of your pull request. 

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -4684,6 +4684,17 @@ error: InstallFailed extracting tarball"#;
 
     use super::{build_models_json, resolve_pi_model, PiProviderConfig};
 
+    #[test]
+    fn test_pi_pin_matches_models_json_auth_contract() {
+        // Pi 0.75.5 is the minimum version with forceAdaptiveThinking support and
+        // the last verified version where bare models.json values such as
+        // OPENAI_API_KEY resolve through the child process environment. Pi 0.80
+        // changed that contract to require $OPENAI_API_KEY and broke every BYOK
+        // provider. Any future pin change must update and re-verify this test.
+        assert_eq!(super::PI_PACKAGE, "@earendil-works/pi-coding-agent@0.75.5");
+        assert_eq!(super::PI_AI_PACKAGE, "@earendil-works/pi-ai@0.75.5");
+    }
+
     fn make_provider_config(provider: &str, model: &str) -> PiProviderConfig {
         PiProviderConfig {
             provider: provider.to_string(),
@@ -4767,6 +4778,10 @@ error: InstallFailed extracting tarball"#;
     async fn test_build_models_json_chatgpt_gpt55_supports_reasoning() {
         let pc = make_provider_config("openai-chatgpt", "gpt-5.5");
         let config = build_models_json(None, Some(&pc)).await;
+        assert_eq!(
+            config["providers"]["openai-chatgpt"]["apiKey"],
+            "OPENAI_CHATGPT_TOKEN"
+        );
         let model = &config["providers"]["openai-chatgpt"]["models"][0];
         assert_eq!(model["id"], "gpt-5.5");
         assert_eq!(model["reasoning"], true);
@@ -4807,6 +4822,7 @@ error: InstallFailed extracting tarball"#;
         let config = build_models_json(None, Some(&pc)).await;
         let providers = config["providers"].as_object().unwrap();
         assert!(providers.contains_key("anthropic-byok"));
+        assert_eq!(providers["anthropic-byok"]["apiKey"], "ANTHROPIC_API_KEY");
         assert_eq!(
             providers["anthropic-byok"]["baseUrl"],
             "https://api.anthropic.com"
@@ -4853,6 +4869,7 @@ error: InstallFailed extracting tarball"#;
         assert_eq!(providers.len(), 2);
         assert!(providers.contains_key("custom"));
         assert_eq!(providers["custom"]["baseUrl"], "http://my-server:8080/v1");
+        assert_eq!(providers["custom"]["apiKey"], "CUSTOM_API_KEY");
     }
 
     #[tokio::test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
-pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.80.6";
-pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.80.6";
+pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.75.5";
+pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.75.5";
 pub const PI_NAMESPACE_DIR: &str = "@earendil-works";
 pub const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
 


### PR DESCRIPTION
## What broke

Screenpipe writes bare environment-variable names into Pi's `models.json`, for example `CUSTOM_API_KEY`.

Pi 0.80 changed that contract: bare values became literal API keys, while environment lookup required `$CUSTOM_API_KEY`. That is why current builds sent `CUSTOM_API_KEY` to OpenAI and received the reported 401.

```text
models.json: CUSTOM_API_KEY
          |
          +-- Pi 0.80.6 --> literal "CUSTOM_API_KEY" --> OpenAI 401
          |
          `-- Pi 0.75.5 --> process.env.CUSTOM_API_KEY --> real secret
```

## Fix

- Pin both shared Pi packages from `0.80.6` back to `0.75.5` for chat and pipes.
- Assert the exact pin and every Screenpipe credential reference: OpenAI, ChatGPT, Anthropic, and custom providers.
- Record a repository-wide dependency rule: use the minimum fixing version, audit every intervening contract, and document/test any broader upgrade.

`0.75.5` is intentional: it is the minimum known version that contains the original `forceAdaptiveThinking` fix, and its published package still resolves Screenpipe's bare environment-variable references. No broader Pi upgrade is required.

## Verification

- `rustfmt --check --edition 2021 apps/screenpipe-app-tauri/src-tauri/src/pi.rs crates/screenpipe-core/src/agents/pi.rs` — passed.
- `git diff --check` — passed.
- `cargo test --bin screenpipe-app pi::tests::test_pi_pin_matches_models_json_auth_contract` — passed: 1 passed, 0 failed.
- `./target/debug/deps/screenpipe_app-1a590899eda6a2cc pi::tests::test_build_models_json` — passed: 21 passed, 0 failed.
- Directly loaded Pi 0.75.5's published `resolve-config-value.js` with sentinel values for `OPENAI_API_KEY`, `OPENAI_CHATGPT_TOKEN`, `ANTHROPIC_API_KEY`, and `CUSTOM_API_KEY` — all four resolved to their environment secrets, not their variable names.

Screenpipe was deliberately not launched during verification at the reporter's request. The affected functional contract was exercised directly through the published Pi 0.75.5 resolver; the remaining untested surface is a live chat request in the packaged desktop application.

## Test harness notes

- The repository-wide `cargo fmt -- --check` also reports pre-existing formatting drift in `src/main.rs` and `src/tray.rs`; both edited Rust files pass targeted `rustfmt --check`.
- The app test build requires generated sidecars and `../out`. Temporary local test-only stand-ins were staged to compile the test harness, then removed. Generated Cargo/schema changes were also removed before commit.
