### PR TITLE
fix(app): spawn update relaunch in its own process group

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -170,14 +170,26 @@ fn relaunch_binary(app: &AppHandle) -> Option<PathBuf> {
 /// running C/C++ atexit handlers. Tauri's built-in restart uses
 /// `std::process::exit`, which can abort in ORT/ggml teardown after the new app
 /// has already launched.
+///
+/// The replacement gets its own process group: launchd kills a job's whole
+/// process group when the job exits, so an inherited group dies with us.
 pub fn force_app_relaunch(app: AppHandle, status: i32) -> ! {
     let env = app.env();
     if let Some(binary) = relaunch_binary(&app) {
-        if let Err(err) = Command::new(&binary)
-            .args(env.args_os.iter().skip(1))
-            .spawn()
+        let mut command = Command::new(&binary);
+        command.args(env.args_os.iter().skip(1));
+        #[cfg(unix)]
         {
-            warn!("safe relaunch: failed to spawn {}: {err}", binary.display());
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+        match command.spawn() {
+            Ok(child) => info!(
+                "safe relaunch: spawned replacement {} (pid {})",
+                binary.display(),
+                child.id()
+            ),
+            Err(err) => warn!("safe relaunch: failed to spawn {}: {err}", binary.display()),
         }
     }
 


### PR DESCRIPTION
## Problem

- after an auto-update the old process logs `safe relaunch requested` and exits cleanly (status 0), but the new app never comes up: no tray, no capture, no error
- in #5242 this left a ~24h gap with zero frames and zero audio, including a live Google Meet interview
- on machines where the relaunched process was not killed outright, it still came up wrong: the Dock showed a generic green "exec" tile instead of the screenpipe icon

## Before

- relaunch after update silently fails whenever the app was autostarted at login via its LaunchAgent; recording stays dead until the user manually reopens the app


https://github.com/user-attachments/assets/8679d3fa-4bc1-4f81-bbf2-64f3dcd534ba


<img width="199" height="85" alt="image" src="https://github.com/user-attachments/assets/e05f2266-6a8a-44c9-86ab-8600495aa68d" />

- when the child did survive (parent not a launchd job), it inherited the parent's process group and registered with a broken Dock identity, so the Dock drew the generic executable placeholder

```
child spawned in the job's process group:
  parent=20600 pgid=20600 child=20603 child_pgid=20600
  -> child killed by launchd within seconds of parent exit
```

## After

- the replacement process survives the old process exiting and boots normally
- the spawn is logged with the child pid so a failed spawn is visible in logs instead of silent


https://github.com/user-attachments/assets/c866c833-c841-4fc9-9cdf-de558b7e634c

<img width="149" height="85" alt="image" src="https://github.com/user-attachments/assets/4bed98b6-fe8d-4503-8e52-c40989fc4263" />

- the relaunched app registers as an independent process, so the Dock resolves the real screenpipe icon instead of the generic tile

```
child spawned in its own process group:
  child pid: 34913
  PID  PGID  STAT COMMAND
  34913 34913 S   /bin/sleep 300
  -> child survived launchd job exit
```

## Root cause

- the login autostart plist (`~/Library/LaunchAgents/screenpipe.plist`) makes the running app a launchd job
- launchd's default (`AbandonProcessGroup=false`) is to SIGKILL every process still in the job's process group when the job's main process exits
- `force_app_relaunch` spawned the replacement with a plain `Command::spawn`, which inherits the parent's process group, then `_exit(0)`; launchd then killed the freshly spawned app mid-boot
- SIGKILL produces no crash report, and file logging initializes late in boot, so the new process left zero traces; without `KeepAlive` nothing ever restarted it
- only bites launchd-launched sessions, which is why it is sporadic; manual Finder/Dock launches relaunch fine
- the generic Dock icon shares this root cause: LaunchServices keys a process's Dock identity on its ASN and parent launch context, not the binary path; a child that inherits the parent's process group and is not opened via LaunchServices registers under the dying parent, so once the parent exits its bundle icon never resolves and the Dock falls back to the executable placeholder

## Fix

- spawn the replacement with `process_group(0)` (unix) in `force_app_relaunch`, detaching it from the doomed group; this covers every restart path (auto-update, banner restart, tray restart-to-update, RunEvent restart) since they all funnel through this function
- detaching also gives the child a clean launch context, so LaunchServices registers it as an independent app and the Dock shows the correct icon
- log the spawned child pid on success, keep the warn on spawn failure
- verified end to end on macOS with a throwaway LaunchAgent running a compiled simulation of the exact code path (posix_spawn with SETPGROUP then `_exit(0)`): the unfixed variant gets killed, the fixed variant survives (outputs above)
