### PR TITLE
[codex] fix Pi browser companion runtime

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/pi-extensions-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/pi-extensions-card.test.tsx
@@ -123,7 +123,7 @@ describe("PiExtensionsCard", () => {
     expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
-  it("repairs an enabled browser package whose companion runtime is missing", async () => {
+  it("repairs an already configured browser package without promoting it to curated defaults", async () => {
     commandMocks.piListExtensionPackages.mockResolvedValueOnce({
       status: "ok",
       data: [
@@ -142,8 +142,14 @@ describe("PiExtensionsCard", () => {
     });
     render(<PiExtensionsCard />);
 
+    expect(screen.queryByText("Browser automation")).not.toBeInTheDocument();
+    expect(
+      await screen.findByText("Installed outside this list"),
+    ).toBeInTheDocument();
     fireEvent.click(
-      await screen.findByRole("button", { name: "Repair Browser automation" }),
+      screen.getByRole("button", {
+        name: "Repair npm:pi-agent-browser-native",
+      }),
     );
 
     await waitFor(() =>
@@ -152,7 +158,9 @@ describe("PiExtensionsCard", () => {
       ),
     );
     expect(
-      await screen.findByRole("switch", { name: "Disable Browser automation" }),
+      await screen.findByRole("switch", {
+        name: "Disable npm:pi-agent-browser-native",
+      }),
     ).toHaveAttribute("aria-checked", "true");
   });
 

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/pi-extensions-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/pi-extensions-card.test.tsx
@@ -123,6 +123,39 @@ describe("PiExtensionsCard", () => {
     expect(onChanged).toHaveBeenCalledTimes(1);
   });
 
+  it("repairs an enabled browser package whose companion runtime is missing", async () => {
+    commandMocks.piListExtensionPackages.mockResolvedValueOnce({
+      status: "ok",
+      data: [
+        ...packageList("npm:pi-subagents"),
+        {
+          source: "npm:pi-agent-browser-native",
+          scope: "user",
+          filtered: false,
+          installed: false,
+        },
+      ],
+    });
+    commandMocks.piInstallExtensionPackage.mockResolvedValueOnce({
+      status: "ok",
+      data: packageList("npm:pi-subagents", "npm:pi-agent-browser-native"),
+    });
+    render(<PiExtensionsCard />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Repair Browser automation" }),
+    );
+
+    await waitFor(() =>
+      expect(commandMocks.piInstallExtensionPackage).toHaveBeenCalledWith(
+        "npm:pi-agent-browser-native",
+      ),
+    );
+    expect(
+      await screen.findByRole("switch", { name: "Disable Browser automation" }),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+
   it("shows installable Pi packages from npm registry search", async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,

--- a/apps/screenpipe-app-tauri/components/settings/pi-extensions-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pi-extensions-card.tsx
@@ -335,7 +335,10 @@ export function PiExtensionsCard({ onChanged }: { onChanged?: () => void }) {
   }, [packages, registryItems]);
 
   const togglePackage = useCallback(
-    async (item: PiExtensionCatalogItem, checked: boolean) => {
+    async (
+      item: Pick<PiExtensionCatalogItem, "name" | "source">,
+      checked: boolean,
+    ) => {
       setBusySource(item.source);
       setError(null);
       try {
@@ -604,14 +607,34 @@ export function PiExtensionsCard({ onChanged }: { onChanged?: () => void }) {
                   {busySource === pkg.source ? (
                     <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                   ) : (
-                    <Switch
-                      checked
-                      disabled={!!busySource}
-                      onCheckedChange={(checked) => {
-                        if (!checked) removePackageSource(pkg.source);
-                      }}
-                      aria-label={`Disable ${pkg.source}`}
-                    />
+                    <>
+                      {!pkg.installed && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={!!busySource}
+                          onClick={() =>
+                            togglePackage(
+                              { name: pkg.source, source: pkg.source },
+                              true,
+                            )
+                          }
+                          aria-label={`Repair ${pkg.source}`}
+                          className="h-7 px-2 text-[10px] uppercase tracking-[0.12em]"
+                        >
+                          repair
+                        </Button>
+                      )}
+                      <Switch
+                        checked
+                        disabled={!!busySource}
+                        onCheckedChange={(checked) => {
+                          if (!checked) removePackageSource(pkg.source);
+                        }}
+                        aria-label={`Disable ${pkg.source}`}
+                      />
+                    </>
                   )}
                 </div>
               </div>

--- a/apps/screenpipe-app-tauri/components/settings/pi-extensions-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pi-extensions-card.tsx
@@ -110,6 +110,18 @@ function PiExtensionRow({
             aria-label={`${item.name} always enabled`}
             className="shrink-0"
           />
+        ) : stale ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled || busy}
+            onClick={() => onToggle(true)}
+            aria-label={`Repair ${item.name}`}
+            className="h-7 shrink-0 px-2 text-[10px] uppercase tracking-[0.12em]"
+          >
+            repair
+          </Button>
         ) : (
           <Switch
             checked={enabled}

--- a/apps/screenpipe-app-tauri/lib/__tests__/pi-extension-catalog.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pi-extension-catalog.test.ts
@@ -21,10 +21,15 @@ describe("Pi extension catalog", () => {
     expect(PI_EXTENSION_CATALOG.map((item) => item.source)).toEqual(
       expect.arrayContaining([
         "npm:pi-subagents",
-        "npm:pi-agent-browser-native",
         "npm:@demigodmode/pi-web-agent",
         "npm:@eko24ive/pi-ask",
       ]),
+    );
+  });
+
+  it("does not promote the optional native browser package into curated defaults", () => {
+    expect(PI_EXTENSION_CATALOG.map((item) => item.source)).not.toContain(
+      "npm:pi-agent-browser-native",
     );
   });
 

--- a/apps/screenpipe-app-tauri/lib/__tests__/pi-extension-catalog.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pi-extension-catalog.test.ts
@@ -21,6 +21,7 @@ describe("Pi extension catalog", () => {
     expect(PI_EXTENSION_CATALOG.map((item) => item.source)).toEqual(
       expect.arrayContaining([
         "npm:pi-subagents",
+        "npm:pi-agent-browser-native",
         "npm:@demigodmode/pi-web-agent",
         "npm:@eko24ive/pi-ask",
       ]),

--- a/apps/screenpipe-app-tauri/lib/pi-extension-catalog.ts
+++ b/apps/screenpipe-app-tauri/lib/pi-extension-catalog.ts
@@ -59,20 +59,6 @@ const PI_PACKAGE_KEYWORDS = new Set([
 
 export const PI_EXTENSION_CATALOG: PiExtensionCatalogItem[] = [
   {
-    id: "pi-agent-browser-native",
-    name: "Browser automation",
-    source: "npm:pi-agent-browser-native",
-    summary: "Drive real browser sessions from Pi with the native agent_browser tool.",
-    details: "Screenpipe also installs the matching agent-browser runtime and exposes it to Pi.",
-    modelFit: "strong-model",
-    modelFitLabel: "Strong model",
-    modelFitCopy: "Browser work benefits from models that can preserve page state and recover from changed controls.",
-    risk: "Can open websites, interact with pages, and access browser state created through the tool.",
-    npmUrl: "https://www.npmjs.com/package/pi-agent-browser-native",
-    sourceUrl: "https://github.com/fitchmultz/pi-agent-browser-native",
-    tags: ["browser", "automation", "agent-browser"],
-  },
-  {
     id: "pi-subagents",
     name: "Subagents",
     source: "npm:pi-subagents",

--- a/apps/screenpipe-app-tauri/lib/pi-extension-catalog.ts
+++ b/apps/screenpipe-app-tauri/lib/pi-extension-catalog.ts
@@ -59,6 +59,20 @@ const PI_PACKAGE_KEYWORDS = new Set([
 
 export const PI_EXTENSION_CATALOG: PiExtensionCatalogItem[] = [
   {
+    id: "pi-agent-browser-native",
+    name: "Browser automation",
+    source: "npm:pi-agent-browser-native",
+    summary: "Drive real browser sessions from Pi with the native agent_browser tool.",
+    details: "Screenpipe also installs the matching agent-browser runtime and exposes it to Pi.",
+    modelFit: "strong-model",
+    modelFitLabel: "Strong model",
+    modelFitCopy: "Browser work benefits from models that can preserve page state and recover from changed controls.",
+    risk: "Can open websites, interact with pages, and access browser state created through the tool.",
+    npmUrl: "https://www.npmjs.com/package/pi-agent-browser-native",
+    sourceUrl: "https://github.com/fitchmultz/pi-agent-browser-native",
+    tags: ["browser", "automation", "agent-browser"],
+  },
+  {
     id: "pi-subagents",
     name: "Subagents",
     source: "npm:pi-subagents",

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -50,6 +50,8 @@ const TEXT_DELTA_EMIT_BATCH_CHARS: usize = 1_200;
 /// Keep in sync with TypeScript: lib/utils/internal-session.ts → INTERNAL_TITLE_PREFIX
 const TITLE_SESSION_PREFIX: &str = "__title:";
 const REQUIRED_PI_EXTENSION_PACKAGE: &str = "npm:pi-subagents";
+const PI_AGENT_BROWSER_PACKAGE: &str = "pi-agent-browser-native";
+const AGENT_BROWSER_RUNTIME_PACKAGE: &str = "agent-browser";
 
 struct PendingAgentTextDelta {
     event: Value,
@@ -3313,15 +3315,178 @@ fn valid_github_path_part(part: &str) -> bool {
 fn pi_package_source_looks_installed(source: &str) -> bool {
     if let Some(package_name) = npm_package_name_from_source(source) {
         if let Ok(config_dir) = get_pi_config_dir() {
-            return config_dir
+            let package_installed = config_dir
                 .join("npm")
                 .join("node_modules")
-                .join(package_name)
+                .join(&package_name)
                 .exists();
+            if package_name == PI_AGENT_BROWSER_PACKAGE {
+                let Some(pi_install_dir) = pi_local_install_dir() else {
+                    return false;
+                };
+                return package_installed
+                    && agent_browser_runtime_ready(&config_dir, &pi_install_dir);
+            }
+            return package_installed;
         }
     }
 
     true
+}
+
+fn agent_browser_runtime_entrypoint(config_dir: &Path) -> PathBuf {
+    config_dir
+        .join("npm")
+        .join("node_modules")
+        .join(AGENT_BROWSER_RUNTIME_PACKAGE)
+        .join("bin")
+        .join("agent-browser.js")
+}
+
+fn agent_browser_launcher_path(pi_install_dir: &Path) -> PathBuf {
+    let bin_dir = pi_install_dir.join("node_modules").join(".bin");
+    if cfg!(windows) {
+        bin_dir.join("agent-browser.cmd")
+    } else {
+        bin_dir.join("agent-browser")
+    }
+}
+
+fn agent_browser_runtime_ready(config_dir: &Path, pi_install_dir: &Path) -> bool {
+    agent_browser_runtime_entrypoint(config_dir).is_file()
+        && agent_browser_launcher_path(pi_install_dir).is_file()
+}
+
+fn agent_browser_baseline_version(wrapper_dir: &Path) -> Option<String> {
+    let baseline = std::fs::read_to_string(
+        wrapper_dir
+            .join("scripts")
+            .join("agent-browser-capability-baseline.mjs"),
+    )
+    .ok()?;
+    let marker = "upstreamPackageVersion:";
+    let value = baseline
+        .lines()
+        .find_map(|line| line.split_once(marker).map(|(_, value)| value.trim()))?;
+    let version = value
+        .trim_end_matches(',')
+        .trim()
+        .trim_matches(['\'', '"']);
+    valid_npm_version_spec(version).then(|| version.to_string())
+}
+
+#[cfg(unix)]
+fn shell_quote(value: &Path) -> String {
+    format!("'{}'", value.to_string_lossy().replace('\'', "'\"'\"'"))
+}
+
+fn write_agent_browser_launcher(
+    launcher_path: &Path,
+    bun: &Path,
+    entrypoint: &Path,
+) -> Result<(), String> {
+    let Some(parent) = launcher_path.parent() else {
+        return Err("Cannot determine the agent-browser launcher directory".to_string());
+    };
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("Failed to create agent-browser launcher directory: {}", e))?;
+
+    #[cfg(windows)]
+    let launcher = format!(
+        "@echo off\r\n\"{}\" \"{}\" %*\r\n",
+        bun.display(),
+        entrypoint.display()
+    );
+    #[cfg(not(windows))]
+    let launcher = format!(
+        "#!/bin/sh\nexec {} {} \"$@\"\n",
+        shell_quote(bun),
+        shell_quote(entrypoint)
+    );
+
+    std::fs::write(launcher_path, launcher)
+        .map_err(|e| format!("Failed to write agent-browser launcher: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(launcher_path)
+            .map_err(|e| format!("Failed to inspect agent-browser launcher: {}", e))?
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(launcher_path, permissions)
+            .map_err(|e| format!("Failed to make agent-browser launcher executable: {}", e))?;
+    }
+
+    Ok(())
+}
+
+fn ensure_agent_browser_runtime_blocking() -> Result<(), String> {
+    let bun = find_bun_executable().ok_or(
+        "Could not find bundled bun. Restart screenpipe or reinstall the app before repairing browser automation.",
+    )?;
+    let config_dir = get_pi_config_dir()?;
+    let npm_dir = config_dir.join("npm");
+    let wrapper_dir = npm_dir
+        .join("node_modules")
+        .join(PI_AGENT_BROWSER_PACKAGE);
+    let version = agent_browser_baseline_version(&wrapper_dir).ok_or_else(|| {
+        "The installed browser extension does not declare a supported agent-browser version. Update the extension and try again.".to_string()
+    })?;
+    let runtime_spec = format!("{}@{}", AGENT_BROWSER_RUNTIME_PACKAGE, version);
+
+    let mut install = bun_command(&bun);
+    install
+        .current_dir(&npm_dir)
+        .args(["add", "--exact", runtime_spec.as_str()]);
+    match run_command_output(install) {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            return Err(format!(
+                "agent-browser runtime install failed: {}",
+                format_install_failure("bun add", &output)
+            ));
+        }
+        Err(e) => return Err(format!("Could not install agent-browser runtime: {}", e)),
+    }
+
+    let entrypoint = agent_browser_runtime_entrypoint(&config_dir);
+    if !entrypoint.is_file() {
+        return Err(format!(
+            "agent-browser runtime install completed but {} is missing",
+            entrypoint.display()
+        ));
+    }
+    let pi_install_dir = pi_local_install_dir()
+        .ok_or_else(|| "Cannot determine the Screenpipe Pi install directory".to_string())?;
+    let launcher = agent_browser_launcher_path(&pi_install_dir);
+    write_agent_browser_launcher(&launcher, Path::new(&bun), &entrypoint)?;
+
+    let mut verify = bun_command(&bun);
+    verify.arg(&entrypoint).arg("--version");
+    match run_command_output(verify) {
+        Ok(output)
+            if output.status.success()
+                && String::from_utf8_lossy(&output.stdout)
+                    .contains(&format!("agent-browser {}", version)) =>
+        {
+            Ok(())
+        }
+        Ok(output) => Err(format!(
+            "agent-browser runtime verification failed: {}",
+            format_install_failure("version check", &output)
+        )),
+        Err(e) => Err(format!("Could not verify agent-browser runtime: {}", e)),
+    }
+}
+
+async fn ensure_extension_companion_runtime(source: &str) -> Result<(), String> {
+    if npm_package_name_from_source(source).as_deref() != Some(PI_AGENT_BROWSER_PACKAGE) {
+        return Ok(());
+    }
+    tokio::task::spawn_blocking(ensure_agent_browser_runtime_blocking)
+        .await
+        .map_err(|e| format!("agent-browser runtime install panicked: {}", e))?
 }
 
 fn ensure_pi_package_manager_settings(bun: &str) -> Result<(), String> {
@@ -3484,7 +3649,8 @@ pub async fn pi_install_extension_package(
 ) -> Result<Vec<PiExtensionPackage>, String> {
     let source = validate_pi_extension_package_source(&source)?;
     stop_idle_pi_sessions_for_package_change(&state).await?;
-    run_pi_package_command(vec!["install".to_string(), source]).await?;
+    run_pi_package_command(vec!["install".to_string(), source.clone()]).await?;
+    ensure_extension_companion_runtime(&source).await?;
     stop_idle_pi_sessions_for_package_change(&state).await?;
     pi_list_extension_packages().await
 }
@@ -4134,6 +4300,77 @@ mod tests {
         assert!(super::validate_pi_extension_package_source("git:repo").is_err());
         assert!(super::validate_pi_extension_package_source("../local-package").is_err());
         assert!(super::validate_pi_extension_package_source("").is_err());
+    }
+
+    #[test]
+    fn parses_agent_browser_version_from_wrapper_baseline() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let scripts = dir.path().join("scripts");
+        std::fs::create_dir_all(&scripts).expect("create scripts");
+        std::fs::write(
+            scripts.join("agent-browser-capability-baseline.mjs"),
+            "const sourceEvidence = {\n  upstreamPackageVersion: \"0.33.0\",\n  other: true,\n};\n",
+        )
+        .expect("write baseline");
+
+        assert_eq!(
+            super::agent_browser_baseline_version(dir.path()).as_deref(),
+            Some("0.33.0")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn writes_executable_bun_launcher_for_agent_browser() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let launcher = dir.path().join("bin").join("agent-browser");
+        let bun = dir.path().join("screenpipe bun");
+        let entrypoint = dir.path().join("agent browser.js");
+
+        super::write_agent_browser_launcher(&launcher, &bun, &entrypoint)
+            .expect("write launcher");
+
+        let contents = std::fs::read_to_string(&launcher).expect("read launcher");
+        assert!(contents.contains(&super::shell_quote(&bun)));
+        assert!(contents.contains(&super::shell_quote(&entrypoint)));
+        assert_ne!(
+            std::fs::metadata(&launcher)
+                .expect("launcher metadata")
+                .permissions()
+                .mode()
+                & 0o111,
+            0
+        );
+    }
+
+    #[test]
+    fn browser_runtime_health_requires_entrypoint_and_managed_launcher() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_dir = dir.path().join("pi-config");
+        let pi_install_dir = dir.path().join("pi-agent");
+        let entrypoint = super::agent_browser_runtime_entrypoint(&config_dir);
+        let launcher = super::agent_browser_launcher_path(&pi_install_dir);
+
+        assert!(!super::agent_browser_runtime_ready(
+            &config_dir,
+            &pi_install_dir
+        ));
+        std::fs::create_dir_all(entrypoint.parent().expect("entrypoint parent"))
+            .expect("create entrypoint parent");
+        std::fs::write(&entrypoint, "#!/usr/bin/env node").expect("write entrypoint");
+        assert!(!super::agent_browser_runtime_ready(
+            &config_dir,
+            &pi_install_dir
+        ));
+        std::fs::create_dir_all(launcher.parent().expect("launcher parent"))
+            .expect("create launcher parent");
+        std::fs::write(&launcher, "launcher").expect("write launcher");
+        assert!(super::agent_browser_runtime_ready(
+            &config_dir,
+            &pi_install_dir
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- manage the separate `agent-browser` runtime required by an already configured `pi-agent-browser-native` extension
- treat a configured wrapper with a missing runtime or launcher as `repair needed`
- keep native browser automation out of Screenpipe's curated/default extension list

## Root cause

The native extension was installed, and Pi successfully loaded and invoked its `agent_browser` tool. The extension is a thin wrapper that shells out to a separate `agent-browser` executable, which it does not bundle or declare as a dependency.

Screenpipe previously considered the wrapper installed as soon as its package directory existed. Pi's isolated PATH included Screenpipe's Pi `.bin` directory and bundled Bun, but no `agent-browser` executable. That made a healthy-looking installed extension fail at runtime with `Executable not found`.

## UX

```text
before                                      after
configured wrapper looks healthy            installed outside this list
agent_browser -> Executable not found       repair needed  [REPAIR]  [ON]
```

## Implementation

- read the wrapper's declared upstream compatibility baseline and install the exact matching `agent-browser` version with Screenpipe's bundled Bun
- write a managed launcher into Screenpipe Pi's isolated `.bin` directory
- support Unix launchers and Windows `.cmd` launchers
- verify the installed runtime reports the expected version
- require the wrapper package, runtime entrypoint, and managed launcher before reporting the extension healthy
- expose an already configured stale package as repairable under `Installed outside this list`

The runtime download happens only when the user explicitly installs or repairs this already configured extension. This PR does not add native browser automation to curated defaults or install it automatically.

## Validation

- focused Vitest: 2 files, 16 tests passed
- focused Rust tests: baseline version parsing, executable launcher generation, and runtime health checks passed
- TypeScript typecheck passed
- focused ESLint passed
- Tauri binding freshness test passed
- `cargo fmt --all -- --check` passed
- `git diff --check` passed
- manual smoke with Screenpipe's bundled Bun and `agent-browser@0.33.0`: opened `https://example.com`, captured a snapshot, and closed the browser session successfully

## Follow-up

The wrapper currently exposes its compatible upstream version through its capability baseline file. A future wrapper release could make this machine-readable package metadata, avoiding the need to parse that file.
