### PR TITLE
fix(app): make recently published Pi packages installable

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/pi-extensions-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/pi-extensions-card.test.tsx
@@ -157,6 +157,43 @@ describe("PiExtensionsCard", () => {
     );
   });
 
+  it("installs a recently published package directly from its compact card", async () => {
+    commandMocks.piInstallExtensionPackage.mockResolvedValueOnce({
+      status: "ok",
+      data: packageList("npm:pi-subagents", "npm:@example/pi-recent-tool"),
+    });
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        total: 1,
+        objects: [
+          {
+            package: {
+              name: "@example/pi-recent-tool",
+              description: "A newly published Pi package.",
+              date: new Date().toISOString(),
+              keywords: ["pi-package"],
+              links: {
+                npm: "https://www.npmjs.com/package/@example/pi-recent-tool",
+              },
+            },
+          },
+        ],
+      }),
+    } as Response);
+    render(<PiExtensionsCard />);
+
+    expect(await screen.findByText("Recently published")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Add Recent Tool" }));
+
+    await waitFor(() =>
+      expect(commandMocks.piInstallExtensionPackage).toHaveBeenCalledWith(
+        "npm:@example/pi-recent-tool",
+      ),
+    );
+    expect(await screen.findByRole("button", { name: "Remove Recent Tool" })).toBeInTheDocument();
+  });
+
   it("locks other extension toggles while a package change is in flight", async () => {
     let resolveInstall: (value: {
       status: "ok";

--- a/apps/screenpipe-app-tauri/components/settings/pi-extensions-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pi-extensions-card.tsx
@@ -155,31 +155,66 @@ function PiExtensionRow({
   );
 }
 
-function PiExtensionRecentCard({ item }: { item: PiExtensionCatalogItem }) {
+function PiExtensionRecentCard({
+  item,
+  enabled,
+  stale,
+  busy,
+  disabled,
+  onToggle,
+}: {
+  item: PiExtensionCatalogItem;
+  enabled: boolean;
+  stale: boolean;
+  busy: boolean;
+  disabled: boolean;
+  onToggle: (checked: boolean) => void;
+}) {
   const published = relativeDate(item.publishedAt);
+  const packageName = item.source.replace(/^npm:/, "");
+  const action = stale ? "repair" : enabled ? "remove" : "add";
 
   return (
-    <button
-      type="button"
-      onClick={() => openUrl(item.npmUrl)}
-      className="min-w-0 border border-border bg-card p-3 text-left transition-colors hover:border-foreground/30 hover:bg-muted/30"
-    >
+    <article className="flex min-h-[132px] min-w-0 flex-col border border-border bg-card p-3 transition-colors hover:border-foreground/30">
       <div className="flex items-start justify-between gap-2">
         <span className="min-w-0 truncate font-mono text-xs font-medium text-foreground">
-          {item.source.replace(/^npm:/, "")}
+          {packageName}
         </span>
-        <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+        <button
+          type="button"
+          onClick={() => openUrl(item.npmUrl)}
+          aria-label={`Open ${item.name} on npm`}
+          className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ExternalLink className="h-3 w-3" />
+        </button>
       </div>
       <p className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-muted-foreground">
         {item.summary}
       </p>
-      {published && (
-        <span className="mt-2 inline-flex items-center gap-1 text-[10px] text-muted-foreground">
-          <Clock3 className="h-3 w-3" />
-          {published}
-        </span>
-      )}
-    </button>
+      <div className="mt-auto flex items-end justify-between gap-2 pt-2">
+        {published ? (
+          <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+            <Clock3 className="h-3 w-3" />
+            {published}
+          </span>
+        ) : (
+          <span />
+        )}
+        <Button
+          type="button"
+          variant={enabled && !stale ? "ghost" : "outline"}
+          size="sm"
+          disabled={disabled || busy}
+          onClick={() => onToggle(stale || !enabled)}
+          aria-label={`${action.charAt(0).toUpperCase()}${action.slice(1)} ${item.name}`}
+          className="h-6 px-2 text-[10px] uppercase tracking-[0.12em]"
+        >
+          {busy && <Loader2 className="h-3 w-3 animate-spin" />}
+          {action}
+        </Button>
+      </div>
+    </article>
   );
 }
 
@@ -467,9 +502,20 @@ export function PiExtensionsCard({ onChanged }: { onChanged?: () => void }) {
                 </span>
               </div>
               <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4">
-                {recentRegistryItems.map((item) => (
-                  <PiExtensionRecentCard key={`recent-${item.id}`} item={item} />
-                ))}
+                {recentRegistryItems.map((item) => {
+                  const normalized = normalizePiPackageSource(item.source);
+                  return (
+                    <PiExtensionRecentCard
+                      key={`recent-${item.id}`}
+                      item={item}
+                      enabled={configuredSources.has(normalized)}
+                      stale={missingSources.has(normalized)}
+                      busy={busySource === item.source}
+                      disabled={changingPackage && busySource !== item.source}
+                      onToggle={(checked) => togglePackage(item, checked)}
+                    />
+                  );
+                })}
               </div>
             </div>
           )}


### PR DESCRIPTION
## problem

The compact **Recently published** cards only opened npm. Unlike the full package rows below them, they had no way to install a package, so the section was a dead end inside Screenpipe.

## fix

- add explicit `add`, `remove`, and `repair` actions to recent package cards
- route those actions through the existing safe Pi install/remove commands
- keep the npm link as a separate action
- share the existing in-flight package lock and status refresh behavior
- cover direct installation from the compact card with a regression test

## visual

```text
RECENTLY PUBLISHED                                      from npm
┌────────────────────────┐  ┌────────────────────────┐
│ @oas-framework/pi    ↗ │  │ @bacnh85/pi-subagent ↗│
│ runtime bridge...      │  │ in-process agents...   │
│ ◷ 13m ago        [ADD] │  │ ◷ 19m ago      REMOVE │
└────────────────────────┘  └────────────────────────┘
```

## verification

- `bunx vitest run --config vitest.config.ts components/settings/__tests__/pi-extensions-card.test.tsx lib/__tests__/pi-extension-catalog.test.ts` — 14 tests passed
- `bun run typecheck`
- `bunx eslint components/settings/pi-extensions-card.tsx components/settings/__tests__/pi-extensions-card.test.tsx`
- `git diff --check`

No backend command or release behavior changed.
