### PR TITLE
 fix(meetings): respect HD recording setting and fix notification navigation race

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/index.tsx
@@ -159,6 +159,53 @@ export function MeetingNotesSection({
   // so this also dedupes the burst — same meeting within 5s is a no-op.
   const pendingOpenRef = useRef<{ id: number; at: number } | null>(null);
 
+  // Fetch a single meeting by id, insert/update it in the list, and select it.
+  const openMeetingNote = useCallback(
+    async (id: number, transcript: boolean) => {
+      pendingOpenRef.current = { id, at: Date.now() };
+      try {
+        const res = await localFetch(`/meetings/${id}`);
+        if (res.ok) {
+          const meeting: MeetingRecord = await res.json();
+          setMeetings((prev) => {
+            const exists = prev.some((m) => m.id === meeting.id);
+            return exists
+              ? prev.map((m) => (m.id === meeting.id ? meeting : m))
+              : [meeting, ...prev];
+          });
+        } else {
+          await fetchPage(0, false, appliedQueryRef.current);
+        }
+      } catch (err) {
+        console.warn("meeting notes: failed to open deep-linked meeting", err);
+        await fetchPage(0, false, appliedQueryRef.current);
+      }
+      if (transcript) {
+        setOpenTranscriptRequest({ id, token: Date.now() });
+      }
+      setSelectedId(id);
+    },
+    [fetchPage],
+  );
+
+  // On mount, if the URL contains a meetingId param (set by Rust when the
+  // user clicks a notification from /settings), open that meeting after
+  // the initial fetchPage finishes.
+  const urlMeetingRef = useRef<{ id: number; transcript: boolean } | null>(
+    (() => {
+      const params = new URLSearchParams(window.location.search);
+      const id = Number(params.get("meetingId"));
+      if (!Number.isFinite(id) || id <= 0) return null;
+      return { id, transcript: params.get("transcript") !== "false" };
+    })(),
+  );
+  useEffect(() => {
+    if (loading || !urlMeetingRef.current) return;
+    const { id, transcript } = urlMeetingRef.current;
+    urlMeetingRef.current = null;
+    void openMeetingNote(id, transcript);
+  }, [loading, openMeetingNote]);
+
   useEffect(() => {
     const unlisten = listen<{ meetingId: number; transcript?: boolean }>(
       "open-meeting-note",
@@ -173,47 +220,14 @@ export function MeetingNotesSection({
         ) {
           return;
         }
-        pendingOpenRef.current = { id, at: now };
 
-        // Fetch and insert into `meetings` BEFORE selecting. The
-        // "selection vanished" effect below resets selectedId to null
-        // whenever the id isn't in the list — if we set selectedId first
-        // and await the fetch after, that effect fires in the gap and
-        // drops the selection, leaving the user on the list view instead
-        // of the note. Notification-triggered opens (a freshly-started
-        // meeting) hit this every time because the new row isn't in the
-        // initial page yet.
-        try {
-          const res = await localFetch(`/meetings/${id}`);
-          if (res.ok) {
-            const meeting: MeetingRecord = await res.json();
-            setMeetings((prev) => {
-              const exists = prev.some((m) => m.id === meeting.id);
-              return exists
-                ? prev.map((m) => (m.id === meeting.id ? meeting : m))
-                : [meeting, ...prev];
-            });
-          } else {
-            await fetchPage(0, false, appliedQueryRef.current);
-          }
-        } catch (err) {
-          console.warn(
-            "meeting notes: failed to open deep-linked meeting",
-            err,
-          );
-          await fetchPage(0, false, appliedQueryRef.current);
-        }
-
-        if (event.payload.transcript !== false) {
-          setOpenTranscriptRequest({ id, token: Date.now() });
-        }
-        setSelectedId(id);
+        await openMeetingNote(id, event.payload.transcript !== false);
       },
     );
     return () => {
       unlisten.then((fn) => fn());
     };
-  }, [fetchPage]);
+  }, [openMeetingNote]);
 
   // Refetch on visibility change — picks up changes made elsewhere.
   // Skip the meetings list refetch when the user is inside a note: a Mac

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -285,7 +285,88 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
         return;
     }
 
-    // Everything else (pipe, api, mute, dismiss, auto_dismiss, legacy string
+    // HD-recording API action. Handled in Rust (like deeplink/meeting_join
+    // above) so native notification clicks work even when no webview is
+    // mounted. The JS handler in notification-handler.tsx remains the path
+    // for in-app notification panel clicks.
+    if action_type == Some("api")
+        && parsed
+            .as_ref()
+            .and_then(|v| v.get("action"))
+            .and_then(|v| v.as_str())
+            == Some("record-hd")
+    {
+        let body = parsed
+            .as_ref()
+            .and_then(|v| v.get("body"))
+            .cloned();
+        let deeplink_url = parsed
+            .as_ref()
+            .and_then(|v| v.get("deeplinkUrl").or_else(|| v.get("deeplink_url")))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+
+        let app_clone = app.clone();
+        std::thread::spawn(move || {
+            use crate::recording::local_api_context_from_app;
+            let api = local_api_context_from_app(&app_clone);
+            let client = reqwest::blocking::Client::new();
+
+            let req = api.apply_auth_blocking(
+                client
+                    .post(api.url("/capture/hd/start"))
+                    .header("Content-Type", "application/json")
+                    .body(
+                        body.map(|b| b.to_string())
+                            .unwrap_or_else(|| "{}".to_string()),
+                    ),
+            );
+
+            let ok = match req.send() {
+                Ok(res) => res.status().is_success(),
+                Err(e) => {
+                    error!("record-hd api call failed: {}", e);
+                    false
+                }
+            };
+
+            if ok {
+                // Confirmation toast — mirrors the JS handler in
+                // notification-handler.tsx.
+                let _ = client
+                    .post(api.url("/notify"))
+                    .header("Content-Type", "application/json")
+                    .body(
+                        serde_json::json!({
+                            "title": "HD recording started",
+                            "body": "Capturing this meeting at high frame rate. Stops automatically when the call ends.",
+                        })
+                        .to_string(),
+                    )
+                    .send();
+
+                // "open note + HD": also navigate to the live meeting note.
+                if let Some(ref url) = deeplink_url {
+                    if is_meeting_deeplink(url) {
+                        let app_for_show = app_clone.clone();
+                        let _ = app_clone.run_on_main_thread(move || {
+                            if let Err(e) = (ShowRewindWindow::Home {
+                                page: Some("meetings".to_string()),
+                            })
+                            .show(&app_for_show)
+                            {
+                                error!("failed to show window for record-hd deeplink: {}", e);
+                            }
+                        });
+                        emit_meeting_note_route_with_retries(&app_clone, url);
+                    }
+                }
+            }
+        });
+        return;
+    }
+
+    // Everything else (pipe, mute, dismiss, auto_dismiss, legacy string
     // actions) still goes to the JS handler. The overlay window owns those
     // because they need access to posthog / localforage / chat prefill.
     let _ = app.emit("native-notification-action", &json);

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -138,7 +138,7 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
             if is_in_app {
                 let target = if is_meeting_deeplink(&url) {
                     ShowRewindWindow::Home {
-                        page: Some("meetings".to_string()),
+                        page: Some(meeting_page_with_id(&url)),
                     }
                 } else {
                     ShowRewindWindow::Main
@@ -205,10 +205,11 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
                 return;
             }
 
+            let meeting_page = meeting_page_with_id(&deeplink_url);
             let app_for_show = app_clone.clone();
             let _ = app_clone.run_on_main_thread(move || {
                 if let Err(e) = (ShowRewindWindow::Home {
-                    page: Some("meetings".to_string()),
+                    page: Some(meeting_page),
                 })
                 .show(&app_for_show)
                 {
@@ -255,7 +256,7 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
             if is_in_app {
                 let target = if is_meeting_deeplink(&url) {
                     ShowRewindWindow::Home {
-                        page: Some("meetings".to_string()),
+                        page: Some(meeting_page_with_id(&url)),
                     }
                 } else {
                     ShowRewindWindow::Main
@@ -348,10 +349,11 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
                 // "open note + HD": also navigate to the live meeting note.
                 if let Some(ref url) = deeplink_url {
                     if is_meeting_deeplink(url) {
+                        let meeting_page = meeting_page_with_id(url);
                         let app_for_show = app_clone.clone();
                         let _ = app_clone.run_on_main_thread(move || {
                             if let Err(e) = (ShowRewindWindow::Home {
-                                page: Some("meetings".to_string()),
+                                page: Some(meeting_page),
                             })
                             .show(&app_for_show)
                             {
@@ -402,6 +404,18 @@ fn parse_meeting_deeplink(url: &str) -> Option<(u64, bool)> {
     Some((meeting_id, transcript))
 }
 
+/// Build the `page` string for `ShowRewindWindow::Home` that encodes the
+/// meeting ID into the URL query string. When `show.rs` formats this into
+/// `/home?section={page}`, the result becomes
+/// `/home?section=meetings&meetingId=42&transcript=true` which the React
+/// page reads on initial mount — surviving full-page navigations.
+fn meeting_page_with_id(deeplink_url: &str) -> String {
+    match parse_meeting_deeplink(deeplink_url) {
+        Some((id, transcript)) => format!("meetings&meetingId={}&transcript={}", id, transcript),
+        None => "meetings".to_string(),
+    }
+}
+
 fn emit_meeting_note_route_with_retries(app: &tauri::AppHandle, deeplink_url: &str) {
     let Some((meeting_id, transcript)) = parse_meeting_deeplink(deeplink_url) else {
         warn!(
@@ -415,7 +429,11 @@ fn emit_meeting_note_route_with_retries(app: &tauri::AppHandle, deeplink_url: &s
         "meetingId": meeting_id,
         "transcript": transcript,
     });
-    let nav = serde_json::json!({ "url": "/home?section=meetings" });
+    let nav_url = format!(
+        "/home?section=meetings&meetingId={}&transcript={}",
+        meeting_id, transcript
+    );
+    let nav = serde_json::json!({ "url": nav_url });
 
     // A notification click can cold-open the Home webview. React listeners are
     // not guaranteed to be mounted when `show()` returns, so a single emit is

--- a/apps/screenpipe-app-tauri/src-tauri/src/meeting_live_notes.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/meeting_live_notes.rs
@@ -455,12 +455,7 @@ fn hd_recording_default(app: &AppHandle) -> String {
         Ok(Some(s)) => s,
         _ => return "ask".to_string(),
     };
-    settings
-        .extra
-        .get("hdRecordingDefault")
-        .and_then(|v| v.as_str())
-        .unwrap_or("ask")
-        .to_string()
+    settings.recording.hd_recording_default
 }
 
 /// Build the HD notification action. Returns `None` when the user's


### PR DESCRIPTION
This PR fixes #5183 three issues with meeting notification buttons:

- HD button ignored user setting: The +HD button always appeared on meeting notifications
  regardless of the HD recording setting never/always/ask.

- open note + HD did nothing from native notification: Clicking "open note + HD" from a macOS
  system notification silently failed. 
  
- Notification navigation race: Clicking open note from settings or any non-meetings section
  navigated to the meetings list but not into the specific meeting note.

Before -

1. HD set to never -> +HD button still shown
2. HD set to always -> +HD button still shown, should auto-start
3. Click open note + HD from native notification -> Nothing happens
4. Click open note from settings page -> Goes to meetings list, not the specific note


https://github.com/user-attachments/assets/11f9a44f-e692-43fe-a1c9-9f806161e7e6


After -

1. HD set to never -> No +HD button
2. HD set to always -> No +HD button, HD auto-starts
3. Click open note + HD from native notification -> Starts HD recording + navigates to meeting note
4. Click open note from settings page -> Navigates directly to the specific meeting note


https://github.com/user-attachments/assets/5e8c1c6d-946f-4377-a4af-af3d46730233


https://github.com/user-attachments/assets/a0387ec8-7343-475c-9099-aded984bba60

