### PR TITLE
fix: show permission recovery during headless startup

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/headless.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/headless.rs
@@ -26,6 +26,10 @@ pub fn is_dormant() -> bool {
     UI_DORMANT.load(Ordering::SeqCst)
 }
 
+pub fn should_suppress_window(dormant: bool, is_permission_recovery: bool) -> bool {
+    dormant && !is_permission_recovery
+}
+
 /// Sync dormant/record-only state to an enterprise hidden-UI policy that flipped
 /// mid-session. The enterprise enforcement path hides (not destroys) windows, so
 /// this only flips the flags that gate pipe suppression and tray wake — without
@@ -194,7 +198,7 @@ pub fn wake_from_tray(app: &AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{should_start_dormant, should_suppress_pipe_runs};
+    use super::{should_start_dormant, should_suppress_pipe_runs, should_suppress_window};
 
     #[test]
     fn headless_startup_never_blocks_incomplete_onboarding() {
@@ -208,5 +212,12 @@ mod tests {
         assert!(should_suppress_pipe_runs(true, true));
         assert!(!should_suppress_pipe_runs(true, false));
         assert!(!should_suppress_pipe_runs(false, true));
+    }
+
+    #[test]
+    fn dormant_ui_still_allows_permission_recovery() {
+        assert!(should_suppress_window(true, false));
+        assert!(!should_suppress_window(true, true));
+        assert!(!should_suppress_window(false, false));
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -445,8 +445,14 @@ impl ShowRewindWindow {
             )));
         }
 
-        if crate::headless::is_dormant() {
-            info!("headless: suppressed '{}' window while UI is dormant", id.label());
+        if crate::headless::should_suppress_window(
+            crate::headless::is_dormant(),
+            id == RewindWindowId::PermissionRecovery,
+        ) {
+            info!(
+                "headless: suppressed '{}' window while UI is dormant",
+                id.label()
+            );
             return Err(tauri::Error::Anyhow(anyhow::anyhow!(
                 "window suppressed while headless UI is dormant: {}",
                 id.label()


### PR DESCRIPTION
## Summary

- allow the permission-recovery window to open while the normal UI is dormant in Headless mode
- keep every other app window suppressed during dormant operation
- add a regression test for the permission-recovery exception

## Root cause

Headless startup set the global dormant flag before the startup permission gate ran. When screen-recording or microphone permission was missing, the gate called `ShowRewindWindow::PermissionRecovery.show(...)`, but the generic dormant-window guard rejected that window along with all normal UI. The returned error was intentionally ignored by the startup caller, leaving the app tray-only with no recovery flow.

## Behavior

https://github.com/user-attachments/assets/74f838b6-9f17-4da2-a7aa-6690544be8da


Headless recording, tray behavior, and suppression of Home, Search, Chat, and overlay windows are unchanged.

## Validation

Tested on mac