### PR TITLE
destroy onboarding window on close

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-redirect.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-redirect.spec.ts
@@ -28,6 +28,14 @@
 import { existsSync } from "node:fs";
 import { E2E_SEED_FLAGS } from "../helpers/app-launcher.js";
 import { saveScreenshot } from "../helpers/screenshot-utils.js";
+import {
+  closeWindow,
+  invokeOrThrow,
+  showWindow,
+  waitForWindowClosed,
+  waitForWindowHandle,
+  waitForWindowUrl,
+} from "../helpers/tauri.js";
 import { t, waitForAppReady } from "../helpers/test-utils.js";
 
 const seedFlags = E2E_SEED_FLAGS.split(",")
@@ -89,6 +97,30 @@ const canRun = !seedFlags.includes("onboarding");
       expect(handles).not.toContain("home");
 
       const filepath = await saveScreenshot("onboarding-redirect");
+      expect(existsSync(filepath)).toBe(true);
+    });
+
+    it("destroys a closed onboarding webview without completing onboarding", async () => {
+      await showWindow({ Home: { page: "home" } });
+      await waitForWindowHandle("home", t(10_000));
+      await browser.switchToWindow("home");
+
+      await closeWindow("Onboarding");
+      await waitForWindowClosed("onboarding", t(10_000));
+
+      const status = await invokeOrThrow<{
+        isCompleted: boolean;
+        currentStep: string | null;
+      }>("get_onboarding_status");
+      expect(status.isCompleted).toBe(false);
+      expect(status.currentStep).toBeNull();
+
+      await showWindow("Onboarding");
+      await waitForWindowHandle("onboarding", t(10_000));
+      await browser.switchToWindow("onboarding");
+      await waitForWindowUrl("/onboarding", undefined, t(15_000));
+
+      const filepath = await saveScreenshot("onboarding-recreated-after-close");
       expect(existsSync(filepath)).toBe(true);
     });
   },

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -219,6 +219,10 @@ fn should_skip_onboarding() -> bool {
         .unwrap_or(false)
 }
 
+fn should_prevent_window_close(label: &str) -> bool {
+    label != "onboarding"
+}
+
 /// Flag passed by tauri-plugin-autostart when the OS launches us at login.
 /// Used to skip Home so login starts stay in the tray.
 const AUTOSTART_ARG: &str = "--autostart";
@@ -724,6 +728,15 @@ async fn main() {
                 });
             }
             tauri::WindowEvent::CloseRequested { api, .. } => {
+                // Onboarding is disposable. Let Tauri destroy its webview so
+                // page effects (notably the live-feed search poller) are torn
+                // down as soon as the user closes the window. Other app
+                // windows stay warm for fast reopen and NSPanel safety.
+                if !should_prevent_window_close(window.label()) {
+                    info!("onboarding window close requested — destroying webview");
+                    return;
+                }
+
                 let _ = window.set_always_on_top(false);
                 let _ = window.set_visible_on_all_workspaces(false);
 
@@ -2115,6 +2128,23 @@ mod autostart_arg_tests {
         assert!(!args_contain_autostart(["screenpipe"]));
         assert!(!args_contain_autostart(["screenpipe", "--check-arc-automation"]));
         assert!(!args_contain_autostart(["screenpipe", "--autostarted"]));
+    }
+}
+
+#[cfg(test)]
+mod window_close_policy_tests {
+    use super::should_prevent_window_close;
+
+    #[test]
+    fn onboarding_close_destroys_its_webview() {
+        assert!(!should_prevent_window_close("onboarding"));
+    }
+
+    #[test]
+    fn persistent_windows_keep_their_existing_close_behavior() {
+        for label in ["home", "main", "main-window", "search", "chat"] {
+            assert!(should_prevent_window_close(label), "label: {label}");
+        }
     }
 }
 


### PR DESCRIPTION
## What changed

- let the onboarding window's close request proceed so Tauri destroys its webview
- preserve the existing hide-on-close behavior for every other app window
- add regression coverage proving close removes the onboarding window without marking onboarding complete, and that onboarding can be recreated afterward

## Why

The global close handler prevented every window from closing and hid it instead. For onboarding, that kept the webview's JavaScript runtime alive after the user clicked the close button, so the live-feed interval continued issuing `/search` requests every two seconds.

The isolated search benchmark used a 5.6 GB cloned database and replayed the exact 45-request workload over 30 seconds. It consumed 18.38 CPU-seconds: 61.2% of one core, or about 15.3% of a four-core machine. About 92% of that CPU time was OCR frame extraction in ffmpeg.

```text
before: close onboarding -> hide webview -> JS interval survives -> /search + ffmpeg continue
after:  close onboarding -> destroy webview -> JS runtime exits  -> polling stops
```

This does not bypass onboarding. Closing the window leaves `isCompleted=false`, and the next onboarding open creates a fresh webview at `/onboarding`.

## Validation

- `cargo test -p screenpipe-app window_close_policy_tests --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml -- --nocapture` — 2 passed, 0 failed
- `SCREENPIPE_E2E_SEED=no-recording bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/onboarding-redirect.spec.ts --mochaOpts.grep 'destroys a closed onboarding webview'` — 1 passed, 0 failed
- `git diff --check` — passed

### Windows CPU benchmark

Measured on Windows with a debug/E2E build, 32 logical processors, and an 808 MB clone of a real search database. The probe exercised the onboarding live-feed search/OCR workload, closed onboarding, then sampled the complete app process tree for 45 seconds.

| Metric after closing onboarding | Base | This PR |
| --- | ---: | ---: |
| Onboarding WebView handle | still alive | destroyed |
| Additional `/search` requests | 78 | 0 |
| Average CPU (% of one core) | 9.42% | 1.54% |
| p95 CPU (% of one core) | 23.47% | 2.98% |
| Average whole-machine CPU | 0.294% | 0.048% |

Residual post-close CPU dropped **83.6%** versus base, and p95 dropped **87.3%**. On the PR build itself, CPU fell from **145.9% of one core** while the search/OCR workload was active to **1.54%** after close, a **98.9% drop**.

The base build reproduced the bug directly: the close request succeeded, the onboarding handle remained, and the hidden webview issued 78 more search requests. With this PR, the handle disappears and the polling runtime exits.

The full onboarding redirect spec still has a pre-existing stale login-copy assertion; the new targeted close/recreate test passes.
