### PR TITLE
[codex] Improve pipe and shortcut telemetry

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/pick-pipe.tsx
@@ -67,7 +67,7 @@ async function waitForServer(maxWaitMs = 30000): Promise<void> {
   throw new Error("server not ready");
 }
 
-// Best-effort immediate run after install/enable so `pipe_scheduled_run`
+// Best-effort immediate run after install/enable so Pipe execution telemetry
 // fires within seconds of the user finishing onboarding, instead of waiting
 // for the next cron tick (hours/days). Silent on failure.
 async function triggerImmediateRun(slug: string): Promise<void> {
@@ -75,7 +75,7 @@ async function triggerImmediateRun(slug: string): Promise<void> {
     await localFetch(`/pipes/${slug}/run`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ trigger_type: "onboarding" }),
     });
   } catch {}
 }

--- a/apps/screenpipe-app-tauri/components/shortcut-reminder.tsx
+++ b/apps/screenpipe-app-tauri/components/shortcut-reminder.tsx
@@ -12,27 +12,6 @@ export function ShortcutTracker() {
   useEffect(() => {
     const unsubscribers: (() => void)[] = [];
 
-    // Shortcut events → "shortcut_used" PostHog event
-    const shortcuts = [
-      { event: "shortcut-show", name: "show_screenpipe" },
-      { event: "shortcut-show-chat", name: "show_chat" },
-      { event: "open-search", name: "show_search" },
-      { event: "shortcut-start-recording", name: "start_recording" },
-      { event: "shortcut-stop-recording", name: "stop_recording" },
-      { event: "shortcut-start-audio", name: "start_audio" },
-      { event: "shortcut-stop-audio", name: "stop_audio" },
-    ];
-
-    shortcuts.forEach(({ event, name }) => {
-      listen(event, () => {
-        posthog.capture("shortcut_used", {
-          shortcut_name: name,
-        });
-      }).then((unlisten) => {
-        unsubscribers.push(unlisten);
-      });
-    });
-
     // Tray menu click events → "view_opened" PostHog event
     const trayEvents = [
       { event: "tray-show-timeline", view: "timeline" },

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -2575,6 +2575,11 @@ pub(crate) async fn show_shortcut_reminder_impl(
             }
             let native_payload = serde_json::Value::Object(map).to_string();
             if native_shortcut_reminder::show(Some(&native_payload)) {
+                native_actions::track_native_overlay_event(
+                    &app_handle,
+                    "shortcut_reminder_shown",
+                    serde_json::json!({}),
+                );
                 // A recording incident may already be active (e.g. this show IS
                 // the incident reveal) — sync the panel's health state. Same
                 // for the bell's unread dot, which is otherwise only pushed on

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -53,10 +53,13 @@ extern "C" fn native_notif_action_callback(json_ptr: *const std::os::raw::c_char
     }));
 }
 
-/// Fire-and-forget product analytics for native inbox interactions, tagged
-/// with surface="native_overlay" so PostHog funnels line up with the webview
-/// bell's identically-named events.
-fn track_inbox_event(app: &tauri::AppHandle, event: &'static str, mut props: serde_json::Value) {
+/// Fire-and-forget product analytics for native overlay interactions, tagged
+/// so PostHog funnels line up with the webview's identically-named events.
+pub(crate) fn track_native_overlay_event(
+    app: &tauri::AppHandle,
+    event: &'static str,
+    mut props: serde_json::Value,
+) {
     if let Some(analytics) =
         app.try_state::<std::sync::Arc<crate::analytics::AnalyticsManager>>()
     {
@@ -124,26 +127,26 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
                 if let Some(id) = id {
                     crate::notifications::store::mark_read_by_id(id);
                 }
-                track_inbox_event(app, "notification_bell_expand", props);
+                track_native_overlay_event(app, "notification_bell_expand", props);
             }
             "remove" => {
                 let props = entry_props(id);
                 if let Some(id) = id {
                     crate::notifications::store::remove_by_id(id);
                 }
-                track_inbox_event(app, "notification_bell_dismiss", props);
+                track_native_overlay_event(app, "notification_bell_dismiss", props);
             }
             "clear_all" => {
                 let count = crate::notifications::store::read_all().len();
                 crate::notifications::store::clear();
-                track_inbox_event(
+                track_native_overlay_event(
                     app,
                     "notification_bell_clear_all",
                     serde_json::json!({ "count": count }),
                 );
             }
             "copy" => {
-                track_inbox_event(app, "notification_bell_copy", entry_props(id));
+                track_native_overlay_event(app, "notification_bell_copy", entry_props(id));
             }
             "action_clicked" => {
                 let mut props = entry_props(id);
@@ -156,7 +159,7 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
                 ) {
                     obj.insert("action_label".into(), serde_json::json!(label));
                 }
-                track_inbox_event(app, "notification_bell_action", props);
+                track_native_overlay_event(app, "notification_bell_action", props);
             }
             _ => {}
         }
@@ -559,21 +562,41 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
             let app_for_show = app_clone.clone();
             match action.as_str() {
                 "open_timeline" => {
+                    track_native_overlay_event(
+                        &app_clone,
+                        "shortcut_reminder_timeline_clicked",
+                        serde_json::json!({}),
+                    );
                     let _ = app_clone.run_on_main_thread(move || {
                         let _ = ShowRewindWindow::Main.show(&app_for_show);
                     });
                 }
                 "open_chat" => {
+                    track_native_overlay_event(
+                        &app_clone,
+                        "shortcut_reminder_chat_clicked",
+                        serde_json::json!({}),
+                    );
                     let _ = app_clone.run_on_main_thread(move || {
                         let _ = ShowRewindWindow::Chat.show(&app_for_show);
                     });
                 }
                 "open_search" => {
+                    track_native_overlay_event(
+                        &app_clone,
+                        "shortcut_reminder_search_clicked",
+                        serde_json::json!({}),
+                    );
                     let _ = app_clone.run_on_main_thread(move || {
                         let _ = (ShowRewindWindow::Search { query: None }).show(&app_for_show);
                     });
                 }
                 "close" => {
+                    track_native_overlay_event(
+                        &app_clone,
+                        "shortcut_reminder_dismissed",
+                        serde_json::json!({}),
+                    );
                     // Emit to JS so it can persist the setting, then hide
                     let _ = app_clone.emit("native-shortcut-close", "");
                     native_shortcut_reminder::hide();
@@ -592,7 +615,7 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
                     ));
                 }
                 "open_inbox" => {
-                    track_inbox_event(
+                    track_native_overlay_event(
                         &app_clone,
                         "shortcut_reminder_inbox_clicked",
                         serde_json::json!({}),
@@ -627,6 +650,11 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
                                     .body(serde_json::json!({ "id": stoppable_id }).to_string()),
                             );
                             if req.send().is_ok() {
+                                track_native_overlay_event(
+                                    &app_clone,
+                                    "shortcut_reminder_meeting_toggled",
+                                    serde_json::json!({ "active": false }),
+                                );
                                 native_shortcut_reminder::set_meeting_active(false);
                                 let _ = app_clone.emit(
                                     "native-shortcut-toggle-meeting",
@@ -649,6 +677,11 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
                                     .body(r#"{"app":"manual"}"#),
                             );
                             if let Ok(res) = req.send() {
+                                track_native_overlay_event(
+                                    &app_clone,
+                                    "shortcut_reminder_meeting_toggled",
+                                    serde_json::json!({ "active": true }),
+                                );
                                 let meeting = res.json::<serde_json::Value>().ok();
                                 native_shortcut_reminder::set_meeting_active(true);
                                 let _ = app_clone.emit(

--- a/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server_core.rs
@@ -662,15 +662,19 @@ impl ServerCore {
             let screenpipe_dir_for_cb = config.data_dir.clone();
             let pm_for_cb = shared_pipe_manager.clone();
             shared_pipe_manager.lock().await.set_on_run_complete(Arc::new(
-                move |pipe_name, execution_id, success, duration_secs, error_type| {
+                move |pipe_name, execution_id, trigger_type, success, duration_secs, error_type| {
                     let mut props = serde_json::json!({
                         "pipe": pipe_name,
+                        "execution_id": execution_id,
+                        "trigger_type": trigger_type,
+                        "telemetry_schema_version": 2,
                         "success": success,
                         "duration_secs": duration_secs,
                     });
                     if let Some(et) = error_type {
                         props["error_type"] = serde_json::Value::String(et.to_string());
                     }
+                    // Keep the legacy event name so existing dashboards continue to work.
                     analytics::capture_event_nonblocking("pipe_scheduled_run", props);
 
                     // Auto-register pipe artifacts to ~/.screenpipe/outputs/

--- a/apps/screenpipe-app-tauri/src-tauri/src/shortcuts.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/shortcuts.rs
@@ -18,6 +18,29 @@ use crate::commands::{hide_main_window, show_main_window};
 use crate::store::{get_store, SettingsStore};
 use crate::window::ShowRewindWindow;
 
+/// Record a physical global-shortcut press once, before any app-wide events
+/// are broadcast to webviews. This avoids duplicate analytics from multiple
+/// mounted listeners and covers native-only window paths.
+fn track_shortcut_used(app: &AppHandle, shortcut_name: &'static str) {
+    if let Some(analytics) =
+        app.try_state::<std::sync::Arc<crate::analytics::AnalyticsManager>>()
+    {
+        let analytics = std::sync::Arc::clone(&analytics);
+        tauri::async_runtime::spawn(async move {
+            let _ = analytics
+                .send_event(
+                    "shortcut_used",
+                    Some(serde_json::json!({
+                        "shortcut_name": shortcut_name,
+                        "source": "global_shortcut",
+                        "telemetry_schema_version": 2,
+                    })),
+                )
+                .await;
+        });
+    }
+}
+
 #[derive(Debug, Default)]
 struct ShortcutConfig {
     show: String,
@@ -152,6 +175,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
 
     // Register show shortcut
     register_shortcut(app, &config.show, config.is_disabled("show"), |app| {
+        track_shortcut_used(app, "show_screenpipe");
         let app_for_closure = app.clone();
         let _ = app.run_on_main_thread(move || {
             let app = &app_for_closure;
@@ -206,6 +230,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
         &config.start,
         config.is_disabled("start_recording"),
         |app| {
+            track_shortcut_used(app, "start_recording");
             let _ = app.emit("shortcut-start-recording", ());
             // The frontend listener only shows an in-app toast, which is
             // invisible when the main window is hidden — i.e. exactly when a
@@ -224,6 +249,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
         &config.stop,
         config.is_disabled("stop_recording"),
         |app| {
+            track_shortcut_used(app, "stop_recording");
             let _ = app.emit("shortcut-stop-recording", ());
             crate::notifications::client::send(
                 "recording paused",
@@ -238,6 +264,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
         &config.start_audio,
         config.is_disabled("start_audio"),
         |app| {
+            track_shortcut_used(app, "start_audio");
             if let Ok(store) = get_store(app, None) {
                 store.set("disableAudio", false);
                 let _ = store.save();
@@ -253,6 +280,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
         &config.stop_audio,
         config.is_disabled("stop_audio"),
         |app| {
+            track_shortcut_used(app, "stop_audio");
             if let Ok(store) = get_store(app, None) {
                 store.set("disableAudio", true);
                 let _ = store.save();
@@ -268,6 +296,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
         &config.show_chat,
         config.is_disabled("show_chat"),
         |app| {
+            track_shortcut_used(app, "show_chat");
             let app_for_closure = app.clone();
             let _ = app.run_on_main_thread(move || {
                 let app = &app_for_closure;
@@ -299,6 +328,7 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
     .await?;
 
     register_shortcut(app, &config.search, config.is_disabled("search"), |app| {
+        track_shortcut_used(app, "show_search");
         let app_for_closure = app.clone();
         let _ = app.run_on_main_thread(move || {
             let app = &app_for_closure;

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -1972,11 +1972,12 @@ fn should_try_fallback_preset(error_type: Option<&str>) -> bool {
 // ---------------------------------------------------------------------------
 
 /// Manages all pipes: loading, scheduling, execution, logs.
-/// Callback fired after each scheduled pipe run completes.
-/// Args: (pipe_name, execution_id, success, duration_secs, error_type)
+/// Callback fired after each pipe run completes.
+/// Args: (pipe_name, execution_id, trigger_type, success, duration_secs, error_type)
 /// `error_type` is a sanitized category (e.g. "rate_limited", "auth_failed", "timeout", "crash")
 /// — never contains user data.
-pub type OnPipeRunComplete = Arc<dyn Fn(&str, Option<i64>, bool, f64, Option<&str>) + Send + Sync>;
+pub type OnPipeRunComplete =
+    Arc<dyn Fn(&str, Option<i64>, &str, bool, f64, Option<&str>) + Send + Sync>;
 
 /// Synchronous scheduler launch guard. Returning `Some(reason)` skips the run.
 pub type SchedulerRunGuard = Arc<dyn Fn() -> Option<String> + Send + Sync>;
@@ -2959,6 +2960,16 @@ impl PipeManager {
     /// in a spawned tokio task.  Use this from API handlers to avoid holding
     /// the PipeManager mutex for the entire execution duration.
     pub async fn start_pipe_background(&self, name: &str) -> Result<()> {
+        self.start_pipe_background_with_trigger(name, "manual")
+            .await
+    }
+
+    /// Start a pipe in the background with an explicit, low-cardinality trigger type.
+    pub async fn start_pipe_background_with_trigger(
+        &self,
+        name: &str,
+        trigger: &str,
+    ) -> Result<()> {
         let (config, body, _raw) = {
             let pipes = self.pipes.lock().await;
             match pipes.get(name).cloned() {
@@ -3081,7 +3092,7 @@ impl PipeManager {
         // Create DB execution row
         let exec_id = if let Some(ref store) = self.store {
             match store
-                .create_execution(name, "manual", &run_model, run_provider.as_deref())
+                .create_execution(name, trigger, &run_model, run_provider.as_deref())
                 .await
             {
                 Ok(id) => {
@@ -3161,6 +3172,7 @@ impl PipeManager {
         let logs_ref = self.logs.clone();
         let store_ref = self.store.clone();
         let on_complete = self.on_run_complete.clone();
+        let trigger_for_cb = trigger.to_string();
         let on_output = self.on_output_line.clone();
         let pipes_dir_for_log = self.pipes_dir.clone();
         let pipe_timeout = config.timeout.unwrap_or(DEFAULT_TIMEOUT_SECS);
@@ -3434,6 +3446,7 @@ impl PipeManager {
                 cb(
                     &name_for_cb,
                     exec_id,
+                    &trigger_for_cb,
                     success,
                     duration_secs,
                     cb_error_type.as_deref(),
@@ -4695,6 +4708,8 @@ impl PipeManager {
                 // high-frequency system events (ui_frame, window_ocr, etc.).
                 let mut event_triggered: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
+                let mut connection_triggered: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
                 {
                     use futures::FutureExt;
 
@@ -4734,6 +4749,7 @@ impl PipeManager {
                                     info!("scheduler: connection trigger fired pipe '{}'", name);
                                     last_run.remove(name);
                                     event_triggered.insert(name.clone());
+                                    connection_triggered.insert(name.clone());
                                 }
                             }
                         }
@@ -4802,6 +4818,13 @@ impl PipeManager {
                     }
 
                     let triggered_by_event = event_triggered.contains(name);
+                    let trigger = if connection_triggered.contains(name) {
+                        "connection"
+                    } else if triggered_by_event {
+                        "event"
+                    } else {
+                        "scheduled"
+                    };
                     let last = last_run.get(name).copied().unwrap_or(DateTime::UNIX_EPOCH);
                     // Structured `schedule_config` is authoritative when set;
                     // otherwise fall back to the legacy `schedule` string.
@@ -4862,11 +4885,6 @@ impl PipeManager {
                             let missing = check(config.connections.clone()).await;
                             if !missing.is_empty() {
                                 let skipped_at = Utc::now();
-                                let trigger = if triggered_by_event {
-                                    "event"
-                                } else {
-                                    "scheduled"
-                                };
                                 let message = format!(
                                     "pipe '{}' skipped: missing required connections: {}",
                                     name,
@@ -4877,6 +4895,7 @@ impl PipeManager {
                                     name, missing
                                 );
                                 last_run.insert(name.clone(), skipped_at);
+                                let mut execution_id = None;
                                 if let Some(ref store) = store {
                                     match store
                                         .create_execution(
@@ -4888,6 +4907,7 @@ impl PipeManager {
                                         .await
                                     {
                                         Ok(id) => {
+                                            execution_id = Some(id);
                                             let _ = store
                                                 .finish_execution(
                                                     id,
@@ -4925,7 +4945,14 @@ impl PipeManager {
                                     }
                                 }
                                 if let Some(ref cb) = on_run_complete {
-                                    cb(name, None, false, 0.0, Some("missing_connections"));
+                                    cb(
+                                        name,
+                                        execution_id,
+                                        trigger,
+                                        false,
+                                        0.0,
+                                        Some("missing_connections"),
+                                    );
                                 }
                                 continue;
                             }
@@ -5024,20 +5051,18 @@ impl PipeManager {
                                 );
                                 warn!("scheduler: pipe '{}': {}", name, message);
                                 let failed_at = Utc::now();
+                                let mut execution_id = None;
                                 if let Some(ref store) = store {
                                     if let Ok(id) = store
                                         .create_execution(
                                             name,
-                                            if triggered_by_event {
-                                                "event"
-                                            } else {
-                                                "scheduled"
-                                            },
+                                            trigger,
                                             &config.model,
                                             config.provider.as_deref(),
                                         )
                                         .await
                                     {
+                                        execution_id = Some(id);
                                         let _ = store
                                             .finish_execution(
                                                 id,
@@ -5075,7 +5100,14 @@ impl PipeManager {
                                     qr.remove(name);
                                 }
                                 if let Some(ref cb) = on_run_complete {
-                                    cb(name, None, false, 0.0, Some("ai_preset_unavailable"));
+                                    cb(
+                                        name,
+                                        execution_id,
+                                        trigger,
+                                        false,
+                                        0.0,
+                                        Some("ai_preset_unavailable"),
+                                    );
                                 }
                                 continue;
                             }
@@ -5165,6 +5197,7 @@ impl PipeManager {
                     );
                     let pipe_name = name.clone();
                     let is_event_triggered = triggered_by_event;
+                    let trigger = trigger.to_string();
                     let logs_ref = logs.clone();
                     let running_ref = running.clone();
                     let running_exec_ids_ref = running_execution_ids.clone();
@@ -5224,14 +5257,9 @@ impl PipeManager {
                         info!("scheduler: running pipe '{}'", pipe_name);
 
                         // Create DB execution row
-                        let trigger = if is_event_triggered {
-                            "event"
-                        } else {
-                            "scheduled"
-                        };
                         let exec_id = if let Some(ref store) = store_ref {
                             match store
-                                .create_execution(&pipe_name, trigger, &model, provider.as_deref())
+                                .create_execution(&pipe_name, &trigger, &model, provider.as_deref())
                                 .await
                             {
                                 Ok(id) => {
@@ -5555,6 +5583,7 @@ impl PipeManager {
                             cb(
                                 &name_for_cb,
                                 exec_id,
+                                &trigger,
                                 success,
                                 duration_secs,
                                 cb_error_type.as_deref(),

--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -1465,9 +1465,12 @@ async fn main() -> anyhow::Result<()> {
     ));
     let (event_runs_active, event_runs_peak) = pipe_manager.event_run_concurrency();
     pipe_manager.set_on_run_complete(std::sync::Arc::new(
-        move |pipe_name, _execution_id, success, duration_secs, error_type| {
+        move |pipe_name, execution_id, trigger_type, success, duration_secs, error_type| {
             let mut props = serde_json::json!({
                 "pipe": pipe_name,
+                "execution_id": execution_id,
+                "trigger_type": trigger_type,
+                "telemetry_schema_version": 2,
                 "success": success,
                 "duration_secs": duration_secs,
                 // Concurrency of event-triggered runs: live count as this run
@@ -1479,6 +1482,7 @@ async fn main() -> anyhow::Result<()> {
             if let Some(et) = error_type {
                 props["error_type"] = serde_json::Value::String(et.to_string());
             }
+            // Keep the legacy event name so existing dashboards continue to work.
             analytics::capture_event_nonblocking("pipe_scheduled_run", props);
         },
     ));

--- a/crates/screenpipe-engine/src/pipes_api.rs
+++ b/crates/screenpipe-engine/src/pipes_api.rs
@@ -206,6 +206,17 @@ pub struct RunPipeBody {
     /// Context from a notification action — injected into the pipe prompt.
     #[serde(default)]
     pub notification_context: Option<Value>,
+    /// Low-cardinality product surface that initiated the run.
+    /// Only the onboarding surface is accepted; all other API calls are manual.
+    #[serde(default)]
+    pub trigger_type: Option<String>,
+}
+
+fn run_trigger_type(body: Option<&RunPipeBody>) -> &'static str {
+    match body.and_then(|b| b.trigger_type.as_deref()) {
+        Some("onboarding") => "onboarding",
+        _ => "manual",
+    }
 }
 
 /// POST /pipes/:id/run — trigger a manual pipe run.
@@ -291,7 +302,10 @@ pub async fn run_pipe_now(
     ]);
     mgr.set_connections_context(conn_ctx);
 
-    let result = mgr.start_pipe_background(&id).await;
+    let trigger_type = run_trigger_type(body.as_ref().map(|Json(b)| b));
+    let result = mgr
+        .start_pipe_background_with_trigger(&id, trigger_type)
+        .await;
 
     // Restore previous extra context
     match prev_context {
@@ -522,6 +536,22 @@ mod tests {
     use tempfile::TempDir;
     use tokio::sync::Notify;
     use tower::ServiceExt;
+
+    #[test]
+    fn only_accepts_onboarding_as_a_non_manual_api_trigger() {
+        let onboarding = RunPipeBody {
+            notification_context: None,
+            trigger_type: Some("onboarding".to_string()),
+        };
+        let untrusted = RunPipeBody {
+            notification_context: None,
+            trigger_type: Some("scheduled".to_string()),
+        };
+
+        assert_eq!(run_trigger_type(Some(&onboarding)), "onboarding");
+        assert_eq!(run_trigger_type(Some(&untrusted)), "manual");
+        assert_eq!(run_trigger_type(None), "manual");
+    }
 
     #[test]
     fn joins_non_empty_connection_context_blocks() {


### PR DESCRIPTION
## What changed

- add `trigger_type`, `execution_id`, and `telemetry_schema_version` to Pipe completion telemetry while preserving the existing `pipe_scheduled_run` event name
- distinguish manual, onboarding, scheduled, workflow-event, and connection-triggered Pipe runs at the execution source
- record global shortcut presses once in Rust before app-wide events are broadcast, removing duplicate-prone webview listeners
- add native macOS shortcut-reminder telemetry parity for shown, timeline, chat, search, dismiss, inbox, and meeting-toggle actions

## Why

The existing Pipe event grouped every completion under a scheduled label, so product analysis could not separate intentional manual use from recurring, workflow, connection, or onboarding runs. Shortcut analytics were emitted from mounted webviews after app-wide broadcasts, which could miss native-only paths and double-count events across windows.

## Impact

Existing PostHog dashboards keep working. New analysis can segment `pipe_scheduled_run` by `trigger_type` and join a completion to its local execution row. Shortcut adoption is counted once per physical global shortcut press, and native reminder funnels now match the webview surface.

## Validation

- `cargo check -p screenpipe-core -p screenpipe-engine`
- `cargo test -p screenpipe-engine pipes_api::tests::only_accepts_onboarding_as_a_non_manual_api_trigger --lib`
- `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml`
- `bun run typecheck` in `apps/screenpipe-app-tauri`
- `cargo fmt --all -- --check`
- `git diff --check`
