### PR TITLE
fix(meetings): include meeting app in search filter

### DIFF
--- a/crates/screenpipe-db/src/db/meetings.rs
+++ b/crates/screenpipe-db/src/db/meetings.rs
@@ -431,7 +431,8 @@ impl DatabaseManager {
             sql.push_str(
                 " AND (LOWER(IFNULL(title, '')) LIKE ? \
                  OR LOWER(IFNULL(attendees, '')) LIKE ? \
-                 OR LOWER(IFNULL(note, '')) LIKE ?)",
+                 OR LOWER(IFNULL(note, '')) LIKE ? \
+                 OR LOWER(IFNULL(meeting_app, '')) LIKE ?)",
             );
         }
         sql.push_str(" ORDER BY meeting_start DESC LIMIT ? OFFSET ?");
@@ -448,7 +449,7 @@ impl DatabaseManager {
             }
             if let Some(qs) = query {
                 let pattern = format!("%{}%", qs.to_lowercase());
-                q = q.bind(pattern.clone()).bind(pattern.clone()).bind(pattern);
+                q = q.bind(pattern.clone()).bind(pattern.clone()).bind(pattern.clone()).bind(pattern);
             }
             q = q.bind(limit).bind(offset);
 

--- a/crates/screenpipe-db/src/db/meetings.rs
+++ b/crates/screenpipe-db/src/db/meetings.rs
@@ -449,7 +449,11 @@ impl DatabaseManager {
             }
             if let Some(qs) = query {
                 let pattern = format!("%{}%", qs.to_lowercase());
-                q = q.bind(pattern.clone()).bind(pattern.clone()).bind(pattern.clone()).bind(pattern);
+                q = q
+                    .bind(pattern.clone())
+                    .bind(pattern.clone())
+                    .bind(pattern.clone())
+                    .bind(pattern);
             }
             q = q.bind(limit).bind(offset);
 

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -142,7 +142,7 @@ pub struct ListMeetingsRequest {
     pub limit: u32,
     #[serde(default)]
     pub offset: u32,
-    /// Case-insensitive substring match against title, attendees, and note.
+    /// Case-insensitive substring match against title, attendees, note, and meeting app.
     /// Empty / whitespace-only values are ignored.
     #[serde(default)]
     pub q: Option<String>,


### PR DESCRIPTION
This PR fixes meeting search not finding meetings by their app name e.g. google meet, discord.

Problem - When meetings have no explicit title, the UI displays meeting_app as the visible name. But the search SQL only checked title, attendees, and note so searching for what the user sees in the list returned no results.


Before -


https://github.com/user-attachments/assets/b48c8fb3-26c6-4a60-8fcb-bb5622f183c2





After -


https://github.com/user-attachments/assets/f5151202-133e-47de-ab61-e60399ca931c