### PR TITLE
fix Brain first-open dashboard and Windows bounds

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -779,7 +779,7 @@ describe("BrainOverview", () => {
     expect(screen.queryByRole("img")).toBeNull();
   });
 
-  it("keeps manual creation available behind the AI-first empty state", async () => {
+  it("creates a usable starter dashboard on first open", async () => {
     mocks.listBrainViews.mockResolvedValue({ status: "ok", data: [] });
     mocks.saveBrainView.mockImplementation(async (request) => ({
       status: "ok",
@@ -796,13 +796,26 @@ describe("BrainOverview", () => {
     }));
     render(<BrainOverview />);
 
+    const dashboardSelector = await screen.findByTestId(
+      "overview-dashboard-selector",
+    );
+    expect(dashboardSelector).toHaveValue("my-dashboard");
+    expect(dashboardSelector).toHaveTextContent("My dashboard");
+    expect(mocks.saveBrainView).toHaveBeenNthCalledWith(1, {
+      id: "my-dashboard",
+      title: "My dashboard",
+      expectedRevision: null,
+      timeRange: "today",
+      periodPolicy: {
+        type: "selectable.v1",
+        values: ["today", "24h", "7d", "30d"],
+      },
+      slots: [],
+    });
     expect(
-      await screen.findByText("What should this Live View show?"),
+      screen.getByPlaceholderText(/Ask AI to create a dashboard/),
     ).toBeTruthy();
-    expect(
-      screen.getByPlaceholderText(/show how I spend my time/),
-    ).toBeTruthy();
-    fireEvent.click(await screen.findByTestId("overview-create"));
+    fireEvent.click(screen.getByText("add your first Block"));
     fireEvent.click(screen.getByTestId("overview-add-card"));
     expect(screen.getByText("Live View name")).toBeTruthy();
     expect(screen.getByText("Block title")).toBeTruthy();
@@ -824,9 +837,9 @@ describe("BrainOverview", () => {
     fireEvent.click(screen.getByTestId("overview-save"));
 
     await waitFor(() => {
-      expect(mocks.saveBrainView).toHaveBeenCalledTimes(1);
+      expect(mocks.saveBrainView).toHaveBeenCalledTimes(2);
     });
-    const request = mocks.saveBrainView.mock.calls[0][0];
+    const request = mocks.saveBrainView.mock.calls[1][0];
     expect(request.slots[0]).toEqual(
       expect.objectContaining({
         title: "Automation opportunities",
@@ -1118,8 +1131,8 @@ describe("BrainOverview", () => {
     );
 
     fireEvent.click(screen.getByTestId("overview-apply-ai"));
-    await waitFor(() => expect(mocks.saveBrainView).toHaveBeenCalledTimes(1));
-    expect(mocks.saveBrainView.mock.calls[0][0].slots).toEqual([
+    await waitFor(() => expect(mocks.saveBrainView).toHaveBeenCalledTimes(2));
+    expect(mocks.saveBrainView.mock.calls[1][0].slots).toEqual([
       expect.objectContaining({
         title: "Time by project",
         component: "bar-chart.v1",

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -118,6 +118,8 @@ type PreviewSource =
 type PreviewDestination = "new" | "replace";
 
 const MAX_DASHBOARDS = 12;
+const STARTER_DASHBOARD_ID = "my-dashboard";
+const STARTER_DASHBOARD_TITLE = "My dashboard";
 
 const COMPONENTS: Array<{
   value: ViewComponent;
@@ -399,15 +401,37 @@ export function BrainOverview({
       try {
         const result = await commands.listBrainViews();
         if (result.status === "error") throw new Error(result.error);
-        setViews(result.data);
+        let loadedViews = result.data;
+        if (loadedViews.length === 0) {
+          const starter = await commands.saveBrainView({
+            id: STARTER_DASHBOARD_ID,
+            title: STARTER_DASHBOARD_TITLE,
+            expectedRevision: null,
+            timeRange: "today",
+            periodPolicy: DEFAULT_LIVE_VIEW_PERIOD_POLICY,
+            slots: [],
+          });
+          if (starter.status === "ok") {
+            loadedViews = [starter.data];
+          } else {
+            // A second mount can win the create race in development or after
+            // a fast route change. Read back before treating that as a failure.
+            const retry = await commands.listBrainViews();
+            if (retry.status === "error" || retry.data.length === 0) {
+              throw new Error(starter.error);
+            }
+            loadedViews = retry.data;
+          }
+        }
+        setViews(loadedViews);
         setView((current) => {
           const preferredId =
             preferredDashboardId ??
             current?.id ??
             selectedLiveViewDashboardId();
           const selected =
-            result.data.find((candidate) => candidate.id === preferredId) ??
-            result.data[0] ??
+            loadedViews.find((candidate) => candidate.id === preferredId) ??
+            loadedViews[0] ??
             null;
           rememberSelectedLiveViewDashboard(selected?.id ?? null);
           return selected;

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -1238,7 +1238,10 @@ export function BrainSection() {
 
   return (
     <div data-testid="section-brain" className="h-full overflow-hidden">
-    <div className="max-w-6xl mx-auto px-6 py-6 space-y-4 h-full flex flex-col">
+    <div
+      data-testid="brain-content"
+      className="max-w-6xl mx-auto px-3 pb-6 pt-10 sm:px-6 space-y-4 h-full flex flex-col"
+    >
       <p className="text-muted-foreground text-sm mb-4">
         what the AI has learned from your activity and what it has generated for you
       </p>

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -7,8 +7,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 73
-- Declared test blocks: 222
-- Weighted coverage points: 172.0
+- Declared test blocks: 223
+- Weighted coverage points: 173.0
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -19,9 +19,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 62 | 207 | 166.3 | 15 | 67 | 93% |
-| macos | 69 | 186 | 143.3 | 17 | 68 | 89% |
-| linux | 53 | 169 | 136.9 | 13 | 63 | 87% |
+| windows | 62 | 208 | 167.3 | 15 | 67 | 93% |
+| macos | 69 | 187 | 144.3 | 17 | 68 | 89% |
+| linux | 53 | 170 | 137.9 | 13 | 63 | 87% |
 
 ## Runtime Results
 
@@ -39,13 +39,13 @@ pass/fail/skip counts.
 | capture-ocr | 2 specs / 15 tests / 6.0 pts | 4 specs / 6 tests / 2.4 pts | 1 specs / 3 tests / 1.2 pts |
 | chat-ai | 18 specs / 31 tests / 22.4 pts | 21 specs / 35 tests / 23.7 pts | 17 specs / 30 tests / 21.9 pts |
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
-| local-api | 15 specs / 95 tests / 79.0 pts | 15 specs / 70 tests / 60.0 pts | 12 specs / 68 tests / 59.2 pts |
+| local-api | 15 specs / 96 tests / 80.0 pts | 15 specs / 71 tests / 61.0 pts | 12 specs / 69 tests / 60.2 pts |
 | notifications | 2 specs / 11 tests / 10.1 pts | 2 specs / 4 tests / 2.4 pts | 1 specs / 3 tests / 2.1 pts |
 | onboarding | 2 specs / 7 tests / 4.6 pts | 2 specs / 7 tests / 4.6 pts | 2 specs / 7 tests / 4.6 pts |
 | os-integration | 5 specs / 17 tests / 16.1 pts | 5 specs / 4 tests / 1.3 pts | - |
 | performance | 2 specs / 44 tests / 44.0 pts | 4 specs / 34 tests / 30.5 pts | 1 specs / 29 tests / 29.0 pts |
-| pipes | 4 specs / 13 tests / 13.0 pts | 4 specs / 13 tests / 13.0 pts | 4 specs / 13 tests / 13.0 pts |
-| real-ui-e2e | 40 specs / 125 tests / 100.1 pts | 42 specs / 112 tests / 89.6 pts | 37 specs / 105 tests / 87.3 pts |
+| pipes | 4 specs / 14 tests / 14.0 pts | 4 specs / 14 tests / 14.0 pts | 4 specs / 14 tests / 14.0 pts |
+| real-ui-e2e | 40 specs / 126 tests / 101.1 pts | 42 specs / 113 tests / 90.6 pts | 37 specs / 106 tests / 88.3 pts |
 | settings | 13 specs / 33 tests / 30.6 pts | 15 specs / 28 tests / 24.3 pts | 12 specs / 25 tests / 22.6 pts |
 | storage-privacy | 6 specs / 21 tests / 20.1 pts | 5 specs / 13 tests / 12.1 pts | 4 specs / 13 tests / 12.1 pts |
 | tauri-command | 10 specs / 19 tests / 12.3 pts | 10 specs / 20 tests / 11.8 pts | 9 specs / 18 tests / 11.3 pts |
@@ -100,7 +100,7 @@ pass/fail/skip counts.
 | app-lifecycle.spec.ts | windows, macos, linux | real-ui-e2e, window-lifecycle | app-launch, home-navigation, webview-stability, route-churn, browser-storage | high | strong | mixed | 14 | Home webview, routing, reload, focus, resize, and storage stability. |
 | artifacts-api.spec.ts | windows, macos, linux | local-api | local-api-auth, artifacts | medium | strong | api | 7 | CRUD coverage for artifact registration, validation, unified listing, upsert, and delete. |
 | audio-fallback.spec.ts | macos | audio-device, settings, notifications | audio-device-health, settings-recording, notifications | medium | conditional | real-user-flow | 1 | Opt-in macOS cloud audio fallback seed. |
-| brain-overview.spec.ts | windows, macos, linux | real-ui-e2e, local-api, pipes | brain, brain-overview, artifacts, pipes | high | strong | real-user-flow | 1 | Creates a Live View template, submits all supported Block payloads with evidence, renders them in the real app, and captures the PR screenshot. |
+| brain-overview.spec.ts | windows, macos, linux | real-ui-e2e, local-api, pipes | brain, brain-overview, artifacts, pipes | high | strong | real-user-flow | 2 | Creates the first-open starter dashboard, renders a Pipe-filled Live View, and checks top and horizontal bounds from the supported 800x600 minimum through 1920x1080. |
 | brain-section.spec.ts | windows, macos, linux | real-ui-e2e | brain, artifacts, memories, viewer-deeplink | medium | strong | real-user-flow | 10 | Brain coverage for filters, search, delete flows, selection pruning, add memory, and inline artifact markdown preview. |
 | capture-frequency-floor.spec.ts | macos | capture-ocr, settings, real-ui-e2e | capture-ocr, settings-recording, restart-flow | high | conditional | real-user-flow | 1 | macOS fixed screenshot cadence regression: persists the 1s setting before immediate Apply & Restart, then verifies real capture attempts and frame writes. |
 | chat-ask-user-tool-card.spec.ts | windows, macos, linux | chat-ai, real-ui-e2e | chat, chat-tools, pi-ask-user | medium | partial | mixed | 1 | Synthetic assistant tool block renders the Pi ask_user dropdown and sends the selected answer through the normal chat reply path. |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -782,7 +782,7 @@
       "criticality": "high",
       "confidence": "strong",
       "ux": "real-user-flow",
-      "notes": "Creates a Live View template, submits all supported Block payloads with evidence, renders them in the real app, and captures the PR screenshot."
+      "notes": "Creates the first-open starter dashboard, renders a Pipe-filled Live View, and checks top and horizontal bounds from the supported 800x600 minimum through 1920x1080."
     },
     {
       "spec": "html-artifact-render.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -26,8 +26,56 @@ interface BrainView {
   id: string;
 }
 
+const SUPPORTED_WINDOW_SIZES = [
+  { width: 800, height: 600, label: "minimum" },
+  { width: 1024, height: 768, label: "compact" },
+  { width: 1280, height: 720, label: "small-windows-laptop" },
+  { width: 1366, height: 768, label: "windows-laptop" },
+  { width: 1440, height: 900, label: "desktop" },
+  { width: 1920, height: 1080, label: "wide" },
+] as const;
+
+async function setCssWindowSize(width: number, height: number) {
+  const devicePixelRatio = (await browser.execute(
+    () => window.devicePixelRatio || 1,
+  )) as number;
+  await browser.setWindowSize(
+    Math.round(width * devicePixelRatio),
+    Math.round(height * devicePixelRatio),
+  );
+}
+
 describe("Brain Live Views", function () {
   this.timeout(120_000);
+
+  it("creates a starter dashboard on first open", async () => {
+    await waitForAppReady();
+    await openHomeWindow();
+
+    const existingViews = await invokeOrThrow<BrainView[]>("list_brain_views");
+    for (const existingView of existingViews) {
+      await invokeOrThrow("delete_brain_view", { id: existingView.id });
+    }
+
+    const brainNav = await $("[data-testid=nav-brain]");
+    await brainNav.waitForExist({ timeout: t(10_000) });
+    await brainNav.click();
+    await waitForTestId("section-brain", 15_000);
+    const selector = await waitForTestId(
+      "overview-dashboard-selector",
+      15_000,
+    );
+    expect(await selector.getValue()).toBe("my-dashboard");
+    expect(await selector.getText()).toContain("My dashboard");
+
+    await setCssWindowSize(1366, 768);
+    await saveScreenshot("brain-first-open-windows");
+
+    const pipesNav = await $("[data-testid=nav-pipes]");
+    await pipesNav.click();
+    await waitForTestId("section-pipes", 15_000);
+    await invokeOrThrow("delete_brain_view", { id: "my-dashboard" });
+  });
 
   it("renders a Pipe-filled Live View template", async () => {
     await waitForAppReady();
@@ -184,7 +232,88 @@ describe("Brain Live Views", function () {
     await brainNav.click();
     await waitForTestId("section-brain", 15_000);
     await waitForTestId("brain-overview-grid", 15_000);
-    await browser.setWindowSize(2200, 1400);
+    for (const size of SUPPORTED_WINDOW_SIZES) {
+      await setCssWindowSize(size.width, size.height);
+      await browser.pause(150);
+      const layout = (await browser.execute(() => {
+        const section = document.querySelector<HTMLElement>(
+          "[data-testid='section-brain']",
+        );
+        const content = document.querySelector<HTMLElement>(
+          "[data-testid='brain-content']",
+        );
+        if (!section || !content) return null;
+        const sectionRect = section.getBoundingClientRect();
+        const firstContentTop =
+          content.firstElementChild?.getBoundingClientRect().top ?? 0;
+        const visibleControls = Array.from(
+          section.querySelectorAll<HTMLElement>(
+            "button, input, select, textarea, a[href]",
+          ),
+        ).filter((element) => {
+          const rect = element.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        });
+        return {
+          viewportWidth: document.documentElement.clientWidth,
+          documentWidth: document.documentElement.scrollWidth,
+          sectionLeft: sectionRect.left,
+          sectionRight: sectionRect.right,
+          firstContentTop,
+          clippedControls: visibleControls
+            .filter((element) => {
+              const rect = element.getBoundingClientRect();
+              return (
+                rect.top < 32 ||
+                rect.left < -1 ||
+                rect.right > document.documentElement.clientWidth + 1
+              );
+            })
+            .map((element) => {
+              const rect = element.getBoundingClientRect();
+              return {
+                label:
+                  element.getAttribute("data-testid") ||
+                  element.getAttribute("aria-label") ||
+                  element.textContent?.trim().slice(0, 40) ||
+                  element.tagName,
+                top: rect.top,
+                left: rect.left,
+                right: rect.right,
+              };
+            }),
+        };
+      })) as {
+        viewportWidth: number;
+        documentWidth: number;
+        sectionLeft: number;
+        sectionRight: number;
+        firstContentTop: number;
+        clippedControls: Array<{
+          label: string;
+          top: number;
+          left: number;
+          right: number;
+        }>;
+      } | null;
+
+      expect(layout).not.toBeNull();
+      expect(layout!.viewportWidth).toBeGreaterThanOrEqual(size.width - 1);
+      expect(layout!.viewportWidth).toBeLessThanOrEqual(size.width + 1);
+      expect(layout!.firstContentTop).toBeGreaterThanOrEqual(32);
+      expect(layout!.sectionLeft).toBeGreaterThanOrEqual(-1);
+      expect(layout!.sectionRight).toBeLessThanOrEqual(
+        layout!.viewportWidth + 1,
+      );
+      expect(layout!.documentWidth).toBeLessThanOrEqual(
+        layout!.viewportWidth + 1,
+      );
+      expect(layout!.clippedControls).toEqual([]);
+      if (size.label === "minimum") {
+        await saveScreenshot("brain-overview-minimum-window");
+      }
+    }
+    await setCssWindowSize(1440, 900);
     const collapseSidebar = await $("[aria-label='collapse sidebar']");
     if (await collapseSidebar.isExisting()) {
       await collapseSidebar.click();

--- a/apps/screenpipe-app-tauri/e2e/wdio.conf.ts
+++ b/apps/screenpipe-app-tauri/e2e/wdio.conf.ts
@@ -29,6 +29,7 @@ const isCi = Boolean(process.env.CI);
 const isWindowsCi = isCi && process.platform === 'win32';
 const allSpecs = [resolve(__dirname, 'specs', '**', '*.spec.ts')];
 const windowsCiSpecs = [
+  'brain-overview.spec.ts',
   'windows-system-integration.spec.ts',
   'windows-user-journey.spec.ts',
 ].map((spec) => resolve(__dirname, 'specs', spec));
@@ -56,8 +57,8 @@ export const config: TestrunnerConfig = {
 
   // Recursive on macOS/Linux. Windows CI repeatedly loses the WebDriver session
   // in generic cross-platform window specs and can burn the full E2E timeout;
-  // keep broad coverage on macOS/Linux while Windows runs its focused Windows
-  // journey/system specs plus the workflow's separate core-recording spec.
+  // keep broad coverage on macOS/Linux while Windows runs its focused Brain
+  // layout, journey/system specs, plus the workflow's separate core-recording spec.
   specs: isWindowsCi ? windowsCiSpecs : allSpecs,
   maxInstances: 1,
   capabilities: [{ browserName: 'chrome' }],


### PR DESCRIPTION
## What changed

- create and persist a usable `My dashboard` when Brain opens with no saved Live Views
- keep the first Brain content below the 32px Windows drag/title region
- reduce horizontal padding in narrow windows without changing the desktop layout
- test first-open behavior and layout bounds at 800x600, 1024x768, 1280x720, 1366x768, 1440x900, and 1920x1080
- include the Brain layout spec in the focused Windows CI lane

## Why

Two states combined on first open:

1. an empty `list_brain_views` response left no selected dashboard, so Brain showed only the AI empty prompt
2. Brain started with 24px top padding while the home window reserves a 32px draggable title region, allowing the first row to sit under the Windows chrome

## Visual proof

```text
Before                         After
┌─ 32px drag/title band ─┐     ┌─ 32px drag/title band ─┐
│ Brain content overlaps │     │                        │
└────────────────────────┘     └────────────────────────┘
                               My dashboard
No dashboard shell             Ask AI... / add first Block
```

The real-app E2E also captures the first-open 1366x768 view and the filled 800x600 minimum view.

## Validation

- 55 focused Brain unit tests passed
- TypeScript typecheck passed
- E2E coverage report is up to date
- debug E2E app build passed with the test entitlement flag
- real-app Brain E2E passed on an isolated API port: 2 tests, including the six-size bounds matrix
