### PR TITLE
fix(ui): load pipe inventory unconditionally to resolve pipe count inaccuracy in recents (#5209)

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -442,14 +442,14 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     }
   }, []);
 
-  // Inventory + exact counts are lazy at the section level. A collapsed Pipes
-  // section does no disk reload or execution-count query.
+  // Always fetch inventory to ensure correct execution counts for pipe groups
+  // that may appear in the Recents section, regardless of Pipes section collapse state.
   useEffect(() => {
-    if (!pipesCollapsed) void fetchPipeInventory();
-  }, [pipesCollapsed, fetchPipeInventory]);
+    void fetchPipeInventory();
+  }, [fetchPipeInventory]);
   useInterval(
     () => void fetchPipeInventory(),
-    pipesCollapsed ? null : 15_000,
+    15_000,
   );
 
   const loadPipeRuns = useCallback(async (pipeName: string) => {
@@ -978,6 +978,10 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
                   existingGroups={existingGroups}
                   openConversationMenuId={openConversationMenuId}
                   setOpenConversationMenuId={setOpenConversationMenuId}
+                  pipeExecutionCounts={pipeExecutionCounts}
+                  pipeInventoryLoaded={pipeInventoryLoaded}
+                  loadingPipeRuns={loadingPipeRuns}
+                  loadedPipeRuns={loadedPipeRuns}
                 />
               )}
             </Section>
@@ -1548,6 +1552,10 @@ function RecentsBody({
   existingGroups: string[];
   openConversationMenuId: string | null;
   setOpenConversationMenuId: (id: string | null) => void;
+  pipeExecutionCounts: Record<string, number>;
+  pipeInventoryLoaded: boolean;
+  loadingPipeRuns: ReadonlySet<string>;
+  loadedPipeRuns: Record<string, SessionRecord[]>;
 }) {
   const renderItem = (item: SidebarItem) =>
     item.kind === "single" ? (
@@ -1587,6 +1595,10 @@ function RecentsBody({
         existingGroups={existingGroups}
         openConversationMenuId={openConversationMenuId}
         setOpenConversationMenuId={setOpenConversationMenuId}
+        executionCount={pipeExecutionCounts[item.title]}
+        executionCountLoading={!pipeInventoryLoaded}
+        runsLoading={loadingPipeRuns.has(item.title)}
+        runsLoaded={loadedPipeRuns[item.title] != null}
       />
     );
 


### PR DESCRIPTION
Fixes #5209

Previously, the `fetchPipeInventory` API call in the chat sidebar was gated by the `!pipesCollapsed` condition. This meant that when the "Pipes" section at the bottom of the sidebar was collapsed (which is the default state), the inventory API was never called.

Because the true `executionCount` wasn't loaded from the inventory, any pipe groups appearing in the **Recents** section would fall back to displaying the length of the locally loaded sessions (e.g., `8`), which is intentionally capped to avoid loading the entire database into memory. When a user later expanded the "Pipes" section, the inventory fetch was finally triggered, instantly updating the count in the Recents section to the true number (e.g., `60+`).

This PR removes the `pipesCollapsed` condition on the `useEffect` and polling interval, guaranteeing that the inventory summary (and true execution counts) is always fetched accurately and kept up to date for the sidebar. 

Importantly, this fix satisfies the issue criteria of "without loading every run": fetching the individual historical runs of a pipe remains securely deferred to `loadPipeRuns()`, which correctly continues to trigger only when a pipe group is manually uncollapsed.

## Verification
- Statically verified that unconditionally fetching `pipeInventory` correctly hydrates the `pipeExecutionCounts` object, resolving the fallback bug in `PipeGroupRow` for the Recents section.
