### PR TITLE
[codex] remove meeting toggle from recording status

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -1066,9 +1066,6 @@ function HomeContent() {
               devices={recordingDevices}
               onDevicesChange={setRecordingDevices}
               meetingActive={meetingState.active ?? false}
-              meetingApp={meetingState.meetingApp}
-              meetingLoading={meetingLoading}
-              onToggleMeeting={() => void toggleMeeting()}
               onPauseRecording={pauseRecording}
               onResumeRecording={resumeRecording}
               isGloballyPaused={isCapturePaused}

--- a/apps/screenpipe-app-tauri/components/recording-status.tsx
+++ b/apps/screenpipe-app-tauri/components/recording-status.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import React from "react";
-import { Monitor, MonitorOff, Mic, MicOff, Volume2, VolumeX, Phone, Pause, Play } from "lucide-react";
+import { Monitor, MonitorOff, Mic, MicOff, Volume2, VolumeX, Pause, Play } from "lucide-react";
 import posthog from "posthog-js";
 import {
   Popover,
@@ -35,9 +35,6 @@ interface RecordingStatusProps {
   devices: RecordingDevice[];
   onDevicesChange: React.Dispatch<React.SetStateAction<RecordingDevice[]>>;
   meetingActive: boolean;
-  meetingApp?: string | null;
-  meetingLoading: boolean;
-  onToggleMeeting: () => void;
   onPauseRecording?: () => void | Promise<void>;
   onResumeRecording?: () => void | Promise<void>;
   /** true when the capture session itself is stopped (global pause via
@@ -74,9 +71,6 @@ export function RecordingStatus({
   devices,
   onDevicesChange,
   meetingActive,
-  meetingApp,
-  meetingLoading,
-  onToggleMeeting,
   onPauseRecording,
   onResumeRecording,
   isGloballyPaused,
@@ -333,29 +327,6 @@ export function RecordingStatus({
             );
           })}
         </div>
-        {(!allCaptureDisabled || meetingActive) && (
-          <div className="flex items-center gap-2 px-3 py-1.5 border-t border-border">
-            <Phone
-              aria-hidden="true"
-              className={cn(
-                "h-3 w-3 shrink-0",
-                meetingActive ? "text-foreground" : "text-muted-foreground"
-              )}
-            />
-            <span className="flex-1 min-w-0 truncate text-[11px] text-foreground">
-              {meetingActive ? `meeting notes${meetingApp ? ` · ${meetingApp}` : ""}` : "meeting notes"}
-            </span>
-            <button
-              onClick={onToggleMeeting}
-              disabled={meetingLoading}
-              data-testid="recording-status-meeting-toggle"
-              title={meetingActive ? "stop the meeting note only" : "start meeting notes"}
-              className="text-[10px] text-muted-foreground hover:text-foreground transition-colors shrink-0 disabled:opacity-50 whitespace-nowrap"
-            >
-              {meetingActive ? "stop notes" : "start notes"}
-            </button>
-          </div>
-        )}
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
## what changed

- removed the meeting-notes start/stop row from the recording-status popover
- removed the now-unused meeting app, loading, and toggle props
- kept the active-meeting signal in the status label and pulsing indicator
- kept manual start/stop controls on the dedicated Meeting Notes page

## why

The recording-status popover mixed recording controls with a second entry point for meeting notes. The duplicate `start notes` action was confusing because the dedicated Meeting Notes page already exposes the clearer `new meeting` flow.

## before / after

```text
before                         after
┌──────────────────────────┐   ┌──────────────────────────┐
│ recording                │   │ recording                │
├──────────────────────────┤   ├──────────────────────────┤
│ display 1          pause │   │ display 1          pause │
│ microphone         pause │   │ microphone         pause │
├──────────────────────────┤   └──────────────────────────┘
│ meeting notes  start notes│
└──────────────────────────┘
```

## validation

- `bunx vitest run --config vitest.config.ts components/__tests__/recording-status.test.tsx`, 11 tests passed
- `bun run typecheck`
- focused ESLint on both changed files, 0 errors
- `git diff --check`
