### PR TITLE
fix(chat): load pi project extensions under 0.80 trust gating, teach connection gate about composio

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/connection-gate.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/connection-gate.ts
@@ -104,6 +104,8 @@ async function findMcpProviderServer(
 }
 
 async function enrichConnection(connection: ConnectionItem, signal?: AbortSignal): Promise<ConnectionItem> {
+  const composio = await composioEnrichment(connection.id, signal);
+  if (composio) return { ...connection, ...composio };
   const server = await findMcpProviderServer(connection.id, signal);
   if (!server) return connection;
   return {
@@ -111,6 +113,51 @@ async function enrichConnection(connection: ConnectionItem, signal?: AbortSignal
     connected: true,
     mcp: true,
     mcp_server_id: server.id,
+  };
+}
+
+// Gmail and Zoom connect through Composio's managed auth: the desktop app
+// registers one shared MCP server whose URL points at screenpipe.com's
+// passthrough. That server only exists after a successful connect, so its
+// presence IS the connected signal. Gmail has no /connections entry at all
+// (it is a frontend-only tile), so without this the gate tells the model
+// Gmail doesn't exist even though the tools are one sp_mcp_call away.
+const COMPOSIO_TOOLKIT_IDS = new Set(["gmail", "zoom"]);
+const COMPOSIO_URL_RE = /^https:\/\/(www\.)?(screenpipe\.com|screenpi\.pe)\/api\/composio\/mcp\/?$/;
+
+async function findComposioServer(signal?: AbortSignal): Promise<McpServerItem | null> {
+  const servers = await fetchMcpServers(signal).catch(() => []);
+  return (
+    servers.find(
+      (item) => item.enabled !== false && COMPOSIO_URL_RE.test(normalizeUrl(item.url || ""))
+    ) ?? null
+  );
+}
+
+async function composioEnrichment(
+  connectionId: string,
+  signal?: AbortSignal
+): Promise<Partial<ConnectionItem> | null> {
+  if (!COMPOSIO_TOOLKIT_IDS.has(connectionId)) return null;
+  const server = await findComposioServer(signal);
+  if (!server) return null;
+  return {
+    connected: true,
+    mcp: true,
+    mcp_server_id: server.id,
+  };
+}
+
+function composioSyntheticConnection(id: string, serverId: string): ConnectionItem {
+  const name = id === "gmail" ? "Gmail" : "Zoom";
+  return {
+    id,
+    name,
+    connected: true,
+    mcp: true,
+    mcp_server_id: serverId,
+    category: id === "gmail" ? "Communication" : "Meetings",
+    description: `${name} via Composio managed auth. Discover tools with sp_mcp_list_tools (server_id "${serverId}"), then call them with sp_mcp_call — e.g. GMAIL_* / ZOOM_* tools through COMPOSIO_SEARCH_TOOLS and COMPOSIO_MULTI_EXECUTE_TOOL.`,
   };
 }
 
@@ -179,6 +226,17 @@ export default function (pi: ExtensionAPI) {
         const enrichedConnections = await Promise.all(
           connections.map((connection) => enrichConnection(connection, signal))
         );
+        // Gmail (and Zoom, if its legacy integration ever goes away) exists
+        // only as a Composio-backed frontend tile — synthesize entries so the
+        // model learns they are reachable through the Composio MCP server.
+        const composioServer = await findComposioServer(signal);
+        if (composioServer) {
+          for (const id of COMPOSIO_TOOLKIT_IDS) {
+            if (!enrichedConnections.some((connection) => connection.id === id)) {
+              enrichedConnections.push(composioSyntheticConnection(id, composioServer.id));
+            }
+          }
+        }
         const visible = enrichedConnections
           .filter((connection) => connection.id !== "owned-default")
           .map((connection) => connectionPayload(connection, connection.id));
@@ -239,9 +297,16 @@ export default function (pi: ExtensionAPI) {
       try {
         const connections = await fetchConnections(signal).catch(() => []);
         const rawConnection = connections.find((item) => item.id === connectionId);
-        const connection = rawConnection
+        let connection = rawConnection
           ? await enrichConnection(rawConnection, signal)
           : undefined;
+        // Gmail has no /connections entry — resolve it via the Composio server.
+        if (!connection && COMPOSIO_TOOLKIT_IDS.has(connectionId)) {
+          const composioServer = await findComposioServer(signal);
+          if (composioServer) {
+            connection = composioSyntheticConnection(connectionId, composioServer.id);
+          }
+        }
         name = connectionLabel(connection, connectionId);
         if (connection?.connected === true) {
           const payload = connectionPayload(connection, connectionId);

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -1884,6 +1884,11 @@ pub async fn pi_start_inner(
     cmd.current_dir(&project_dir).args([
         "--mode",
         "rpc",
+        // pi 0.80 gates project-dir .pi/extensions behind a trust prompt that
+        // rpc mode can never answer — without --approve, mcp-bridge and
+        // connection-gate silently don't load. The project dir is created and
+        // populated exclusively by screenpipe, so it is trusted by definition.
+        "--approve",
         "--provider",
         &pi_provider,
         "--model",
@@ -4332,10 +4337,12 @@ error: InstallFailed extracting tarball"#;
         } else {
             Command::new(&pi_path)
         };
-        cmd.args(["--mode", "rpc", "--provider", provider, "--model", model])
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        cmd.args([
+            "--mode", "rpc", "--approve", "--provider", provider, "--model", model,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
         cmd.spawn().ok()
     }
 

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1425,6 +1425,12 @@ impl PiExecutor {
         // as a single string, and the long prompt text can break arg parsing
         // if flags come after it.
         cmd.arg("--mode").arg("json");
+        // pi 0.80 gates project-dir resources (.pi/extensions — mcp-bridge,
+        // connection-gate, …) behind a project-trust prompt that can never be
+        // answered in non-interactive mode, so without this flag every project
+        // extension is silently skipped. The working dir is created and
+        // populated exclusively by screenpipe, so it is trusted by definition.
+        cmd.arg("--approve");
         if continue_session {
             cmd.arg("--continue");
         } else {


### PR DESCRIPTION
### Description:

- before:

<img width="1197" height="813" alt="image" src="https://github.com/user-attachments/assets/b2056a90-e312-4e4a-a346-02eb72297389" />

- after:

https://github.com/user-attachments/assets/5c40bfdf-688b-4b49-b1bc-8d5f28b397a7


Fixes the chat agent saying "I can't access your Gmail" even with Composio connected and the server side working. Two root causes, both fixed here.

Root cause 1, the big one: pi 0.80 introduced project trust gating. Project-dir `.pi/extensions` only load when the working dir is trusted, and in rpc/json mode the trust prompt can never be shown, so pi silently skipped every project extension: mcp-bridge (the sp_mcp tools), connection-gate, web-search, save-artifact. This regressed when the pi pin moved to 0.80.6 and it broke every user-registered MCP server in chat, not just Composio. Confirmed by the trace: package extensions (subagents) still loaded while all project extensions vanished, and `~/.screenpipe/pi-config/trust.json` did not exist.

- pass `--approve` on every pi spawn (chat rpc, pipes json, title-gen rpc). The project dirs are created and populated exclusively by screenpipe, so they are trusted by definition

Root cause 2: the connection-gate extension lists `/connections`, and Gmail has no entry there (it is a frontend-only tile backed by the Composio MCP server). The gate told the model Gmail doesn't exist, and the model trusted it.

- the gate now recognizes the Composio MCP server by its screenpipe.com passthrough URL and reports Gmail and Zoom as connected via MCP, with the server id and tool guidance
- `screenpipe_connect_app("gmail")` also resolves through the Composio server instead of dead-ending

Verified: the backend chain works end to end (`/mcp-servers/composio/tools` returns Composio's tool list through the deployed passthrough). cargo check clean on screenpipe-core.

### Note for maintainer:

Takes effect on the next app build (the extension is embedded via include_str and the flag is in the spawn args). No env or config changes needed.
