### PR TITLE
fix(enterprise): fail closed for encrypted customer uploads

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise/sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise/sync.rs
@@ -41,8 +41,9 @@ use tracing::{debug, error, info, warn};
 #[path = "upload.rs"]
 mod enterprise_upload;
 use enterprise_upload::{
-    upload_direct_encrypted_batch, upload_direct_readable_batch, DirectUploadCursors,
-    DirectUploadRecordCounts, EnterpriseUploadMode,
+    scrub_direct_upload_secrets_from_environment, upload_direct_encrypted_batch,
+    upload_direct_readable_batch, DirectUploadCursors, DirectUploadRecordCounts,
+    EnterpriseUploadMode,
 };
 
 /// How often we wake up and try to sync.
@@ -142,21 +143,27 @@ impl EnterpriseSyncConfig {
             .ok()
             .filter(|s| !s.trim().is_empty())
             .unwrap_or_else(|| DEFAULT_INGEST_URL.to_string());
-        // Honor an explicit env override at boot for MDM / dev / test flows.
-        // Fail-closed semantics: if the operator explicitly set a mode and
-        // it can't be honored (invalid keys etc.), refuse to start sync — a
-        // silent fallback to plaintext could leak data. When no override is
-        // set we start in HostedIngest and let `resolve_upload_mode` ask
-        // the control plane what this license is actually configured for.
+        // Honor only an enforceable non-default env override at boot for MDM /
+        // dev / test flows. Otherwise start blocked until the control plane
+        // positively resolves the license policy. Starting in HostedIngest
+        // could transmit plaintext during a policy-lookup outage before the
+        // hosted route has a chance to reject the request.
         let explicit_mode = std::env::var("SCREENPIPE_ENTERPRISE_UPLOAD_MODE")
             .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty() && s != "auto");
+            .map(|s| s.trim().to_ascii_lowercase())
+            .filter(|s| {
+                !s.is_empty() && s != "auto" && s != "screenpipe_write" && s != "hosted_ingest"
+            });
         let upload_mode = if explicit_mode.is_some() {
             EnterpriseUploadMode::from_env(&ingest_url)?
         } else {
-            EnterpriseUploadMode::HostedIngest
+            EnterpriseUploadMode::Blocked(
+                "enterprise upload mode has not been resolved by the control plane".to_string(),
+            )
         };
+        if matches!(&upload_mode, EnterpriseUploadMode::DirectEncrypted(_)) {
+            scrub_direct_upload_secrets_from_environment();
+        }
         let cursor_path = app_data_dir.join(CURSOR_FILENAME);
         Some(Self {
             license_key,
@@ -179,8 +186,28 @@ impl EnterpriseSyncConfig {
     /// → uploads start" flow possible without any env-var setup on the
     /// customer's machine.
     pub async fn resolve_upload_mode(&mut self) {
-        let resolved = EnterpriseUploadMode::resolve(&self.license_key, &self.ingest_url).await;
-        self.upload_mode = resolved;
+        if let Some(resolved) =
+            EnterpriseUploadMode::resolve(&self.license_key, &self.ingest_url).await
+        {
+            if matches!(
+                &self.upload_mode,
+                EnterpriseUploadMode::DirectEncrypted(_)
+            ) && matches!(&resolved, EnterpriseUploadMode::Blocked(_))
+            {
+                // Root keys are deliberately scrubbed from the process
+                // environment after first load so child agents cannot inherit
+                // them. Keep the already-loaded encrypted config instead of
+                // treating the scrubbed env as a downgrade or outage.
+                return;
+            }
+            self.upload_mode = resolved;
+            if matches!(
+                &self.upload_mode,
+                EnterpriseUploadMode::DirectEncrypted(_)
+            ) {
+                scrub_direct_upload_secrets_from_environment();
+            }
+        }
     }
 }
 
@@ -466,6 +493,8 @@ pub enum EnterpriseSyncError {
     IngestServerError(u16),
     #[error("control-plane network error: {0}")]
     Network(String),
+    #[error("enterprise upload configuration blocked: {0}")]
+    Configuration(String),
     #[error("io: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -696,6 +725,10 @@ pub async fn run_one_sync(
     local: &dyn LocalApiClient,
     http: &reqwest::Client,
 ) -> Result<SyncTickReport, EnterpriseSyncError> {
+    if let EnterpriseUploadMode::Blocked(reason) = &cfg.upload_mode {
+        return Err(EnterpriseSyncError::Configuration(reason.clone()));
+    }
+
     // First-run safeguard: if cursor is empty, backfill SAFE_BACKFILL only —
     // not the entire DB. An enterprise customer enrolling a long-running
     // device shouldn't dump 6 months of personal history upstream.
@@ -863,6 +896,9 @@ pub async fn run_one_sync(
                 DirectUploadCursors::from_cursor(&next_cursor),
             )
             .await?;
+        }
+        EnterpriseUploadMode::Blocked(reason) => {
+            return Err(EnterpriseSyncError::Configuration(reason.clone()));
         }
     }
 
@@ -1372,6 +1408,16 @@ async fn fulfill_log_requests(
     http: &reqwest::Client,
     already_handled: Option<&str>,
 ) -> Option<String> {
+    // Customer-storage modes promise that telemetry bodies stay out of
+    // Screenpipe Cloud. Diagnostic logs are bodies too, so remote support-log
+    // collection is disabled unless the resolved policy explicitly uses
+    // hosted ingest. The server applies the same gate before queuing/serving a
+    // request.
+    if !matches!(cfg.upload_mode, EnterpriseUploadMode::HostedIngest) {
+        debug!("log-requests: disabled for customer-storage or unresolved mode");
+        return None;
+    }
+
     let base = control_plane_base(&cfg.ingest_url)?;
     let url = format!("{base}/api/enterprise/log-requests");
 
@@ -1454,7 +1500,7 @@ fn enterprise_http_client() -> reqwest::Client {
 }
 
 pub async fn run(
-    cfg: EnterpriseSyncConfig,
+    mut cfg: EnterpriseSyncConfig,
     local: Arc<dyn LocalApiClient>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) {
@@ -1474,6 +1520,10 @@ pub async fn run(
     ));
 
     loop {
+        // Re-resolve before touching local telemetry. This picks up a live
+        // hosted-to-customer-storage policy change without requiring an app
+        // restart, and preserves the last safe mode on lookup failure.
+        cfg.resolve_upload_mode().await;
         let result = run_one_sync(&cfg, &mut cursor, local.as_ref(), &http).await;
 
         match &result {
@@ -1674,6 +1724,20 @@ mod tests {
         let empty: LogRequestsResponse = serde_json::from_str(r#"{}"#).unwrap();
         assert!(!empty.requested);
         assert!(empty.requested_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn customer_storage_mode_never_collects_remote_diagnostic_logs() {
+        let dir = TempDir::new().unwrap();
+        let cfg = direct_test_cfg(
+            &dir,
+            "http://should-not-be-called/ticket".to_string(),
+            "http://should-not-be-called/complete".to_string(),
+        );
+
+        let handled = fulfill_log_requests(&cfg, &reqwest::Client::new(), None).await;
+
+        assert!(handled.is_none());
     }
 
     #[tokio::test]
@@ -2126,10 +2190,7 @@ mod tests {
                 .expect("license set, must yield Some");
         assert_eq!(cfg.ingest_url, DEFAULT_INGEST_URL);
         assert_eq!(cfg.license_key, "sek_test");
-        assert!(matches!(
-            cfg.upload_mode,
-            EnterpriseUploadMode::HostedIngest
-        ));
+        assert!(matches!(cfg.upload_mode, EnterpriseUploadMode::Blocked(_)));
 
         // Case 4: ingest url override is respected.
         std::env::set_var("SCREENPIPE_ENTERPRISE_INGEST_URL", "https://staging/ingest");
@@ -2181,7 +2242,12 @@ mod tests {
             EnterpriseUploadMode::DirectReadable(_) => {
                 panic!("expected encrypted direct upload mode")
             }
+            EnterpriseUploadMode::Blocked(reason) => panic!("unexpected blocked mode: {reason}"),
         }
+        assert!(std::env::var("SCREENPIPE_ENTERPRISE_DIRECT_UPLOAD_ROOT_KEY_B64").is_err());
+        assert!(
+            std::env::var("SCREENPIPE_ENTERPRISE_DIRECT_UPLOAD_RECOVERY_ROOT_KEY_B64").is_err()
+        );
 
         // Case 6: readable direct upload does not require customer-held root keys.
         std::env::set_var(
@@ -2204,6 +2270,7 @@ mod tests {
             EnterpriseUploadMode::DirectEncrypted(_) => {
                 panic!("expected readable direct upload mode")
             }
+            EnterpriseUploadMode::Blocked(reason) => panic!("unexpected blocked mode: {reason}"),
         }
 
         // Case 7: encrypted direct upload without a valid root key fails closed.
@@ -2356,6 +2423,23 @@ mod tests {
             upload_mode: EnterpriseUploadMode::HostedIngest,
             log_dirs: vec![dir.path().to_path_buf()],
         }
+    }
+
+    #[tokio::test]
+    async fn unresolved_mode_blocks_before_reading_local_telemetry() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_cfg(&dir, "http://should-not-be-called".to_string());
+        cfg.upload_mode = EnterpriseUploadMode::Blocked("policy unresolved".to_string());
+        let local = MockLocal::new(Vec::new(), Vec::new());
+        let mut cursor = Cursor::default();
+
+        let error = run_one_sync(&cfg, &mut cursor, &local, &reqwest::Client::new())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, EnterpriseSyncError::Configuration(_)));
+        assert!(cursor.last_frame_ts.is_none());
+        assert!(local.last_frames_since.lock().unwrap().is_none());
     }
 
     fn direct_test_cfg(

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise/sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise/sync.rs
@@ -1408,13 +1408,14 @@ async fn fulfill_log_requests(
     http: &reqwest::Client,
     already_handled: Option<&str>,
 ) -> Option<String> {
-    // Customer-storage modes promise that telemetry bodies stay out of
-    // Screenpipe Cloud. Diagnostic logs are bodies too, so remote support-log
-    // collection is disabled unless the resolved policy explicitly uses
-    // hosted ingest. The server applies the same gate before queuing/serving a
-    // request.
-    if !matches!(cfg.upload_mode, EnterpriseUploadMode::HostedIngest) {
-        debug!("log-requests: disabled for customer-storage or unresolved mode");
+    // Only strict encrypted/no-read storage disables remote support logs.
+    // Existing readable customer-storage orgs deliberately grant Screenpipe
+    // read access so cloud pipes and support workflows continue to work.
+    if matches!(
+        cfg.upload_mode,
+        EnterpriseUploadMode::DirectEncrypted(_) | EnterpriseUploadMode::Blocked(_)
+    ) {
+        debug!("log-requests: disabled for strict no-read or unresolved mode");
         return None;
     }
 
@@ -1727,13 +1728,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn customer_storage_mode_never_collects_remote_diagnostic_logs() {
+    async fn strict_customer_storage_never_collects_remote_diagnostic_logs() {
         let dir = TempDir::new().unwrap();
         let cfg = direct_test_cfg(
             &dir,
             "http://should-not-be-called/ticket".to_string(),
             "http://should-not-be-called/complete".to_string(),
         );
+
+        let handled = fulfill_log_requests(&cfg, &reqwest::Client::new(), None).await;
+
+        assert!(handled.is_none());
+    }
+
+    #[tokio::test]
+    async fn readable_customer_storage_keeps_remote_diagnostic_logs_available() {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/api/enterprise/log-requests"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "requested": false })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let mut cfg = readable_direct_test_cfg(
+            &dir,
+            "http://should-not-be-called/ticket".to_string(),
+            "http://should-not-be-called/complete".to_string(),
+        );
+        cfg.ingest_url = format!("{}/api/enterprise/ingest", server.uri());
 
         let handled = fulfill_log_requests(&cfg, &reqwest::Client::new(), None).await;
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise/upload.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise/upload.rs
@@ -35,6 +35,19 @@ const DIRECT_UPLOAD_MODE: &str = "direct_upload_encrypted";
 const DIRECT_UPLOAD_READABLE_MODE: &str = "direct_upload_readable";
 const DIRECT_UPLOAD_MAX_RETRIES: u32 = 3;
 const DIRECT_UPLOAD_INITIAL_BACKOFF: Duration = Duration::from_secs(2);
+const DIRECT_UPLOAD_SECRET_ENV_VARS: [&str; 2] = [
+    "SCREENPIPE_ENTERPRISE_DIRECT_UPLOAD_ROOT_KEY_B64",
+    "SCREENPIPE_ENTERPRISE_DIRECT_UPLOAD_RECOVERY_ROOT_KEY_B64",
+];
+
+/// Remove customer root keys after loading them into the in-memory upload
+/// config. Child agents inherit the app environment by default; leaving these
+/// values there would let an unrelated pipe or agent read the decryption keys.
+pub fn scrub_direct_upload_secrets_from_environment() {
+    for name in DIRECT_UPLOAD_SECRET_ENV_VARS {
+        std::env::remove_var(name);
+    }
+}
 
 impl From<SyncError> for EnterpriseSyncError {
     fn from(value: SyncError) -> Self {
@@ -68,6 +81,10 @@ pub enum EnterpriseUploadMode {
     HostedIngest,
     DirectEncrypted(DirectUploadConfig),
     DirectReadable(DirectUploadConfig),
+    /// The control plane requires customer-held encryption, but this device
+    /// cannot satisfy that contract. Keep sync alive so policy can recover,
+    /// while refusing every telemetry upload until the configuration is fixed.
+    Blocked(String),
 }
 
 impl EnterpriseUploadMode {
@@ -78,6 +95,7 @@ impl EnterpriseUploadMode {
             Self::HostedIngest => "hosted_ingest",
             Self::DirectEncrypted(_) => "direct_encrypted",
             Self::DirectReadable(_) => "direct_readable",
+            Self::Blocked(_) => "blocked",
         }
     }
 }
@@ -104,11 +122,10 @@ impl EnterpriseUploadMode {
     /// on every device — the storage binding in the dashboard is the
     /// single source of truth.
     ///
-    /// Fails open to `HostedIngest` on any error (network down, license
-    /// invalid, server flake). The legacy env-var override is still
-    /// honored for advanced/test scenarios when explicitly set to
-    /// anything other than the default `screenpipe_write`.
-    pub async fn resolve(license_key: &str, ingest_url: &str) -> Self {
+    /// Returns `None` on a transient control-plane failure so the caller can
+    /// preserve its last known mode. A strict encrypted response never
+    /// downgrades: missing or invalid customer keys produce `Blocked`.
+    pub async fn resolve(license_key: &str, ingest_url: &str) -> Option<Self> {
         // Explicit env override — for MDM rollouts and local testing.
         // Only takes effect when set to a non-default value; the empty /
         // default case falls through to server resolution.
@@ -125,12 +142,32 @@ impl EnterpriseUploadMode {
                          SCREENPIPE_ENTERPRISE_UPLOAD_MODE env override ({})",
                         normalized
                     );
-                    return mode;
+                    return Some(mode);
                 }
+                return Some(Self::Blocked(format!(
+                    "explicit enterprise upload mode '{normalized}' could not be configured"
+                )));
             }
         }
 
         match fetch_desired_mode_from_server(license_key, ingest_url).await {
+            Ok(ServerModeHint::DirectUploadEncrypted) => {
+                if let Some(mode) = Self::build_direct_encrypted(ingest_url) {
+                    tracing::info!(
+                        "enterprise sync: server requires customer-encrypted direct upload"
+                    );
+                    Some(mode)
+                } else {
+                    tracing::error!(
+                        "enterprise sync: strict encrypted direct upload is active, but the \
+                         customer-held primary or recovery key is missing or invalid; uploads blocked"
+                    );
+                    Some(Self::Blocked(
+                        "strict encrypted direct upload requires valid customer-held primary and recovery keys"
+                            .to_string(),
+                    ))
+                }
+            }
             Ok(ServerModeHint::DirectUpload) => {
                 // Encrypted if MDM root keys are present, readable
                 // otherwise. Same logic the env path uses; just gated by
@@ -141,7 +178,7 @@ impl EnterpriseUploadMode {
                             "enterprise sync: server requested direct upload + MDM keys \
                              present → direct_upload_encrypted"
                         );
-                        return mode;
+                        return Some(mode);
                     }
                     tracing::warn!(
                         "enterprise sync: server requested direct upload + MDM keys present \
@@ -151,19 +188,21 @@ impl EnterpriseUploadMode {
                 tracing::info!(
                     "enterprise sync: server requested direct upload → direct_upload_readable"
                 );
-                Self::DirectReadable(DirectUploadConfig::without_recipients(ingest_url))
+                Some(Self::DirectReadable(
+                    DirectUploadConfig::without_recipients(ingest_url),
+                ))
             }
             Ok(ServerModeHint::HostedIngest) => {
                 tracing::info!("enterprise sync: server requested hosted_ingest");
-                Self::HostedIngest
+                Some(Self::HostedIngest)
             }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
                     "enterprise sync: control-plane mode lookup failed; \
-                     defaulting to hosted_ingest (will retry next batch)"
+                     preserving the last known upload mode (will retry next batch)"
                 );
-                Self::HostedIngest
+                None
             }
         }
     }
@@ -283,6 +322,7 @@ impl EnterpriseUploadMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ServerModeHint {
     DirectUpload,
+    DirectUploadEncrypted,
     HostedIngest,
 }
 
@@ -321,8 +361,13 @@ async fn fetch_desired_mode_from_server(
         .json()
         .await
         .map_err(|e| EnterpriseSyncError::Network(format!("mode response parse failed: {e}")))?;
-    match parsed.desired_mode.trim().to_ascii_lowercase().as_str() {
+    parse_server_mode_hint(&parsed.desired_mode)
+}
+
+fn parse_server_mode_hint(raw: &str) -> Result<ServerModeHint, EnterpriseSyncError> {
+    match raw.trim().to_ascii_lowercase().as_str() {
         "direct_upload" => Ok(ServerModeHint::DirectUpload),
+        "direct_upload_encrypted" => Ok(ServerModeHint::DirectUploadEncrypted),
         "hosted_ingest" | "screenpipe_write" | "" => Ok(ServerModeHint::HostedIngest),
         other => Err(EnterpriseSyncError::Network(format!(
             "unknown desired_mode '{other}' from control plane"
@@ -698,6 +743,22 @@ mod tests {
         assert_eq!(
             EnterpriseUploadMode::DirectEncrypted(direct_cfg()).label(),
             "direct_encrypted"
+        );
+        assert_eq!(
+            EnterpriseUploadMode::Blocked("missing customer key".to_string()).label(),
+            "blocked"
+        );
+    }
+
+    #[test]
+    fn strict_server_mode_is_distinct_from_legacy_direct_upload() {
+        assert_eq!(
+            parse_server_mode_hint("direct_upload_encrypted").unwrap(),
+            ServerModeHint::DirectUploadEncrypted
+        );
+        assert_eq!(
+            parse_server_mode_hint("direct_upload").unwrap(),
+            ServerModeHint::DirectUpload
         );
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise/upload.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise/upload.rs
@@ -168,6 +168,14 @@ impl EnterpriseUploadMode {
                     ))
                 }
             }
+            Ok(ServerModeHint::DirectUploadReadable) => {
+                tracing::info!(
+                    "enterprise sync: server requires readable customer storage for cloud processing"
+                );
+                Some(Self::DirectReadable(
+                    DirectUploadConfig::without_recipients(ingest_url),
+                ))
+            }
             Ok(ServerModeHint::DirectUpload) => {
                 // Encrypted if MDM root keys are present, readable
                 // otherwise. Same logic the env path uses; just gated by
@@ -323,6 +331,7 @@ impl EnterpriseUploadMode {
 enum ServerModeHint {
     DirectUpload,
     DirectUploadEncrypted,
+    DirectUploadReadable,
     HostedIngest,
 }
 
@@ -368,6 +377,7 @@ fn parse_server_mode_hint(raw: &str) -> Result<ServerModeHint, EnterpriseSyncErr
     match raw.trim().to_ascii_lowercase().as_str() {
         "direct_upload" => Ok(ServerModeHint::DirectUpload),
         "direct_upload_encrypted" => Ok(ServerModeHint::DirectUploadEncrypted),
+        "direct_upload_readable" => Ok(ServerModeHint::DirectUploadReadable),
         "hosted_ingest" | "screenpipe_write" | "" => Ok(ServerModeHint::HostedIngest),
         other => Err(EnterpriseSyncError::Network(format!(
             "unknown desired_mode '{other}' from control plane"
@@ -759,6 +769,10 @@ mod tests {
         assert_eq!(
             parse_server_mode_hint("direct_upload").unwrap(),
             ServerModeHint::DirectUpload
+        );
+        assert_eq!(
+            parse_server_mode_hint("direct_upload_readable").unwrap(),
+            ServerModeHint::DirectUploadReadable
         );
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
@@ -811,10 +811,6 @@ mod imp {
 
         let (tx, rx) = tokio::sync::watch::channel(false);
         tauri::async_runtime::spawn(async move {
-            // Small startup delay so the local screenpipe server is up before
-            // we hammer it. Mirrors calendar publisher's `sleep(10)`.
-            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
-
             // Ask the control plane what upload mode this license should run
             // in. Replaces the old "set SCREENPIPE_ENTERPRISE_UPLOAD_MODE on
             // every customer machine" UX — the dashboard binding is now the
@@ -826,6 +822,12 @@ mod imp {
                 "enterprise sync: resolved upload mode = {}",
                 cfg.upload_mode.label()
             );
+
+            // Small startup delay so the local screenpipe server is up before
+            // we hammer it. Mode resolution runs first so customer root keys
+            // are removed from the process environment before child agents
+            // can inherit them.
+            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
             ee_sync::run(cfg, local, rx).await;
         });


### PR DESCRIPTION
## Phase 1: encrypted customer archive

This desktop change makes strict customer storage fail closed.

```text
local telemetry -> encrypt on device -> customer S3 or S3-compatible storage
                         |
                         +-> manifest and operational metadata -> Screenpipe control plane
```

Screenpipe Cloud does not receive the telemetry body or customer root keys. The desktop refuses to read or upload local telemetry until the control plane resolves an exact mode, and strict mode never downgrades to readable or Screenpipe-hosted storage.

Companion control-plane PR: screenpipe/website#549

## Behavior

| Server mode | Desktop behavior | Screenpipe-hosted processing |
|---|---|---|
| direct_upload_encrypted | encrypt locally; upload ciphertext only; fail closed on missing keys | unavailable |
| direct_upload_readable | upload readable JSONL to customer storage | cloud pipes, Workflow Studio, and support remain compatible |
| direct_upload | legacy behavior retained | retained for existing deployments |

Strict mode also:

- removes customer primary and recovery keys from the process environment after loading them
- preserves the last safe resolved mode during transient lookup failures
- re-resolves policy before each telemetry tick
- disables remote diagnostic-log collection
- blocks frame fulfillment for Screenpipe-hosted processors

## Verification

Rebased onto current main at app v2.5.130.

- 75 Enterprise-filtered app tests passed
- 18 Enterprise sync integration tests passed
- encrypted batches contain no plaintext and decrypt only with the customer key
- unresolved policy blocks before reading local telemetry
- strict customer storage blocks remote diagnostic logs
- readable customer storage retains its existing support behavior
- git diff --check passed

The previous red Ubuntu and Windows/Linux E2E jobs were outside this three-file diff: a transient SQLite table lock and search admission stress expectations. Current CI is rerunning on the rebased head.

## Deployment order

1. Merge and release this desktop change.
2. Apply and deploy screenpipe/website#549 and its binding-mode migration.
3. Validate a synthetic canary against customer-owned write-only storage.
4. Expand only after ciphertext, manifest, denial, recovery, and retention checks pass.

## Boundary

This phase is a centralized encrypted archive, not a centrally queryable Company Brain. Cloud pipes and Workflow Studio remain unavailable until a customer-hosted decrypt/query runner exists.

Screenpipe still sees manifests and operational metadata. A signed BAA, security/legal review, key-custody and recovery runbooks, and a synthetic end-to-end canary remain required before any PHI workload.
