### PR TITLE
fix: make notification links easier to click

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/swift/notification_panel.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/notification_panel.swift
@@ -661,25 +661,25 @@ private struct ViewerOverrideButton: View {
     @State private var isHovered = false
 
     var body: some View {
-        Button(action: {
-            // Try Obsidian first for markdown — same logic as Rust's
-            // `open_note_path`. Falls through to NSWorkspace.open(URL).
-            let lower = path.lowercased()
-            if lower.hasSuffix(".md") || lower.hasSuffix(".markdown") {
-                if let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                   let obsidian = URL(string: "obsidian://open?path=\(encoded)") {
-                    if NSWorkspace.shared.open(obsidian) { return }
+        Text("↗")
+            .font(Brand.swiftUIMonoFont(size: 10))
+            .foregroundColor(isHovered ? .primary.opacity(0.9) : .primary.opacity(0.35))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                // Try Obsidian first for markdown — same logic as Rust's
+                // `open_note_path`. Falls through to NSWorkspace.open(URL).
+                let lower = path.lowercased()
+                if lower.hasSuffix(".md") || lower.hasSuffix(".markdown") {
+                    if let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+                       let obsidian = URL(string: "obsidian://open?path=\(encoded)") {
+                        if NSWorkspace.shared.open(obsidian) { return }
+                    }
                 }
-            }
-            let fileUrl = URL(fileURLWithPath: path)
-            NSWorkspace.shared.open(fileUrl)
-        }) {
-            Text("↗")
-                .font(Brand.swiftUIMonoFont(size: 10))
-                .foregroundColor(isHovered ? .primary.opacity(0.9) : .primary.opacity(0.35))
+                let fileUrl = URL(fileURLWithPath: path)
+                NSWorkspace.shared.open(fileUrl)
         }
-        .buttonStyle(.plain)
-        .contentShape(Rectangle())
         .help("open in default app")
         .onHover { h in
             withAnimation(.linear(duration: Brand.animDuration)) { isHovered = h }
@@ -704,9 +704,8 @@ private func openLinkUrl(_ url: URL) {
     NSWorkspace.shared.open(url)
 }
 
-/// A clickable link rendered as a Button so it works in non-activating panels.
-/// SwiftUI Text with AttributedString links requires key focus to handle clicks,
-/// which non-activating panels don't provide. Button works without activation.
+/// A clickable link rendered with an explicit tap target so near-miss clicks
+/// work in the non-activating notification panel.
 @available(macOS 13.0, *)
 private struct LinkButton: View {
     let label: String
@@ -714,16 +713,16 @@ private struct LinkButton: View {
     @State private var isHovered = false
 
     var body: some View {
-        Button(action: {
-            openLinkUrl(url)
-        }) {
-            Text(label)
-                .font(Brand.swiftUIMonoFont(size: 11))
-                .foregroundColor(isHovered ? .primary.opacity(0.9) : .primary.opacity(0.7))
-                .underline()
-        }
-        .buttonStyle(.plain)
-        .contentShape(Rectangle())
+        Text(label)
+            .font(Brand.swiftUIMonoFont(size: 11))
+            .foregroundColor(isHovered ? .primary.opacity(0.9) : .primary.opacity(0.7))
+            .underline()
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                openLinkUrl(url)
+            }
         .onHover { h in
             withAnimation(.linear(duration: Brand.animDuration)) { isHovered = h }
         }


### PR DESCRIPTION
Fixes #5435

What changed:
- made inline markdown links in the Swift notification panel use a larger tap target
- used the same tap-target path for the small external-open control beside viewer links
- left the visual styling unchanged

Why:
The link could react visually near the edge, but the click did not always fire unless the cursor was close to the text. Now the padded rectangle owns the tap, so normal near-miss clicks around the link open it.

Testing:
- swiftc -parse apps/screenpipe-app-tauri/src-tauri/swift/notification_panel.swift
- swiftc -typecheck apps/screenpipe-app-tauri/src-tauri/swift/notification_panel.swift

Recordings:

Before:

<video src="https://github.com/user-attachments/assets/8c8a651f-5faa-459b-8acf-10ffe98121d6" controls></video>

After:

<video src="https://github.com/user-attachments/assets/c1bccd96-7b3f-47d1-85c3-382ee488b674" controls></video>
