### PR TITLE
fix(app): windows update banner uses the build's real channel + auth

### DIFF
--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -8,7 +8,7 @@ import { listen } from "@tauri-apps/api/event";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { commands } from "@/lib/utils/tauri";
 import { check, type Update } from "@tauri-apps/plugin-updater";
-import { platform, arch } from "@tauri-apps/plugin-os";
+import { platform } from "@tauri-apps/plugin-os";
 import { useToast } from "@/components/ui/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -65,26 +65,21 @@ interface UpdateBannerProps {
 }
 
 async function getWindowsUpdateOptions() {
-  const cpuArch = arch();
-  const isEnterprise = await commands.isEnterpriseBuildCmd().catch(() => false);
-  const channel = isEnterprise ? "enterprise" : "stable";
-  const headers: Record<string, string> = {};
-
-  if (isEnterprise) {
-    const licenseKey = await commands.getEnterpriseLicenseKey().catch(() => null);
-    if (licenseKey) {
-      headers["X-License-Key"] = licenseKey;
-    }
-  }
+  // Backend is the single source of truth for endpoint + auth: it returns the
+  // channel endpoint baked into this build (stable/beta/enterprise) and the
+  // headers the backend update path itself would send. The old hardcoded list
+  // silently switched beta users to stable and dropped Bearer auth for paid
+  // downloads.
+  const config = await commands.getUpdateCheckConfig();
+  const headers: Record<string, string> = Object.fromEntries(config.headers);
+  const hasHeaders = Object.keys(headers).length > 0;
 
   return {
     checkOptions: {
-      endpoints: [
-        `https://screenpipe.com/api/app-update/${channel}/windows-${cpuArch}/{{current_version}}`,
-      ],
-      ...(Object.keys(headers).length > 0 ? { headers } : {}),
+      ...(config.endpoints.length > 0 ? { endpoints: config.endpoints } : {}),
+      ...(hasHeaders ? { headers } : {}),
     },
-    downloadOptions: Object.keys(headers).length > 0 ? { headers } : undefined,
+    downloadOptions: hasHeaders ? { headers } : undefined,
   };
 }
 

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -786,6 +786,9 @@ async getSyncStatus() : Promise<Result<SyncStatusResponse, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async getUpdateCheckConfig() : Promise<UpdateCheckConfig> {
+    return await TAURI_INVOKE("get_update_check_config");
+},
 async hideMainWindow() : Promise<void> {
     await TAURI_INVOKE("hide_main_window");
 },
@@ -3353,6 +3356,18 @@ export type SyncDeviceInfo = { id: string; deviceId: string; deviceName: string 
  * Sync status response.
  */
 export type SyncStatusResponse = { enabled: boolean; isSyncing: boolean; lastSync: string | null; lastError: string | null; storageUsed: number | null; storageLimit: number | null; deviceCount: number | null; deviceLimit: number | null; syncTier: string | null; machineId: string }
+/**
+ * The update endpoint(s) baked into this build plus the auth headers the
+ * backend would send. Single source of truth for the Windows banner path,
+ * which used to hardcode stable/enterprise endpoints — silently switching
+ * beta-channel users to stable and dropping Bearer auth for paid users.
+ */
+export type UpdateCheckConfig = {
+/**
+ * Endpoint templates verbatim from tauri.conf ({{target}} etc. are
+ * substituted by the updater plugin at check time).
+ */
+endpoints: string[]; headers: ([string, string])[] }
 export type User = { id: string | null; name: string | null; email: string | null; image: string | null; token: string | null; clerk_id: string | null; api_key: string | null; credits: Credits | null; stripe_connected: boolean | null; stripe_account_status: string | null; github_username: string | null; bio: string | null; website: string | null; contact: string | null; cloud_subscribed: boolean | null; credits_balance: number | null; app_entitled: boolean | null; subscription_plan: string | null; entitlement: JsonValue | null }
 export type ViewerContent = { kind: "text"; text: string; name: string; path: string; truncated: boolean; total_bytes: number } | { kind: "image"; data_url: string; name: string; path: string } |
 /**

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -1210,6 +1210,55 @@ pub async fn trigger_update_check(
         .map_err(|e| e.to_string())
 }
 
+/// The update endpoint(s) baked into this build plus the auth headers the
+/// backend would send. Single source of truth for the Windows banner path,
+/// which used to hardcode stable/enterprise endpoints — silently switching
+/// beta-channel users to stable and dropping Bearer auth for paid users.
+#[derive(serde::Serialize, specta::Type)]
+pub struct UpdateCheckConfig {
+    /// Endpoint templates verbatim from tauri.conf ({{target}} etc. are
+    /// substituted by the updater plugin at check time).
+    pub endpoints: Vec<String>,
+    pub headers: Vec<(String, String)>,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_update_check_config(app: tauri::AppHandle) -> UpdateCheckConfig {
+    let endpoints = app
+        .config()
+        .plugins
+        .0
+        .get("updater")
+        .and_then(|u| u.get("endpoints"))
+        .and_then(|e| e.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut headers: Vec<(String, String)> = Vec::new();
+    if is_enterprise_build(&app) {
+        if let Some(license_key) = crate::commands::get_enterprise_license_key() {
+            headers.push(("X-License-Key".to_string(), license_key));
+        }
+    } else if let Ok(Some(settings)) = SettingsStore::get(&app) {
+        if let Some(token) = settings
+            .user
+            .token
+            .clone()
+            .filter(|t| !t.is_empty())
+            .or_else(crate::auth_token::cached_cloud_token)
+        {
+            headers.push(("Authorization".to_string(), format!("Bearer {token}")));
+        }
+    }
+
+    UpdateCheckConfig { endpoints, headers }
+}
+
 pub fn start_update_check(
     app: &tauri::AppHandle,
     interval_minutes: u64,


### PR DESCRIPTION
## Summary
- Windows update banner was hardcoding `stable`/`enterprise` endpoints and only sending `X-License-Key` for enterprise, which silently moved beta-channel users onto stable and dropped Bearer auth for paid downloads.
- Add `get_update_check_config` so the banner uses the updater endpoints baked into this build plus the same auth headers the backend update path would send.
- Wire `getWindowsUpdateOptions()` through that command (bindings in `tauri.ts`).

## Test plan
- [ ] Stable Windows build: banner check hits the stable updater endpoint from `tauri.conf`
- [ ] Beta Windows build: banner check hits the beta endpoint (not stable)
- [ ] Paid/cloud user: download request includes `Authorization: Bearer …`
- [ ] Enterprise build: download request includes `X-License-Key` when a license is present
- [ ] Source/dev build without updater endpoints still no-ops cleanly