### PR TITLE
fix: skip PostHog init when analytics opted-out (#4885)

### DIFF
--- a/apps/screenpipe-app-tauri/app/providers.tsx
+++ b/apps/screenpipe-app-tauri/app/providers.tsx
@@ -70,9 +70,12 @@ export const Providers = forwardRef<
       // plus pollute prod analytics with test traffic.
       const isE2E = process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
       if (isDebug || isE2E) return;
-      // Read the cached analytics preference to sync PostHog opt-in/out
-      // after init. undefined = first boot → allow capturing (default true).
+      // Read the cached analytics preference synchronously from localStorage
+      // BEFORE touching PostHog. undefined = first boot → allow capturing
+      // (default true). false = user opted out → skip init entirely so no
+      // session cookie, feature-flag fetch, or network request is fired.
       const cachedEnabled = readCachedAnalyticsEnabled();
+      if (cachedEnabled === false) return;
       // Bootstrap with the stable per-install id (mirrors settings.analyticsId,
       // cached by the identify() effect in use-settings) so EVERY event — incl.
       // ones fired by overlay windows like the floating search bar before the
@@ -90,12 +93,6 @@ export const Providers = forwardRef<
           ? { bootstrap: { distinctID: cachedAnalyticsId, isIdentifiedID: true } }
           : {}),
       });
-      // sync opt-in/out with cached preference on every boot
-      if (cachedEnabled === false) {
-        posthog.opt_out_capturing();
-      } else {
-        posthog.opt_in_capturing();
-      }
     }
   }, []);
 


### PR DESCRIPTION
## description

Fix privacy violation where opted-out users still have PostHog telemetry initialized on every boot. When `analyticsEnabled=false` is persisted in localStorage, the boot effect now returns before calling `posthog.init()`, preventing session cookie creation, feature-flag fetches, and any network requests to PostHog for opted-out users.

Previously the code always called `posthog.init()` and then called `opt_out_capturing()` after — but PostHog was already initialized and had already fired requests.

related issue: #4885

## before

PostHog initializes unconditionally on boot regardless of `analyticsEnabled` preference. Opted-out users still see:
- PostHog session cookie set in browser
- Feature-flag fetches to `us.i.posthog.com` on every launch
- Early events queued before the async settings save handler runs `opt_out_capturing()`

## after

When `analyticsEnabled=false` is cached in localStorage, the boot effect returns early — `posthog.init()` is never called. Zero network requests to PostHog, no session cookie, no feature-flag fetches. When the user re-enables telemetry via Settings, the existing settings-save handler correctly calls `posthog.opt_in_capturing()`.

## how to test

1. Open DevTools → Application → Local Storage → set `screenpipe_analytics_enabled` to `false`
2. Refresh the app
3. Open DevTools → Network tab → verify zero requests to `us.i.posthog.com`
4. Toggle `screenpipe_analytics_enabled` to `true`, refresh → verify PostHog initializes normally
5. Verify all `posthog.capture()` calls throughout the app silently no-op when uninitialized (no errors in console)

## notes

- Sentry is NOT affected — it is only initialized inside settings save handlers (`privacy-section.tsx`, `recording-settings.tsx`), never at boot
- All `posthog.capture()` calls across the codebase are safe when uninitialized — posthog-js returns noop methods before `init()`
- First boot (no cached value) defaults to `analyticsEnabled=true` — PostHog inits normally as before
