### PR TITLE
fix(app): reflect disabled recording in tray and popup

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -572,9 +572,23 @@ function HomeContent() {
 
       // When globally paused the device APIs may return empty (session torn
       // down). Preserve the last known device list so the user can still see
-      // what was recording and hit "resume".
+      // what was recording and hit "resume". Use the functional updater to
+      // avoid a stale-closure over recordingDevices.
+      if (capturePaused && devices.length === 0) {
+        setRecordingDevices((prev) => {
+          const updated = prev.map((d) => ({ ...d, active: false }));
+          const snap = JSON.stringify(updated);
+          if (snap !== recordingDevicesSnapshotRef.current) {
+            recordingDevicesSnapshotRef.current = snap;
+            return updated;
+          }
+          return prev;
+        });
+        return;
+      }
+
       const effective = capturePaused
-        ? (devices.length > 0 ? devices : recordingDevices).map((d) => ({ ...d, active: false }))
+        ? devices.map((d) => ({ ...d, active: false }))
         : devices;
 
       const snapshot = JSON.stringify(effective);

--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -570,8 +570,11 @@ function HomeContent() {
         }
       }
 
+      // When globally paused the device APIs may return empty (session torn
+      // down). Preserve the last known device list so the user can still see
+      // what was recording and hit "resume".
       const effective = capturePaused
-        ? devices.map((d) => ({ ...d, active: false }))
+        ? (devices.length > 0 ? devices : recordingDevices).map((d) => ({ ...d, active: false }))
         : devices;
 
       const snapshot = JSON.stringify(effective);
@@ -1057,6 +1060,8 @@ function HomeContent() {
               isGloballyPaused={isCapturePaused}
               isTranslucent={isTranslucent}
               floatingOverMedia={sidebarCollapsed && activeSection === "timeline"}
+              allCaptureDisabled={!!(settings.disableAudio && settings.disableVision)}
+              onOpenRecordingSettings={() => router.push("/settings?section=recording")}
             />
           </div>
 

--- a/apps/screenpipe-app-tauri/components/__tests__/recording-status.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/recording-status.test.tsx
@@ -51,6 +51,109 @@ async function simulateToggleAll(
   return "noop";
 }
 
+/**
+ * Mirrors the visibleDevices display logic from recording-status.tsx.
+ * When allCaptureDisabled is true, devices are hidden from the UI.
+ */
+function computeDisplayState(
+  devices: RecordingDevice[],
+  allCaptureDisabled: boolean,
+) {
+  const visibleDevices = allCaptureDisabled ? [] : devices;
+  const pausedCount = visibleDevices.filter((d) => !d.active).length;
+  const allActive = visibleDevices.length > 0 && pausedCount === 0;
+  const canPauseRecording = visibleDevices.some((d) => d.active);
+  const allPaused = visibleDevices.length > 0 && !canPauseRecording;
+
+  const summary =
+    visibleDevices.length === 0
+      ? "not recording"
+      : pausedCount === 0
+        ? "recording"
+        : `${pausedCount} device${pausedCount > 1 ? "s" : ""} paused`;
+
+  return { visibleDevices, summary, allActive, allPaused, canPauseRecording };
+}
+
+describe("RecordingStatus — allCaptureDisabled display logic", () => {
+  it("shows 'not recording' with no visible devices when all capture disabled", () => {
+    const devices = makeDevices();
+    const state = computeDisplayState(devices, true);
+
+    expect(state.summary).toBe("not recording");
+    expect(state.visibleDevices).toHaveLength(0);
+    expect(state.allActive).toBe(false);
+    expect(state.allPaused).toBe(false);
+    expect(state.canPauseRecording).toBe(false);
+  });
+
+  it("shows 'recording' with all devices when capture is enabled", () => {
+    const devices = makeDevices();
+    const state = computeDisplayState(devices, false);
+
+    expect(state.summary).toBe("recording");
+    expect(state.visibleDevices).toHaveLength(3);
+    expect(state.allActive).toBe(true);
+    expect(state.canPauseRecording).toBe(true);
+  });
+
+  it("shows paused count when some devices inactive and capture enabled", () => {
+    const devices = makeDevices([
+      { active: true },
+      { active: false },
+      { active: false },
+    ]);
+    const state = computeDisplayState(devices, false);
+
+    expect(state.summary).toBe("2 devices paused");
+    expect(state.allPaused).toBe(false);
+    expect(state.canPauseRecording).toBe(true);
+  });
+
+  it("ignores active devices when all capture disabled", () => {
+    const devices = makeDevices([
+      { active: true },
+      { active: true },
+      { active: true },
+    ]);
+    const state = computeDisplayState(devices, true);
+
+    expect(state.summary).toBe("not recording");
+    expect(state.visibleDevices).toHaveLength(0);
+  });
+
+  it("shows 'not recording' when no devices and capture enabled", () => {
+    const state = computeDisplayState([], false);
+
+    expect(state.summary).toBe("not recording");
+    expect(state.visibleDevices).toHaveLength(0);
+  });
+
+  it("shows singular 'paused' for one device", () => {
+    const devices = makeDevices([
+      { active: true },
+      { active: true },
+      { active: false },
+    ]);
+    const state = computeDisplayState(devices, false);
+
+    expect(state.summary).toBe("1 device paused");
+  });
+
+  it("shows allPaused when all devices inactive and capture enabled", () => {
+    const devices = makeDevices([
+      { active: false },
+      { active: false },
+      { active: false },
+    ]);
+    const state = computeDisplayState(devices, false);
+
+    expect(state.summary).toBe("3 devices paused");
+    expect(state.allPaused).toBe(true);
+    expect(state.canPauseRecording).toBe(false);
+  });
+});
+
 describe("RecordingStatus — toggleAllRecording logic", () => {
   it("calls onResumeRecording when globally paused (capture session torn down)", async () => {
     const devices = makeDevices([

--- a/apps/screenpipe-app-tauri/components/recording-status.tsx
+++ b/apps/screenpipe-app-tauri/components/recording-status.tsx
@@ -47,6 +47,11 @@ interface RecordingStatusProps {
   isTranslucent?: boolean;
   /** buttons float over full-bleed video (timeline, sidebar collapsed) */
   floatingOverMedia?: boolean;
+  /** true when both audio and vision are disabled in settings — hides
+   * recording controls since nothing can record. */
+  allCaptureDisabled?: boolean;
+  /** navigate to recording settings */
+  onOpenRecordingSettings?: () => void;
 }
 
 const KIND_ICONS: Record<
@@ -77,6 +82,8 @@ export function RecordingStatus({
   isGloballyPaused,
   isTranslucent,
   floatingOverMedia,
+  allCaptureDisabled,
+  onOpenRecordingSettings,
 }: RecordingStatusProps) {
   const [open, setOpen] = React.useState(false);
   const [pauseLoading, setPauseLoading] = React.useState(false);
@@ -228,7 +235,7 @@ export function RecordingStatus({
         <div className="px-3 py-2 border-b border-border">
           <span className="text-xs font-medium text-foreground">{label}</span>
         </div>
-        {(onPauseRecording || onResumeRecording) && (
+        {(onPauseRecording || onResumeRecording) && !allCaptureDisabled && (
           <div className="px-3 py-2 border-b border-border">
             <button
               type="button"
@@ -250,9 +257,19 @@ export function RecordingStatus({
           </div>
         )}
         <div className="py-1">
-          {devices.length === 0 && (
+          {allCaptureDisabled && devices.length === 0 && (
             <div className="px-3 py-2 text-[11px] text-muted-foreground">
-              no capture devices reported
+              no devices enabled{" "}
+              <button
+                type="button"
+                onClick={() => {
+                  onOpenRecordingSettings?.();
+                  setOpen(false);
+                }}
+                className="underline text-foreground hover:opacity-70 transition-opacity"
+              >
+                open settings
+              </button>
             </div>
           )}
           {devices.map((device) => {
@@ -307,27 +324,29 @@ export function RecordingStatus({
             );
           })}
         </div>
-        <div className="flex items-center gap-2 px-3 py-1.5 border-t border-border">
-          <Phone
-            aria-hidden="true"
-            className={cn(
-              "h-3 w-3 shrink-0",
-              meetingActive ? "text-foreground" : "text-muted-foreground"
-            )}
-          />
-          <span className="flex-1 min-w-0 truncate text-[11px] text-foreground">
-            {meetingActive ? `meeting notes${meetingApp ? ` · ${meetingApp}` : ""}` : "meeting notes"}
-          </span>
-          <button
-            onClick={onToggleMeeting}
-            disabled={meetingLoading}
-            data-testid="recording-status-meeting-toggle"
-            title={meetingActive ? "stop the meeting note only" : "start meeting notes"}
-            className="text-[10px] text-muted-foreground hover:text-foreground transition-colors shrink-0 disabled:opacity-50 whitespace-nowrap"
-          >
-            {meetingActive ? "stop notes" : "start notes"}
-          </button>
-        </div>
+        {(!allCaptureDisabled || meetingActive) && (
+          <div className="flex items-center gap-2 px-3 py-1.5 border-t border-border">
+            <Phone
+              aria-hidden="true"
+              className={cn(
+                "h-3 w-3 shrink-0",
+                meetingActive ? "text-foreground" : "text-muted-foreground"
+              )}
+            />
+            <span className="flex-1 min-w-0 truncate text-[11px] text-foreground">
+              {meetingActive ? `meeting notes${meetingApp ? ` · ${meetingApp}` : ""}` : "meeting notes"}
+            </span>
+            <button
+              onClick={onToggleMeeting}
+              disabled={meetingLoading}
+              data-testid="recording-status-meeting-toggle"
+              title={meetingActive ? "stop the meeting note only" : "start meeting notes"}
+              className="text-[10px] text-muted-foreground hover:text-foreground transition-colors shrink-0 disabled:opacity-50 whitespace-nowrap"
+            >
+              {meetingActive ? "stop notes" : "start notes"}
+            </button>
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/apps/screenpipe-app-tauri/components/recording-status.tsx
+++ b/apps/screenpipe-app-tauri/components/recording-status.tsx
@@ -88,12 +88,15 @@ export function RecordingStatus({
   const [open, setOpen] = React.useState(false);
   const [pauseLoading, setPauseLoading] = React.useState(false);
 
-  const pausedCount = devices.filter((d) => !d.active).length;
-  const allActive = devices.length > 0 && pausedCount === 0;
-  const canPauseRecording = devices.some((d) => d.active);
+  // When all capture is disabled in settings, treat the device list as empty
+  // even if the sidecar still reports devices — nothing is actually recording.
+  const visibleDevices = allCaptureDisabled ? [] : devices;
+  const pausedCount = visibleDevices.filter((d) => !d.active).length;
+  const allActive = visibleDevices.length > 0 && pausedCount === 0;
+  const canPauseRecording = visibleDevices.some((d) => d.active);
 
   const summary =
-    devices.length === 0
+    visibleDevices.length === 0
       ? "not recording"
       : pausedCount === 0
         ? "recording"
@@ -143,7 +146,7 @@ export function RecordingStatus({
     }
   };
 
-  const allPaused = devices.length > 0 && !canPauseRecording;
+  const allPaused = visibleDevices.length > 0 && !canPauseRecording;
 
   const toggleAllRecording = async () => {
     if (pauseLoading) return;
@@ -215,7 +218,7 @@ export function RecordingStatus({
                     : allActive
                       ? "bg-foreground"
                       : "border border-foreground bg-transparent",
-                  devices.length === 0 && "opacity-40",
+                  visibleDevices.length === 0 && "opacity-40",
                   meetingActive && "animate-pulse"
                 )}
               />
@@ -257,22 +260,28 @@ export function RecordingStatus({
           </div>
         )}
         <div className="py-1">
-          {allCaptureDisabled && devices.length === 0 && (
+          {visibleDevices.length === 0 && (
             <div className="px-3 py-2 text-[11px] text-muted-foreground">
-              no devices enabled{" "}
-              <button
-                type="button"
-                onClick={() => {
-                  onOpenRecordingSettings?.();
-                  setOpen(false);
-                }}
-                className="underline text-foreground hover:opacity-70 transition-opacity"
-              >
-                open settings
-              </button>
+              {allCaptureDisabled ? (
+                <>
+                  no devices enabled{" "}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onOpenRecordingSettings?.();
+                      setOpen(false);
+                    }}
+                    className="underline text-foreground hover:opacity-70 transition-opacity"
+                  >
+                    open settings
+                  </button>
+                </>
+              ) : (
+                "no capture devices reported"
+              )}
             </div>
           )}
-          {devices.map((device) => {
+          {visibleDevices.map((device) => {
             const Icon = device.active
               ? KIND_ICONS[device.kind].active
               : KIND_ICONS[device.kind].paused;

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -889,7 +889,7 @@ fn create_dynamic_menu(
     let all_capture_disabled = data.all_capture_disabled;
     let effective_status = get_effective_recording_status();
     let status_text = match effective_status {
-        _ if all_capture_disabled && effective_status == RecordingStatus::Recording => "○ Stopped",
+        RecordingStatus::Recording if all_capture_disabled => "○ Stopped",
         RecordingStatus::Starting => "○ Starting…",
         RecordingStatus::Recording => "● Recording",
         RecordingStatus::Paused => "◐ Paused",

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -53,6 +53,8 @@ struct TrayMenuData {
     has_permission_issue: bool,
     app_ui_hidden: bool,
     disable_timeline: bool,
+    /// Both audio and vision are disabled in settings — nothing can record.
+    all_capture_disabled: bool,
 }
 
 /// Gather all data needed by `create_dynamic_menu` on the current (non-main)
@@ -115,6 +117,8 @@ fn prefetch_tray_menu_data(app: &AppHandle) -> TrayMenuData {
     let cloud_subscribed = settings.user.cloud_subscribed == Some(true);
     let subscription_plan = settings.user.subscription_plan.clone();
     let disable_timeline = settings.recording.disable_timeline;
+    let all_capture_disabled =
+        settings.recording.disable_audio && settings.recording.disable_vision;
 
     let app_ui_hidden = is_app_ui_hidden();
 
@@ -142,6 +146,7 @@ fn prefetch_tray_menu_data(app: &AppHandle) -> TrayMenuData {
         has_permission_issue,
         app_ui_hidden,
         disable_timeline,
+        all_capture_disabled,
     }
 }
 
@@ -479,6 +484,7 @@ fn snapshot_menu_state(data: &TrayMenuData, effective_status: RecordingStatus) -
         cloud_subscribed: data.cloud_subscribed,
         subscription_plan: data.subscription_plan.clone(),
         hd: hd_menu_state(&hd),
+        all_capture_disabled: data.all_capture_disabled,
     }
 }
 
@@ -632,6 +638,8 @@ struct MenuState {
     /// The per-tick countdown is updated on the existing item instead of being
     /// part of this equality key, which avoids rebuilding the native menu.
     hd: HdMenuState,
+    /// Both audio and vision disabled in settings.
+    all_capture_disabled: bool,
 }
 
 pub fn setup_tray(app: &AppHandle, update_item: Option<&tauri::menu::MenuItem<Wry>>) -> Result<()> {
@@ -878,8 +886,10 @@ fn create_dynamic_menu(
     }
 
     // --- Recording status + devices ---
+    let all_capture_disabled = data.all_capture_disabled;
     let effective_status = get_effective_recording_status();
     let status_text = match effective_status {
+        _ if all_capture_disabled && effective_status == RecordingStatus::Recording => "○ Stopped",
         RecordingStatus::Starting => "○ Starting…",
         RecordingStatus::Recording => "● Recording",
         RecordingStatus::Paused => "◐ Paused",
@@ -889,8 +899,9 @@ fn create_dynamic_menu(
     };
     menu_builder = menu_builder.item(&PredefinedMenuItem::separator(app)?);
 
-    if effective_status == RecordingStatus::Recording
-        || effective_status == RecordingStatus::Starting
+    if !all_capture_disabled
+        && (effective_status == RecordingStatus::Recording
+            || effective_status == RecordingStatus::Starting)
     {
         menu_builder = menu_builder.item(
             &MenuItemBuilder::with_id("privacy_info", "Your data stays local")
@@ -905,7 +916,7 @@ fn create_dynamic_menu(
             .build(app)?,
     );
 
-    {
+    if !all_capture_disabled {
         let info = get_recording_info();
 
         // Monitors: CheckMenuItem when the sidecar reports a numeric id (per-display
@@ -1063,17 +1074,22 @@ fn create_dynamic_menu(
     if !is_tray_item_hidden("tray_recording_controls") {
         menu_builder = menu_builder.item(&PredefinedMenuItem::separator(app)?);
 
-        let is_recording = effective_status == RecordingStatus::Recording;
-        let label = match effective_status {
-            RecordingStatus::Recording => "Recording",
-            RecordingStatus::Paused => "Paused — click to resume",
-            RecordingStatus::ScheduledPause => "Outside work hours — paused by schedule",
-            RecordingStatus::Starting => "Starting…",
-            RecordingStatus::Error => "Error — click to retry",
-            _ => "Stopped — click to record",
+        let is_recording = effective_status == RecordingStatus::Recording && !all_capture_disabled;
+        let label = if all_capture_disabled {
+            "Stopped — no devices enabled"
+        } else {
+            match effective_status {
+                RecordingStatus::Recording => "Recording",
+                RecordingStatus::Paused => "Paused — click to resume",
+                RecordingStatus::ScheduledPause => "Outside work hours — paused by schedule",
+                RecordingStatus::Starting => "Starting…",
+                RecordingStatus::Error => "Error — click to retry",
+                _ => "Stopped — click to record",
+            }
         };
         let toggle = CheckMenuItemBuilder::with_id("toggle_recording", label)
             .checked(is_recording)
+            .enabled(!all_capture_disabled)
             .build(app)?;
         menu_builder = menu_builder.item(&toggle);
 
@@ -1094,6 +1110,7 @@ fn create_dynamic_menu(
         // No indefinite mode — every session has a natural end (meeting end
         // or timer expiry). Hits /capture/hd/{start,stop} so changes take
         // effect on the next capture tick.
+        // Hidden when no devices are enabled — nothing to record in HD.
         let hd = get_high_fps_status();
         if hd.active {
             let item = MenuItemBuilder::with_id("stop_hd_recording", hd_stop_menu_label(&hd))
@@ -1106,7 +1123,7 @@ fn create_dynamic_menu(
             menu_builder = menu_builder.item(
                 &MenuItemBuilder::with_id("extend_hd_30", "Extend HD by +30 min").build(app)?,
             );
-        } else {
+        } else if !all_capture_disabled {
             *HD_STOP_MENU_ITEM.lock().unwrap_or_else(|e| e.into_inner()) = None;
             // Idle: offer timer-bound sessions only. The meeting-bound path
             // is reached via the meeting-start notification's "+ HD" action.
@@ -1117,6 +1134,8 @@ fn create_dynamic_menu(
                 .item(&MenuItemBuilder::with_id("hd_timer_120", "2 hours").build(app)?)
                 .build()?;
             menu_builder = menu_builder.item(&submenu);
+        } else {
+            *HD_STOP_MENU_ITEM.lock().unwrap_or_else(|e| e.into_inner()) = None;
         }
     }
 


### PR DESCRIPTION
This PR fixes several recording UX inconsistencies where the tray and status popup showed misleading state when all capture was disabled in settings: 

  - tray was showing "Recording ✓" with pause/resume controls even when both audio and screen capture were disabled in settings — now shows "Stopped — no devices enabled" (greyed out, not clickable)
  - status popup was showing devices and "recording" when nothing was actually recording - now shows "not recording" with "no devices enabled · open settings" link
  - hid pause button, Record HD submenu, and meeting notes row when all capture is disabled since none of those actions can work
  - preserved device list in popup when globally paused (not disabled) so resume path still works
  

Before -

https://github.com/user-attachments/assets/5b6f705d-d979-4fe7-973d-d7ef3f754d34

After -

https://github.com/user-attachments/assets/af432ee7-204a-4c1e-a058-60a0f5b50ba8



