### PR TITLE
fix(chat): prevent duplicate image paste on windows

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-attachments.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-attachments.ts
@@ -276,7 +276,11 @@ export function useChatAttachments({
         if (tryDispatch(item.getAsFile())) didDispatch = true;
       }
     }
-    if (files && files.length > 0) {
+    // Only fall back to clipboard.files if items didn't yield anything.
+    // On Windows, both items and files contain the same image but as
+    // different File object references, so the handled-Set dedup fails
+    // and the image gets added twice.
+    if (!didDispatch && files && files.length > 0) {
       for (let i = 0; i < files.length; i++) {
         if (tryDispatch(files[i])) didDispatch = true;
       }


### PR DESCRIPTION
This PR fixes pasted screenshots appearing twice in the chat composer on Windows.

On Windows, the clipboard DataTransfer populates both `items` and `files` with the same image as separate File objects, so the reference-based Set dedup didn't catch the duplicate. The fix gates the `files` loop to only run when `items` yields nothing.

Before -

https://github.com/user-attachments/assets/9e89c9fb-f48e-431e-8018-aa53fcc5c1a1

After -

https://github.com/user-attachments/assets/e74b4b73-8254-426b-8e0f-698a1c4d4d5c



