### PR TITLE
fix(sidebar): pipe session cleanup

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/chat-sidebar-grouping.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/chat-sidebar-grouping.test.ts
@@ -411,14 +411,14 @@ describe("buildSidebarRecentsSections", () => {
 // ── listMoveTargetGroups ─────────────────────────────────────────────
 
 describe("listMoveTargetGroups", () => {
-  it("lists manual groups before recurring pipe groups", () => {
+  it("lists only manual groups, not auto pipe groups", () => {
     const result = listMoveTargetGroups([
       s("a", "chat", undefined, "work"),
       s("p1", "daily #1", "daily"),
       s("p2", "daily #2", "daily"),
       s("u", "ungrouped chat"),
     ]);
-    expect(result).toEqual(["work", "daily"]);
+    expect(result).toEqual(["work"]);
   });
 
   it("omits pipe names that appear only once", () => {

--- a/apps/screenpipe-app-tauri/components/__tests__/chat-sidebar-grouping.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/chat-sidebar-grouping.test.ts
@@ -18,11 +18,11 @@ import {
 import type { SessionRecord } from "@/lib/stores/chat-store";
 
 describe("pipeHasSidebarSchedule", () => {
-  test("excludes manual pipes from the recurring sidebar section", () => {
+  it("excludes manual pipes from the recurring sidebar section", () => {
     expect(pipeHasSidebarSchedule({ schedule: "manual" })).toBe(false);
   });
 
-  test("includes legacy and structured schedules", () => {
+  it("includes legacy and structured schedules", () => {
     expect(pipeHasSidebarSchedule({ schedule: "every 30m" })).toBe(true);
     expect(
       pipeHasSidebarSchedule({
@@ -31,10 +31,28 @@ describe("pipeHasSidebarSchedule", () => {
       }),
     ).toBe(true);
   });
+
+  it("includes triggered pipes even when schedule is manual", () => {
+    expect(
+      pipeHasSidebarSchedule({
+        schedule: "manual",
+        trigger: { events: ["meeting_ended"] },
+      }),
+    ).toBe(true);
+  });
+
+  it("excludes pipes with empty trigger arrays", () => {
+    expect(
+      pipeHasSidebarSchedule({
+        schedule: "manual",
+        trigger: { events: [], custom: [], sources: [] },
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("visibleSidebarPipeNames", () => {
-  test("does not restore a known manual pipe from its run history", () => {
+  it("does not restore a known manual pipe from its run history", () => {
     expect(
       visibleSidebarPipeNames(
         [

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -510,7 +510,12 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
       // deduping the same saved row returned by both sources. Filter out
       // sessions that were deleted (dropped from the store) but still linger
       // in the loadedPipeRuns cache.
-      const cached = (loadedPipeRuns[name] ?? []).filter((s) => s.id in storeSessionIds);
+      const cached = (loadedPipeRuns[name] ?? []).filter((s) => {
+        const live = storeSessionIds[s.id];
+        // Drop deleted, pinned, or archived sessions from the cache —
+        // they either no longer exist or belong to a different section.
+        return live && !live.pinned && !live.hidden;
+      });
       const merged = [...(sessionsByPipe.get(name) ?? []), ...cached];
       const seen = new Set<string>();
       const sessions = merged.filter((session) => {

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -489,6 +489,10 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     }
   }, [loadedPipeRuns, loadingPipeRuns]);
 
+  // Live session ids from the store — used to discard stale loadedPipeRuns
+  // entries after a pipe run is deleted.
+  const storeSessionIds = useChatStore((s) => s.sessions);
+
   const pipeItems = useMemo(() => {
     const sessionsByPipe = new Map<string, SessionRecord[]>();
     for (const session of pipes) {
@@ -503,8 +507,11 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
 
     return orderedNames.map((name) => {
       // Keep a newly-started watch/run visible after history was loaded, while
-      // deduping the same saved row returned by both sources.
-      const merged = [...(sessionsByPipe.get(name) ?? []), ...(loadedPipeRuns[name] ?? [])];
+      // deduping the same saved row returned by both sources. Filter out
+      // sessions that were deleted (dropped from the store) but still linger
+      // in the loadedPipeRuns cache.
+      const cached = (loadedPipeRuns[name] ?? []).filter((s) => s.id in storeSessionIds);
+      const merged = [...(sessionsByPipe.get(name) ?? []), ...cached];
       const seen = new Set<string>();
       const sessions = merged.filter((session) => {
         if (seen.has(session.id)) return false;
@@ -518,7 +525,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
         sessions,
       };
     });
-  }, [pipeInventory, pipes, loadedPipeRuns]);
+  }, [pipeInventory, pipes, loadedPipeRuns, storeSessionIds]);
 
   const pipeExecutionCounts = useMemo(
     () => Object.fromEntries(

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -677,13 +677,11 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     } catch { /* ignore */ }
   }, [groupedSections]);
 
-  // Group names offered in the "Move to group" submenu, derived from all
-  // visible non-hidden sessions (pinned + recents): manual groups plus the
-  // auto pipe-groups the user actually sees in the sidebar. Moving a chat
-  // into a pipe-group's name folds it into that same group.
+  // Group names offered in the "Move to group" submenu: manual sidebar
+  // groups only (no auto pipe-groups).
   const existingGroups = useMemo(
-    () => listMoveTargetGroups([...pinned, ...recents, ...pipes]),
-    [pinned, recents, pipes],
+    () => listMoveTargetGroups([...pinned, ...recents]),
+    [pinned, recents],
   );
 
   const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null);
@@ -1737,9 +1735,6 @@ function PipeGroupRow({
               onDeleteRequest={onDeleteRequest}
               onTogglePin={onTogglePin}
               onRenameRequest={onRenameRequest}
-              onMoveToGroup={onMoveToGroup}
-              onNewGroupRequest={onNewGroupRequest}
-              existingGroups={existingGroups}
               insideGroup
               openConversationMenuId={openConversationMenuId}
               setOpenConversationMenuId={setOpenConversationMenuId}

--- a/apps/screenpipe-app-tauri/components/chat/chat-history-view.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/chat-history-view.tsx
@@ -317,8 +317,7 @@ export function ChatHistoryView({
     [patchSidebarSession, visibleById]
   );
 
-  // Group names for the "Move to group" submenu: manual groups plus the
-  // auto pipe-groups visible in the sidebar. Insertion order preserved.
+  // Group names for the "Move to group" submenu: manual groups only.
   const existingGroups = useMemo(
     () => listMoveTargetGroups(conversations),
     [conversations],
@@ -534,6 +533,7 @@ export function ChatHistoryView({
                   <Pin className="h-3 w-3 text-muted-foreground" />
                   {conv.pinned ? "Unpin" : "Pin"}
                 </DropdownMenuItem>
+                {conv.kind !== "pipe-run" && conv.kind !== "pipe-watch" && (
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger className="text-[11px] h-[30px] px-2 gap-2 rounded-none focus:bg-muted/30">
                     <FolderOpen className="h-3 w-3 text-muted-foreground" />
@@ -586,6 +586,7 @@ export function ChatHistoryView({
                     </div>
                   </DropdownMenuSubContent>
                 </DropdownMenuSub>
+                )}
                 {!conv.hidden ? (
                   <DropdownMenuItem
                     className="text-[11px] h-[30px] px-2 gap-2 rounded-none focus:bg-muted/30"

--- a/apps/screenpipe-app-tauri/lib/utils/chat-sidebar-grouping.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-sidebar-grouping.ts
@@ -183,9 +183,8 @@ function recurringPipeDisplayNames(
 
 /**
  * Group names to offer in the "Move to group" submenu: manual sidebar
- * groups first (insertion order, original casing), then auto pipe-groups
- * (the groups the user actually sees in the sidebar). Deduped
- * case-insensitively so a manual group shadowing a pipe name appears once.
+ * groups only (insertion order, original casing). Auto pipe-groups are
+ * excluded — pipe sessions are managed automatically, not by the user.
  */
 export function listMoveTargetGroups(
   sessions: ReadonlyArray<GroupableSession>,
@@ -199,11 +198,6 @@ export function listMoveTargetGroups(
     if (seen.has(lower)) continue;
     seen.add(lower);
     out.push(g);
-  }
-  for (const [lower, display] of recurringPipeDisplayNames(sessions)) {
-    if (seen.has(lower)) continue;
-    seen.add(lower);
-    out.push(display);
   }
   return out;
 }

--- a/apps/screenpipe-app-tauri/lib/utils/chat-sidebar-grouping.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-sidebar-grouping.ts
@@ -7,11 +7,17 @@ import type { SessionRecord } from "@/lib/stores/chat-store";
 type SidebarPipeSchedule = {
   schedule?: string | null;
   schedule_config?: unknown | null;
+  trigger?: { events?: unknown[]; custom?: unknown[]; sources?: unknown[] } | null;
 };
 
-/** The sidebar Pipes section is for recurring automations, not manual templates. */
+/** The sidebar Pipes section is for automated pipes (scheduled or triggered), not manual templates. */
 export function pipeHasSidebarSchedule(config: SidebarPipeSchedule): boolean {
+  const isTriggered =
+    !!(config.trigger?.events?.length) ||
+    !!(config.trigger?.custom?.length) ||
+    !!(config.trigger?.sources?.length);
   return (
+    isTriggered ||
     config.schedule_config != null ||
     (typeof config.schedule === "string" &&
       config.schedule.length > 0 &&


### PR DESCRIPTION
This PR fixes several pipe sidebar issues:

1. triggered pipes (like meeting-summary) weren't showing in the pipes sidebar section, aligned the sidebar filter with
   the pipes list page
2. "move to group" was showing on pipe run sessions - removed it since pipe runs are auto-grouped by pipe name
3. pipe group names were appearing as suggestions in "move to group" for regular chats now only manual groups
  show
4. deleted pipe runs kept appearing in he sidebar after deletion - stale cache wasn't being cleaned up
5. pinned or archived pipe runs were duplicated in both their section and the pipe group now they only show in
  pinned/archived
  
  
Before -

https://github.com/user-attachments/assets/ad85daf4-61f8-4691-9943-8d3e1b67ace7


After -
  
  

https://github.com/user-attachments/assets/42fb9d77-fd04-41ed-b747-2961988c0c9d

