### PR TITLE
[codex] keep agent learning in user-owned skills

### DIFF
--- a/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
+++ b/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
@@ -5,8 +5,6 @@ description: Query the user's data via the local screenpipe REST API at localhos
 
 # Screenpipe API
 
-After completing a complex Screenpipe query, always delegate reusable learning to an asynchronous subagent: have it improve the most relevant existing skill after the user-visible answer so reflection adds no response latency. Create a new skill only when no existing skill fits, and never save one-off facts as skills.
-
 Local REST API at `http://localhost:3030`.
 
 ## Authentication

--- a/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
+++ b/crates/screenpipe-core/assets/skills/screenpipe-api/SKILL.md
@@ -5,6 +5,8 @@ description: Query the user's data via the local screenpipe REST API at localhos
 
 # Screenpipe API
 
+After completing a complex Screenpipe query, always delegate reusable procedural learning to an asynchronous subagent after the user-visible answer so reflection adds no response latency. Store that learning in a separate user-owned skill: update a dedicated user-owned skill when it already fits the workflow; otherwise create a new narrowly scoped skill. Never modify this `screenpipe-api` skill or any other bundled, vendor-installed, or externally managed skill. Never save one-off facts as skills.
+
 Local REST API at `http://localhost:3030`.
 
 ## Authentication

--- a/crates/screenpipe-engine/src/cli/agent.rs
+++ b/crates/screenpipe-engine/src/cli/agent.rs
@@ -611,9 +611,11 @@ mod tests {
     }
 
     #[test]
-    fn test_api_skill_does_not_instruct_agents_to_modify_skills() {
+    fn test_api_skill_routes_learning_to_user_owned_skills() {
         assert!(!API_SKILL_MD.contains("improve the most relevant existing skill"));
-        assert!(!API_SKILL_MD.contains("Create a new skill only when no existing skill fits"));
+        assert!(API_SKILL_MD.contains("Store that learning in a separate user-owned skill"));
+        assert!(API_SKILL_MD.contains("Never modify this `screenpipe-api` skill"));
+        assert!(API_SKILL_MD.contains("bundled, vendor-installed, or externally managed skill"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/cli/agent.rs
+++ b/crates/screenpipe-engine/src/cli/agent.rs
@@ -611,6 +611,12 @@ mod tests {
     }
 
     #[test]
+    fn test_api_skill_does_not_instruct_agents_to_modify_skills() {
+        assert!(!API_SKILL_MD.contains("improve the most relevant existing skill"));
+        assert!(!API_SKILL_MD.contains("Create a new skill only when no existing skill fits"));
+    }
+
+    #[test]
     fn test_codex_and_claude_code_have_skill_directories() {
         let codex = layout("codex").unwrap();
         assert!(codex


### PR DESCRIPTION
## Summary

- preserve asynchronous reusable learning after complex Screenpipe queries
- route that learning to a separate user-owned skill: update a dedicated user-owned skill when it fits, otherwise create a narrowly scoped one
- make screenpipe-api and all bundled, vendor-installed, or externally managed skills explicitly read-only
- add a regression test for both the learning behavior and ownership boundary

## Root cause

PR #5259 told the post-query subagent to improve the most relevant existing skill and create a new skill only as a fallback. That made the bundled screenpipe-api reference an attractive mutation target. The installed pi-hermes-memory extension also encourages procedural learning, but keeps managed skills in its own store; pi-subagents only supplies the delegation mechanism.

## Impact

Agents keep learning reusable Screenpipe workflows without bloating or rewriting the canonical API reference. Existing dedicated user-owned skills can evolve, and novel workflows get their own narrow skill.

## Validation

- cargo test -p screenpipe-engine --lib cli::agent::tests::test_api_skill_routes_learning_to_user_owned_skills -- --exact
- cargo fmt --all -- --check
- git diff --check
- focused source scan confirms the old prefer-existing wording is gone and the ownership guard is present