### PR TITLE
docs: add mcpindex screened badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![mcpindex](https://mcpindex.ai/api/v1/badge/io-github-screenpipe-screenpipe-mcp)](https://mcpindex.ai/server/io-github-screenpipe-screenpipe-mcp)
+
 
 <img width="1500" height="500" alt="image" src="https://github.com/user-attachments/assets/058a44b8-fcad-4a37-92d8-830167dbd400" />
 


### PR DESCRIPTION
Hey, ran screenpipe's registered MCP server through mcpindex's screening (description-level check for injection/manipulation patterns). Came back clean, so added the badge to your README. It's advisory, not a security cert. Close this if it's not useful, no worries at all.