### PR TITLE
feat(cli): add top-level setup command

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -314,6 +314,10 @@ async fn main() -> anyhow::Result<()> {
             screenpipe_engine::cli::agent::handle_agent_command(subcommand).await?;
             return Ok(());
         }
+        Command::Setup { ref api_url } => {
+            screenpipe_engine::cli::agent::setup_all_detected(api_url)?;
+            return Ok(());
+        }
         Command::Service { ref subcommand } => {
             screenpipe_engine::cli::service::handle_service_command(subcommand).await?;
             return Ok(());

--- a/crates/screenpipe-engine/src/cli/agent.rs
+++ b/crates/screenpipe-engine/src/cli/agent.rs
@@ -163,15 +163,12 @@ pub fn maybe_prompt_connect_detected(data_dir: &Path) {
                 "\n  {} {error}",
                 "some tools were not connected:".yellow().bold()
             );
-            eprintln!(
-                "  retry with {}",
-                "screenpipe agent setup --all".green().bold()
-            );
+            eprintln!("  retry with {}", "screenpipe setup".green().bold());
         }
     } else {
         eprintln!(
             "  not now — run {} whenever you're ready.\n",
-            "screenpipe agent setup --all".green().bold()
+            "screenpipe setup".green().bold()
         );
     }
 }
@@ -250,7 +247,7 @@ fn has_screenpipe_mcp(layout: &AgentLayout) -> bool {
     }
 }
 
-fn setup_all_detected(api_url: &str) -> Result<()> {
+pub fn setup_all_detected(api_url: &str) -> Result<()> {
     let home = dirs::home_dir().context("could not resolve home dir")?;
     let detected = detected_agents_in(&home);
     if detected.is_empty() {

--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -250,6 +250,13 @@ pub enum Command {
         subcommand: agent::AgentCommand,
     },
 
+    /// Connect screenpipe to every supported AI tool detected on this computer
+    Setup {
+        /// screenpipe REST API base URL the skills + MCP should target.
+        #[arg(long, default_value = "http://localhost:3030")]
+        api_url: String,
+    },
+
     /// Run screenpipe as a background service that starts at boot + stays up
     /// (systemd on Linux, launchd on macOS). For always-on boxes / VPS.
     Service {
@@ -2358,6 +2365,34 @@ mod tests {
         match cli.command {
             Command::Survey => {}
             _ => panic!("expected Survey command"),
+        }
+    }
+
+    #[test]
+    fn test_setup_command_parses_with_default_api_url() {
+        let cli = Cli::try_parse_from(["screenpipe", "setup"]).unwrap();
+        match cli.command {
+            Command::Setup { api_url } => {
+                assert_eq!(api_url, "http://localhost:3030");
+            }
+            _ => panic!("expected Setup command"),
+        }
+    }
+
+    #[test]
+    fn test_setup_command_accepts_remote_api_url() {
+        let cli = Cli::try_parse_from([
+            "screenpipe",
+            "setup",
+            "--api-url",
+            "https://screenpipe.example",
+        ])
+        .unwrap();
+        match cli.command {
+            Command::Setup { api_url } => {
+                assert_eq!(api_url, "https://screenpipe.example");
+            }
+            _ => panic!("expected Setup command"),
         }
     }
 

--- a/crates/screenpipe-engine/src/cli_reminder.rs
+++ b/crates/screenpipe-engine/src/cli_reminder.rs
@@ -117,10 +117,7 @@ fn print_mcp_tip() {
         "  {} connect screenpipe to every AI tool detected on this computer:",
         "tip:".cyan().bold(),
     );
-    eprintln!(
-        "       {}",
-        "npx screenpipe@latest agent setup --all".green().bold(),
-    );
+    eprintln!("       {}", "npx screenpipe@latest setup".green().bold());
     eprintln!(
         "       adds MCP + supported skills to Claude, Codex, Cursor, OpenClaw, Hermes, and Windsurf/Devin",
     );


### PR DESCRIPTION
## Why

`npx screenpipe@latest setup` currently fails with an unrecognized-subcommand error even though it is the natural command people try when they want to connect screenpipe to their AI tools.

## What changed

- adds `screenpipe setup [--api-url ...]` as the short, intentional path for connecting every supported AI tool detected on the computer
- keeps the existing advanced `screenpipe agent setup --all` and per-tool setup commands working
- reuses the existing safe installer, so unrelated MCP configuration is preserved and repeat runs are no-ops
- updates CLI tips and declined/retry prompts to point people to `npx screenpipe@latest setup`

## Before / after

<img src="https://litter.catbox.moe/c6oyyh.gif" alt="Before: setup is rejected. After: detected AI tools receive screenpipe skills and MCP configuration." width="720">

## Validation

- `cargo fmt --check`
- `git diff --check`
- full `screenpipe-engine` library suite: 1,108 passed, 0 failed, 8 ignored
- 23 focused AI setup/config-safety tests passed
- 2 new CLI parser tests passed, including custom `--api-url`
- native end-to-end run against isolated Codex, Cursor, and Hermes homes
- repeat-run/idempotence, remote API, and no-supported-tools paths verified
- exact npm path verified through a local registry: `npx screenpipe@latest setup`, repeat run, and `setup --help`

## Compatibility

No existing command is removed or changed. This is a top-level alias over the existing all-detected setup behavior.
