### PR TITLE
fix enterprise headless tray status refresh

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -640,10 +640,10 @@ pub fn setup_tray(app: &AppHandle, update_item: Option<&tauri::menu::MenuItem<Wr
         // Set autosaveName so macOS remembers position after user Cmd+drags it
         set_autosave_name(&main_tray);
 
-        // Start menu updater only when we have an update item (not enterprise)
-        if let Some(item) = update_item {
-            setup_tray_menu_updater(app.clone(), item);
-        }
+        // Recording/device state must refresh in every build. Enterprise builds
+        // intentionally omit the self-update menu item, but they still need the
+        // poller or the startup "Starting…" menu is never rebuilt.
+        setup_tray_menu_updater(app.clone(), update_item);
     }
     Ok(())
 }
@@ -1652,9 +1652,18 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
     }
 }
 
+fn replace_menu_state_if_changed(last_state: &mut MenuState, new_state: MenuState) -> bool {
+    if *last_state == new_state {
+        return false;
+    }
+
+    *last_state = new_state;
+    true
+}
+
 async fn update_menu_if_needed(
     app: &AppHandle,
-    update_item: &tauri::menu::MenuItem<Wry>,
+    update_item: Option<&tauri::menu::MenuItem<Wry>>,
 ) -> Result<()> {
     #[cfg(target_os = "macos")]
     let _ = update_item;
@@ -1669,12 +1678,7 @@ async fn update_menu_if_needed(
     // Compare with last state (poison-safe: run handler must not panic)
     let should_update = {
         let mut last_state = LAST_MENU_STATE.lock().unwrap_or_else(|e| e.into_inner());
-        if *last_state != new_state {
-            *last_state = new_state.clone();
-            true
-        } else {
-            false
-        }
+        replace_menu_state_if_changed(&mut last_state, new_state.clone())
     };
 
     // Tooltip refreshes every tick regardless of menu rebuild — countdown
@@ -1717,7 +1721,7 @@ async fn update_menu_if_needed(
             // the old one from the manager), NSStatusBar _removeStatusItem fires on the wrong
             // thread and crashes.
             let app_for_thread = app.clone();
-            let update_item = update_item.clone();
+            let update_item = update_item.cloned();
             let _ = app.run_on_main_thread(move || {
                 if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     if let Some(tray) = app_for_thread.tray_by_id("screenpipe_main") {
@@ -1725,7 +1729,7 @@ async fn update_menu_if_needed(
                         if let Ok(menu) = create_dynamic_menu(
                             &app_for_thread,
                             &new_state,
-                            Some(&update_item),
+                            update_item.as_ref(),
                             &data,
                         ) {
                             let _ = install_tray_menu(&tray, menu);
@@ -1751,8 +1755,8 @@ async fn update_menu_if_needed(
     Ok(())
 }
 
-pub fn setup_tray_menu_updater(app: AppHandle, update_item: &tauri::menu::MenuItem<Wry>) {
-    let update_item = update_item.clone();
+pub fn setup_tray_menu_updater(app: AppHandle, update_item: Option<&tauri::menu::MenuItem<Wry>>) {
+    let update_item = update_item.cloned();
     tauri::async_runtime::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
         loop {
@@ -1761,7 +1765,7 @@ pub fn setup_tray_menu_updater(app: AppHandle, update_item: &tauri::menu::MenuIt
                 info!("Tray menu updater received quit request, shutting down.");
                 break;
             }
-            if let Err(e) = update_menu_if_needed(&app, &update_item).await {
+            if let Err(e) = update_menu_if_needed(&app, update_item.as_ref()).await {
                 let msg = format!("{:#}", e);
                 error!("Failed to update tray menu: {}", msg);
                 // Tauri resource table can go stale after in-place updates on
@@ -1785,6 +1789,25 @@ fn to_accelerator(shortcut: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn enterprise_tray_refreshes_recording_status_without_an_update_item() {
+        // Compile-time contract: enterprise builds can start the tray state
+        // updater even though they intentionally omit the self-update item.
+        let _updater: fn(AppHandle, Option<&tauri::menu::MenuItem<Wry>>) = setup_tray_menu_updater;
+
+        let mut previous = MenuState {
+            recording_status: Some(RecordingStatus::Starting),
+            ..MenuState::default()
+        };
+        let recording = MenuState {
+            recording_status: Some(RecordingStatus::Recording),
+            ..MenuState::default()
+        };
+
+        assert!(replace_menu_state_if_changed(&mut previous, recording));
+        assert_eq!(previous.recording_status, Some(RecordingStatus::Recording));
+    }
 
     #[test]
     fn hd_countdown_ticks_do_not_change_the_menu_rebuild_key() {


### PR DESCRIPTION
## what changed

- run the tray state updater in enterprise builds even when the self-update menu item is absent
- keep the update menu item optional while allowing Windows to rebuild the tray from current recording/device state
- add a regression test covering the enterprise `None` update-item contract and the `Starting` → `Recording` menu-state transition

## root cause

Enterprise builds intentionally do not create a self-update menu item. Tray polling was incorrectly started only when that item existed, so the initial menu built during startup was never refreshed. In headless mode this left the Windows tray displaying `Starting…` even after capture health had transitioned to `Recording`.

## impact

Enterprise headless users now see the current recording state in the Windows tray. Consumer update behavior is unchanged.

## visual

```text
before                                  after
┌────────────────────────────┐          ┌────────────────────────────┐
│ ○ Starting…                │          │ ● Recording                │
│                            │          │                            │
│ capture is already active  │          │ capture is active          │
│ tray never refreshes       │          │ tray refreshes every 5s    │
└────────────────────────────┘          └────────────────────────────┘
```

## validation

- `cargo test tray::tests` — 3 passed
- `cargo test --features enterprise-build tray::tests` — 3 passed
- `cargo test health::tests` — 59 passed
- `git diff --check`

## manual QA

- Windows enterprise headless smoke test is still recommended: launch with hidden UI, wait for capture health, then confirm the tray changes from `Starting…` to `Recording`.
