### PR TITLE
fix(app): make recording health alerts opt-in

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/notification-registry.test.ts
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/notification-registry.test.ts
@@ -47,6 +47,12 @@ describe("notification registry", () => {
     }
   });
 
+  it("keeps experimental recording health alerts opt-in", () => {
+    expect(NOTIFICATION_CATEGORY_BY_ID.captureStalls.default).toBe(false);
+    expect(DEFAULT_NOTIFICATION_PREFS.captureStalls).toBe(false);
+    expect(categoryValuesForPreset("recommended").captureStalls).toBe(false);
+  });
+
   it("indexes categories by id", () => {
     for (const c of NOTIFICATION_CATEGORIES) {
       expect(NOTIFICATION_CATEGORY_BY_ID[c.id]).toBe(c);

--- a/apps/screenpipe-app-tauri/components/settings/notification-registry.ts
+++ b/apps/screenpipe-app-tauri/components/settings/notification-registry.ts
@@ -83,14 +83,14 @@ export const NOTIFICATION_GROUPS: NotificationGroup[] = [
 export const NOTIFICATION_CATEGORIES: NotificationCategory[] = [
   {
     id: "captureStalls",
-    label: "Capture stalls",
+    label: "Recording health alerts",
     description:
-      "Alert when audio or screen capture stops — may send false positives",
+      "Show “recording needs help” and notify when capture stops — may send false positives",
     group: "recording",
-    default: true,
+    default: false,
     experimental: true,
     mirrorsShowRestartNotifications: true,
-    keywords: ["recording stopped", "capture health", "stall", "frozen"],
+    keywords: ["recording needs help", "recording stopped", "capture health", "stall", "frozen"],
   },
   {
     id: "meetingLiveNotes",

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -728,6 +728,7 @@ let DEFAULT_SETTINGS: Settings = {
 			disableKeyboardCapture: true,
 			disableClickCapture: false,
 			keepComputerAwake: false,
+			showRestartNotifications: false,
 			experimentalCoreaudioSystemAudio: false,
 			experimentalMeetingPiggyback: false,
 			alwaysRecordBluetoothMic: false,

--- a/apps/screenpipe-app-tauri/src-tauri/src/overlay_health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/overlay_health.rs
@@ -122,6 +122,32 @@ fn dismiss_state(inner: &mut Inner) -> bool {
     was_auto_revealed
 }
 
+/// Return the overlay to its normal shortcut state while recording-health
+/// alerts are disabled. If this feature revealed an otherwise-hidden overlay,
+/// the caller must hide it again; a user-enabled shortcut overlay stays open.
+fn disable_alert_state(inner: &mut Inner) -> TickEffect {
+    let was_active = inner.state != OverlayHealthState::Normal;
+    let was_auto_revealed = inner.auto_revealed;
+
+    inner.state = OverlayHealthState::Normal;
+    inner.dismissed = false;
+    inner.auto_revealed = false;
+    inner.fixing_since = None;
+    inner.fixing_seen_down = false;
+    inner.recovered_at = None;
+    inner.healthy_ticks = 0;
+    inner.not_broken_ticks = 0;
+    inner.last_detail.clear();
+
+    if was_auto_revealed {
+        TickEffect::PushAndUnreveal(OverlayHealthState::Normal)
+    } else if was_active {
+        TickEffect::Push(OverlayHealthState::Normal, None)
+    } else {
+        TickEffect::None
+    }
+}
+
 /// Pure overlay state transition. All Tauri/Swift side effects stay in
 /// `on_tick`; keeping the reducer independent lets tests drive long temporal
 /// sequences with an injected clock and boot phase.
@@ -328,17 +354,32 @@ fn track(app: &tauri::AppHandle, event: &'static str) {
 ///             signal that confirms a recovery.
 /// The two are not complements: during a restart both are false.
 pub async fn on_tick(app: &tauri::AppHandle, broken: bool, healthy: bool) {
+    // This detector still produces false positives, so all visible effects are
+    // opt-in through Settings > Notifications > Recording health alerts.
+    // Read the persisted flag each tick so toggling it off clears an active
+    // incident without restarting the app.
+    let alerts_enabled = crate::store::SettingsStore::get(app)
+        .ok()
+        .flatten()
+        .map(|s| s.show_restart_notifications)
+        .unwrap_or(false);
+
     let effect = {
         let mut inner = match INNER.lock() {
             Ok(i) => i,
             Err(_) => return,
         };
-        let boot_detail = if inner.state == OverlayHealthState::Fixing && !healthy {
-            boot_phase_detail()
+
+        if !alerts_enabled {
+            disable_alert_state(&mut inner)
         } else {
-            ""
-        };
-        transition_tick(&mut inner, broken, healthy, Instant::now(), boot_detail)
+            let boot_detail = if inner.state == OverlayHealthState::Fixing && !healthy {
+                boot_phase_detail()
+            } else {
+                ""
+            };
+            transition_tick(&mut inner, broken, healthy, Instant::now(), boot_detail)
+        }
     };
 
     match effect {
@@ -538,6 +579,45 @@ mod tests {
         );
         assert_eq!(inner.state, OverlayHealthState::Normal);
         assert!(!inner.auto_revealed);
+    }
+
+    #[test]
+    fn disabled_alerts_suppress_new_incidents() {
+        let mut inner = test_inner(OverlayHealthState::Normal);
+
+        assert_eq!(disable_alert_state(&mut inner), TickEffect::None);
+        assert_eq!(inner.state, OverlayHealthState::Normal);
+        assert!(!inner.dismissed);
+    }
+
+    #[test]
+    fn disabling_alerts_clears_incident_and_rehides_auto_revealed_overlay() {
+        let mut inner = test_inner(OverlayHealthState::Failure);
+        inner.auto_revealed = true;
+        inner.fixing_since = Some(Instant::now());
+        inner.healthy_ticks = 1;
+        inner.last_detail = "starting audio".to_string();
+
+        assert_eq!(
+            disable_alert_state(&mut inner),
+            TickEffect::PushAndUnreveal(OverlayHealthState::Normal)
+        );
+        assert_eq!(inner.state, OverlayHealthState::Normal);
+        assert!(!inner.auto_revealed);
+        assert!(inner.fixing_since.is_none());
+        assert_eq!(inner.healthy_ticks, 0);
+        assert!(inner.last_detail.is_empty());
+    }
+
+    #[test]
+    fn disabling_alerts_preserves_user_enabled_shortcut_overlay() {
+        let mut inner = test_inner(OverlayHealthState::Failure);
+
+        assert_eq!(
+            disable_alert_state(&mut inner),
+            TickEffect::Push(OverlayHealthState::Normal, None)
+        );
+        assert_eq!(inner.state, OverlayHealthState::Normal);
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -973,8 +973,9 @@ pub struct SettingsStore {
     #[serde(rename = "chatAlwaysOnTop", default = "default_true")]
     pub chat_always_on_top: bool,
 
-    /// Show restart notifications when audio/vision capture stalls.
-    /// Disabled by default for now until the stall detector is more reliable.
+    /// Show recording-health overlay alerts and restart notifications when
+    /// audio/vision capture stalls. Disabled by default for now until the
+    /// detector is more reliable.
     #[serde(rename = "showRestartNotifications", default)]
     pub show_restart_notifications: bool,
 
@@ -2118,6 +2119,24 @@ mod tests {
     #[test]
     fn auto_update_defaults_to_disabled() {
         assert!(!SettingsStore::default().auto_update);
+    }
+
+    #[test]
+    fn recording_health_alerts_default_to_disabled() {
+        assert!(!SettingsStore::default().show_restart_notifications);
+
+        let missing: SettingsStore = serde_json::from_value(json!({
+            "aiPresets": []
+        }))
+        .unwrap();
+        assert!(!missing.show_restart_notifications);
+
+        let opted_in: SettingsStore = serde_json::from_value(json!({
+            "aiPresets": [],
+            "showRestartNotifications": true
+        }))
+        .unwrap();
+        assert!(opted_in.show_restart_notifications);
     }
 
     #[test]


### PR DESCRIPTION
## what

- make the experimental recording-health alert default off
- reuse Settings > Notifications > Recording health alerts as the opt-in switch
- gate the recording needs help / fixing / recovered overlay states on that persisted setting
- when switched off during an incident, clear the alert and only re-hide the shortcut overlay if the health feature auto-opened it

## settings preview

~~~text
notifications
└─ recording health
   [ off ] recording health alerts    experimental
           Show “recording needs help” and notify when capture stops
~~~

The regular shortcut reminder remains independently controlled by Show Shortcut Reminder.

## verification

- settings registry tests: 13 passed
- recording-health state tests: 12 passed
- settings default/deserialization test: 1 passed
- TypeScript typecheck: passed
- diff check: passed

Repository-wide Rust formatting currently reports pre-existing drift in unrelated files on main; this PR does not rewrite those files.