### PR TITLE
fix(app): hide stale trial expiration after upgrade

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -1120,8 +1120,7 @@ function HomeContent() {
               </div>
 
               <PlanExpirationNotice
-                expiresAt={(settings.user as AppUser | null)?.plan_expires_at}
-                plan={(settings.user as AppUser | null)?.subscription_plan}
+                user={settings.user as AppUser | null}
                 onClick={() => openSettings("account")}
               />
 

--- a/apps/screenpipe-app-tauri/components/plan-expiration-notice.test.tsx
+++ b/apps/screenpipe-app-tauri/components/plan-expiration-notice.test.tsx
@@ -6,8 +6,10 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getPlanExpiration,
+  getUserPlanExpiration,
   PlanExpirationNotice,
 } from "./plan-expiration-notice";
+import type { AppUser } from "@/lib/app-entitlement";
 
 const analyticsMocks = vi.hoisted(() => ({ capture: vi.fn() }));
 
@@ -37,6 +39,24 @@ describe("PlanExpirationNotice", () => {
     expect(getPlanExpiration("2026-07-21T11:59:59.000Z", now)).toBeNull();
   });
 
+  it("hides a stale signup-trial expiration after billing takes over", () => {
+    const expiration = getUserPlanExpiration(
+      {
+        plan_expires_at: "2026-08-04T12:00:00.000Z",
+        subscription_plan: "pro",
+        entitlement: {
+          active: true,
+          plan: "pro",
+          source: "subscription",
+          status: "active",
+        },
+      } as AppUser,
+      Date.parse("2026-07-21T12:00:00.000Z"),
+    );
+
+    expect(expiration).toBeNull();
+  });
+
   it("renders the countdown and opens its destination", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-21T12:00:00.000Z"));
@@ -44,8 +64,11 @@ describe("PlanExpirationNotice", () => {
 
     render(
       <PlanExpirationNotice
-        expiresAt="2026-07-24T12:00:00.000Z"
-        plan="pro"
+        user={{
+          plan_expires_at: "2026-07-24T12:00:00.000Z",
+          subscription_plan: "pro",
+          entitlement: { source: "signup_trial" },
+        } as AppUser}
         onClick={onClick}
       />,
     );
@@ -82,8 +105,10 @@ describe("PlanExpirationNotice", () => {
 
     render(
       <PlanExpirationNotice
-        expiresAt="2026-07-22T12:00:00.000Z"
-        plan="standard"
+        user={{
+          plan_expires_at: "2026-07-22T12:00:00.000Z",
+          subscription_plan: "standard",
+        } as AppUser}
         onClick={vi.fn()}
       />,
     );

--- a/apps/screenpipe-app-tauri/components/plan-expiration-notice.test.tsx
+++ b/apps/screenpipe-app-tauri/components/plan-expiration-notice.test.tsx
@@ -39,7 +39,29 @@ describe("PlanExpirationNotice", () => {
     expect(getPlanExpiration("2026-07-21T11:59:59.000Z", now)).toBeNull();
   });
 
-  it("hides a stale signup-trial expiration after billing takes over", () => {
+  it("shows the countdown for a profile-granted trial (server source: manual)", () => {
+    // Mirrors the exact /api/user shape for the 14-day signup Business trial:
+    // resolveAppEntitlement resolves profile grants as source "manual" —
+    // there is no "signup_trial" source in the server vocabulary.
+    const expiration = getUserPlanExpiration(
+      {
+        plan_expires_at: "2026-08-04T12:00:00.000Z",
+        subscription_plan: "pro",
+        entitlement: {
+          active: true,
+          plan: "pro",
+          source: "manual",
+          status: "active",
+          expires_at: "2026-08-04T12:00:00.000Z",
+        },
+      } as AppUser,
+      Date.parse("2026-07-21T12:00:00.000Z"),
+    );
+
+    expect(expiration?.daysRemaining).toBe(14);
+  });
+
+  it("hides a stale profile-grant trial expiration after billing takes over", () => {
     const expiration = getUserPlanExpiration(
       {
         plan_expires_at: "2026-08-04T12:00:00.000Z",
@@ -67,7 +89,7 @@ describe("PlanExpirationNotice", () => {
         user={{
           plan_expires_at: "2026-07-24T12:00:00.000Z",
           subscription_plan: "pro",
-          entitlement: { source: "signup_trial" },
+          entitlement: { source: "manual" },
         } as AppUser}
         onClick={onClick}
       />,

--- a/apps/screenpipe-app-tauri/components/plan-expiration-notice.tsx
+++ b/apps/screenpipe-app-tauri/components/plan-expiration-notice.tsx
@@ -6,7 +6,11 @@
 import { useEffect } from "react";
 import { ArrowRight, Clock } from "lucide-react";
 import posthog from "posthog-js";
-import { planDisplayName } from "@/lib/app-entitlement";
+import {
+  hasBillingSubscriptionEntitlement,
+  planDisplayName,
+  type AppUser,
+} from "@/lib/app-entitlement";
 
 export type PlanExpiration = {
   expiresAt: Date;
@@ -30,20 +34,27 @@ export function getPlanExpiration(
   };
 }
 
+export function getUserPlanExpiration(
+  user: AppUser | null | undefined,
+  nowMs = Date.now(),
+): PlanExpiration | null {
+  if (hasBillingSubscriptionEntitlement(user)) return null;
+  return getPlanExpiration(user?.plan_expires_at, nowMs);
+}
+
 type PlanExpirationNoticeProps = {
-  expiresAt: string | null | undefined;
-  plan: string | null | undefined;
+  user: AppUser | null | undefined;
   onClick: () => void;
   variant?: "sidebar" | "account";
 };
 
 export function PlanExpirationNotice({
-  expiresAt,
-  plan,
+  user,
   onClick,
   variant = "sidebar",
 }: PlanExpirationNoticeProps) {
-  const expiration = getPlanExpiration(expiresAt);
+  const expiration = getUserPlanExpiration(user);
+  const plan = user?.subscription_plan;
   const planName = planDisplayName(plan);
   const daysRemaining = expiration?.daysRemaining ?? null;
   const expirationIso = expiration?.expiresAt.toISOString() ?? null;

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -159,8 +159,8 @@ describe("AccountSection subscription/login gating", () => {
       entitlement: {
         active: true,
         plan: "pro",
-        source: "signup_trial",
-        status: "trialing",
+        source: "manual",
+        status: "active",
       },
     };
 
@@ -211,8 +211,8 @@ describe("AccountSection subscription/login gating", () => {
       entitlement: {
         active: true,
         plan: "pro",
-        source: "signup_trial",
-        status: "trialing",
+        source: "manual",
+        status: "active",
       },
     };
     vi.stubGlobal(

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -17,7 +17,14 @@
 // header and the active-plan card can never contradict each other.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   state: { user: null as any },
@@ -27,6 +34,13 @@ const mocks = vi.hoisted(() => ({
   piUpdateConfig: vi.fn().mockResolvedValue(undefined),
   capture: vi.fn(),
   openUrl: vi.fn().mockResolvedValue(undefined),
+  eventHandlers: new Map<string, (event: any) => unknown>(),
+  listen: vi.fn(
+    async (event: string, handler: (event: any) => unknown) => {
+      mocks.eventHandlers.set(event, handler);
+      return () => mocks.eventHandlers.delete(event);
+    },
+  ),
 }));
 
 // AccountSection reads everything through useSettings + the tauri `commands`
@@ -70,7 +84,7 @@ vi.mock("@tauri-apps/plugin-deep-link", () => ({
   onOpenUrl: vi.fn().mockResolvedValue(() => {}),
 }));
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn().mockResolvedValue(() => {}),
+  listen: mocks.listen,
 }));
 
 // ReferralCard pulls its own data deps; it is irrelevant to the gate.
@@ -90,6 +104,7 @@ describe("AccountSection subscription/login gating", () => {
     vi.useRealTimers();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    mocks.eventHandlers.clear();
     mocks.state.user = null;
   });
 
@@ -141,6 +156,12 @@ describe("AccountSection subscription/login gating", () => {
       cloud_subscribed: true,
       subscription_plan: "pro",
       plan_expires_at: "2026-08-04T12:00:00.000Z",
+      entitlement: {
+        active: true,
+        plan: "pro",
+        source: "signup_trial",
+        status: "trialing",
+      },
     };
 
     render(<AccountSection />);
@@ -148,6 +169,89 @@ describe("AccountSection subscription/login gating", () => {
 
     expect(screen.getByText("Business plan ends in 14 days")).toBeInTheDocument();
     expect(mocks.openUrl).toHaveBeenCalledWith("https://screenpipe.com/account/billing");
+  });
+
+  it("hides a stale trial end date after the paid subscription starts", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T12:00:00.000Z"));
+    mocks.state.user = {
+      id: "u1",
+      email: "paid@screenpipe.test",
+      token: "tok",
+      cloud_subscribed: true,
+      subscription_plan: "pro",
+      plan_expires_at: "2026-08-04T12:00:00.000Z",
+      entitlement: {
+        active: true,
+        plan: "pro",
+        source: "subscription",
+        status: "active",
+      },
+    };
+
+    render(<AccountSection />);
+
+    expect(
+      screen.queryByTestId("account-plan-expiration-notice"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Business plan ends in 14 days"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the trial date and refreshes entitlement when checkout activates", async () => {
+    vi.useFakeTimers();
+    mocks.state.user = {
+      id: "u1",
+      email: "trial@screenpipe.test",
+      token: "tok",
+      cloud_subscribed: true,
+      subscription_plan: "pro",
+      plan_expires_at: "2026-08-04T12:00:00.000Z",
+      entitlement: {
+        active: true,
+        plan: "pro",
+        source: "signup_trial",
+        status: "trialing",
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ url: "https://checkout.stripe.test/session" }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              hasSubscription: true,
+              subscription: { status: "active" },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+    );
+
+    render(<AccountSection />);
+    const trayUpgrade = mocks.eventHandlers.get("tray-upgrade");
+    expect(trayUpgrade).toBeDefined();
+
+    await act(async () => {
+      await trayUpgrade?.({ event: "tray-upgrade", id: 1, payload: null });
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      user: expect.objectContaining({
+        cloud_subscribed: true,
+        plan_expires_at: null,
+      }),
+    });
+    expect(mocks.loadUser).toHaveBeenCalledWith("tok", true);
   });
 
   it("does not regress the logged-in Basic plan badge (token, no cloud)", () => {

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -254,7 +254,8 @@ export function AccountSection() {
                       } as AppUser,
                     });
                     // Refresh the complete entitlement so its source changes
-                    // from signup_trial to subscription in this session.
+                    // from manual (the profile trial grant) to subscription
+                    // in this session.
                     await loadUser(settings.user.token, true);
                   }
                   toast({

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -50,7 +50,7 @@ import posthog from "posthog-js";
 import { describeDeepLinkForLog } from "@/lib/utils/deep-link-log";
 import { screenpipeWebUrl } from "@/lib/web-url";
 import {
-  getPlanExpiration,
+  getUserPlanExpiration,
   PlanExpirationNotice,
 } from "@/components/plan-expiration-notice";
 
@@ -117,8 +117,8 @@ export function AccountSection() {
   const [connectionsSyncing, setConnectionsSyncing] = useState(false);
   const subscriptionPlan = settings.user?.subscription_plan ?? null;
   const hasNamedPlan = !!subscriptionPlan && subscriptionPlan !== "none";
-  const planExpiresAt = (settings.user as AppUser | null)?.plan_expires_at;
-  const hasExpiringProfilePlan = getPlanExpiration(planExpiresAt) !== null;
+  const appUser = settings.user as AppUser | null;
+  const hasExpiringProfilePlan = getUserPlanExpiration(appUser) !== null;
 
   useEffect(() => {
     if (!settings.user?.email) {
@@ -246,9 +246,16 @@ export function AccountSection() {
                   // (This poll runs token-authenticated, so the guard is
                   // belt-and-suspenders.)
                   if (settings.user?.token) {
-                    updateSettings({
-                      user: { ...settings.user, cloud_subscribed: true },
+                    await updateSettings({
+                      user: {
+                        ...settings.user,
+                        cloud_subscribed: true,
+                        plan_expires_at: null,
+                      } as AppUser,
                     });
+                    // Refresh the complete entitlement so its source changes
+                    // from signup_trial to subscription in this session.
+                    await loadUser(settings.user.token, true);
                   }
                   toast({
                     title: "subscription activated",
@@ -375,8 +382,7 @@ export function AccountSection() {
           </div>
 
           <PlanExpirationNotice
-            expiresAt={planExpiresAt}
-            plan={subscriptionPlan}
+            user={appUser}
             onClick={() => openExternalUrl(BILLING_URL)}
             variant="account"
           />

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -127,9 +127,10 @@ function asEntitlement(entitlement: AppUser["entitlement"] | undefined): AppEnti
 }
 
 /**
- * Whether billing has superseded a profile-granted plan such as a signup
- * trial. The profile's plan_expires_at metadata can linger after checkout, but
- * the selected entitlement source switches to subscription.
+ * Whether billing has superseded a profile-granted plan such as the signup
+ * trial (which the server resolves as source "manual"). The profile's
+ * plan_expires_at metadata can linger after checkout, but the selected
+ * entitlement source switches to subscription.
  */
 export function hasBillingSubscriptionEntitlement(
   user: AppUser | null | undefined,

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -126,6 +126,21 @@ function asEntitlement(entitlement: AppUser["entitlement"] | undefined): AppEnti
   return entitlement as AppEntitlement;
 }
 
+/**
+ * Whether billing has superseded a profile-granted plan such as a signup
+ * trial. The profile's plan_expires_at metadata can linger after checkout, but
+ * the selected entitlement source switches to subscription.
+ */
+export function hasBillingSubscriptionEntitlement(
+  user: AppUser | null | undefined,
+): boolean {
+  const source = asEntitlement(user?.entitlement)?.source;
+  return (
+    typeof source === "string" &&
+    source.trim().toLowerCase() === "subscription"
+  );
+}
+
 export function getEnterpriseAccount(
   user: AppUser | null | undefined,
 ): AppEnterpriseAccount | null {


### PR DESCRIPTION
## What changed

- make plan-expiration visibility aware of the selected entitlement source
- hide profile-granted trial expiration copy once a billing subscription supersedes the trial
- clear the cached trial date and force a verified user refresh when checkout polling detects activation
- use the same subscription-aware expiration decision in Account, the sidebar, and checkout routing

## Why

A future `plan_expires_at` value was treated as authoritative by itself. That profile metadata can remain set after a Business trial user upgrades, so the paid subscriber continued to see “Business plan ends in 14 days.” The same stale value could also keep checkout routing in the expiring-trial path.

The current entitlement source is the authoritative discriminator. The server's source vocabulary (website `resolveAppEntitlement`) is `none | subscription | manual | enterprise | lifetime`; the 14-day signup Business trial is a profile grant that resolves as `manual`:

- `manual` (profile grant, e.g. the signup trial) → show the profile expiration
- `subscription` → billing has taken over; suppress the stale trial expiration

The server also only includes `plan_expires_at` in `/api/user` when the source is `manual`, and both the Stripe verify fallback and the webhook null it in the DB once a real subscription exists — so the stale value lives purely in client-persisted state between checkout-poll activation and the next refresh, which is exactly the window this PR closes.

## Before / after

```text
before paid activation             after paid activation
┌──────────────────────────┐       ┌──────────────────────────┐
│ Screenpipe Business      │       │ Screenpipe Business      │
│ active                   │       │ active                   │
│                          │       │                          │
│ plan ends in 14 days     │  →    │ trial notice removed     │
│ [manage subscription]    │       │                          │
└──────────────────────────┘       └──────────────────────────┘
```

## Shared-mechanism audit

- Account expiration notice → affected; now uses the subscription-aware user expiration
- sidebar expiration notice → affected; now uses the same shared decision
- Account checkout routing → affected; no longer treats a paid subscription as an expiring trial
- raw date parsing → safe; remains an internal parsing primitive and has no production call sites that bypass the user-level decision

## Validation

- `bun run test:vitest -- components/plan-expiration-notice.test.tsx components/settings/__tests__/account-section.subscription-gate.test.tsx lib/app-entitlement.test.ts` — 52 tests passed
- `bun run typecheck` — passed
- ESLint on all changed TypeScript files — 0 errors (3 pre-existing warnings in `home/page.tsx`)
- `git diff --check` — passed

## Follow-up commit

An earlier revision of this PR (and its tests) assumed a `signup_trial` entitlement source. That value does not exist in the server vocabulary — the trial resolves as `manual`. The follow-up commit aligns all test fixtures with the exact `/api/user` shape (`source: "manual", status: "active"`), adds a test asserting the real trial case shows the countdown, and corrects the comments.
