### PR TITLE
fix(activity-summary): balance audio context across requested range

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.test.ts
@@ -53,6 +53,57 @@ describe("meeting-context image notes", () => {
   });
 });
 
+describe("meeting-context transcript fallback", () => {
+  it("samples both early and late fragments when only eight fit", () => {
+    const meeting: MeetingRecord = {
+      id: 42,
+      meeting_start: "2026-06-04T15:00:00.000Z",
+      meeting_end: "2026-06-04T15:30:00.000Z",
+      meeting_app: "zoom",
+      title: "Design review",
+      attendees: null,
+      note: null,
+      detection_source: "manual",
+      created_at: "2026-06-04T15:00:00.000Z",
+    };
+    const topTranscriptions = Array.from({ length: 20 }, (_, index) => ({
+      transcription: `fragment-${String(index).padStart(2, "0")}`,
+      speaker: "Alice",
+      device: "mic",
+      timestamp: new Date(Date.UTC(2026, 5, 4, 15, index)).toISOString(),
+    }));
+    const context: MeetingContext = {
+      activity: {
+        apps: [],
+        windows: [],
+        audio_summary: {
+          segment_count: topTranscriptions.length,
+          speakers: [],
+          top_transcriptions: topTranscriptions,
+        },
+        total_frames: 0,
+        time_range: {
+          start: meeting.meeting_start,
+          end: meeting.meeting_end,
+        },
+      },
+      clipboardCount: 0,
+      ok: true,
+    };
+
+    const prompt = buildEnrichedSummarizePrompt({
+      meeting,
+      context,
+      transcript: [],
+    });
+    const sampledFragments = prompt.match(/fragment-\d{2}/g) ?? [];
+
+    expect(sampledFragments).toHaveLength(8);
+    expect(sampledFragments[0]).toBe("fragment-00");
+    expect(sampledFragments[sampledFragments.length - 1]).toBe("fragment-19");
+  });
+});
+
 function chunk(overrides: Partial<MeetingAudioChunk>): MeetingAudioChunk {
   return {
     audioChunkId: 1,

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
@@ -352,6 +352,18 @@ export function pathFromUrl(url: string): string {
   }
 }
 
+function evenlySpacedItems<T>(items: readonly T[], limit: number): T[] {
+  if (items.length === 0 || limit <= 0) return [];
+  if (items.length <= limit) return [...items];
+  if (limit === 1) return [items[0]];
+
+  const lastIndex = items.length - 1;
+  return Array.from({ length: limit }, (_, index) => {
+    const sourceIndex = Math.round((index * lastIndex) / (limit - 1));
+    return items[sourceIndex];
+  });
+}
+
 // ─── Prompt builder ──────────────────────────────────────────────────────
 
 interface SummarizeInput {
@@ -443,7 +455,10 @@ export function buildEnrichedSummarizePrompt({
       !transcript?.length &&
       a.audio_summary.top_transcriptions.length > 0
     ) {
-      const lines = a.audio_summary.top_transcriptions.slice(0, 8).map((t) => {
+      const chronological = [...a.audio_summary.top_transcriptions].sort(
+        (left, right) => timestampMs(left.timestamp) - timestampMs(right.timestamp),
+      );
+      const lines = evenlySpacedItems(chronological, 8).map((t) => {
         const ts = formatTimeShort(t.timestamp);
         const txt = t.transcription.replace(/\s+/g, " ").trim().slice(0, 240);
         const sp = t.speaker && t.speaker !== "unknown" ? `[${t.speaker}] ` : "";

--- a/crates/screenpipe-engine/src/routes/activity_summary.rs
+++ b/crates/screenpipe-engine/src/routes/activity_summary.rs
@@ -34,6 +34,8 @@ use screenpipe_db::DatabaseManager;
 /// by the per-app / per-window `minutes` SQL and the whole-range
 /// `total_active_minutes` so the three definitions never drift apart.
 const IDLE_CAP_SECS: i64 = 300;
+const MAX_TOP_TRANSCRIPTIONS: u32 = 20;
+const MAX_AUDIO_SEGMENTS_PER_BUCKET: u32 = 2;
 
 // ---------- query ----------
 
@@ -156,7 +158,7 @@ pub struct SpeakerSummary {
 pub struct AudioSummary {
     pub segment_count: i64,
     pub speakers: Vec<SpeakerSummary>,
-    /// Top transcriptions with actual text (sorted by length, most substantial first)
+    /// Substantial transcriptions sampled across the requested time range.
     pub top_transcriptions: Vec<AudioSegment>,
 }
 
@@ -544,20 +546,10 @@ async fn collect_summary_core(
          GROUP BY at.speaker_id ORDER BY 2 DESC LIMIT 10"
     );
 
-    // Top transcriptions by length — the AI summary prompt uses these as
-    // "notable quotes." Full transcript is fetched separately via /search.
-    let audio_transcripts_query = format!(
-        "SELECT at.transcription, \
-         COALESCE(s.name, 'Unknown') as speaker, \
-         at.device, \
-         at.timestamp \
-         FROM audio_transcriptions at \
-         LEFT JOIN speakers s ON at.speaker_id = s.id \
-         WHERE at.timestamp BETWEEN '{start}' AND '{end}' \
-         AND TRIM(at.transcription) != '' \
-         AND LENGTH(at.transcription) > 5 \
-         ORDER BY LENGTH(at.transcription) DESC LIMIT 20"
-    );
+    // Keep notable quotes representative of the whole requested range. A
+    // newest-first or global length sort lets one recent meeting consume the
+    // context for a weekly summary.
+    let audio_transcripts_query = balanced_audio_query(start, end, "", MAX_TOP_TRANSCRIPTIONS);
 
     // Cap at 50 paths — a 1000-file workspace would be noise anyway.
     let edited_files_query = format!(
@@ -869,16 +861,7 @@ async fn load_snippets(
         })
         .unwrap_or_default();
 
-    let audio_query = format!(
-        "SELECT at.transcription, COALESCE(s.name, 'Unknown') AS speaker, at.timestamp \
-         FROM audio_transcriptions at \
-         LEFT JOIN speakers s ON at.speaker_id = s.id \
-         WHERE at.timestamp BETWEEN '{start}' AND '{end}'{audio_text_filter} \
-         AND TRIM(at.transcription) != '' \
-         AND LENGTH(at.transcription) > 5 \
-         ORDER BY at.timestamp DESC \
-         LIMIT {audio_limit}"
-    );
+    let audio_query = balanced_audio_query(start, end, &audio_text_filter, audio_limit);
 
     let screen_candidates: Vec<&KeyText> = key_texts
         .iter()
@@ -970,6 +953,47 @@ fn evenly_spaced_indices(len: usize, limit: usize) -> Vec<usize> {
         indices.push(index);
     }
     indices
+}
+
+/// Select useful audio from evenly sized wall-clock buckets across the
+/// requested interval. Ranking by bucket before rank gives every occupied part
+/// of the range one slot before a period gets a second, and the per-bucket cap
+/// prevents any dense meeting from consuming the context on its own.
+fn balanced_audio_query(start: &str, end: &str, extra_filter: &str, limit: u32) -> String {
+    let limit = limit.max(1);
+    let last_bucket = limit - 1;
+    let per_bucket = MAX_AUDIO_SEGMENTS_PER_BUCKET;
+
+    format!(
+        "WITH bucketed AS ( \
+           SELECT at.transcription, \
+             COALESCE(s.name, 'Unknown') AS speaker, \
+             at.device, \
+             at.timestamp, \
+             MIN({last_bucket}, CAST( \
+               ((JULIANDAY(at.timestamp) - JULIANDAY('{start}')) \
+                / NULLIF(JULIANDAY('{end}') - JULIANDAY('{start}'), 0)) \
+               * {limit} AS INTEGER \
+             )) AS time_bucket \
+           FROM audio_transcriptions at \
+           LEFT JOIN speakers s ON at.speaker_id = s.id \
+           WHERE at.timestamp BETWEEN '{start}' AND '{end}'{extra_filter} \
+           AND TRIM(at.transcription) != '' \
+           AND LENGTH(at.transcription) > 5 \
+         ), ranked AS ( \
+           SELECT transcription, speaker, device, timestamp, time_bucket, \
+             ROW_NUMBER() OVER ( \
+               PARTITION BY time_bucket \
+               ORDER BY LENGTH(transcription) DESC, timestamp DESC \
+             ) AS bucket_rank \
+           FROM bucketed \
+         ) \
+         SELECT transcription, speaker, device, timestamp \
+         FROM ranked \
+         WHERE bucket_rank <= {per_bucket} \
+         ORDER BY bucket_rank ASC, time_bucket ASC, timestamp ASC \
+         LIMIT {limit}"
+    )
 }
 
 // ---------- status + guidance ----------
@@ -1895,6 +1919,100 @@ mod db_tests {
             .iter()
             .any(|sp| sp.name == "Alice"));
         assert_eq!(core.audio_summary.top_transcriptions.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn weekly_audio_context_is_not_consumed_by_the_last_few_minutes() {
+        let (db, _d) = fresh_db().await;
+        db.execute_raw_sql("INSERT INTO audio_chunks (id, file_path) VALUES (1, 'test.wav')")
+            .await
+            .unwrap();
+        db.execute_raw_sql("INSERT INTO speakers (id, name) VALUES (1, 'Alice')")
+            .await
+            .unwrap();
+
+        // One useful segment per day, followed by enough longer segments in
+        // the final minutes to crowd every older row out of the old global
+        // length sort and newest-first snippet query.
+        for day in 1..=7 {
+            db.execute_raw_sql(&format!(
+                "INSERT INTO audio_transcriptions \
+                 (audio_chunk_id, offset_index, timestamp, transcription, device, speaker_id) \
+                 VALUES (1, {day}, '2026-06-0{day} 10:00:00', \
+                 'weekly audio day {day} project update with decisions and next steps', 'mic', 1)"
+            ))
+            .await
+            .unwrap();
+        }
+        for second in 0..24 {
+            db.execute_raw_sql(&format!(
+                "INSERT INTO audio_transcriptions \
+                 (audio_chunk_id, offset_index, timestamp, transcription, device, speaker_id) \
+                 VALUES (1, {}, '2026-06-07 23:59:{second:02}', \
+                 'recent burst {second:02} with substantially longer detailed discussion that must not replace the rest of the requested week', \
+                 'mic', 1)",
+                100 + second
+            ))
+            .await
+            .unwrap();
+        }
+
+        let start = "2026-06-01 00:00:00";
+        let end = "2026-06-08 00:00:00";
+        let core = collect_summary_core(&db, &query(None), start, end).await;
+        let top_days = core
+            .audio_summary
+            .top_transcriptions
+            .iter()
+            .map(|segment| segment.timestamp.get(..10).unwrap_or(""))
+            .collect::<std::collections::HashSet<_>>();
+
+        assert!(
+            top_days.contains("2026-06-01"),
+            "top transcriptions lost early-week audio: {top_days:?}"
+        );
+        assert!(
+            top_days.contains("2026-06-07"),
+            "top transcriptions should still include recent audio: {top_days:?}"
+        );
+        assert!(
+            top_days.len() >= 6,
+            "weekly audio should cover the range, got days {top_days:?}"
+        );
+        let final_minute_count = core
+            .audio_summary
+            .top_transcriptions
+            .iter()
+            .filter(|segment| segment.timestamp.starts_with("2026-06-07 23:59"))
+            .count();
+        assert!(
+            final_minute_count <= MAX_AUDIO_SEGMENTS_PER_BUCKET as usize,
+            "one recent minute consumed the audio context: {final_minute_count} rows"
+        );
+
+        let mut snippet_query = query(None);
+        snippet_query.max_snippets = 12;
+        let snippets = load_snippets(&db, &snippet_query, &[], start, end)
+            .await
+            .expect("load weekly snippets");
+        let audio_days = snippets
+            .iter()
+            .filter(|snippet| snippet.source == "audio")
+            .map(|snippet| snippet.timestamp.get(..10).unwrap_or(""))
+            .collect::<std::collections::HashSet<_>>();
+
+        assert!(
+            audio_days.contains("2026-06-01"),
+            "audio snippets lost early-week context: {audio_days:?}"
+        );
+        assert!(
+            audio_days.contains("2026-06-07"),
+            "audio snippets should still include recent context: {audio_days:?}"
+        );
+        assert!(
+            audio_days.len() >= 5,
+            "audio snippets should span the week, got days {audio_days:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/screenpipe-engine/src/routes/activity_summary.rs
+++ b/crates/screenpipe-engine/src/routes/activity_summary.rs
@@ -35,7 +35,6 @@ use screenpipe_db::DatabaseManager;
 /// `total_active_minutes` so the three definitions never drift apart.
 const IDLE_CAP_SECS: i64 = 300;
 const MAX_TOP_TRANSCRIPTIONS: u32 = 20;
-const MAX_AUDIO_SEGMENTS_PER_BUCKET: u32 = 2;
 
 // ---------- query ----------
 
@@ -956,13 +955,12 @@ fn evenly_spaced_indices(len: usize, limit: usize) -> Vec<usize> {
 }
 
 /// Select useful audio from evenly sized wall-clock buckets across the
-/// requested interval. Ranking by bucket before rank gives every occupied part
-/// of the range one slot before a period gets a second, and the per-bucket cap
-/// prevents any dense meeting from consuming the context on its own.
+/// requested interval. Rows are selected in rank rounds across occupied
+/// buckets, so the whole range is represented before later ranks backfill any
+/// unused capacity. The selected rows are returned chronologically.
 fn balanced_audio_query(start: &str, end: &str, extra_filter: &str, limit: u32) -> String {
     let limit = limit.max(1);
     let last_bucket = limit - 1;
-    let per_bucket = MAX_AUDIO_SEGMENTS_PER_BUCKET;
 
     format!(
         "WITH bucketed AS ( \
@@ -987,12 +985,15 @@ fn balanced_audio_query(start: &str, end: &str, extra_filter: &str, limit: u32) 
                ORDER BY LENGTH(transcription) DESC, timestamp DESC \
              ) AS bucket_rank \
            FROM bucketed \
+         ), selected AS ( \
+           SELECT transcription, speaker, device, timestamp \
+           FROM ranked \
+           ORDER BY bucket_rank ASC, time_bucket ASC, timestamp ASC \
+           LIMIT {limit} \
          ) \
          SELECT transcription, speaker, device, timestamp \
-         FROM ranked \
-         WHERE bucket_rank <= {per_bucket} \
-         ORDER BY bucket_rank ASC, time_bucket ASC, timestamp ASC \
-         LIMIT {limit}"
+         FROM selected \
+         ORDER BY timestamp ASC"
     )
 }
 
@@ -1960,6 +1961,11 @@ mod db_tests {
         let start = "2026-06-01 00:00:00";
         let end = "2026-06-08 00:00:00";
         let core = collect_summary_core(&db, &query(None), start, end).await;
+        assert_eq!(
+            core.audio_summary.top_transcriptions.len(),
+            MAX_TOP_TRANSCRIPTIONS as usize,
+            "unused slots should be backfilled after every occupied period is represented"
+        );
         let top_days = core
             .audio_summary
             .top_transcriptions
@@ -1975,19 +1981,17 @@ mod db_tests {
             top_days.contains("2026-06-07"),
             "top transcriptions should still include recent audio: {top_days:?}"
         );
-        assert!(
-            top_days.len() >= 6,
-            "weekly audio should cover the range, got days {top_days:?}"
+        assert_eq!(
+            top_days.len(),
+            7,
+            "weekly audio should cover the full range, got days {top_days:?}"
         );
-        let final_minute_count = core
-            .audio_summary
-            .top_transcriptions
-            .iter()
-            .filter(|segment| segment.timestamp.starts_with("2026-06-07 23:59"))
-            .count();
         assert!(
-            final_minute_count <= MAX_AUDIO_SEGMENTS_PER_BUCKET as usize,
-            "one recent minute consumed the audio context: {final_minute_count} rows"
+            core.audio_summary
+                .top_transcriptions
+                .windows(2)
+                .all(|pair| pair[0].timestamp <= pair[1].timestamp),
+            "selected transcriptions should be returned chronologically"
         );
 
         let mut snippet_query = query(None);
@@ -2013,6 +2017,48 @@ mod db_tests {
             audio_days.len() >= 5,
             "audio snippets should span the week, got days {audio_days:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn audio_context_backfills_capacity_from_one_dense_period() {
+        let (db, _d) = fresh_db().await;
+        db.execute_raw_sql("INSERT INTO audio_chunks (id, file_path) VALUES (1, 'test.wav')")
+            .await
+            .unwrap();
+        db.execute_raw_sql("INSERT INTO speakers (id, name) VALUES (1, 'Alice')")
+            .await
+            .unwrap();
+
+        for second in 0..24 {
+            db.execute_raw_sql(&format!(
+                "INSERT INTO audio_transcriptions \
+                 (audio_chunk_id, offset_index, timestamp, transcription, device, speaker_id) \
+                 VALUES (1, {second}, '2026-06-07 23:59:{second:02}', \
+                 'dense meeting transcript {second:02} with enough detail for summary context', \
+                 'mic', 1)"
+            ))
+            .await
+            .unwrap();
+        }
+
+        let core = collect_summary_core(
+            &db,
+            &query(None),
+            "2026-06-01 00:00:00",
+            "2026-06-08 00:00:00",
+        )
+        .await;
+
+        assert_eq!(
+            core.audio_summary.top_transcriptions.len(),
+            MAX_TOP_TRANSCRIPTIONS as usize,
+            "a single occupied bucket should backfill all available slots"
+        );
+        assert!(core
+            .audio_summary
+            .top_transcriptions
+            .iter()
+            .all(|segment| segment.timestamp.starts_with("2026-06-07 23:59")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## description

Balances the audio context returned by `/activity-summary` across the full requested time range.

Previously, the top transcriptions and snippets could all come from one dense recent meeting. Audio is now sampled from time buckets, with each bucket capped at two segments.

Related issue: #5096

## before

A weekly summary could use most of its audio context on activity from the last few minutes.

https://github.com/user-attachments/assets/37906795-0683-47af-8f4b-1cb8f7d54114

<!-- Drag the before recording here -->

## after

Audio context represents the requested range while still including recent activity.

https://github.com/user-attachments/assets/ed52baa1-f209-4c25-b8dc-45560ed849b8


<!-- Drag the after recording here -->

## how to test

1. Run `cargo test -p screenpipe-engine weekly_audio_context_is_not_consumed_by_the_last_few_minutes -- --nocapture`.
2. Run `cargo fmt --all -- --check`.
3. Request a weekly activity summary containing older audio and a dense recent burst. Confirm that multiple days are represented and the recent bucket contributes no more than two top transcripts.

## desktop app checklist (if applicable)

Not applicable. This PR does not change Tauri commands or frontend bindings.