### PR TITLE
fix(windows-arm64): openblas.dll missing from installer bundle — installed app crashes at launch

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/setup_openblas.js
+++ b/apps/screenpipe-app-tauri/scripts/setup_openblas.js
@@ -46,6 +46,11 @@ export async function setupOpenBlas({ cwd, winArch }) {
 			) {
 				return false
 			}
+			// ARM64 exe imports the PE internal name "openblas.dll" — the
+			// installer bundles bin/*.dll, so both names must be present.
+			if (winArch === 'arm64' && !(await fs.exists(path.join(directory, 'bin', 'openblas.dll')))) {
+				return false
+			}
 			const configHeader = await fs
 				.readFile(path.join(directory, 'include', 'openblas_config.h'), 'utf8')
 				.catch(() => '')
@@ -87,11 +92,22 @@ async function flattenOpenBlas(openblasPath, winArch) {
 			}
 			await fs.rmdir(includeOpenblas)
 		}
-		// Rename openblas.dll → libopenblas.dll (expected by runtime loader)
+		// The woa64 package ships the DLL as openblas.dll on disk, but its PE
+		// internal name is also "openblas.dll" — the exe's import table resolves
+		// that name at runtime. Build tooling expects libopenblas.dll (matching
+		// x64). Keep BOTH names in bin/ so the installer bundle glob
+		// (tauri.windows.conf.json "openblas\\bin\\*.dll") ships both: renaming
+		// away openblas.dll caused installed ARM64 apps to crash at launch with
+		// "openblas.dll was not found". Copies in whichever direction is missing
+		// so previously-cached extractions (only libopenblas.dll) self-heal.
 		const openblasDll = path.join(openblasPath, 'bin', 'openblas.dll')
 		const libOpenblasDll = path.join(openblasPath, 'bin', 'libopenblas.dll')
-		if (await fs.exists(openblasDll)) {
-			await fs.rename(openblasDll, libOpenblasDll)
+		const hasOpenblasDll = await fs.exists(openblasDll)
+		const hasLibOpenblasDll = await fs.exists(libOpenblasDll)
+		if (hasOpenblasDll && !hasLibOpenblasDll) {
+			await fs.copyFile(openblasDll, libOpenblasDll)
+		} else if (hasLibOpenblasDll && !hasOpenblasDll) {
+			await fs.copyFile(libOpenblasDll, openblasDll)
 		}
 		// Rename openblas.lib → libopenblas.lib (MSVC import library for linking)
 		const openblasLib = path.join(openblasPath, 'lib', 'openblas.lib')


### PR DESCRIPTION
## description

Fixes the ARM64 Windows installed-app launch crash:

> Error: The code execution cannot proceed because openblas.dll was not found. Reinstalling the program may fix this problem.

Root cause: the OpenBLAS woa64 DLL's **PE export name is `openblas.dll`** (verified by parsing the export directory of the real 0.3.31 woa64 binary), so the exe's import table resolves that exact name at runtime. `setup_openblas.js` renamed the file on disk to `libopenblas.dll`, and #4207 patched around it by copying `openblas.dll` back into the **cargo target dir** — which fixed `tauri dev` but not the installer: the NSIS bundle ships from the glob `openblas\bin\*.dll` (`tauri.windows.conf.json`), and `bin/` only contained `libopenblas.dll`. Every installed ARM64 build crashed at launch.

Fix (in the mechanism, not another call site):
- `setup_openblas.js` now keeps **both** names in `openblas/bin/` — copy instead of rename, healing in whichever direction is missing so previously-cached extractions (which only have `libopenblas.dll`) self-repair on the next build.
- arm64 cache validation additionally requires `bin/openblas.dll`, so stale caches fail validation and repopulate.

Call-site audit of everything consuming the openblas dir:

| site | verdict |
|---|---|
| `tauri.windows.conf.json` `openblas\bin\*.dll` glob (installer) | **was broken — fixed**: now ships both names |
| `src-tauri/build.rs` arm64 target-dir copy (#4207, dev builds) | still correct, untouched |
| `setup_openblas.js` cache `validate` | strengthened for arm64 |
| `lib/libopenblas.lib` rename (MSVC link) | link-time only, unchanged |
| `windows-integration-test.yml` `bin/*.dll` copy | x64 only, unaffected (would also benefit) |
| release-app / release-enterprise workflows | build via `pre_build.js → setupOpenBlas`; CI disables the native cache so every run gets the fixed layout |
| Linux (`libopenblas0` deb dep) | different mechanism, unaffected |

x64 is untouched: its package ships `libopenblas.dll` with a matching internal name, and the arm64 branch of the flatten logic doesn't run.

Cost: one extra ~10 MB DLL in the arm64 bundle (identical bytes; NSIS LZMA solid compression dedupes it to near zero).

## before

No UI change — installed ARM64 Windows app crashes at launch with the system dialog quoted above. (Human: drop the customer screenshot here if wanted.)

## after

App launches. `openblas.dll` and `libopenblas.dll` both present next to `screenpipe-app.exe` in the install dir.

Verified end-to-end on the real release zips (fresh arm64 download, fresh x64, and stale-cache heal — 9/9 assertions pass), plus PE export-table parse of the woa64 DLL confirming internal name `openblas.dll` on machine `0xaa64` (ARM64).

## how to test

1. `cd apps/screenpipe-app-tauri && bun scripts/setup_openblas.js` on a Windows ARM64 machine (or call `setupOpenBlas({cwd, winArch: 'arm64'})`) → `src-tauri/openblas/bin/` must contain **both** `openblas.dll` and `libopenblas.dll`.
2. Re-run against a pre-existing extraction that only has `libopenblas.dll` (the old layout) → `openblas.dll` is restored.
3. `bun tauri build --target aarch64-pc-windows-msvc`, install the NSIS installer → app launches, no `openblas.dll was not found` dialog; both DLLs sit next to the exe.
4. x64: `bun tauri dev` / build unaffected.

## desktop app checklist (if applicable)

N/A — build-script-only change (`scripts/setup_openblas.js`); no `#[tauri::command]` or exported-type surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
