### PR TITLE
fix: show rendered HTML artifacts first

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/file-viewer-html-render.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/file-viewer-html-render.test.tsx
@@ -82,14 +82,14 @@ describe("file viewer — html render", () => {
     expect(iframe?.getAttribute("srcdoc") ?? "").toContain("1a1a2e");
   });
 
-  it("shows an UNMARKED bare snippet as source first, but offers a render toggle", () => {
+  it("renders an unmarked bare snippet by default with source one click away", () => {
     const content = htmlContent("<h1>just a heading</h1>");
-    render(<ViewerFileContent path={content.path} content={content} />);
-    // toggle present (rendering is always available)…
+    const { container } = render(
+      <ViewerFileContent path={content.path} content={content} />,
+    );
     const toggle = screen.getByTestId("html-render-toggle");
-    expect(toggle.textContent).toContain("preview rendered");
-    // …but a bare snippet defaults to source — nothing rendered yet
-    expect(document.querySelector("iframe")).toBeNull();
+    expect(toggle.textContent).toContain("view source");
+    expect(container.querySelector("iframe")).not.toBeNull();
   });
 
   it("renders a marked snippet by default", () => {
@@ -105,12 +105,12 @@ describe("file viewer — html render", () => {
     const { container } = render(
       <ViewerFileContent path={content.path} content={content} />,
     );
-    // starts as source
-    expect(container.querySelector("iframe")).toBeNull();
-    fireEvent.click(screen.getByTestId("html-render-toggle")); // → rendered
+    // starts rendered
     expect(container.querySelector("iframe")).not.toBeNull();
     fireEvent.click(screen.getByTestId("html-render-toggle")); // → source
     expect(container.querySelector("iframe")).toBeNull();
+    fireEvent.click(screen.getByTestId("html-render-toggle")); // → rendered
+    expect(container.querySelector("iframe")).not.toBeNull();
   });
 
   it("offers NO render for a truncated (>10MB) document — could be cut mid-tag", () => {

--- a/apps/screenpipe-app-tauri/components/file-viewer.tsx
+++ b/apps/screenpipe-app-tauri/components/file-viewer.tsx
@@ -230,9 +230,9 @@ export function ViewerFileContent({
   }, [content]);
 
   // Choose the FIRST tab (rendered vs source) once the content for a path
-  // loads, then leave it under the user's control. Full documents / marked
-  // artifacts open rendered; bare snippets open as source. A ref keyed on the
-  // path makes this init-once so a user's later toggle is never overridden, and
+  // loads, then leave it under the user's control. Every renderable HTML file
+  // opens rendered; source remains one click away. A ref keyed on the path
+  // makes this init-once so a user's later toggle is never overridden, and
   // re-applies when navigating to a different file.
   const defaultInitRef = useRef<string | null>(null);
   useEffect(() => {

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/artifact-html-body.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/artifact-html-body.test.tsx
@@ -75,6 +75,22 @@ describe("ArtifactHtmlBody (Brain html artifact)", () => {
     expect(hostStyleLeaked()).toBe(false);
   });
 
+  it("expanded: renders a bare HTML fragment first with source one click away", () => {
+    const { container } = render(
+      <ArtifactHtmlBody
+        title="fragment"
+        content="<h1>Fragment artifact</h1>"
+        expanded={true}
+        onToggleExpanded={() => {}}
+      />,
+    );
+
+    expect(container.querySelector("iframe")).not.toBeNull();
+    expect(screen.getByTestId("brain-html-render-toggle").textContent).toContain(
+      "view source",
+    );
+  });
+
   it("expanded: 'view source' toggles to escaped source (still no leak)", () => {
     render(
       <ArtifactHtmlBody

--- a/apps/screenpipe-app-tauri/components/settings/artifact-html-body.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/artifact-html-body.tsx
@@ -38,8 +38,8 @@ export function ArtifactHtmlBody({
   onToggleExpanded,
   hideTitle = false,
 }: ArtifactHtmlBodyProps) {
-  // Source vs rendered. Initialized once per expansion from the content shape
-  // (full doc / marked → rendered; bare snippet → source), then user-controlled.
+  // Source vs rendered. Every non-empty HTML artifact opens rendered on each
+  // expansion, then stays under the user's control.
   const [showSource, setShowSource] = useState(false);
   const initedRef = useRef(false);
   useEffect(() => {

--- a/apps/screenpipe-app-tauri/lib/utils/__tests__/html-sandbox.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/__tests__/html-sandbox.test.ts
@@ -134,9 +134,13 @@ describe("shouldRenderHtmlByDefault", () => {
     ).toBe(true);
   });
 
-  it("returns false for bare fragments without marker", () => {
-    expect(shouldRenderHtmlByDefault("<p>just a paragraph</p>")).toBe(false);
-    expect(shouldRenderHtmlByDefault("<div>snippet</div>")).toBe(false);
+  it("returns true for bare fragments without marker", () => {
+    expect(shouldRenderHtmlByDefault("<p>just a paragraph</p>")).toBe(true);
+    expect(shouldRenderHtmlByDefault("<div>snippet</div>")).toBe(true);
+  });
+
+  it("returns false for empty content", () => {
+    expect(shouldRenderHtmlByDefault("")).toBe(false);
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/utils/html-sandbox.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/html-sandbox.test.ts
@@ -101,7 +101,7 @@ describe("looksLikeFullHtmlDocument", () => {
 });
 
 describe("shouldRenderHtmlByDefault", () => {
-  it("renders full documents and marked artifacts first", () => {
+  it("renders full documents, marked artifacts, and bare fragments first", () => {
     expect(shouldRenderHtmlByDefault("<!doctype html><html><body>x")).toBe(true);
     expect(shouldRenderHtmlByDefault("<style>.a{}</style><div>x</div>")).toBe(
       true,
@@ -115,12 +115,13 @@ describe("shouldRenderHtmlByDefault", () => {
         '<meta name="screenpipe:render" content="human"><h1>hi</h1>',
       ),
     ).toBe(true);
+    expect(shouldRenderHtmlByDefault("<h1>just a heading</h1>")).toBe(true);
+    expect(shouldRenderHtmlByDefault("<div>code sample</div>")).toBe(true);
   });
 
-  it("shows source first for an unmarked bare snippet", () => {
-    expect(shouldRenderHtmlByDefault("<h1>just a heading</h1>")).toBe(false);
-    expect(shouldRenderHtmlByDefault("<div>code sample</div>")).toBe(false);
+  it("does not render empty content", () => {
     expect(shouldRenderHtmlByDefault("")).toBe(false);
+    expect(shouldRenderHtmlByDefault("  \n ")).toBe(false);
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/utils/html-sandbox.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/html-sandbox.ts
@@ -20,14 +20,10 @@
 //!      external origins: `default-src 'none'`, no `connect-src`, no remote
 //!      `img-src`, no `form-action`. Nothing can phone home.
 //!
-//!   2. INTENT (default view, NOT a gate): any `.html` can be rendered in the
-//!      sandbox, and a "view source" toggle is always one click away. The
-//!      producer marker (`HUMAN_RENDER_MARKER`) and a full-document shape only
-//!      decide whether the rendered or the source tab is shown FIRST. They do
-//!      not change containment — every artifact is wrapped and rendered inside
-//!      the same locked-down iframe whether or not it is marked. (Earlier this
-//!      module required the marker to render at all; that just meant real AI
-//!      artifacts never rendered, so the marker was demoted to a default hint.)
+//!   2. INTENT (default view, NOT a gate): any non-empty `.html` opens rendered
+//!      in the sandbox, and a "view source" toggle is always one click away.
+//!      Full documents and bare fragments follow the same rule because the
+//!      sandbox wrapper safely turns either shape into a complete document.
 //!
 //! Multiple CSPs intersect (a resource must pass every policy), so an artifact
 //! that ships its own permissive `<meta>` CSP cannot loosen the one we inject.
@@ -61,10 +57,8 @@ export const SANDBOX_CSP = [
 ].join("; ");
 
 /**
- * Producer opt-in marker. A pipe/agent MUST embed this comment for the viewer
- * to offer a rendered preview; without it, the `.html` is shown as source only.
- * Accepts `screenpipe:render=human` or `screenpipe:render=html`, whitespace
- * tolerant, e.g. `<!-- screenpipe:render=human -->`.
+ * Legacy producer marker. Rendering no longer requires this marker, but keep
+ * recognizing it for artifacts produced by older pipes and agents.
  */
 export const HUMAN_RENDER_MARKER =
   /<!--\s*screenpipe:render\s*=\s*(?:human|html)\s*-->/i;
@@ -93,12 +87,10 @@ export function isHtmlFileName(name: string): boolean {
 }
 
 /**
- * Heuristic: does this text look like a full, human-facing HTML *document*
- * (rather than a tiny snippet)? A document-level tag means the producer almost
- * certainly intends it to be looked at rendered, not as source. Used only to
- * pick the DEFAULT view — it never affects containment (the sandbox + CSP wrap
- * everything regardless). Matches `<!doctype html>`, `<html>`, `<head>`,
- * `<body>`, or a `<style>` block anywhere in the text, case-insensitively.
+ * Heuristic retained for callers that need to distinguish a full HTML document
+ * from a fragment. The viewer no longer uses this to choose its default tab.
+ * Matches `<!doctype html>`, `<html>`, `<head>`, `<body>`, or a `<style>` block
+ * anywhere in the text, case-insensitively.
  */
 export function looksLikeFullHtmlDocument(text: string): boolean {
   return /<(?:!doctype\s+html|html|head|body|style)[\s>]/i.test(text);
@@ -106,15 +98,15 @@ export function looksLikeFullHtmlDocument(text: string): boolean {
 
 /**
  * Should an HTML artifact open as a rendered preview (vs. source) by default?
- * True when the producer explicitly opted in (marker) OR the content looks like
- * a full document. A bare fragment with no marker stays source-first so a code
- * snippet someone is inspecting isn't surprisingly executed in the sandbox.
+ * Every non-empty artifact opens rendered, including bare fragments. The file
+ * extension establishes that this is an HTML artifact; source stays one click
+ * away for inspection.
  *
  * IMPORTANT: this only chooses the initial tab. Rendering is ALWAYS done inside
  * the locked-down sandbox iframe; this flag is not a security gate.
  */
 export function shouldRenderHtmlByDefault(text: string): boolean {
-  return hasHumanRenderMarker(text) || looksLikeFullHtmlDocument(text);
+  return text.trim().length > 0;
 }
 
 /**


### PR DESCRIPTION
## why

HTML artifact behavior depended on content shape. Full documents opened rendered, but bare fragments such as `<h1>report</h1>` opened as raw source and made people click **preview rendered**.

## changed

- open every non-empty, fully loaded `.html` artifact rendered first
- keep raw HTML one click away behind **view source**
- apply the same behavior in the full file viewer and Brain artifact rows
- preserve the locked-down iframe sandbox and CSP; empty and truncated files still do not render

## visual

```text
before                                    after
┌ html · sandboxed · source ─────────┐    ┌ html · sandboxed · rendered ──────┐
│                 preview rendered ↗ │    │                       view source │
│ <h1>weekly report</h1>             │    │                                 │
└────────────────────────────────────┘    │          weekly report          │
                                          └─────────────────────────────────┘
```

## validation

- focused Vitest: 48 passed
- HTML sandbox Bun tests: 21 passed
- TypeScript typecheck: passed
- focused ESLint: passed
- `git diff --check`: passed
