### PR TITLE
test: serialize shared-pool E2E search requests

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/api-search-stress.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/api-search-stress.spec.ts
@@ -12,6 +12,14 @@ import {
   waitForLocalApi,
 } from "../helpers/api-utils.js";
 
+async function runSerially<T>(requests: Array<() => Promise<T>>): Promise<T[]> {
+  const results: T[] = [];
+  for (const request of requests) {
+    results.push(await request());
+  }
+  return results;
+}
+
 describe("Local API search and stability", function () {
   this.timeout(240_000);
 
@@ -447,12 +455,13 @@ describe("Local API search and stability", function () {
     expectNoServerError(res, "public audio status");
   });
 
-  it("handles 20 concurrent authenticated search requests", async function () {
+  it("handles 20 authenticated searches within the SQLite concurrency budget", async function () {
     if (!key) this.skip();
-    const requests = Array.from({ length: 20 }, (_, i) =>
-      authedGet(`/search?limit=1&q=concurrent-${i}`),
+    const requests = Array.from(
+      { length: 20 },
+      (_, i) => () => authedGet(`/search?limit=1&q=concurrent-${i}`),
     );
-    const results = await Promise.all(requests);
+    const results = await runSerially(requests);
     const unexpectedErrors = results.filter(
       (res) => !res.ok && !isSearchBusyResponse(res),
     );
@@ -490,25 +499,38 @@ describe("Local API search and stability", function () {
 
   it("handles mixed readonly API load while the UI stays responsive", async function () {
     if (!key) this.skip();
-    const endpoints = [
-      "/health",
+    // Uncached searches share the SQLite read pool and its route admission
+    // budget. Keep that subgroup serial while unrelated readonly APIs still
+    // apply concurrent load and exercise UI responsiveness.
+    const sharedPoolEndpoints = [
       "/search?limit=1&content_type=ocr",
       "/search?limit=1&content_type=audio",
+    ];
+    const otherEndpoints = [
+      "/health",
       "/audio/device/status",
       "/vision/status",
       "/meetings/status",
     ];
-    const results = await Promise.all(
-      Array.from({ length: 4 }, () => endpoints)
-        .flat()
-        .map(async (path) => ({
-          path,
-          response:
-            path === "/health" || path === "/audio/device/status"
-              ? await fetchJson(apiUrl(path))
-              : await authedGet(path),
-        })),
-    );
+    const [otherResults, sharedPoolResults] = await Promise.all([
+      Promise.all(
+        Array.from({ length: 4 }, () => otherEndpoints)
+          .flat()
+          .map(async (path) => ({
+            path,
+            response:
+              path === "/health" || path === "/audio/device/status"
+                ? await fetchJson(apiUrl(path))
+                : await authedGet(path),
+          })),
+      ),
+      runSerially(
+        Array.from({ length: 4 }, () => sharedPoolEndpoints)
+          .flat()
+          .map((path) => async () => ({ path, response: await authedGet(path) })),
+      ),
+    ]);
+    const results = [...otherResults, ...sharedPoolResults];
     const unexpectedErrors = results.filter(
       ({ path, response }) =>
         !response.ok &&

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-system-integration.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-system-integration.spec.ts
@@ -438,26 +438,41 @@ $uniqueNames = @($names | Sort-Object -Unique)
     if (!isWindows || !api) this.skip();
 
     const started = Date.now();
-    const requests = [
-      ...Array.from({ length: 12 }, async () => ({
-        kind: "health" as const,
-        response: await fetchJson(apiUrl(api!, "/health")),
-      })),
-      ...Array.from({ length: 8 }, (_, i) =>
-        fetchJson(
-          apiUrl(api!, `/search?limit=1&q=windows-load-${i}`),
-          authHeaders(api!.key),
-        ).then((response) => ({ kind: "search" as const, response })),
+    const runSearches = async () => {
+      const results = [];
+      // Uncached searches share the SQLite read pool. Windows CI uses a pool
+      // size whose route admission budget is one, so keep this group serial
+      // while health and vision requests continue exercising the API in parallel.
+      for (let i = 0; i < 8; i += 1) {
+        results.push({
+          kind: "search" as const,
+          response: await fetchJson(
+            apiUrl(api!, `/search?limit=1&q=windows-load-${i}`),
+            authHeaders(api!.key),
+          ),
+        });
+      }
+      return results;
+    };
+    const [healthResults, searchResults, visionResults] = await Promise.all([
+      Promise.all(
+        Array.from({ length: 12 }, async () => ({
+          kind: "health" as const,
+          response: await fetchJson(apiUrl(api!, "/health")),
+        })),
       ),
-      ...Array.from({ length: 4 }, async () => ({
-        kind: "vision" as const,
-        response: await fetchJson(
-          apiUrl(api!, "/vision/status"),
-          authHeaders(api!.key),
-        ),
-      })),
-    ];
-    const results = await Promise.all(requests);
+      runSearches(),
+      Promise.all(
+        Array.from({ length: 4 }, async () => ({
+          kind: "vision" as const,
+          response: await fetchJson(
+            apiUrl(api!, "/vision/status"),
+            authHeaders(api!.key),
+          ),
+        })),
+      ),
+    ]);
+    const results = [...healthResults, ...searchResults, ...visionResults];
     const elapsed = Date.now() - started;
 
     expect(elapsed).toBeLessThan(t(30_000));


### PR DESCRIPTION
## Summary

- serialize SQLite-backed search request groups in the Windows mixed-load and cross-platform API stress tests
- keep health, vision, audio-status, meetings, and other readonly requests concurrent
- align the tests with the pool-derived search route admission budget

## Failure

The existing E2E tests launched distinct uncached searches at once. The route correctly rejected excess cache misses with HTTP 503 and `search is busy — retry shortly`, so the Windows test failed repeatedly and the Linux API stress spec failed after its retries.

Original Windows failure: https://github.com/screenpipe/screenpipe/actions/runs/29863837504/job/88746980341?pr=5321

Follow-up Linux failure: https://github.com/screenpipe/screenpipe/actions/runs/29875579106/job/88785280296

## Before / after

```text
Before:  uncached searches ──parallel──> SQLite admission budget ──> 503s

After:   uncached searches ──serial────> SQLite admission budget ──> success
         non-SQLite health/vision/audio/meetings load remains parallel
```

## Validation

- targeted TypeScript check for both changed E2E specs
- `git diff --check`
- Windows E2E `Run E2E Tests` passed on the first CI revision

The full E2E TypeScript project check remains blocked by unrelated existing errors in `updater-harness.ts` and `pipes.spec.ts`.