### PR TITLE
fix(onboarding): remove login scrollbar

### DIFF
--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -282,7 +282,7 @@ export default function OnboardingPage() {
       <div className="w-full bg-background p-3" data-tauri-drag-region />
 
       {/* Content */}
-      <div className="flex-1 flex items-center justify-center p-6 overflow-auto">
+      <div className="flex-1 flex items-center justify-center p-6 overflow-hidden">
         <div
           className={`w-full max-w-lg mx-auto transition-opacity duration-300 ${
             isVisible ? "opacity-100" : "opacity-0"


### PR DESCRIPTION
This PR removes the unwanted scrollbar from the onboarding login screen.
The onboarding slides use fixed window sizes, so the content container should not scroll.
Tested the login screen manually; no content is clipped.


Before -
<img width="613" height="569" alt="image" src="https://github.com/user-attachments/assets/ffd9570d-ef1e-417e-a2a0-31c05862b76c" />



After -
<img width="613" height="569" alt="image" src="https://github.com/user-attachments/assets/9446e038-110b-4907-89c4-c1e0ad3d7ba2" />

