### PR TITLE
[codex] avoid macOS permission settings launcher panics

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -20,6 +20,33 @@ pub enum OSPermission {
     Calendar,
 }
 
+#[cfg(target_os = "macos")]
+const MACOS_OPEN_COMMAND: &str = "/usr/bin/open";
+
+#[cfg(target_os = "macos")]
+fn permission_settings_url(permission: &OSPermission) -> &'static str {
+    match permission {
+        OSPermission::ScreenRecording => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+        }
+        OSPermission::Microphone => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        }
+        OSPermission::Accessibility => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+        }
+        OSPermission::Automation => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+        }
+        OSPermission::InputMonitoring => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+        }
+        OSPermission::Calendar => {
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars"
+        }
+    }
+}
+
 #[tauri::command(async)]
 #[specta::specta]
 #[allow(unused_variables)] // permission used on macOS
@@ -28,36 +55,12 @@ pub fn open_permission_settings(permission: OSPermission) {
     {
         use std::process::Command;
 
-        match permission {
-            OSPermission::ScreenRecording => Command::new("open")
-                .arg(
-                    "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
-                )
-                .spawn()
-                .expect("Failed to open Screen Recording settings"),
-            OSPermission::Microphone => Command::new("open")
-                .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-                .spawn()
-                .expect("Failed to open Microphone settings"),
-            OSPermission::Accessibility => Command::new("open")
-                .arg(
-                    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
-                )
-                .spawn()
-                .expect("Failed to open Accessibility settings"),
-            OSPermission::Automation => Command::new("open")
-                .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
-                .spawn()
-                .expect("Failed to open Automation settings"),
-            OSPermission::InputMonitoring => Command::new("open")
-                .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")
-                .spawn()
-                .expect("Failed to open Input Monitoring settings"),
-            OSPermission::Calendar => Command::new("open")
-                .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
-                .spawn()
-                .expect("Failed to open Calendar settings"),
-        };
+        let settings_url = permission_settings_url(&permission);
+        if let Err(error) = Command::new(MACOS_OPEN_COMMAND).arg(settings_url).spawn() {
+            // Opening a settings pane is a recovery affordance. A missing or
+            // unavailable launcher must not crash onboarding or the app.
+            error!("failed to open macOS permission settings ({settings_url}): {error}");
+        }
     }
 }
 
@@ -1282,6 +1285,34 @@ mod screen_recording_preflight_tests {
             screen_recording_preflight_status(false),
             OSPermissionStatus::Denied
         );
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod permission_settings_tests {
+    use super::*;
+
+    #[test]
+    fn uses_the_absolute_macos_launcher_path() {
+        assert_eq!(MACOS_OPEN_COMMAND, "/usr/bin/open");
+    }
+
+    #[test]
+    fn maps_each_permission_to_its_system_settings_pane() {
+        let cases = [
+            (OSPermission::ScreenRecording, "Privacy_ScreenCapture"),
+            (OSPermission::Microphone, "Privacy_Microphone"),
+            (OSPermission::Accessibility, "Privacy_Accessibility"),
+            (OSPermission::Automation, "Privacy_Automation"),
+            (OSPermission::InputMonitoring, "Privacy_ListenEvent"),
+            (OSPermission::Calendar, "Privacy_Calendars"),
+        ];
+
+        for (permission, expected_pane) in cases {
+            let url = permission_settings_url(&permission);
+            assert!(url.starts_with("x-apple.systempreferences:"));
+            assert!(url.ends_with(expected_pane));
+        }
     }
 }
 


### PR DESCRIPTION
## What

- use the absolute macOS `/usr/bin/open` launcher for Privacy & Security panes;
- replace every launcher `expect` with recoverable error logging;
- centralize permission-to-settings URL mapping;
- add tests covering the launcher path and every supported permission pane.

## Why

A recent macOS onboarding diagnostic report showed a panic when opening the Automation settings pane because the `open` command could not be resolved. Opening System Settings is a recovery affordance; its failure must not crash onboarding or the app.

```text
before
permission button -> PATH lookup for `open` -> spawn error -> expect panic

after
permission button -> `/usr/bin/open` -> spawn error handled -> app remains alive
```

This is a narrow hardening change. It prevents the launcher panic but does not claim to solve the broader permission-loss/onboarding state machine tracked in #5310.

## Root cause

The command relied on an inherited `PATH` and called `.expect(...)` for all six permission panes. A GUI app can have a restricted environment, and any spawn failure crossed a Tauri command boundary as a Rust panic.

## Checks

- focused macOS permission settings tests
- `rustfmt --check` on `permissions.rs`
- `git diff --check`

## Privacy

No customer identifier, local path, or raw diagnostic content is included in this PR.
