### PR TITLE
fix(audio): recover macOS CoreAudio after internal restarts

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/recording/db_wedge.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording/db_wedge.rs
@@ -101,6 +101,81 @@ fn db_wedge_recovery_decision(
     DbWedgeRecoveryDecision::Restart
 }
 
+/// A DB-wedge restart rebuilds CoreAudio in the same process. On macOS the
+/// rebuilt input can exist without ever receiving a callback; that exact state
+/// needs a process boundary. Wait for an input stream to exist first so slow
+/// model startup, disabled audio, and missing devices never trigger a relaunch.
+#[cfg(target_os = "macos")]
+fn watch_rebuilt_audio(
+    app: tauri::AppHandle,
+    audio_manager: Arc<screenpipe_audio::audio_manager::AudioManager>,
+    server_state: Arc<tokio::sync::Mutex<Option<crate::server_core::ServerCore>>>,
+    wants_recording: Arc<std::sync::atomic::AtomicBool>,
+) {
+    const START_WAIT: Duration = Duration::from_secs(120);
+    const CALLBACK_WAIT: Duration = Duration::from_secs(35);
+
+    tauri::async_runtime::spawn(async move {
+        let guard_started = std::time::Instant::now();
+        let mut input_opened_at = None;
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            if guard_started.elapsed() >= START_WAIT {
+                return;
+            }
+
+            let same_generation = server_state.lock().await.as_ref().is_some_and(|server| {
+                Arc::ptr_eq(&server.audio_manager, &audio_manager)
+            });
+            if !same_generation
+                || !wants_recording.load(Ordering::SeqCst)
+                || audio_manager.is_disabled().await
+                || screenpipe_config::should_pause_audio_for_lock()
+            {
+                return;
+            }
+
+            let inputs = audio_manager
+                .current_devices()
+                .into_iter()
+                .filter(|device| {
+                    device.device_type == screenpipe_audio::core::device::DeviceType::Input
+                })
+                .map(|device| device.to_string())
+                .collect::<std::collections::HashSet<_>>();
+            if inputs.is_empty() {
+                input_opened_at = None;
+                continue;
+            }
+
+            let levels = audio_manager.metrics.per_device_rms_snapshot();
+            if inputs.iter().any(|input| levels.contains_key(input)) {
+                info!("db wedge auto-recovery: rebuilt macOS input is receiving callbacks");
+                return;
+            }
+
+            let opened_at = input_opened_at.get_or_insert_with(std::time::Instant::now);
+            if opened_at.elapsed() < CALLBACK_WAIT {
+                continue;
+            }
+
+            error!(
+                "db wedge auto-recovery: rebuilt macOS input produced no callbacks for {}s; \
+                 relaunching the app",
+                CALLBACK_WAIT.as_secs()
+            );
+            crate::process_exit::run_blocking_pre_exit_teardown(app.clone());
+            crate::process_exit::request_app_relaunch(
+                app,
+                "macOS audio did not restart after DB recovery",
+                Duration::from_millis(250),
+            );
+            return;
+        }
+    });
+}
+
 /// Build the `PersistentFailureHook` the DB layer fires when writes wedge
 /// persistently. The hook itself is sync (`Fn()`), so it spawns the async
 /// restart. Captures an `AppHandle` (cheap clone, Send+Sync) and the shared
@@ -247,6 +322,24 @@ async fn recover_from_db_wedge(
         // manual recovery threshold rather than waiting for the health
         // watchdog to grind through more doomed respawns.
         crate::db_relaunch::note_respawn_failure(&app, &e).await;
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    let audio_manager = {
+        let server = recording_state.server.lock().await;
+        server
+            .as_ref()
+            .map(|server| server.audio_manager.clone())
+    };
+    #[cfg(target_os = "macos")]
+    if let Some(audio_manager) = audio_manager {
+        watch_rebuilt_audio(
+            app.clone(),
+            audio_manager,
+            recording_state.server.clone(),
+            recording_state.wants_recording.clone(),
+        );
     }
 }
 

--- a/crates/screenpipe-audio/src/core/run_record_and_transcribe.rs
+++ b/crates/screenpipe-audio/src/core/run_record_and_transcribe.rs
@@ -158,6 +158,35 @@ fn should_reconnect_after_silent_input(
     zero_fill_reconnect_enabled_for_platform()
 }
 
+/// Tracks mic-only callback liveness for the software-AEC recorder.
+///
+/// Speaker callbacks and the AEC processing timer must not mask a dead mic stream.
+struct AecMicReceiveWatchdog {
+    stream_started_at: Instant,
+    last_chunk_at: Instant,
+}
+
+impl AecMicReceiveWatchdog {
+    fn new(now: Instant) -> Self {
+        Self {
+            stream_started_at: now,
+            last_chunk_at: now,
+        }
+    }
+
+    fn note_chunk(&mut self, now: Instant) {
+        self.last_chunk_at = now;
+    }
+
+    fn timed_out(&self, now: Instant) -> bool {
+        let startup_timeout =
+            Duration::from_secs(STREAM_STARTUP_GRACE_SECS + AUDIO_RECEIVE_TIMEOUT_SECS);
+        now.saturating_duration_since(self.stream_started_at) >= startup_timeout
+            && now.saturating_duration_since(self.last_chunk_at)
+                >= Duration::from_secs(AUDIO_RECEIVE_TIMEOUT_SECS)
+    }
+}
+
 fn meeting_frame_from_recorder_output(
     samples: Vec<f32>,
     audio_stream: &AudioStream,
@@ -220,6 +249,8 @@ pub async fn run_record_and_transcribe(
         let mut collected_audio = Vec::new();
         let mut segment_start_time = now_epoch_secs();
         let mut last_diagnostics_time = Instant::now();
+        let mut mic_receive_watchdog = AecMicReceiveWatchdog::new(Instant::now());
+        let mut terminal_stream_death: Option<StreamDeath> = None;
         let mut _last_non_zero_at: Option<Instant> = None;
         let mut _sck_watchdog = crate::core::sck_output_watchdog::SckOutputWatchdog::default();
 
@@ -274,6 +305,9 @@ pub async fn run_record_and_transcribe(
                         match mic_res {
                             Ok(chunk) => {
                                 metrics.update_audio_levels(&device_name, &chunk);
+                                if !chunk.is_empty() {
+                                    mic_receive_watchdog.note_chunk(Instant::now());
+                                }
                                 if !chunk.is_empty() && chunk.iter().any(|&x| x.abs() >= SILENT_BUFFER_PEAK_THRESHOLD) {
                                     _last_non_zero_at = Some(Instant::now());
                                     update_device_capture_time(&device_name);
@@ -294,6 +328,9 @@ pub async fn run_record_and_transcribe(
                                 mic_sample_counter += chunk_len as u64;
                             }
                             Err(broadcast::error::RecvError::Lagged(n)) => {
+                                // The producer is alive and delivered data even
+                                // though this subscriber could not keep up.
+                                mic_receive_watchdog.note_chunk(Instant::now());
                                 metrics.record_chunks_lagged(n);
                                 debug!("AEC: Mic channel lagged by {} messages", n);
                             }
@@ -330,6 +367,28 @@ pub async fn run_record_and_transcribe(
                     }
                     // Timeout to prevent hanging when silent
                     _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+                }
+
+                // A deliberate stop/invalidation may land while select is
+                // waiting. Let the existing flush/teardown path handle it
+                // instead of misclassifying shutdown as a watchdog failure.
+                if !is_running.load(Ordering::Relaxed)
+                    || audio_stream.is_disconnected.load(Ordering::Relaxed)
+                {
+                    break;
+                }
+
+                if mic_receive_watchdog.timed_out(Instant::now()) {
+                    metrics.record_stream_timeout();
+                    audio_stream.is_disconnected.store(true, Ordering::Relaxed);
+                    warn!(
+                        "AEC: no microphone data received from {} for {}s — stream dead, triggering reconnect",
+                        device_name, AUDIO_RECEIVE_TIMEOUT_SECS
+                    );
+                    terminal_stream_death = Some(StreamDeath::ReceiveTimeout {
+                        secs: AUDIO_RECEIVE_TIMEOUT_SECS,
+                    });
+                    break;
                 }
 
                 // Pull processed frames from AEC processor
@@ -371,6 +430,10 @@ pub async fn run_record_and_transcribe(
                 }
             }
 
+            if terminal_stream_death.is_some() {
+                break;
+            }
+
             flush_audio(
                 &mut collected_audio,
                 overlap_samples,
@@ -401,7 +464,10 @@ pub async fn run_record_and_transcribe(
             warn!("AEC: Final mic flush failed for {}: {}", device_name, e);
         }
 
-        if audio_stream.is_disconnected.load(Ordering::Relaxed) {
+        if let Some(stream_death) = terminal_stream_death {
+            info!("AEC: Stopped recording for {} (stream dead)", device_name);
+            Err(anyhow!(stream_death))
+        } else if audio_stream.is_disconnected.load(Ordering::Relaxed) {
             info!("AEC: Stopped recording for {} (disconnected)", device_name);
             Err(anyhow::anyhow!("device {} disconnected", device_name))
         } else {
@@ -904,6 +970,26 @@ mod tests {
             found,
             "ReceiveTimeout must remain downcastable after context wrapping"
         );
+    }
+
+    #[test]
+    fn aec_mic_receive_watchdog_matches_startup_and_steady_state_timeouts() {
+        let start = Instant::now();
+        let mut watchdog = AecMicReceiveWatchdog::new(start);
+        let one_millisecond = Duration::from_millis(1);
+        let receive_timeout = Duration::from_secs(AUDIO_RECEIVE_TIMEOUT_SECS);
+        let startup_timeout =
+            Duration::from_secs(STREAM_STARTUP_GRACE_SECS + AUDIO_RECEIVE_TIMEOUT_SECS);
+
+        assert!(!watchdog.timed_out(start + startup_timeout - one_millisecond));
+        assert!(watchdog.timed_out(start + startup_timeout));
+
+        // A real mic callback resets the steady-state timeout. Speaker activity
+        // is intentionally absent from this state, so it cannot mask a dead mic.
+        let mic_chunk_at = start + Duration::from_secs(60);
+        watchdog.note_chunk(mic_chunk_at);
+        assert!(!watchdog.timed_out(mic_chunk_at + receive_timeout - one_millisecond));
+        assert!(watchdog.timed_out(mic_chunk_at + receive_timeout));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- detect a software-AEC microphone receiver that stopped getting callbacks even while speaker/timer activity keeps the shared task alive
- mark only that microphone stream disconnected, flush processed partial audio, and let the existing device monitor reconnect it
- after a successful DB-wedge engine recovery on macOS, relaunch only if that exact rebuilt generation has an input stream but still produces no input callbacks

## What the two local incidents prove

### Display/wake recurrence

In the first v2.5.130 occurrence, audio was healthy immediately before a display/wake invalidation. The built-in mic was recreated and software AEC started, but every later AEC diagnostic showed `mic_buf=0.0ms` and `processed=0`. Speaker buffering continued, so the shared AEC task stayed alive even though the mic receiver got no more callbacks.

The active configuration was:

```text
screenpipeAecEnabled: true
macosInputVpioEnabled: false
```

These modes are mutually exclusive. This was software AEC consuming a plain CoreAudio/HAL/CPAL input stream, not macOS VoiceProcessingIO. AEC exposed the missing microphone data; the evidence does not show that the AEC DSP caused it.

### DB-recovery recurrence

A second occurrence at `2026-07-22T21:32:11Z` followed the DB-wedge in-process recovery. Before teardown, mic AEC and the system-audio Process Tap were both delivering callbacks. Teardown completed and the new generation logged successful input and Process Tap creation, but neither stream delivered a callback afterward; mic diagnostics stayed at `mic_buf=0.0ms`, `processed=0` for more than four minutes.

An independent one-shot input probe in a separate process then blocked inside Apple's:

```text
AudioOutputUnitStart
-> AudioDeviceStart
-> HALC_ProxyIOContext::StartIOProc
-> HALB_IOThread::StartAndWaitForState
```

That is below AEC and proves this recurrence was a CoreAudio/HAL start wedge. A per-device reconnect cannot recover if reopening the OS stream itself blocks; the process must exit.

## Recovery behavior

```text
software-AEC mic callbacks stop
-> mic-only watchdog expires (startup guard, then 8s steady-state timeout)
-> mark only that stream disconnected
-> flush already-processed partial audio
-> existing device monitor reconnects that mic
```

For the observed post-DB-recovery failure only:

```text
DB wedge recovery successfully rebuilds the engine
-> wait until that exact audio manager has a current input stream
-> allow 35s for any input callback, including a silent callback
-> if still callbackless, run bounded pre-exit teardown and relaunch the app
```

## Safety boundaries

The process-level fallback is macOS-only and is armed only after a successful DB-triggered in-process engine recovery. It exits without relaunching when:

- the server/audio-manager generation was replaced
- recording is no longer intended
- audio capture is disabled
- audio is intentionally suspended for screen lock
- no current input stream exists
- any input callback arrived, including a zero-valued/silent buffer
- no input stream appears within 120s

The app relaunch is not driven by silence, mute, AEC output, transcription latency, or the DB error alone. A normal launch, normal capture restart, Windows/Linux, VoiceProcessingIO DSP, device selection, and the existing zero-fill policy are unchanged.

The earlier implementation was intentionally removed: there is no new `AudioManager` state field, no 120s OS-open marker tracker, and no all-device restart on a mic-only timeout. The final diff touches two files.

## Testing

- `cargo test -p screenpipe-audio --lib` — 389 passed, 7 ignored
- deterministic watchdog unit coverage exercises startup and steady-state timeout boundaries
- one local synthetic no-callback run exercised the real async AEC loop and returned typed `ReceiveTimeout` after 18.01s
- full macOS desktop Clippy/type compile passed after the simplification; 109 existing repository warnings, no new compile errors
- `cargo fmt --all -- --check`
- `git diff --check`

## Validation status

- the earlier mic-watchdog head passed all 26 GitHub checks, including macOS/Windows/Ubuntu Rust CI, cross-platform E2E, AppImage smoke, Clippy, CodeQL, dependency checks, and secret scan
- fresh checks for this simplified head are required after force-push
- keep this PR draft until those checks pass and a packaged macOS runtime canary exercises the DB-recovery/CoreAudio escalation end to end

No before/after video is attached because this is a non-visual low-level audio recovery change; the source-backed evidence is the health/log sequence, independent CoreAudio stack sample, and recovery behavior.
