### PR TITLE
fix(onboarding): reschedule engine auto-advance

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.test.tsx
@@ -113,6 +113,44 @@ describe("onboarding engine startup", () => {
     );
   });
 
+  it("reschedules the advance when dependencies change during the ready delay", async () => {
+    mocks.localFetch.mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          status: "healthy",
+          status_code: 200,
+          frame_status: "ok",
+          audio_status: "ok",
+        }),
+        { status: 200 },
+      ),
+    );
+    const initialNextSlide = vi.fn();
+    const replacementNextSlide = vi.fn();
+
+    const { rerender } = render(
+      <EngineStartup handleNextSlide={initialNextSlide} />,
+    );
+
+    await waitFor(() =>
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "onboarding_engine_started",
+        expect.any(Object),
+      ),
+    );
+
+    // A settings/context update changes the callback identity while the
+    // completed-state delay is pending. The cleanup cancels the first timer;
+    // the replacement effect must still be allowed to schedule another one.
+    rerender(<EngineStartup handleNextSlide={replacementNextSlide} />);
+
+    await waitFor(
+      () => expect(replacementNextSlide).toHaveBeenCalledTimes(1),
+      { timeout: 2000 },
+    );
+    expect(initialNextSlide).not.toHaveBeenCalled();
+  });
+
   it("does not advance when the startup command reports an error", async () => {
     mocks.localFetch.mockRejectedValue(new Error("engine not listening yet"));
     mocks.spawnScreenpipe.mockResolvedValue({

--- a/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/engine-startup.tsx
@@ -108,6 +108,7 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
   const [bootPhase, setBootPhase] = useState<BootPhaseSnapshot | null>(null);
 
   const hasAdvancedRef = useRef(false);
+  const hasReportedReadyRef = useRef(false);
   const mountTimeRef = useRef(Date.now());
 
   // The preceding permissions screen checks macOS TCC directly before it
@@ -279,16 +280,24 @@ export default function EngineStartup({ handleNextSlide }: EngineStartupProps) {
   // follow this screen added another wait before users could finish setup.
   useEffect(() => {
     if (state !== "running" || hasAdvancedRef.current) return;
-    hasAdvancedRef.current = true;
 
-    posthog.capture("onboarding_engine_started", {
-      time_spent_ms: Date.now() - mountTimeRef.current,
-    });
+    if (!hasReportedReadyRef.current) {
+      hasReportedReadyRef.current = true;
+      posthog.capture("onboarding_engine_started", {
+        time_spent_ms: Date.now() - mountTimeRef.current,
+      });
+    }
 
     // Keep the completed progress visible briefly before advancing.
+    // Dependencies can change while this timer is pending (for example when
+    // settings finish hydrating). React then cancels this timer and re-runs the
+    // effect. Do not mark the transition complete until the replacement timer
+    // actually fires, or the completed engine screen can remain forever.
     const elapsed = Date.now() - mountTimeRef.current;
     const delay = Math.max(0, 1200 - elapsed);
     const timer = setTimeout(async () => {
+      if (hasAdvancedRef.current) return;
+      hasAdvancedRef.current = true;
       try {
         await ensureDefaultPreset();
       } catch {}


### PR DESCRIPTION
## summary

- keep the engine auto-advance guard unset until the delay actually fires
- allow React effect cleanup to cancel and safely reschedule the ready-state transition
- report engine readiness analytics once across reschedules
- add regression coverage for a callback/context rerender during the completed-state delay

## failure and fix

```mermaid
flowchart LR
  A[engine health recognized] --> B[completed animation]
  B --> C[advance timer scheduled]
  C --> D[settings rerender]
  D --> E[timer cleanup]
  E --> F{advance guard}
  F -->|before| G[already true: stuck forever]
  F -->|after| H[still false: timer rescheduled]
  H --> I[next onboarding step]
```

## testing

- `bun run test:vitest -- components/onboarding/engine-startup.test.tsx app/onboarding/page.test.tsx` — 12 passed
- `bun run typecheck` — passed
- `bunx eslint components/onboarding/engine-startup.tsx components/onboarding/engine-startup.test.tsx` — passed
- `bun run test` — 1,501 passed; 26 unrelated existing environment failures because the test runtime exposes `localStorage.clear` as non-callable in three suites
