### PR TITLE
fix: allow verbose free chat tool schemas

### DIFF
--- a/packages/ai-gateway/src/services/free-chat-limit.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.test.ts
@@ -17,8 +17,8 @@ import {
 	FREE_CHAT_MAX_RESPONSE_FORMAT_BYTES,
 	FREE_CHAT_MAX_STRUCTURE_DEPTH,
 	FREE_CHAT_MAX_TEXT_BYTES,
-	FREE_CHAT_MAX_TOOL_BYTES,
 	FREE_CHAT_MAX_TOOLS,
+	FREE_CHAT_MAX_TOOLS_BYTES,
 	acquireFreeChatLease,
 	applyFreeChatRequestLimits,
 	prepareFreeChatTurn,
@@ -546,7 +546,7 @@ describe('validateFreeChatRequestLimits', () => {
 		expect(disguisedFile?.code).toBe('free_chat_image_unverifiable');
 	});
 
-	it('caps tool count and each serialized schema', () => {
+	it('caps tool count and aggregate schema bytes without rejecting one verbose tool', () => {
 		const tool = { type: 'function', function: { name: 'tool', description: 'x', parameters: { type: 'object', properties: {} } } };
 		const tooMany = validateFreeChatRequestLimits({
 			...bodyWith([{ role: 'user', content: 'hello' }]),
@@ -554,11 +554,17 @@ describe('validateFreeChatRequestLimits', () => {
 		}, preview);
 		expect(tooMany?.code).toBe('free_chat_too_many_tools');
 
-		const oversized = validateFreeChatRequestLimits({
+		const verboseTool = validateFreeChatRequestLimits({
 			...bodyWith([{ role: 'user', content: 'hello' }]),
-			tools: [{ ...tool, function: { ...tool.function, description: 'x'.repeat(FREE_CHAT_MAX_TOOL_BYTES) } }],
+			tools: [{ ...tool, function: { ...tool.function, description: 'x'.repeat(32 * 1024) } }],
 		}, preview);
-		expect(oversized?.code).toBe('free_chat_tool_too_large');
+		expect(verboseTool).toBeNull();
+
+		const oversizedTotal = validateFreeChatRequestLimits({
+			...bodyWith([{ role: 'user', content: 'hello' }]),
+			tools: [{ ...tool, function: { ...tool.function, description: 'x'.repeat(FREE_CHAT_MAX_TOOLS_BYTES) } }],
+		}, preview);
+		expect(oversizedTotal?.code).toBe('free_chat_tools_too_large');
 	});
 
 	it('rejects malformed tools and assistant tool calls before provider dispatch', () => {

--- a/packages/ai-gateway/src/services/free-chat-limit.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.ts
@@ -15,7 +15,6 @@ export const FREE_CHAT_MAX_TEXT_BYTES = 64 * 1024;
 export const FREE_CHAT_MAX_IMAGES = 4;
 export const FREE_CHAT_MAX_IMAGE_BYTES = 2 * 1024 * 1024;
 export const FREE_CHAT_MAX_TOOLS = 48;
-export const FREE_CHAT_MAX_TOOL_BYTES = 16 * 1024;
 export const FREE_CHAT_MAX_TOOLS_BYTES = 96 * 1024;
 export const FREE_CHAT_MAX_RESPONSE_FORMAT_BYTES = 16 * 1024;
 export const FREE_CHAT_MAX_STRUCTURE_DEPTH = 32;
@@ -321,12 +320,6 @@ export function validateFreeChatRequestBodyLimits(
 		return requestTooLarge(
 			'free_chat_tools_too_large',
 			`Free hosted chat tool definitions are limited to ${FREE_CHAT_MAX_TOOLS_BYTES} bytes per request.`,
-		);
-	}
-	if (tools.some((tool) => jsonByteLength(tool) > FREE_CHAT_MAX_TOOL_BYTES)) {
-		return requestTooLarge(
-			'free_chat_tool_too_large',
-			`Each free hosted chat tool definition is limited to ${FREE_CHAT_MAX_TOOL_BYTES} bytes.`,
 		);
 	}
 	if (


### PR DESCRIPTION
## Summary
- remove the redundant 16 KiB per-tool schema cap that blocked the desktop app built-in tools for free users
- retain the 96 KiB aggregate tool-schema cap and all existing request, spend, concurrency, and agent-step limits
- add regression coverage for a verbose single tool and the aggregate-size rejection

## Test plan
- bun test packages/ai-gateway/src/services/free-chat-limit.test.ts (34 passed)