### PR TITLE
fix(app): updater hardening, startup abort, atomic install, idle-aware restart

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -10939,7 +10939,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.120"
+version = "2.5.121"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",
@@ -10974,6 +10974,7 @@ dependencies = [
  "image 0.25.10",
  "ini",
  "lazy_static",
+ "libc",
  "log",
  "muda",
  "nokhwa-bindings-macos",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -175,6 +175,9 @@ tauri-plugin-webdriver = { version = "0.2", optional = true }
 tauri-plugin-single-instance = { version = "2.3.7", features = ["deep-link"] }
 tauri-plugin-updater = "2.10.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 muda = "0.19"
 tracing-oslog = "0.3.0"

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -226,7 +226,7 @@ fn should_prevent_window_close(label: &str) -> bool {
 
 /// Flag passed by tauri-plugin-autostart when the OS launches us at login.
 /// Used to skip Home so login starts stay in the tray.
-const AUTOSTART_ARG: &str = "--autostart";
+pub(crate) const AUTOSTART_ARG: &str = "--autostart";
 
 /// True when this process was started by the OS login/autostart entry
 /// (LaunchAgent / Run registry), not a manual user launch.

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -285,8 +285,57 @@ macro_rules! define_specta_builder {
     }};
 }
 
+/// Rebind closed or broken standard fds (0-2) to /dev/null.
+///
+/// A GUI app's stdio is only meaningful in dev; in production the fds may be
+/// closed outright (relaunch chains, login items) or be pipes whose reader is
+/// gone (parent terminal closed). Rust's print macros panic on write failure
+/// (EBADF/EPIPE), so a single stray `println!` anywhere aborts the app.
+/// Detect both cases per fd and point the fd at /dev/null instead.
+#[cfg(unix)]
+fn sanitize_stdio_fds() {
+    for fd in 0..=2 {
+        // fcntl fails with EBADF if the fd is not open at all
+        let closed = unsafe { libc::fcntl(fd, libc::F_GETFD) } == -1;
+        // a pipe whose read end is closed reports POLLHUP on macOS (POLLERR on
+        // Linux); writes to it would EPIPE. stdin is exempt: reads from a dead
+        // stdin just return EOF, harmless.
+        let broken = !closed && fd != 0 && {
+            let mut pfd = libc::pollfd {
+                fd,
+                events: libc::POLLOUT,
+                revents: 0,
+            };
+            (unsafe { libc::poll(&mut pfd, 1, 0) }) > 0
+                && (pfd.revents & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL)) != 0
+        };
+        if closed || broken {
+            unsafe {
+                let flags = if fd == 0 {
+                    libc::O_RDONLY
+                } else {
+                    libc::O_WRONLY
+                };
+                let null_fd = libc::open(c"/dev/null".as_ptr(), flags);
+                if null_fd >= 0 && null_fd != fd {
+                    libc::dup2(null_fd, fd);
+                    libc::close(null_fd);
+                }
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    // Rebind dead stdio to /dev/null BEFORE anything can print. When the app
+    // is relaunched by the updater or its parent terminal goes away, fds 0-2
+    // can be closed (EBADF) or pipes with no reader (EPIPE). `println!`/
+    // `eprintln!` panic on write failure, and a panic inside the panic hook's
+    // own eprintln! double-panics into abort() — a guaranteed startup crash.
+    #[cfg(unix)]
+    sanitize_stdio_fds();
+
     // Raise the file-descriptor soft limit BEFORE any DB/socket work. The app
     // embeds the engine in-process, so it never ran the engine binary's main()
     // and kept macOS's default soft RLIMIT_NOFILE of 256 — too low for the
@@ -557,9 +606,12 @@ async fn main() {
     }
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
+        use std::io::Write;
         // Log the actual panic first — before any processing. Once unwinding hits
         // Obj-C (e.g. tao::send_event), we get panic_cannot_unwind and lose the real message.
-        eprintln!("PANIC: {}", info);
+        // Never eprintln! here: it panics if stderr is dead, and a panic inside
+        // the panic hook is an instant abort() before we log or reach Sentry.
+        let _ = writeln!(std::io::stderr(), "PANIC: {}", info);
 
         let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
             s.to_string()
@@ -574,9 +626,11 @@ async fn main() {
             .unwrap_or_default();
 
         if crate::process_exit::is_orderly_shutdown_panic(&payload) {
-            eprintln!(
+            let _ = writeln!(
+                std::io::stderr(),
                 "(suppressed orderly-shutdown panic at {}: {})",
-                location, payload
+                location,
+                payload
             );
             return;
         }
@@ -592,7 +646,7 @@ async fn main() {
         );
 
         // Log to stderr (survives even if tracing isn't initialized yet)
-        eprintln!("{}", crash_msg);
+        let _ = writeln!(std::io::stderr(), "{}", crash_msg);
 
         // Write to a crash log file — this survives abort() since we fsync
         // Critical for diagnosing panics inside tao's extern "C" callbacks
@@ -606,7 +660,6 @@ async fn main() {
             .append(true)
             .open(&crash_path)
         {
-            use std::io::Write;
             let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
             let _ = writeln!(f, "[{}] {}", timestamp, crash_msg);
             let _ = f.sync_all(); // fsync before abort() kills us

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -148,6 +148,68 @@ fn extract_cf_bundle_executable(info_plist: &str) -> Option<String> {
     Some(rest[..string_end].trim().to_string())
 }
 
+/// `<bundle>.app/Contents/MacOS/<exe>` -> `<bundle>.app`, or None for
+/// non-bundle (dev) binaries.
+#[cfg(any(target_os = "macos", test))]
+fn bundle_root_from_binary(binary: &Path) -> Option<PathBuf> {
+    let macos_directory = binary.parent()?;
+    if macos_directory.file_name() != Some(std::ffi::OsStr::new("MacOS")) {
+        return None;
+    }
+    let contents_directory = macos_directory.parent()?;
+    if contents_directory.file_name() != Some(std::ffi::OsStr::new("Contents")) {
+        return None;
+    }
+    contents_directory.parent().map(Path::to_path_buf)
+}
+
+/// Relaunch through LaunchServices (`/usr/bin/open -n`) instead of spawning the
+/// binary ourselves. launchd spawns the new instance: PID-1 parent, /dev/null
+/// stdio, its own session, TCC attribution to the bundle — nothing inherited
+/// from this dying process. This is how Sparkle relaunches after an update.
+///
+/// Only `--autostart` is replayed: it keeps a login-launched app in the tray
+/// after an overnight auto-update. Everything else in argv (stale deep links,
+/// one-shot flags) must not re-fire in the new instance.
+///
+/// Returns false when the binary isn't in a bundle (dev build) or `open` could
+/// not be spawned, so the caller can fall back to a direct spawn.
+#[cfg(target_os = "macos")]
+fn relaunch_via_launch_services(env: &tauri::Env, binary: &Path) -> bool {
+    let Some(bundle) = bundle_root_from_binary(binary) else {
+        return false;
+    };
+    let mut command = Command::new("/usr/bin/open");
+    // -n: launch a new instance even though LaunchServices still sees this
+    // dying one as running.
+    command.arg("-n").arg(&bundle);
+    if env
+        .args_os
+        .iter()
+        .skip(1)
+        .any(|a| a == std::ffi::OsStr::new(crate::AUTOSTART_ARG))
+    {
+        command.arg("--args").arg(crate::AUTOSTART_ARG);
+    }
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    match command.spawn() {
+        Ok(_) => {
+            info!(
+                "safe relaunch: requested LaunchServices launch of {}",
+                bundle.display()
+            );
+            true
+        }
+        Err(err) => {
+            warn!("safe relaunch: failed to spawn /usr/bin/open: {err}");
+            false
+        }
+    }
+}
+
 fn relaunch_binary(app: &AppHandle) -> Option<PathBuf> {
     let env = app.env();
     let current_binary = match tauri::process::current_binary(&env) {
@@ -176,28 +238,37 @@ fn relaunch_binary(app: &AppHandle) -> Option<PathBuf> {
 pub fn force_app_relaunch(app: AppHandle, status: i32) -> ! {
     let env = app.env();
     if let Some(binary) = relaunch_binary(&app) {
-        let mut command = Command::new(&binary);
-        command.args(env.args_os.iter().skip(1));
-        // Null stdio, don't inherit: our stdout/stderr may be pipes into a
-        // terminal that dies with us. The replacement would hold widowed pipe
-        // write ends, and its first println! would panic (EPIPE) during setup —
-        // startup abort right after an auto-update. Logs go to files anyway.
-        command
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null());
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            command.process_group(0);
-        }
-        match command.spawn() {
-            Ok(child) => info!(
-                "safe relaunch: spawned replacement {} (pid {})",
-                binary.display(),
-                child.id()
-            ),
-            Err(err) => warn!("safe relaunch: failed to spawn {}: {err}", binary.display()),
+        #[cfg(target_os = "macos")]
+        let launched = relaunch_via_launch_services(&env, &binary);
+        #[cfg(not(target_os = "macos"))]
+        let launched = false;
+
+        // Direct-spawn fallback: Linux/Windows always, macOS only for
+        // non-bundle dev binaries or if `open` itself failed to spawn.
+        if !launched {
+            let mut command = Command::new(&binary);
+            command.args(env.args_os.iter().skip(1));
+            // Null stdio, don't inherit: our stdout/stderr may be pipes into a
+            // terminal that dies with us. The replacement would hold widowed pipe
+            // write ends, and its first println! would panic (EPIPE) during setup —
+            // startup abort right after an auto-update. Logs go to files anyway.
+            command
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::CommandExt;
+                command.process_group(0);
+            }
+            match command.spawn() {
+                Ok(child) => info!(
+                    "safe relaunch: spawned replacement {} (pid {})",
+                    binary.display(),
+                    child.id()
+                ),
+                Err(err) => warn!("safe relaunch: failed to spawn {}: {err}", binary.display()),
+            }
         }
     }
 
@@ -577,7 +648,26 @@ pub fn request_app_quit(app: AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_cf_bundle_executable;
+    use super::{bundle_root_from_binary, extract_cf_bundle_executable};
+    use std::path::Path;
+
+    #[test]
+    fn bundle_root_derived_from_bundle_binary() {
+        assert_eq!(
+            bundle_root_from_binary(Path::new(
+                "/Applications/screenpipe.app/Contents/MacOS/screenpipe-app"
+            )),
+            Some("/Applications/screenpipe.app".into())
+        );
+    }
+
+    #[test]
+    fn bundle_root_rejects_non_bundle_binary() {
+        assert_eq!(
+            bundle_root_from_binary(Path::new("/tmp/target/debug/screenpipe-app")),
+            None
+        );
+    }
 
     #[test]
     fn extracts_bundle_executable_from_xml_plist() {

--- a/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/process_exit.rs
@@ -178,6 +178,14 @@ pub fn force_app_relaunch(app: AppHandle, status: i32) -> ! {
     if let Some(binary) = relaunch_binary(&app) {
         let mut command = Command::new(&binary);
         command.args(env.args_os.iter().skip(1));
+        // Null stdio, don't inherit: our stdout/stderr may be pipes into a
+        // terminal that dies with us. The replacement would hold widowed pipe
+        // write ends, and its first println! would panic (EPIPE) during setup —
+        // startup abort right after an auto-update. Logs go to files anyway.
+        command
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1690,7 +1690,7 @@ impl SettingsStore {
 }
 
 pub fn init_store(app: &AppHandle) -> Result<SettingsStore, String> {
-    println!("Initializing settings store");
+    tracing::info!("Initializing settings store");
 
     let raw_obj = get_store(app, None)
         .ok()
@@ -1811,7 +1811,7 @@ pub fn init_store(app: &AppHandle) -> Result<SettingsStore, String> {
 }
 
 pub fn init_onboarding_store(app: &AppHandle) -> Result<OnboardingStore, String> {
-    println!("Initializing onboarding store");
+    tracing::info!("Initializing onboarding store");
 
     let (onboarding, should_save) = match OnboardingStore::get(app) {
         Ok(Some(onboarding)) => (onboarding, false),


### PR DESCRIPTION
Fixes the v2.5.120 startup SIGABRT after auto-update and hardens the updater end to end. Based on the crash report plus source dissection of tauri-plugin-updater 2.10's install code and Sparkle 2.9.4. One commit per concern.

- crash: the update relaunch inherited dead stdio pipes; the first `println!` panicked (EPIPE), the panic hook's `eprintln!` panicked on the same dead stderr, panic-in-panic aborted. repro on 2.5.120: `screenpipe-app 2>&1 | true`
- crash fix, four layers: sanitize std fds at the top of `main()` (macOS reports POLLHUP not POLLERR for widowed pipes), panic hook writes can no longer panic, relaunch spawns with null stdio, and relaunch now goes through LaunchServices (`open -n <bundle>`, PID-1 parent, clean session; only `--autostart` is replayed so stale deep links stop re-firing)
- self-managed macOS install (`updater_install.rs`): the plugin's installer deletes its own backup on a failed rename, has a no-app window between renames, ships 0700 bundle perms, and validates nothing. we now stage on the same volume, validate (Info.plist, executable, codesign --verify --deep, staged version must match the manifest claim), swap atomically with `renamex_np(RENAME_SWAP)`, keep the old bundle until the new version boots ready (local rollback), guard downgrades, GC after 10 days. falls back to the plugin installer for non-writable bundles and dev binaries
- failure handling: download-failure cooldown persisted to the store (was memory-only, crash-looping machines re-downloaded every boot), error classification by plugin enum variants instead of substring matching, `rollback_to_version` now honors the restart gate (#3622) and dedupes against an in-flight restart
- restart behavior: periodic checks keep running after a download is staged so a newer release supersedes it; auto-restart waits for 5 min of input idleness (4h cap) instead of a fixed 30s yank; a banner click during the wait still restarts immediately
- windows banner: new `get_update_check_config` command as single source of truth; the banner hardcoded stable/enterprise endpoints, silently switching beta users to stable and dropping Bearer auth on paid downloads

Testing: crash matrix on a standalone repro binary (old behavior exits 134/SIGABRT reproducing the report, fixed behavior boots clean in every dead-stdio scenario), `updater_install` tests exercise a real `renamex_np` swap on APFS and a real .tar.gz extract+validate round trip, 25 new/updated tests green, `bun run bindings:check` green. Full suite has 2 failures that pre-exist on main (details in comments). Upstream reports filed for the plugin and core bugs: tauri-apps/plugins-workspace#3505, tauri-apps/plugins-workspace#3506, tauri-apps/tauri#15742.
