### PR TITLE
fix(app): skip redundant pipe catalog reloads on token saves

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -639,11 +639,12 @@ pub async fn set_cloud_token(
     if let Some((pipe_manager, enforce_free_plan_retention)) = server_handles {
         enforce_free_plan_retention.store(is_free_plan, std::sync::atomic::Ordering::SeqCst);
         let mut pipe_manager = pipe_manager.lock().await;
-        pipe_manager.set_max_non_template_pipes(restrict_paid_features.then_some(2));
-        pipe_manager
-            .load_pipes()
-            .await
-            .map_err(|e| format!("failed to reload pipes after plan change: {e}"))?;
+        if pipe_manager.set_max_non_template_pipes(restrict_paid_features.then_some(2)) {
+            pipe_manager
+                .load_pipes()
+                .await
+                .map_err(|e| format!("failed to reload pipes after plan change: {e}"))?;
+        }
     }
 
     // #3943: persist to the encrypted secret store (authoritative at-rest copy)

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -2192,8 +2192,14 @@ impl PipeManager {
     ///
     /// Setting it never deletes pipe files. Over-limit pipes are kept on disk
     /// but omitted from the runtime until the limit is raised or a slot opens.
-    pub fn set_max_non_template_pipes(&mut self, limit: Option<usize>) {
+    /// Returns whether the effective limit changed, so live policy refreshes
+    /// can avoid rebuilding the full pipe catalog when nothing changed.
+    pub fn set_max_non_template_pipes(&mut self, limit: Option<usize>) -> bool {
+        if self.max_non_template_pipes == limit {
+            return false;
+        }
         self.max_non_template_pipes = limit;
+        true
     }
 
     /// Set extra context that gets appended to every pipe prompt.
@@ -6986,6 +6992,16 @@ mod tests {
         let path = dir.join(format!("{}.md", name));
         std::fs::write(&path, pipe_source(template, name)).unwrap();
         path
+    }
+
+    #[test]
+    fn unchanged_pipe_limit_does_not_require_catalog_reload() {
+        let mut manager = test_pipe_manager();
+
+        assert!(manager.set_max_non_template_pipes(Some(2)));
+        assert!(!manager.set_max_non_template_pipes(Some(2)));
+        assert!(manager.set_max_non_template_pipes(None));
+        assert!(!manager.set_max_non_template_pipes(None));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

Avoid rebuilding the full pipe catalog when `set_cloud_token` receives the same effective free-plan pipe limit already applied to the running server.

Real plan transitions still reload once, so newly restricted pipes are stopped and newly available pipes are restored. Repeated settings/token writes now update retention state and persist the token without rescanning every pipe file.

## Reproduction

On the packaged v2.5.134 app with 135 installed pipes, repeated settings writes produced 867 `loaded 135 pipes` events in about 20 minutes, commonly in bursts of 6 to 8 every 7 to 9 seconds. The app reached 310% CPU in process sampling and 409% in Activity Monitor.

The sampled hot path was dominated by Tauri filesystem scope resolution and canonicalization while `PipeManager::load_pipes` repeatedly read the catalog.

Before:

```text
settings writes from open webviews
              |
              v
set_cloud_token (same plan limit)
              |
              v
load_pipes scans the full catalog every call
```

After:

```text
same limit    -> persist token, no catalog reload
changed limit -> reload once to enforce the transition
```

The regression test was added first and failed against `main`, because the setter exposed no change signal and callers could not distinguish an idempotent update. It passes after this change.

## Validation

- `cargo test -p screenpipe-core unchanged_pipe_limit_does_not_require_catalog_reload --no-fail-fast`
- `cargo test -p screenpipe-core pipes::tests:: --no-fail-fast` (140 passed)
- `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml -q`
- targeted `rustfmt --check`
- `git diff --check`

## Scope

This removes the confirmed full-catalog amplification. The broad Tauri filesystem scope remains a separate performance surface and is not changed here.
