### PR TITLE
fix: clarify stale memories warning

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-section.filter.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-section.filter.test.tsx
@@ -160,6 +160,28 @@ describe("BrainSection type filter", () => {
     expect(artifactRows().length).toBe(0);
   });
 
+  it("keeps the stale warning specific to memories", async () => {
+    const now = vi
+      .spyOn(Date, "now")
+      .mockReturnValue(new Date("2026-07-14T00:00:00Z").getTime());
+
+    try {
+      render(<BrainSection />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/memories haven't updated in/i)).toBeTruthy();
+        expect(
+          screen.getByText(
+            /check that a memory-writing pipe is installed and enabled/i,
+          ),
+        ).toBeTruthy();
+      });
+      expect(screen.queryByText(/artifact-writing/)).toBeNull();
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it("artifacts tab hides every memory row", async () => {
     render(<BrainSection />);
     await waitFor(() => expect(memoryRows().length).toBeGreaterThan(0));

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -1084,8 +1084,8 @@ export function BrainSection() {
         <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-yellow-600 dark:text-yellow-400">
           <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
           <span>
-            hasn&apos;t updated in {staleDays} day{staleDays !== 1 ? "s" : ""}.
-            check that a memory-writing or artifact-writing pipe is installed and enabled
+            memories haven&apos;t updated in {staleDays} day{staleDays !== 1 ? "s" : ""}.
+            check that a memory-writing pipe is installed and enabled
             &mdash;{" "}
             <a
               href="?section=pipes&tab=discover&q=memory"


### PR DESCRIPTION
fixes #5182

brain's stale banner is driven by the latest memory timestamp, but the copy also pointed at artifact-writing pipes. that made the artifacts tab look involved even when artifact generation was fine.

this keeps the warning specific to memories and covers the copy in the existing brain section test.

manual check with a temporary stale memory:

https://github.com/user-attachments/assets/5671b2cf-fee5-41b5-9742-c047d7ea57c8

tested:

```bash
./node_modules/.bin/vitest run --config vitest.config.ts components/settings/__tests__/brain-section.filter.test.tsx
```
