### PR TITLE
fix(app): allow custom data dir in webview fs scope so chat history persists

### DIFF
--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-storage.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-storage.test.ts
@@ -297,6 +297,28 @@ describe("chat-storage bounded history", () => {
     expect(meta?.lastContentAt).toBe(200);
   });
 
+  it("re-throws and reports when the disk write fails (forbidden path, #5306)", async () => {
+    const { writeTextFile } = await import("@tauri-apps/plugin-fs");
+    vi.mocked(writeTextFile).mockRejectedValueOnce(
+      new Error("forbidden path: D:\\Users\\Evan\\.screenpipe\\chats")
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await expect(
+        saveConversationFile({
+          id: "save-fail",
+          title: "save-fail",
+          messages: [],
+          createdAt: 100,
+          updatedAt: 100,
+        })
+      ).rejects.toThrow("forbidden path");
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
   it("leaves lastViewedAt undefined for legacy files that predate unread persistence", () => {
     const meta = conversationMetaFromJson({
       id: "legacy",

--- a/apps/screenpipe-app-tauri/lib/chat-storage.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-storage.ts
@@ -103,7 +103,39 @@ function conversationFilename(id: string): string {
   return `${id.replace(/[<>:"/\\|?*]/g, "_")}.json`;
 }
 
+// One-time user-visible alert when persisting chat history fails. Saves
+// failed silently for weeks when a relocated data dir fell outside the
+// webview fs scope (#5306) — the only trace was a console-level unhandled
+// rejection. Surface the first failure so data loss is never silent again.
+let saveFailureNotified = false;
+async function notifySaveFailure(e: unknown): Promise<void> {
+  console.error("[chat-storage] failed to persist conversation:", e);
+  if (saveFailureNotified) return;
+  saveFailureNotified = true;
+  try {
+    const { toast } = await import("@/components/ui/use-toast");
+    toast({
+      title: "failed to save chat history",
+      description: String(e),
+      variant: "destructive",
+    });
+  } catch {
+    // non-UI context (tests/SSR); the console.error above still fires
+  }
+}
+
 export async function saveConversationFile(
+  conv: ChatConversation
+): Promise<void> {
+  try {
+    await saveConversationFileInner(conv);
+  } catch (e) {
+    await notifySaveFailure(e);
+    throw e;
+  }
+}
+
+async function saveConversationFileInner(
   conv: ChatConversation
 ): Promise<void> {
   const dir = await ensureChatsDir();

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1163,6 +1163,33 @@ async fn main() {
             // sidecar inherits this env).
             std::env::set_var("SCREENPIPE_DATA_DIR", &data_dir);
 
+            // The fs-plugin scope in capabilities/main.json only whitelists
+            // static locations ($HOME/.screenpipe, $APPDATA, …). A custom
+            // data dir (e.g. another drive on Windows) matches none of them,
+            // so every webview fs call into it failed with "forbidden path":
+            // chat history was never persisted, pipe-run records and the
+            // feedback log collector broke the same way (#5306). Extend the
+            // fs scope and the asset-protocol scope (media previews) at
+            // runtime to cover the resolved dir. No-op redundant grant when
+            // the dir is the default ~/.screenpipe.
+            {
+                use tauri_plugin_fs::FsExt;
+                if let Err(e) = app.fs_scope().allow_directory(&data_dir, true) {
+                    warn!(
+                        "failed to allow data dir {} in fs scope: {}",
+                        data_dir.display(),
+                        e
+                    );
+                }
+                if let Err(e) = app.asset_protocol_scope().allow_directory(&data_dir, true) {
+                    warn!(
+                        "failed to allow data dir {} in asset protocol scope: {}",
+                        data_dir.display(),
+                        e
+                    );
+                }
+            }
+
             // Enterprise builds can identify org/device health in Sentry and
             // PostHog without sending the raw license key. No-op on consumer
             // builds; explicit MDM/support env vars still win when provided.


### PR DESCRIPTION
### Description:

Fixes #5306



- Users with a relocated data dir (e.g. `D:\...\.screenpipe` on Windows) lost all chat history: the Tauri fs-plugin scope in `capabilities/main.json` only whitelists static locations (`$HOME/.screenpipe`, `$APPDATA`, ...), so every webview fs call into the custom dir failed with `forbidden path`. Chats lived only in memory and vanished on window close/reload. Pipe-run records and the feedback log collector broke the same way (that's why the reporter's log uploads contained only `[Error reading file: forbidden path]`).
- Fix: at startup, right after the data dir is resolved and `SCREENPIPE_DATA_DIR` is pinned, extend the fs scope and the asset-protocol scope at runtime to cover the resolved dir (`fs_scope().allow_directory(&data_dir, true)`). Redundant no-op for default `~/.screenpipe` users.
- Chat saves no longer fail silently: `saveConversationFile` now logs the error and shows a one-time destructive toast ("failed to save chat history") before re-throwing, so this class of data loss is never invisible again.
- Added a regression test simulating the exact reported failure (writeTextFile rejecting with `forbidden path`) asserting the save rejects and reports.
- Verified: `cargo check` clean, `tsc --noEmit` clean, `vitest` chat-storage 26/26 + pi-event-router/chat-history-injection 23/23.