### PR TITLE
[codex] remove onboarding activity recap

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -307,22 +307,22 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
     setState("stuck");
   }, [state, bootPhase?.phase, bootPhase?.error]);
 
-  // Transition from "running" to "live-feed" instead of auto-advancing
+  // Move on as soon as the engine is ready. The activity recap that used to
+  // follow this screen added another wait before users could finish setup.
   useEffect(() => {
-    if (state !== "running") return;
+    if (state !== "running" || hasAdvancedRef.current) return;
+    hasAdvancedRef.current = true;
 
     posthog.capture("onboarding_engine_started", {
       time_spent_ms: Date.now() - mountTimeRef.current,
     });
-    // Small delay so user sees the completed progress, then transition to live feed
+
+    // Keep the completed progress visible briefly before advancing.
     const elapsed = Date.now() - mountTimeRef.current;
     const delay = Math.max(0, 1200 - elapsed);
-    const timer = setTimeout(() => {
-      feedStartRef.current = Date.now();
-      setState("live-feed");
-    }, delay);
+    const timer = setTimeout(() => handleNextSlide(), delay);
     return () => clearTimeout(timer);
-  }, [state]);
+  }, [state, handleNextSlide]);
 
   // Live feed: poll search for recent activity + thumbnails
   const emptyPollCountRef = useRef(0);

--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -28,68 +28,10 @@ interface EngineStartupProps {
   handleNextSlide: () => void;
 }
 
-type StartupState = "starting" | "running" | "live-feed" | "stuck";
-
-interface ActivityItem {
-  id: string;
-  timestamp: string;
-  app_name: string;
-  text_snippet: string;
-}
+type StartupState = "starting" | "running" | "stuck";
 
 const TAKING_LONGER_MS = 8000;
 const STUCK_TIMEOUT_MS = 15000;
-// Fallback timer — if the streaming summary never completes (no token, network
-// fails, model errors), we still let the user continue after this delay.
-const LIVE_FEED_FALLBACK_MS = 7000;
-const LIVE_FEED_POLL_MS = 2000;
-// One real signal is enough to summarize. Holding out for two means a quiet
-// machine (or one whose accessibility text just hasn't flushed yet) blocks the
-// summary from ever starting and the user stares at "settling in" forever.
-const SUMMARY_MIN_ITEMS = 1;
-const SUMMARY_MAX_ITEMS = 8;
-const MAX_THUMBNAILS = 3;
-// If we have zero captured signals after this long the engine just isn't
-// producing data fast enough to summarize warmly — switch the copy to honest
-// "i'm running, activity will appear here" instead of the cryptic spinner.
-const NO_ACTIVITY_GRACE_MS = 9000;
-// Stop hammering the search route for frames after this long with zero
-// returns. The mp4 file may not have any extractable keyframes yet (the
-// backend logs "failed to extract frame: no data received"); pretending
-// otherwise just spams the engine.
-const HIDE_THUMBS_AFTER_MS = 10000;
-// Minimum size for a frame to be plausibly real. Smaller than this and it's
-// almost certainly a corrupted/empty payload — render nothing rather than a
-// broken-image icon.
-const MIN_FRAME_B64_LEN = 1000;
-
-// Words that smell like plumbing. The system prompt forbids them, but models
-// leak. If any show up in the stream we drop the chunk on the floor and let
-// the next one through — we'd rather have a slightly choppy paragraph than
-// "i extracted accessibility data from your frame buffer".
-const BANNED_WORDS = [
-  "ocr",
-  "accessibility",
-  "a11y",
-  "frame",
-  "capture",
-  "snapshot",
-  "extract",
-  "scrape",
-  "parse",
-  "buffer",
-  "queue",
-  "thread",
-  "metadata",
-  "schema",
-  "keystroke",
-  "transcription",
-  "transcript",
-  "pixel",
-  "ax api",
-  "ui tree",
-  "dom",
-];
 
 // Boot phases emitted by the Rust backend — see src-tauri/src/health.rs.
 // We use these to show actionable copy during long migrations (Mike Cloke
@@ -140,26 +82,11 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
   }, []);
   const { settings, updateSettings } = useSettings();
 
-  // Live feed state
-  const [activityItems, setActivityItems] = useState<ActivityItem[]>([]);
-  const [thumbnails, setThumbnails] = useState<string[]>([]);
-  const [feedSeconds, setFeedSeconds] = useState(0);
-  const [canContinue, setCanContinue] = useState(false);
-  const [showSkip, setShowSkip] = useState(false);
-
-  // Streaming summary state
-  const [summaryText, setSummaryText] = useState("");
-  const [summaryStreaming, setSummaryStreaming] = useState(false);
-  const [summaryComplete, setSummaryComplete] = useState(false);
-  const summaryStartedRef = useRef(false);
-  const summaryAbortRef = useRef<AbortController | null>(null);
-
   // Boot phase — polled via Tauri IPC, available before HTTP server binds
   const [bootPhase, setBootPhase] = useState<BootPhaseSnapshot | null>(null);
 
   const hasAdvancedRef = useRef(false);
   const mountTimeRef = useRef(Date.now());
-  const feedStartRef = useRef(0);
 
   // Progress 0→1
   const progressVal =
@@ -230,7 +157,7 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
 
   // Poll health
   useEffect(() => {
-    if (state === "running" || state === "live-feed") return;
+    if (state === "running") return;
 
     const poll = async () => {
       try {
@@ -263,7 +190,7 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
   // Poll boot phase via Tauri IPC — available before HTTP server binds.
   // Crucial on large-db migrations where /health is unreachable for minutes.
   useEffect(() => {
-    if (state === "running" || state === "live-feed") return;
+    if (state === "running") return;
 
     let cancelled = false;
     const poll = async () => {
@@ -287,8 +214,7 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
   // backend after all bind retries are exhausted. Flip straight to "stuck"
   // with an actionable message instead of letting the generic timer fire.
   useEffect(() => {
-    if (state === "running" || state === "live-feed" || state === "stuck")
-      return;
+    if (state === "running" || state === "stuck") return;
     if (bootPhase?.phase !== "error" || !bootPhase.error) return;
 
     const isPortConflict = /port.*in use|already in use/i.test(bootPhase.error);
@@ -307,6 +233,17 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
     setState("stuck");
   }, [state, bootPhase?.phase, bootPhase?.error]);
 
+  const ensureDefaultPreset = useCallback(async () => {
+    if (settings.aiPresets.length === 0) {
+      const isPro = settings.user?.cloud_subscribed === true;
+      await updateSettings({ aiPresets: makeDefaultPresets(isPro) as any });
+    }
+  }, [
+    settings.aiPresets.length,
+    settings.user?.cloud_subscribed,
+    updateSettings,
+  ]);
+
   // Move on as soon as the engine is ready. The activity recap that used to
   // follow this screen added another wait before users could finish setup.
   useEffect(() => {
@@ -320,420 +257,14 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
     // Keep the completed progress visible briefly before advancing.
     const elapsed = Date.now() - mountTimeRef.current;
     const delay = Math.max(0, 1200 - elapsed);
-    const timer = setTimeout(() => handleNextSlide(), delay);
-    return () => clearTimeout(timer);
-  }, [state, handleNextSlide]);
-
-  // Live feed: poll search for recent activity + thumbnails
-  const emptyPollCountRef = useRef(0);
-  // Auth-race: /search 401s when _apiKey in lib/api.ts hasn't propagated to
-  // the webview yet (ensureInitialized retries getLocalApiConfig up to 30×
-  // 500ms; on corp-VDI Windows 11 that init sometimes exhausts before the
-  // engine binds its key). Surface it explicitly instead of leaving the user
-  // staring at "no activity" for the full 15s.
-  const [authNotReady, setAuthNotReady] = useState(false);
-  // Tracks the last-logged value of authNotReady so the 401 warning only
-  // fires on the false->true transition, not on every 2s poll while the
-  // race persists. A ref (not the state var) because `poll` is captured
-  // once by this effect and never sees state updates from later renders.
-  const authNotReadyLoggedRef = useRef(false);
-
-  useEffect(() => {
-    if (state !== "live-feed") return;
-    emptyPollCountRef.current = 0;
-    authNotReadyLoggedRef.current = false;
-
-    const poll = async () => {
+    const timer = setTimeout(async () => {
       try {
-        const useFallback = emptyPollCountRef.current >= 2;
-        const contentType = useFallback ? "all" : "accessibility";
-
-        // We pull OCR with include_frames=true purely for the visual proof
-        // tiles below the prose. filter_pii=true is on every search — these
-        // results are about to be summarized by an LLM, and we don't want the
-        // user's password manager text or 2FA codes round-tripping through it.
-        const [mainRes, audioRes, ocrFramesRes] = await Promise.all([
-          localFetch(
-            `/search?content_type=${contentType}&start_time=${encodeURIComponent("3m ago")}&limit=8&max_content_length=120&filter_pii=true`,
-            { signal: AbortSignal.timeout(3000) },
-          ).catch(() => null),
-          localFetch(
-            `/search?content_type=audio&start_time=${encodeURIComponent("3m ago")}&limit=4&max_content_length=120&filter_pii=true`,
-            { signal: AbortSignal.timeout(3000) },
-          ).catch(() => null),
-          thumbnails.length < MAX_THUMBNAILS
-            ? localFetch(
-                `/search?content_type=ocr&start_time=${encodeURIComponent("3m ago")}&limit=${MAX_THUMBNAILS}&include_frames=true&max_content_length=1`,
-                { signal: AbortSignal.timeout(5000) },
-              ).catch(() => null)
-            : Promise.resolve(null),
-        ]);
-
-        // Detect the auth-key propagation race: if lib/api.ts _apiKey hasn't
-        // landed yet, /search returns 401. Surface it so the copy tells the
-        // user this is an auth issue, not a data-flow issue.
-        if (mainRes?.status === 401 || audioRes?.status === 401) {
-          if (!authNotReadyLoggedRef.current) {
-            console.warn(
-              "onboarding live-feed: /search returned 401 — api key not yet propagated to webview",
-            );
-            authNotReadyLoggedRef.current = true;
-          }
-          setAuthNotReady(true);
-        }
-
-        // Clear the hint on any successful response — auth has recovered as
-        // soon as the key propagates, independent of whether this poll
-        // happened to find anything to show (e.g. idle machine, no
-        // activity yet, but auth is fine). Evaluated separately from the
-        // items.length check below so an all-empty-but-200 poll still
-        // clears a stuck "auth still initializing" hint.
-        if (mainRes?.ok || audioRes?.ok) {
-          authNotReadyLoggedRef.current = false;
-          setAuthNotReady(false);
-        }
-
-        const items: ActivityItem[] = [];
-        const seen = new Set<string>();
-
-        if (mainRes?.ok) {
-          const mainData = await mainRes.json();
-          for (const result of mainData.data || []) {
-            const appName =
-              result.content?.app_name ||
-              result.content?.window_name?.split(" — ")[0] ||
-              "";
-            const text = result.content?.text || "";
-            if (!appName || !text.trim()) continue;
-            const key = `${appName}-${text.slice(0, 30)}`;
-            if (seen.has(key)) continue;
-            seen.add(key);
-            items.push({
-              id: `${result.content?.timestamp || Date.now()}-${items.length}`,
-              timestamp: result.content?.timestamp || new Date().toISOString(),
-              app_name: appName,
-              text_snippet:
-                text.slice(0, 100) + (text.length > 100 ? "..." : ""),
-            });
-          }
-        }
-
-        if (audioRes?.ok) {
-          const audioData = await audioRes.json();
-          for (const result of audioData.data || []) {
-            const text = result.content?.transcription || "";
-            if (!text.trim()) continue;
-            const key = `audio-${text.slice(0, 30)}`;
-            if (seen.has(key)) continue;
-            seen.add(key);
-            items.push({
-              id: `${result.content?.timestamp || Date.now()}-${items.length}`,
-              timestamp: result.content?.timestamp || new Date().toISOString(),
-              app_name: "voice",
-              text_snippet:
-                text.slice(0, 100) + (text.length > 100 ? "..." : ""),
-            });
-          }
-        }
-
-        if (ocrFramesRes?.ok) {
-          const ocrData = await ocrFramesRes.json();
-          const frames: string[] = [];
-          for (const result of ocrData.data || []) {
-            const frame = result.content?.frame;
-            // Defensive: backend logs "failed to extract frame: no data
-            // received" when ffmpeg can't seek to the requested offset
-            // (file still being written). It then returns null/empty/short
-            // payload — render nothing rather than a broken image.
-            if (
-              typeof frame === "string" &&
-              frame.length >= MIN_FRAME_B64_LEN
-            ) {
-              frames.push(frame);
-            }
-            if (frames.length >= MAX_THUMBNAILS) break;
-          }
-          if (frames.length > 0) {
-            setThumbnails((prev) =>
-              prev.length >= frames.length ? prev : frames,
-            );
-          }
-        }
-
-        if (items.length > 0) {
-          setActivityItems(items.slice(0, SUMMARY_MAX_ITEMS));
-          emptyPollCountRef.current = 0;
-        } else {
-          emptyPollCountRef.current++;
-        }
-      } catch {
-        emptyPollCountRef.current++;
-      }
-    };
-
-    poll();
-    const interval = setInterval(poll, LIVE_FEED_POLL_MS);
-    return () => clearInterval(interval);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
-
-  // Build a digest from collected signals. Plain prose, app + voice grouped,
-  // capped per-line so we don't blow the context.
-  const buildDigest = useCallback((items: ActivityItem[]): string => {
-    const lines: string[] = [];
-    const byApp = new Map<string, string[]>();
-    for (const item of items.slice(0, SUMMARY_MAX_ITEMS)) {
-      const bucket = byApp.get(item.app_name) ?? [];
-      bucket.push(item.text_snippet);
-      byApp.set(item.app_name, bucket);
-    }
-    for (const [app, snippets] of byApp.entries()) {
-      const joined = snippets.slice(0, 3).join(" | ");
-      lines.push(`${app}: ${joined.slice(0, 240)}`);
-    }
-    return lines.join("\n");
-  }, []);
-
-  // Deterministic local prose summary. Runs offline, no auth, no model.
-  // This is the fallback that ALWAYS works as long as we have any signal —
-  // the LLM stream upgrades it once it arrives, but we never gate the user
-  // on a network round-trip. Prior implementation only had the LLM path,
-  // so any auth/network/format glitch left the user staring at "settling
-  // in…" forever.
-  const buildLocalProse = useCallback((items: ActivityItem[]): string => {
-    if (items.length === 0) return "";
-    const apps: string[] = [];
-    const seen = new Set<string>();
-    let voiceSnippet = "";
-    for (const item of items) {
-      if (item.app_name === "voice") {
-        if (!voiceSnippet) voiceSnippet = item.text_snippet;
-        continue;
-      }
-      const name = item.app_name?.trim().toLowerCase();
-      if (!name || seen.has(name)) continue;
-      seen.add(name);
-      apps.push(item.app_name);
-      if (apps.length >= 4) break;
-    }
-    const parts: string[] = [];
-    if (apps.length === 1) {
-      parts.push(`i caught a bit of your work in ${apps[0]}`);
-    } else if (apps.length === 2) {
-      parts.push(`i caught you moving between ${apps[0]} and ${apps[1]}`);
-    } else if (apps.length >= 3) {
-      const last = apps[apps.length - 1];
-      const head = apps.slice(0, -1).join(", ");
-      parts.push(`i caught you across ${head}, and ${last}`);
-    }
-    if (voiceSnippet) {
-      const trimmed = voiceSnippet.replace(/\s+/g, " ").slice(0, 80).trim();
-      parts.push(
-        `heard a bit of you talking — "${trimmed}${voiceSnippet.length > 80 ? "…" : ""}"`,
-      );
-    }
-    if (parts.length === 0) return "";
-    parts.push(
-      "i'll keep watching quietly so we can pick up where you left off",
-    );
-    return parts.join(". ") + ".";
-  }, []);
-
-  // Stream a warm summary using the user's default preset, falling back to
-  // their cloud token. If neither is available, leave summary empty and let
-  // the fallback timer release the continue button.
-  // Track attempts so a transient failure (no token at first poll, network
-  // blip) gets retried instead of permanently breaking the slide.
-  const summaryAttemptsRef = useRef(0);
-  const MAX_SUMMARY_ATTEMPTS = 3;
-
-  const startSummaryStream = useCallback(
-    async (digest: string) => {
-      if (summaryStartedRef.current) return;
-      if (summaryAttemptsRef.current >= MAX_SUMMARY_ATTEMPTS) return;
-      summaryStartedRef.current = true;
-      summaryAttemptsRef.current += 1;
-
-      const presets = settings.aiPresets ?? [];
-      const preset =
-        (presets.find((p: any) => p.defaultPreset) as any) ??
-        (presets[0] as any);
-
-      let endpoint = "";
-      let model = "claude-haiku-4-5";
-      let auth: Record<string, string> = {};
-
-      const userToken = settings.user?.token;
-
-      if (preset?.provider === "screenpipe-cloud" && userToken) {
-        endpoint = "https://api.screenpipe.com/v1/chat/completions";
-        model = preset.model || model;
-        auth = { Authorization: `Bearer ${userToken}` };
-      } else if (
-        (preset?.provider === "openai" ||
-          preset?.provider === "custom" ||
-          preset?.provider === "anthropic") &&
-        preset.apiKey &&
-        preset.url
-      ) {
-        endpoint = `${preset.url.replace(/\/$/, "")}/chat/completions`;
-        model = preset.model;
-        auth = { Authorization: `Bearer ${preset.apiKey}` };
-      } else if (userToken) {
-        // Fall back to cloud even if preset is non-cloud but token exists.
-        endpoint = "https://api.screenpipe.com/v1/chat/completions";
-        auth = { Authorization: `Bearer ${userToken}` };
-      } else {
-        // No way to call any model. Bail and reset the gate so a later poll
-        // can retry — settings.user.token can land asynchronously after the
-        // login slide completes.
-        summaryStartedRef.current = false;
-        return;
-      }
-
-      const controller = new AbortController();
-      summaryAbortRef.current = controller;
-      setSummaryStreaming(true);
-
-      const systemPrompt = `you are writing a friendly, warm 4-5 sentence note to a person who just started screenpipe. they are watching this on their onboarding screen. the goal is to make them feel SEEN — show that you noticed what they were doing in the last few minutes — without sounding like a surveillance log.
-
-style:
-- lowercase, plain conversational tone, like a thoughtful friend
-- use "you" — speak directly to the person
-- weave the apps, voice, and topics into a flowing narrative — not a bulleted list
-- 4-5 short sentences, ~40-70 words total
-- end with one warm sentence like "i'll keep watching quietly so we can pick up where you left off."
-
-NEVER use these technical words: ocr, accessibility, a11y, frame, capture, snapshot, extract, scrape, parse, buffer, queue, thread, metadata, schema, keystroke, transcription, transcript, pixel, dom, ui tree. these break the spell.
-
-instead say things like: "you spent some time in slack", "you were typing notes about X", "you had a quick voice conversation about Y", "i caught a bit of your work in vscode".
-
-if the input is sparse, just describe what little you have warmly. don't apologize for not having more.`;
-
-      try {
-        const resp = await fetch(endpoint, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", ...auth },
-          signal: controller.signal,
-          body: JSON.stringify({
-            model,
-            stream: true,
-            max_tokens: 300,
-            messages: [
-              { role: "system", content: systemPrompt },
-              {
-                role: "user",
-                content: `here is what you saw in the last few minutes:\n\n${digest}\n\nwrite the note now.`,
-              },
-            ],
-          }),
-        });
-
-        if (!resp.ok || !resp.body) {
-          throw new Error(`${resp.status}`);
-        }
-
-        const reader = resp.body.getReader();
-        const decoder = new TextDecoder();
-        let buf = "";
-        let acc = "";
-
-        const lower = (s: string) => s.toLowerCase();
-        const containsBanned = (chunk: string) =>
-          BANNED_WORDS.some((w) => lower(chunk).includes(w));
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buf += decoder.decode(value, { stream: true });
-
-          // SSE: split on \n\n, each event is a "data: {...}" line
-          let nl = buf.indexOf("\n\n");
-          while (nl !== -1) {
-            const event = buf.slice(0, nl);
-            buf = buf.slice(nl + 2);
-            nl = buf.indexOf("\n\n");
-
-            for (const rawLine of event.split("\n")) {
-              const line = rawLine.trim();
-              if (!line.startsWith("data:")) continue;
-              const data = line.slice(5).trim();
-              if (data === "[DONE]") continue;
-              try {
-                const parsed = JSON.parse(data);
-                const delta = parsed?.choices?.[0]?.delta?.content;
-                if (typeof delta === "string" && delta.length > 0) {
-                  if (containsBanned(delta)) continue; // skip leaked plumbing words
-                  acc += delta;
-                  setSummaryText(acc);
-                }
-              } catch {
-                // partial JSON, ignore
-              }
-            }
-          }
-        }
-
-        setSummaryComplete(true);
-      } catch (err) {
-        // Network / model error — leave whatever streamed so far visible.
-        // The fallback timer releases the continue button. Reset the started
-        // flag so the next poll cycle gets one more shot up to
-        // MAX_SUMMARY_ATTEMPTS — a stale settings.user.token at the very
-        // first poll (login slide just finished, token not yet propagated)
-        // would otherwise permanently kill the summary.
-        if ((err as any)?.name !== "AbortError") {
-          console.warn("summary stream failed:", err);
-          summaryStartedRef.current = false;
-        }
-      } finally {
-        setSummaryStreaming(false);
-      }
-    },
-    [settings.aiPresets, settings.user?.token],
-  );
-
-  // Kick off the summary once we have enough signals.
-  useEffect(() => {
-    if (state !== "live-feed") return;
-    if (summaryStartedRef.current) return;
-    if (activityItems.length < SUMMARY_MIN_ITEMS) return;
-    const digest = buildDigest(activityItems);
-    if (!digest.trim()) return;
-    startSummaryStream(digest);
-  }, [state, activityItems, buildDigest, startSummaryStream]);
-
-  useEffect(() => {
-    return () => {
-      summaryAbortRef.current?.abort();
-    };
-  }, []);
-
-  // Live feed timer
-  useEffect(() => {
-    if (state !== "live-feed") return;
-    const interval = setInterval(() => setFeedSeconds((s) => s + 1), 1000);
-    return () => clearInterval(interval);
-  }, [state]);
-
-  // Continue is gated on the streaming summary completing — that's the moment
-  // the user has actually seen something meaningful. The fallback timer is a
-  // safety net for users with no token / offline / model errors.
-  useEffect(() => {
-    if (summaryComplete) setCanContinue(true);
-  }, [summaryComplete]);
-
-  useEffect(() => {
-    if (state !== "live-feed") return;
-    const timer = setTimeout(() => setCanContinue(true), LIVE_FEED_FALLBACK_MS);
+        await ensureDefaultPreset();
+      } catch {}
+      handleNextSlide();
+    }, delay);
     return () => clearTimeout(timer);
-  }, [state]);
-
-  useEffect(() => {
-    if (state !== "live-feed") return;
-    const timer = setTimeout(() => setShowSkip(true), 15000);
-    return () => clearTimeout(timer);
-  }, [state]);
+  }, [state, handleNextSlide, ensureDefaultPreset]);
 
   // Timers for taking-longer and stuck.
   //
@@ -755,8 +286,7 @@ if the input is sparse, just describe what little you have warmly. don't apologi
   }, []);
 
   useEffect(() => {
-    if (state === "running" || state === "live-feed" || state === "stuck")
-      return;
+    if (state === "running" || state === "stuck") return;
     // If backend is actively progressing (or reports error explicitly) we
     // don't want to fire the generic "stuck" path on a timer. The backend's
     // own error path will set phase=error, which we handle separately.
@@ -764,7 +294,7 @@ if the input is sparse, just describe what little you have warmly. don't apologi
     const stuckTimer = setTimeout(() => {
       // Re-check at fire time — state or phase may have advanced.
       setState((current) => {
-        if (current === "running" || current === "live-feed") return current;
+        if (current === "running") return current;
         const activePhases: BootPhaseSnapshot["phase"][] = [
           "migrating_database",
           "building_audio",
@@ -788,29 +318,6 @@ if the input is sparse, just describe what little you have warmly. don't apologi
     return () => clearTimeout(stuckTimer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state, bootPhase?.phase]);
-
-  const ensureDefaultPreset = useCallback(async () => {
-    if (settings.aiPresets.length === 0) {
-      const isPro = settings.user?.cloud_subscribed === true;
-      await updateSettings({ aiPresets: makeDefaultPresets(isPro) as any });
-    }
-  }, [
-    settings.aiPresets.length,
-    settings.user?.cloud_subscribed,
-    updateSettings,
-  ]);
-
-  const handleContinue = async () => {
-    posthog.capture("onboarding_livefeed_continued", {
-      time_spent_ms: Date.now() - mountTimeRef.current,
-      feed_time_ms: Date.now() - feedStartRef.current,
-      items_shown: activityItems.length,
-    });
-    try {
-      await ensureDefaultPreset();
-    } catch {}
-    handleNextSlide();
-  };
 
   const handleSkip = async () => {
     posthog.capture("onboarding_startup_skipped", {
@@ -965,206 +472,6 @@ if the input is sparse, just describe what little you have warmly. don't apologi
       active: serverStarted && !visionReady && audioReady,
     },
   ];
-
-  // ── Live feed phase ──
-  if (state === "live-feed") {
-    const placeholderTiles = MAX_THUMBNAILS - thumbnails.length;
-    // Always have something to render the moment we have any captured
-    // signal — built locally, no network, no auth, no model. The LLM
-    // stream overrides this if/when its text actually arrives.
-    const localProse = buildLocalProse(activityItems);
-    const displayedProse = summaryText.length > 0 ? summaryText : localProse;
-    const isLocalProse = displayedProse === localProse && localProse.length > 0;
-    // After the grace window, if we still have nothing displayable
-    // (no LLM text AND no captured signals), show the honest "i'm up
-    // and watching" copy. Triggers on `displayedProse` being empty so
-    // any failure path — silent LLM error, no auth token yet, search
-    // returning zero items — converges to the same friendly state.
-    const noActivityYet =
-      feedSeconds >= NO_ACTIVITY_GRACE_MS / 1000 &&
-      !summaryStreaming &&
-      displayedProse.length === 0;
-    const showWaiting =
-      !summaryStreaming && displayedProse.length === 0 && !noActivityYet;
-    // Hide the dashed-tile row if we haven't gotten any real frames after
-    // the cutoff — placeholder dashes that never fill in look broken.
-    const hideThumbnailRow =
-      thumbnails.length === 0 && feedSeconds >= HIDE_THUMBS_AFTER_MS / 1000;
-    // Unlock Continue once we have anything to show — local prose, LLM
-    // prose, or the honest "no activity yet" copy. Don't make the user
-    // wait on the LLM call when local prose is already rendered.
-    const allowContinueNow =
-      canContinue || noActivityYet || displayedProse.length > 0;
-
-    return (
-      <div className="w-full flex flex-col items-center justify-center min-h-[400px]">
-        <motion.div
-          className="flex items-center space-x-2 mb-6"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.1 }}
-          role="status"
-          aria-label="screenpipe is watching your screen"
-        >
-          <motion.div
-            className="w-1.5 h-1.5 rounded-full bg-foreground"
-            animate={{ opacity: [1, 0.3, 1] }}
-            transition={{ duration: 1.5, repeat: Infinity }}
-            aria-hidden="true"
-          />
-          <span
-            className="font-mono text-[10px] tracking-wider lowercase text-muted-foreground/70"
-            aria-hidden="true"
-          >
-            watching · {feedSeconds}s
-          </span>
-        </motion.div>
-
-        <motion.div
-          className="flex flex-col items-center space-y-7 w-full max-w-md"
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          <h2 className="font-mono text-base lowercase tracking-wide text-foreground">
-            here&apos;s what i picked up
-          </h2>
-
-          {/* Streaming prose — sans-serif body, soft and readable */}
-          <div
-            className="w-full min-h-[140px] flex flex-col items-start"
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            {noActivityYet ? (
-              <motion.p
-                className="font-sans text-sm text-muted-foreground/70 leading-relaxed text-center w-full"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-              >
-                screenpipe is up and watching. as you work, what you see and say
-                will start appearing here. you can continue now.
-              </motion.p>
-            ) : showWaiting ? (
-              <motion.p
-                className="font-sans text-sm text-muted-foreground/50 leading-relaxed text-center w-full"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-              >
-                <span className="inline-block animate-pulse">
-                  settling in. give me a moment to notice what you&apos;re up
-                  to…
-                </span>
-              </motion.p>
-            ) : (
-              <motion.p
-                key={isLocalProse ? "local" : "llm"}
-                className="font-sans text-[15px] leading-relaxed text-foreground/90"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                transition={{ duration: 0.3 }}
-              >
-                {displayedProse}
-                {summaryStreaming && !isLocalProse && (
-                  <motion.span
-                    className="inline-block w-[6px] h-[14px] bg-foreground/60 ml-0.5 align-middle"
-                    animate={{ opacity: [1, 0, 1] }}
-                    transition={{ duration: 0.9, repeat: Infinity }}
-                  />
-                )}
-              </motion.p>
-            )}
-            {/* Auth-race hint — identical whether we're showing the
-                "no activity yet" copy or the "settling in" copy, so it's
-                rendered once here instead of duplicated inside both
-                branches above. */}
-            {authNotReady && (noActivityYet || showWaiting) && (
-              <span className="block text-xs text-muted-foreground/60 mt-2 text-center w-full">
-                auth still initializing — if this persists, quit and relaunch
-                screenpipe
-              </span>
-            )}
-          </div>
-
-          {/* Thumbnail tiles — small, blurred, decorative proof of capture.
-              Only render the row if we have real frames or are still within
-              the grace window — empty dashed boxes look broken. */}
-          {!hideThumbnailRow && (
-            <div className="flex gap-2 w-full justify-center">
-              {thumbnails.map((b64, i) => (
-                <motion.div
-                  key={`thumb-${i}`}
-                  className="relative w-20 h-14 overflow-hidden border border-border/60 bg-muted/30"
-                  initial={{ opacity: 0, scale: 0.9 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ delay: i * 0.12, duration: 0.4 }}
-                >
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={`data:image/jpeg;base64,${b64}`}
-                    alt=""
-                    className="w-full h-full object-cover blur-[6px] scale-110 opacity-70"
-                  />
-                  <div className="absolute inset-0 bg-foreground/5" />
-                </motion.div>
-              ))}
-              {Array.from({ length: Math.max(0, placeholderTiles) }).map(
-                (_, i) => (
-                  <motion.div
-                    key={`ph-${i}`}
-                    className="w-20 h-14 border border-dashed border-border/40 bg-muted/10"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ delay: 0.2 + i * 0.1 }}
-                  />
-                ),
-              )}
-            </div>
-          )}
-
-          <p className="font-mono text-[10px] text-muted-foreground/50 text-center lowercase tracking-wide">
-            stays on your machine ·{" "}
-            <button
-              type="button"
-              onClick={() => openUrl("https://screenpipe.com/security")}
-              className="underline hover:text-muted-foreground transition-colors"
-            >
-              how it works ↗
-            </button>
-          </p>
-
-          <button
-            onClick={handleContinue}
-            disabled={!allowContinueNow}
-            className={`w-full border py-3 font-mono text-sm uppercase tracking-widest transition-colors duration-150 ${
-              allowContinueNow
-                ? "border-foreground bg-foreground text-background hover:bg-background hover:text-foreground"
-                : "border-border text-muted-foreground/30 cursor-not-allowed"
-            }`}
-          >
-            {allowContinueNow ? "continue" : "writing…"}
-          </button>
-        </motion.div>
-
-        <div className="h-6 mt-4">
-          <AnimatePresence>
-            {showSkip && (
-              <motion.button
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                onClick={handleSkip}
-                className="font-mono text-[11px] text-muted-foreground/40 hover:text-muted-foreground transition-colors lowercase"
-              >
-                skip — i&apos;ll show you later when there&apos;s more to see
-              </motion.button>
-            )}
-          </AnimatePresence>
-        </div>
-      </div>
-    );
-  }
 
   // ── Engine startup phase (starting / stuck) ──
   return (


### PR DESCRIPTION
## What changed

- delete the entire “here’s what i picked up” onboarding slide
- delete its activity/audio search polling, AI and local summaries, thumbnail extraction, timers, state, UI, and telemetry
- advance directly after the recording engine reaches ready, preserving the brief completed-progress animation
- preserve default AI preset initialization before advancing

## Why

The recap was a blocking extra slide before users could finish setup.

## Validation

- `bun run typecheck`
- `bunx eslint components/onboarding/engine-startup.tsx`
- `git diff --check`
- verified no `live-feed`, recap text, summary, activity-item, or thumbnail implementation remains in `engine-startup.tsx`