### PR TITLE
Make pipe play action primary

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -2555,6 +2555,48 @@ export function PipesSection() {
                 className="max-h-0 overflow-hidden opacity-0 pointer-events-none transition-[max-height,opacity] duration-150 group-hover:max-h-16 group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:max-h-16 group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
               >
                 <div className="flex items-center gap-1 px-3 pb-2.5 pt-0.5">
+                  {/* Run is the primary action: keep it first and visually larger
+                      than the AI editing actions that follow. */}
+                  <div className="flex items-center shrink-0">
+                    {isRunning ? (
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="h-9 w-9"
+                        onClick={() => stopPipe(pipe.config.name)}
+                        disabled={stoppingPipe === pipe.config.name}
+                        title="stop pipe"
+                        aria-label="stop pipe"
+                      >
+                        {stoppingPipe === pipe.config.name ? (
+                          <Loader2 className="h-5 w-5 animate-spin" />
+                        ) : (
+                          <Square className="h-5 w-5" />
+                        )}
+                      </Button>
+                    ) : (
+                      <Button
+                        variant={hasMissingConnections ? "outline" : "default"}
+                        size="icon"
+                        className={cn("h-9 w-9", hasMissingConnections && "text-destructive")}
+                        onClick={() => {
+                          if (hasMissingConnections) {
+                            setConnectionModal({ pipeName: pipe.config.name, connections: pipe.config.connections ?? [] });
+                          } else {
+                            runPipe(pipe.config.name);
+                          }
+                        }}
+                        disabled={runningPipe === pipe.config.name}
+                        title={hasMissingConnections ? "configure required connections first" : "run pipe"}
+                        aria-label={hasMissingConnections ? "configure required connections first" : "run pipe"}
+                      >
+                        {hasMissingConnections
+                          ? <AlertCircle className="h-5 w-5" />
+                          : <Play className="h-5 w-5 fill-current" />}
+                      </Button>
+                    )}
+                  </div>
+
                 {/* optimize with ai — opens a chat that reads the pipe's prompt
                     + recent run logs and suggests improvements in plain english */}
                 {!isReceivedTeamPipe(pipe) && (
@@ -2600,46 +2642,8 @@ export function PipesSection() {
                   </Button>
                 )}
 
-                {/* run + overflow */}
-                <div className="flex items-center gap-0.5 shrink-0">
-                  {/* Run / Stop button */}
-                  {isRunning ? (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7"
-                      onClick={() => stopPipe(pipe.config.name)}
-                      disabled={stoppingPipe === pipe.config.name}
-                      title="stop pipe"
-                    >
-                      {stoppingPipe === pipe.config.name ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <Square className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className={cn("h-7 w-7", hasMissingConnections && "text-destructive")}
-                      onClick={() => {
-                        if (hasMissingConnections) {
-                          setConnectionModal({ pipeName: pipe.config.name, connections: pipe.config.connections ?? [] });
-                        } else {
-                          runPipe(pipe.config.name);
-                        }
-                      }}
-                      disabled={runningPipe === pipe.config.name}
-                      title={hasMissingConnections ? "configure required connections first" : "run pipe"}
-                    >
-                      {hasMissingConnections
-                        ? <AlertCircle className="h-3.5 w-3.5" />
-                        : <Play className="h-3.5 w-3.5" />}
-                    </Button>
-                  )}
-
-                  {/* Overflow menu */}
+                {/* Overflow menu */}
+                <div className="flex items-center shrink-0">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0">

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -328,12 +328,11 @@ function buildOptimizeDisplayLabel(pipeName: string): string {
   return `Optimize pipe: ${pipeName.trim()}`;
 }
 
-// "remix" = make your own version of an existing pipe. We don't mutate the
+// "fork" = make your own version of an existing pipe. We don't mutate the
 // original — the agent reads it and creates a NEW customized pipe. Framing
-// authoring as "customize a working thing" is the lever that turns installers
-// into creators (see Replit remix / Notion duplicate).
-function buildRemixPrompt(pipeName: string): string {
-  return `i want to remix my existing pipe "${pipeName}" into a new one.
+// authoring as "customize a working thing" turns installers into creators.
+function buildForkPrompt(pipeName: string): string {
+  return `i want to fork my existing pipe "${pipeName}" into a new one.
 
 ## your task
 1. read the original pipe: ~/.screenpipe/pipes/${pipeName}/pipe.md
@@ -2620,7 +2619,7 @@ export function PipesSection() {
                   </Button>
                 )}
 
-                {/* remix — create a NEW pipe based on this one and customize it */}
+                {/* fork — create a NEW pipe based on this one and customize it */}
                 {!isReceivedTeamPipe(pipe) && (
                   <Button
                     variant="ghost"
@@ -2629,16 +2628,16 @@ export function PipesSection() {
                     onClick={() => {
                       posthog.capture("pipe_remix_started", { source: "row_button" });
                       navigateHomeAndPrefill({
-                        context: "the user wants to remix their pipe into a new one",
-                        prompt: buildRemixPrompt(pipe.config.name),
-                        displayLabel: `Remix pipe: ${pipe.config.name}`,
+                        context: "the user wants to fork their pipe into a new one",
+                        prompt: buildForkPrompt(pipe.config.name),
+                        displayLabel: `Fork pipe: ${pipe.config.name}`,
                         autoSend: true,
                       });
                     }}
-                    title="remix — create a new pipe based on this one and customize it"
+                    title="fork — create a new pipe based on this one and customize it"
                   >
                     <GitFork className="h-3.5 w-3.5" />
-                    remix
+                    fork
                   </Button>
                 )}
 

--- a/apps/screenpipe-app-tauri/docs/media/pipe-card-actions-hover.svg
+++ b/apps/screenpipe-app-tauri/docs/media/pipe-card-actions-hover.svg
@@ -10,14 +10,14 @@
   <text x="1078" y="181" fill="#777" font-family="monospace" font-size="18">◷ 1h</text>
   <text x="1270" y="181" fill="#777" font-family="monospace" font-size="18">just now</text>
   <line x1="56" y1="252" x2="1384" y2="252" stroke="#eeeeee"/>
-  <rect x="58" y="277" width="250" height="48" fill="#111"/>
-  <text x="79" y="308" fill="#fff" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="1.25">✧  OPTIMIZE WITH AI</text>
-  <rect x="324" y="277" width="114" height="48" fill="#fff" stroke="#cfcfcf"/>
-  <text x="345" y="308" fill="#4a4a4a" font-family="Arial, sans-serif" font-size="17" font-weight="700" letter-spacing="1.4">⌘  REMIX</text>
-  <rect x="454" y="277" width="48" height="48" fill="#fff" stroke="#cfcfcf"/>
-  <path d="M472 290l17 11-17 11z" fill="#111"/>
-  <rect x="518" y="277" width="48" height="48" fill="#fff" stroke="#cfcfcf"/>
-  <circle cx="534" cy="301" r="3" fill="#111"/><circle cx="542" cy="301" r="3" fill="#111"/><circle cx="550" cy="301" r="3" fill="#111"/>
+  <rect x="58" y="268" width="66" height="66" fill="#111"/>
+  <path d="M82 284l25 17-25 17z" fill="#fff"/>
+  <rect x="140" y="277" width="250" height="48" fill="#fff" stroke="#cfcfcf"/>
+  <text x="161" y="308" fill="#4a4a4a" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="1.25">✧  OPTIMIZE WITH AI</text>
+  <rect x="406" y="277" width="114" height="48" fill="#fff" stroke="#cfcfcf"/>
+  <text x="427" y="308" fill="#4a4a4a" font-family="Arial, sans-serif" font-size="17" font-weight="700" letter-spacing="1.4">⌘  REMIX</text>
+  <rect x="536" y="277" width="48" height="48" fill="#fff" stroke="#cfcfcf"/>
+  <circle cx="552" cy="301" r="3" fill="#111"/><circle cx="560" cy="301" r="3" fill="#111"/><circle cx="568" cy="301" r="3" fill="#111"/>
   <rect x="1248" y="277" width="106" height="48" fill="#111"/>
   <rect x="1316" y="288" width="26" height="26" fill="#fff"/>
   <rect x="1166" y="137" width="176" height="33" fill="#111"/>

--- a/apps/screenpipe-app-tauri/docs/media/pipe-card-actions-hover.svg
+++ b/apps/screenpipe-app-tauri/docs/media/pipe-card-actions-hover.svg
@@ -15,7 +15,7 @@
   <rect x="140" y="277" width="250" height="48" fill="#fff" stroke="#cfcfcf"/>
   <text x="161" y="308" fill="#4a4a4a" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="1.25">✧  OPTIMIZE WITH AI</text>
   <rect x="406" y="277" width="114" height="48" fill="#fff" stroke="#cfcfcf"/>
-  <text x="427" y="308" fill="#4a4a4a" font-family="Arial, sans-serif" font-size="17" font-weight="700" letter-spacing="1.4">⌘  REMIX</text>
+  <text x="427" y="308" fill="#4a4a4a" font-family="Arial, sans-serif" font-size="17" font-weight="700" letter-spacing="1.4">⌘  FORK</text>
   <rect x="536" y="277" width="48" height="48" fill="#fff" stroke="#cfcfcf"/>
   <circle cx="552" cy="301" r="3" fill="#111"/><circle cx="560" cy="301" r="3" fill="#111"/><circle cx="568" cy="301" r="3" fill="#111"/>
   <rect x="1248" y="277" width="106" height="48" fill="#111"/>

--- a/apps/screenpipe-app-tauri/e2e/specs/pipes.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/pipes.spec.ts
@@ -501,6 +501,33 @@ describe.skip('Pipes: discover → install → play', function () {
     );
     await browser.pause(400);
 
+    const actionHierarchy = await browser.execute((name: string) => {
+      for (const nameEl of Array.from(document.querySelectorAll<HTMLElement>('button, span'))) {
+        if (nameEl.textContent?.trim() !== name) continue;
+        const row = nameEl.closest<HTMLElement>('div.group');
+        if (!row) continue;
+        const actions = Array.from(row.querySelectorAll<HTMLButtonElement>('[data-testid="pipe-card-actions"] button'));
+        const runButton = row.querySelector<HTMLButtonElement>('button[title="run pipe"]');
+        const optimizeButton = row.querySelector<HTMLButtonElement>('button[title^="optimize this pipe"]');
+        if (!runButton || !optimizeButton) return null;
+        return {
+          runIndex: actions.indexOf(runButton),
+          optimizeIndex: actions.indexOf(optimizeButton),
+          runHeight: runButton.getBoundingClientRect().height,
+          optimizeHeight: optimizeButton.getBoundingClientRect().height,
+          playIconWidth: runButton.querySelector('svg')?.getBoundingClientRect().width ?? 0,
+          optimizeIconWidth: optimizeButton.querySelector('svg')?.getBoundingClientRect().width ?? 0,
+        };
+      }
+      return null;
+    }, installedPipeName);
+
+    expect(actionHierarchy).not.toBeNull();
+    expect(actionHierarchy!.runIndex).toBe(0);
+    expect(actionHierarchy!.runIndex).toBeLessThan(actionHierarchy!.optimizeIndex);
+    expect(actionHierarchy!.runHeight).toBeGreaterThan(actionHierarchy!.optimizeHeight);
+    expect(actionHierarchy!.playIconWidth).toBeGreaterThan(actionHierarchy!.optimizeIconWidth);
+
     const played = await browser.execute((name: string) => {
       for (const nameBtn of Array.from(document.querySelectorAll<HTMLElement>('button, span'))) {
         if (nameBtn.textContent?.trim() !== name) continue;


### PR DESCRIPTION
## what changed

- moved the Play/Stop control to the first position in each pipe's action row
- made Play the primary filled action at 36px with a 20px icon
- kept Optimize with AI secondary at 28px with a 14px icon
- renamed Remix to Fork across the button, tooltip, AI prompt, and chat label
- added accessible labels and kept the larger control stable while a pipe is running
- extended the Pipes end-to-end scenario to assert the action order and size hierarchy

## why

Optimize was visually dominant and appeared before Play even though running a pipe is the primary action. This makes the intended action obvious at a glance.

## visual

![Play is first and larger than Optimize with AI](https://raw.githubusercontent.com/screenpipe/screenpipe/ea192501a/apps/screenpipe-app-tauri/docs/media/pipe-card-actions-hover.svg)

## validation

- `bun run typecheck`
- focused ESLint: no errors (3 existing hook dependency warnings in `pipes-section.tsx`)
- `xmllint --noout apps/screenpipe-app-tauri/docs/media/pipe-card-actions-hover.svg`
- `git diff --check`
- rendered and visually inspected the updated Pipes action-row preview
