### PR TITLE
fix(ui): show last-run time instead of count in pipe sidebar

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -446,18 +446,6 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
       });
       setPipeInventory(inventory);
       setPipeInventoryAuthoritative(true);
-      // Pre-seed cache for pipes with zero runs so expanding them
-      // shows "no saved runs" instantly instead of flashing a skeleton.
-      setLoadedPipeRuns((prev) => {
-        let next = prev;
-        for (const pipe of inventory) {
-          if (pipe.executionCount === 0 && !prev[pipe.name]) {
-            if (next === prev) next = { ...prev };
-            next[pipe.name] = [];
-          }
-        }
-        return next;
-      });
     } catch {
       // Keep recent in-memory pipe groups available if the engine is still
       // starting or an older build does not expose the inventory endpoint.

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -446,6 +446,18 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
       });
       setPipeInventory(inventory);
       setPipeInventoryAuthoritative(true);
+      // Pre-seed cache for pipes with zero runs so expanding them
+      // shows "no saved runs" instantly instead of flashing a skeleton.
+      setLoadedPipeRuns((prev) => {
+        let next = prev;
+        for (const pipe of inventory) {
+          if (pipe.executionCount === 0 && !prev[pipe.name]) {
+            if (next === prev) next = { ...prev };
+            next[pipe.name] = [];
+          }
+        }
+        return next;
+      });
     } catch {
       // Keep recent in-memory pipe groups available if the engine is still
       // starting or an older build does not expose the inventory endpoint.
@@ -532,12 +544,12 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     });
   }, [pipeInventory, pipes, loadedPipeRuns, storeSessionIds]);
 
-  const pipeExecutionCounts = useMemo(
+  const pipeLastRuns = useMemo(
     () => Object.fromEntries(
       pipeInventory.flatMap((pipe) =>
-        pipe.executionCount == null ? [] : [[pipe.name, pipe.executionCount]],
+        pipe.lastRun == null ? [] : [[pipe.name, pipe.lastRun]],
       ),
-    ) as Record<string, number>,
+    ) as Record<string, string>,
     [pipeInventory],
   );
 
@@ -1025,9 +1037,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
                     <PipeGroupRow
                       key={item.key}
                       item={item}
-                      executionCount={pipeExecutionCounts[item.title]}
-                      executionCountLoading={!pipeInventoryLoaded}
-                      runsLoading={loadingPipeRuns.has(item.title)}
+                      lastRun={pipeLastRuns[item.title]}
                       runsLoaded={loadedPipeRuns[item.title] != null}
                       expanded={expandedGroups.has(item.key)}
                       onToggleExpand={() => toggleGroupExpanded(item.key)}
@@ -1653,9 +1663,7 @@ function RecentsBody({
  */
 function PipeGroupRow({
   item,
-  executionCount,
-  executionCountLoading = false,
-  runsLoading = false,
+  lastRun,
   runsLoaded = false,
   expanded,
   onToggleExpand,
@@ -1674,9 +1682,7 @@ function PipeGroupRow({
   setOpenConversationMenuId,
 }: {
   item: Extract<SidebarItem, { kind: "group" }>;
-  executionCount?: number;
-  executionCountLoading?: boolean;
-  runsLoading?: boolean;
+  lastRun?: string;
   runsLoaded?: boolean;
   expanded: boolean;
   onToggleExpand: () => void;
@@ -1694,6 +1700,8 @@ function PipeGroupRow({
   openConversationMenuId: string | null;
   setOpenConversationMenuId: (id: string | null) => void;
 }) {
+  const now = useMinuteTick(!!lastRun);
+  const lastRunAge = lastRun ? formatCompactAge(new Date(lastRun).getTime(), now) : null;
   return (
     <div data-testid={`pipe-group-${item.key}`}>
       <button
@@ -1706,32 +1714,27 @@ function PipeGroupRow({
         aria-expanded={expanded}
       >
         <span className="truncate flex-1 text-xs">{item.title}</span>
-        <span className="inline-flex items-center gap-1.5 shrink-0">
-          <span className="text-[10px] tabular-nums text-muted-foreground/60">
-            {executionCountLoading ? "…" : executionCount ?? item.sessions.length}
-          </span>
-          {expanded ? (
-            <ChevronDown
-              className="h-3 w-3 text-muted-foreground/60"
-              aria-hidden
-            />
-          ) : (
-            <ChevronRight
-              className="h-3 w-3 text-muted-foreground/60"
-              aria-hidden
-            />
+        <span className="relative inline-flex items-center justify-end shrink-0 w-6 h-4">
+          {lastRunAge && !expanded && (
+            <span className="absolute inset-0 flex items-center justify-end text-[10px] tabular-nums text-muted-foreground/60 opacity-100 group-hover/pipe:opacity-0 transition-opacity duration-150">
+              {lastRunAge}
+            </span>
           )}
+          <span className={cn(
+            "absolute inset-0 flex items-center justify-end transition-opacity duration-150",
+            expanded ? "opacity-100" : "opacity-0 group-hover/pipe:opacity-100"
+          )}>
+            {expanded ? (
+              <ChevronDown className="h-3 w-3 text-muted-foreground/60" aria-hidden />
+            ) : (
+              <ChevronRight className="h-3 w-3 text-muted-foreground/60" aria-hidden />
+            )}
+          </span>
         </span>
       </button>
       {expanded && (
         <div className="pl-3">
-          {runsLoading ? (
-            <div className="px-2 py-1.5 space-y-1.5" aria-busy="true">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <Skeleton key={i} className="h-6 w-full rounded-md" />
-              ))}
-            </div>
-          ) : runsLoaded && item.sessions.length === 0 ? (
+          {runsLoaded && item.sessions.length === 0 ? (
             <div className="px-2 py-1.5 text-[11px] text-muted-foreground/60 italic">
               no saved runs
             </div>


### PR DESCRIPTION
This PR replace raw execution count ("0", "7") with relative last-run time ("2h", "3d") in pipe group header. Also removes skeleton loader flash when expanding pipe groups.

Before -

<img width="867" height="691" alt="image" src="https://github.com/user-attachments/assets/b4e17a3a-80da-4fc0-a955-6d2d10604257" />


After -


https://github.com/user-attachments/assets/a3492c5a-a2d8-43fe-82d8-74e678b41eb5
