### PR TITLE
fix(overlay): don't open timeline when dragging the shortcut reminder…

### DIFF
--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -194,6 +194,7 @@ export default function ShortcutReminderPage() {
   const handleRestartRecording = useCallback(async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (consumeDrag()) return;
     // Optimistic — Rust pushes the authoritative "fixing" immediately after.
     setHealthState("fixing");
     try {
@@ -206,6 +207,7 @@ export default function ShortcutReminderPage() {
   const handleDismissIncident = useCallback(async (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    if (consumeDrag()) return;
     try {
       await commands.overlayDismissIncident();
     } catch (err) {
@@ -213,15 +215,49 @@ export default function ShortcutReminderPage() {
     }
   }, []);
 
-  // Use Tauri's native startDragging for window movement
-  const handleMouseDown = useCallback(async (e: React.MouseEvent) => {
-    if (e.button === 0) {
-      try {
-        await getCurrentWindow().startDragging();
-      } catch {
+  // Use Tauri's native startDragging for window movement — but only once the
+  // press has actually moved past a small threshold. startDragging() hands
+  // off to the OS drag loop; a press-release with negligible movement still
+  // fires a normal DOM click on release, so without this threshold any press
+  // that starts on/near an action button (timeline, chat, restart, ...) opens
+  // that button's target the instant the user tries to drag the overlay.
+  // Mirrors the 4pt threshold already used by the native macOS overlay
+  // (DraggableHostingView in shortcut_reminder.swift).
+  const dragStateRef = useRef<{ startX: number; startY: number; dragging: boolean } | null>(null);
+  const DRAG_THRESHOLD_PX = 4;
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    if (e.button !== 0) return;
+    const state = { startX: e.clientX, startY: e.clientY, dragging: false };
+    dragStateRef.current = state;
+
+    const handleWindowMouseMove = (moveEvent: MouseEvent) => {
+      if (state.dragging) return;
+      const dx = moveEvent.clientX - state.startX;
+      const dy = moveEvent.clientY - state.startY;
+      if (Math.hypot(dx, dy) < DRAG_THRESHOLD_PX) return;
+      state.dragging = true;
+      window.removeEventListener("mousemove", handleWindowMouseMove);
+      window.removeEventListener("mouseup", handleWindowMouseUp);
+      getCurrentWindow().startDragging().catch(() => {
         // Ignore drag errors
-      }
-    }
+      });
+    };
+    const handleWindowMouseUp = () => {
+      window.removeEventListener("mousemove", handleWindowMouseMove);
+      window.removeEventListener("mouseup", handleWindowMouseUp);
+    };
+    window.addEventListener("mousemove", handleWindowMouseMove);
+    window.addEventListener("mouseup", handleWindowMouseUp);
+  }, []);
+
+  // Every action button's onClick calls this first. Returns true (and clears
+  // the drag state) if the mousedown that led to this click turned into a
+  // drag, so the caller can bail instead of e.g. opening the timeline.
+  const consumeDrag = useCallback(() => {
+    const wasDragging = dragStateRef.current?.dragging ?? false;
+    dragStateRef.current = null;
+    return wasDragging;
   }, []);
 
   // Handle close button - hide overlay permanently
@@ -229,7 +265,8 @@ export default function ShortcutReminderPage() {
     // Prevent any event bubbling that might trigger drag
     e.preventDefault();
     e.stopPropagation();
-    
+    if (consumeDrag()) return;
+
     try {
       const store = await getStore();
       const settings = await store.get<Record<string, unknown>>("settings") || {};
@@ -271,7 +308,7 @@ export default function ShortcutReminderPage() {
         style={{ background: "transparent" }}
       >
         <div
-          onMouseDown={handleMouseDown}
+          onMouseDownCapture={handleMouseDown}
           className="select-none w-full h-full border border-red-500/40 flex flex-col"
           style={{ background: "rgba(0, 0, 0, 0.88)", cursor: "grab" }}
         >
@@ -332,7 +369,7 @@ export default function ShortcutReminderPage() {
         style={{ background: "transparent" }}
       >
         <div
-          onMouseDown={handleMouseDown}
+          onMouseDownCapture={handleMouseDown}
           className="select-none w-full h-full border border-white/25 flex items-center justify-center"
           style={{
             background: "rgba(0, 0, 0, 0.88)",
@@ -362,7 +399,7 @@ export default function ShortcutReminderPage() {
         style={{ background: "transparent" }}
       >
         <div
-          onMouseDown={handleMouseDown}
+          onMouseDownCapture={handleMouseDown}
           className="select-none w-full h-full border border-green-500/40 flex items-center justify-center"
           style={{
             background: "rgba(0, 0, 0, 0.88)",
@@ -391,7 +428,7 @@ export default function ShortcutReminderPage() {
       style={{ background: "transparent" }}
     >
       <div
-        onMouseDown={handleMouseDown}
+        onMouseDownCapture={handleMouseDown}
         className="select-none w-full h-full"
         style={{ cursor: "grab" }}
       >
@@ -408,6 +445,7 @@ export default function ShortcutReminderPage() {
           <button
             onClick={(e) => {
               e.stopPropagation();
+              if (consumeDrag()) return;
               commands.showWindow("Main");
               posthog.capture("shortcut_reminder_timeline_clicked");
             }}
@@ -430,6 +468,7 @@ export default function ShortcutReminderPage() {
           <button
             onClick={(e) => {
               e.stopPropagation();
+              if (consumeDrag()) return;
               commands.showWindow("Chat");
               posthog.capture("shortcut_reminder_chat_clicked");
             }}
@@ -451,6 +490,7 @@ export default function ShortcutReminderPage() {
           <button
             onClick={(e) => {
               e.stopPropagation();
+              if (consumeDrag()) return;
               commands.showWindow({ Search: { query: null } });
               posthog.capture("shortcut_reminder_search_clicked");
             }}
@@ -493,6 +533,7 @@ export default function ShortcutReminderPage() {
             <button
               onClick={(e) => {
                 e.stopPropagation();
+                if (consumeDrag()) return;
                 commands.showNotificationInbox();
                 posthog.capture("shortcut_reminder_inbox_clicked");
               }}

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -661,7 +661,7 @@ class ShortcutReminderController: NSObject {
     static let shared = ShortcutReminderController()
 
     private var panel: NSPanel?
-    private var hostingView: NSHostingView<AnyView>?
+    private var hostingView: DraggableHostingView<AnyView>?
     private var trackingView: ReminderTrackingView?
 
     private var overlayShortcut = "⌘⌃S"
@@ -990,6 +990,15 @@ class ShortcutReminderController: NSObject {
     }
 
     private func sendAction(_ action: String) {
+        // A press that starts on a SwiftUI Button and turns into a window
+        // drag still delivers a belated action here: performDrag() moves the
+        // window under the cursor 1:1, so from the Button's own (window-
+        // relative) frame the release never left its bounds, and it fires
+        // its action once the drag's internal loop hands the event back —
+        // regardless of the local monitor already having called
+        // performDrag() for that press. Drop the action when this press was
+        // actually a drag rather than trying to out-race that internal loop.
+        if hostingView?.draggingThisPress == true { return }
         guard let cb = gShortcutCallback else { return }
         action.withCString { cb($0) }
     }
@@ -1051,6 +1060,14 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
     private var dragMonitor: Any?
     private var dragStartLocation: NSPoint = .zero
 
+    // Set once this press's movement has crossed the drag threshold below,
+    // and read by ShortcutReminderController.sendAction() to drop a belated
+    // Button action for the same press (see the comment there for why
+    // performDrag() swallowing the triggering event isn't enough on its
+    // own). Reset at the start of every new press so it never leaks into an
+    // unrelated later click.
+    private(set) var draggingThisPress = false
+
     deinit {
         if let m = dragMonitor {
             NSEvent.removeMonitor(m)
@@ -1059,6 +1076,8 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
 
     override func mouseDown(with event: NSEvent) {
         super.mouseDown(with: event)
+
+        draggingThisPress = false
 
         guard let window = window else { return }
 
@@ -1088,6 +1107,7 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
                         NSEvent.removeMonitor(m)
                         self.dragMonitor = nil
                     }
+                    self.draggingThisPress = true
                     window.performDrag(with: event)
                     return nil
                 }


### PR DESCRIPTION
## description

dragging the shortcut-reminder overlay pill (the small floating widget with the timeline/chat/search/bell icons) opened the timeline instead of just moving the window, whenever the drag started on or near an action button — most noticeably the timeline icon.

both overlay implementations had the same gap:
- **native macOS overlay** (`shortcut_reminder.swift`, macOS 13+): the existing drag-vs-click threshold logic correctly starts the OS window drag (`performDrag`), but `performDrag` moves the window under the cursor 1:1 — so from the SwiftUI button's own (window-relative) frame, the eventual release never really "left" the button, and it still fires a belated click.
- **web/Tauri overlay** (`shortcut-reminder/page.tsx`) — the only overlay on Windows/Linux, and the fallback on macOS <13 or when native init fails: there was no drag-vs-click distinction at all, so a press-release near a button fired its click regardless of intent to drag.

fix: track whether the current press actually crossed a movement threshold and became a real drag, and drop the belated button action on both platforms when it did.

related issue: #5319

## before

https://github.com/user-attachments/assets/3a1f4233-3724-473a-b203-47c20f7f25f8

## after

https://github.com/user-attachments/assets/d4d7bb98-f0bf-4ca2-ac72-5f8bd5707ddd

## how to test

1. run the app from source (`./scripts/dev/sp-dev-app` from the repo root), or a build with this branch
2. in Settings → Shortcuts → enable "toggle screenpipe overlay" to show the pill
3. click and hold on the timeline icon (left side of the pill), drag a good distance, then release — the timeline should **not** open, only the pill should move
4. plain click (no movement) on the timeline icon — timeline should open normally, confirming clicks still work

## desktop app checklist (if applicable)

n/a — no `#[tauri::command]` handlers or Rust-to-frontend types were added or changed.