### PR TITLE
[codex] add Live View retention analytics

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -445,6 +445,39 @@ describe("BrainOverview", () => {
     expect(screen.getByText("artifact #88 · v2")).toBeTruthy();
   });
 
+  it("captures a privacy-safe Live View impression with result readiness", async () => {
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    render(<BrainOverview />);
+
+    await screen.findByText("How I worked today");
+    await waitFor(() =>
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "live_view_viewed",
+        expect.objectContaining({
+          analytics_schema_version: 1,
+          entry_method: "initial",
+          dashboard_count: 1,
+          block_count: 1,
+          bound_block_count: 1,
+          result_block_count: 1,
+          source_pipe_count: 1,
+          time_range: "today",
+          has_result: true,
+          is_onboarding: false,
+        }),
+      ),
+    );
+    const properties = mocks.capture.mock.calls.find(
+      ([event]) => event === "live_view_viewed",
+    )?.[1];
+    expect(JSON.stringify(properties)).not.toContain("my-overview");
+    expect(JSON.stringify(properties)).not.toContain("How I worked today");
+    expect(JSON.stringify(properties)).not.toContain("daily-summary");
+  });
+
   it("switches between named dashboards without changing either one", async () => {
     const weeklyView: ViewDefinition = {
       ...populatedView,
@@ -583,6 +616,27 @@ describe("BrainOverview", () => {
     expect(screen.getByTestId("overview-apply-ai").textContent).toContain(
       "create dashboard",
     );
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "live_view_generation_started",
+      expect.objectContaining({
+        analytics_schema_version: 1,
+        scope: "dashboard",
+        intent: "new-dashboard",
+        prompt_length: "show my GTM progress this week".length,
+      }),
+    );
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "live_view_generation_completed",
+      expect.objectContaining({
+        generated_block_count: 1,
+        generated_bound_block_count: 1,
+        duration_ms: expect.any(Number),
+      }),
+    );
+    const generationProperties = mocks.capture.mock.calls.find(
+      ([event]) => event === "live_view_generation_started",
+    )?.[1];
+    expect(generationProperties).not.toHaveProperty("prompt");
   });
 
   it("keeps one stable visible refresh label while data is loading", async () => {
@@ -600,6 +654,43 @@ describe("BrainOverview", () => {
     expect(loadingButton).toBeDisabled();
     expect(loadingButton.textContent).toBe("refresh data");
     expect(screen.queryByText("loading data")).toBeNull();
+  });
+
+  it("captures a failed refresh outcome without sending Pipe names", async () => {
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    mocks.localFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "private failure detail" }),
+    });
+    render(<BrainOverview />);
+
+    fireEvent.click(await screen.findByTestId("overview-refresh-data"));
+
+    await waitFor(() =>
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "live_view_refresh_completed",
+        expect.objectContaining({
+          analytics_schema_version: 1,
+          trigger: "manual",
+          status: "error",
+          requested_block_count: 1,
+          requested_pipe_count: 1,
+          refreshed_block_count: 0,
+          pipe_start_failure_count: 1,
+        }),
+      ),
+    );
+    const properties = mocks.capture.mock.calls.find(
+      ([event, eventProperties]) =>
+        event === "live_view_refresh_completed" &&
+        eventProperties?.status === "error",
+    )?.[1];
+    expect(JSON.stringify(properties)).not.toContain("daily-summary");
+    expect(JSON.stringify(properties)).not.toContain("private failure detail");
   });
 
   it("keeps the dashboard controls aligned as one responsive control group", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -152,6 +152,25 @@ beforeAll(() => {
   Element.prototype.scrollIntoView ||= () => {};
 });
 
+function setDocumentVisibility(state: "visible" | "hidden"): () => void {
+  const original = Object.getOwnPropertyDescriptor(
+    Document.prototype,
+    "visibilityState",
+  );
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(document, "visibilityState", original);
+    } else {
+      delete (document as { visibilityState?: DocumentVisibilityState })
+        .visibilityState;
+    }
+  };
+}
+
 const populatedView: ViewDefinition = {
   id: "my-overview",
   title: "How I worked today",
@@ -457,7 +476,7 @@ describe("BrainOverview", () => {
       expect(mocks.capture).toHaveBeenCalledWith(
         "live_view_viewed",
         expect.objectContaining({
-          analytics_schema_version: 1,
+          analytics_schema_version: 2,
           entry_method: "initial",
           dashboard_count: 1,
           block_count: 1,
@@ -466,7 +485,10 @@ describe("BrainOverview", () => {
           source_pipe_count: 1,
           time_range: "today",
           has_result: true,
+          all_bound_blocks_have_results: true,
+          reviewed_block_count: 0,
           is_onboarding: false,
+          onboarding_goal_category: "unknown",
         }),
       ),
     );
@@ -476,6 +498,64 @@ describe("BrainOverview", () => {
     expect(JSON.stringify(properties)).not.toContain("my-overview");
     expect(JSON.stringify(properties)).not.toContain("How I worked today");
     expect(JSON.stringify(properties)).not.toContain("daily-summary");
+  });
+
+  it("captures a visible source-backed result separately from a dashboard view", async () => {
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    render(<BrainOverview />);
+
+    await screen.findByText("How I worked today");
+    await waitFor(() =>
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "live_view_result_viewed",
+        expect.objectContaining({
+          analytics_schema_version: 2,
+          entry_method: "initial",
+          result_block_count: 1,
+          all_bound_blocks_have_results: true,
+          positive_feedback_block_count: 0,
+          negative_feedback_block_count: 0,
+        }),
+      ),
+    );
+    const properties = mocks.capture.mock.calls.find(
+      ([event]) => event === "live_view_result_viewed",
+    )?.[1];
+    expect(JSON.stringify(properties)).not.toContain("my-overview");
+    expect(JSON.stringify(properties)).not.toContain("How I worked today");
+    expect(JSON.stringify(properties)).not.toContain("daily-summary");
+    expect(JSON.stringify(properties)).not.toContain("88");
+  });
+
+  it("does not count a result as viewed until the app is visible", async () => {
+    const restoreVisibility = setDocumentVisibility("hidden");
+    try {
+      mocks.listBrainViews.mockResolvedValue({
+        status: "ok",
+        data: [populatedView],
+      });
+      render(<BrainOverview />);
+
+      await screen.findByText("How I worked today");
+      expect(
+        mocks.capture.mock.calls.some(
+          ([event]) => event === "live_view_result_viewed",
+        ),
+      ).toBe(false);
+    } finally {
+      restoreVisibility();
+    }
+
+    fireEvent(document, new Event("visibilitychange"));
+    await waitFor(() =>
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "live_view_result_viewed",
+        expect.objectContaining({ entry_method: "initial" }),
+      ),
+    );
   });
 
   it("switches between named dashboards without changing either one", async () => {
@@ -619,7 +699,7 @@ describe("BrainOverview", () => {
     expect(mocks.capture).toHaveBeenCalledWith(
       "live_view_generation_started",
       expect.objectContaining({
-        analytics_schema_version: 1,
+        analytics_schema_version: 2,
         scope: "dashboard",
         intent: "new-dashboard",
         prompt_length: "show my GTM progress this week".length,
@@ -674,13 +754,15 @@ describe("BrainOverview", () => {
       expect(mocks.capture).toHaveBeenCalledWith(
         "live_view_refresh_completed",
         expect.objectContaining({
-          analytics_schema_version: 1,
+          analytics_schema_version: 2,
           trigger: "manual",
           status: "error",
           requested_block_count: 1,
           requested_pipe_count: 1,
           refreshed_block_count: 0,
           pipe_start_failure_count: 1,
+          produced_result: false,
+          all_requested_blocks_refreshed: false,
         }),
       ),
     );
@@ -1595,6 +1677,17 @@ describe("BrainOverview", () => {
       rating: "up",
       correction: null,
     });
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "live_view_card_feedback",
+      expect.objectContaining({
+        analytics_schema_version: 2,
+        action: "up",
+        previous_action: "none",
+        is_first_feedback: true,
+        result_block_count: 1,
+        is_onboarding: false,
+      }),
+    );
 
     fireEvent.click(
       screen.getByRole("button", { name: "regenerate Focus time" }),

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -134,7 +134,7 @@ type PreviewDestination = "new" | "replace";
 const MAX_DASHBOARDS = 12;
 const STARTER_DASHBOARD_ID = "my-dashboard";
 const STARTER_DASHBOARD_TITLE = "My dashboard";
-const LIVE_VIEW_ANALYTICS_SCHEMA_VERSION = 1;
+const LIVE_VIEW_ANALYTICS_SCHEMA_VERSION = 2;
 
 function analyticsErrorType(error: unknown): string {
   return error instanceof Error ? error.name : "unknown";
@@ -145,22 +145,48 @@ function liveViewAnalyticsProperties(
   dashboardCount: number,
 ) {
   const boundSlots = targetView.slots.filter((slot) => slot.binding);
+  const resultSlots = targetView.slots.filter((slot) => slot.value !== null);
+  const positiveFeedbackBlockCount = targetView.slots.filter(
+    (slot) => slot.feedback?.current?.rating === "up",
+  ).length;
+  const negativeFeedbackBlockCount = targetView.slots.filter(
+    (slot) => slot.feedback?.current?.rating === "down",
+  ).length;
   return {
     analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
     dashboard_count: dashboardCount,
     block_count: targetView.slots.length,
     bound_block_count: boundSlots.length,
-    result_block_count: targetView.slots.filter((slot) => slot.value !== null)
-      .length,
+    result_block_count: resultSlots.length,
     source_pipe_count: new Set(
       boundSlots
         .map((slot) => slot.binding?.pipeName)
         .filter((name): name is string => Boolean(name)),
     ).size,
     time_range: targetView.timeRange,
-    has_result: targetView.slots.some((slot) => slot.value !== null),
+    has_result: resultSlots.length > 0,
+    all_bound_blocks_have_results:
+      boundSlots.length > 0 &&
+      boundSlots.every((slot) => slot.value !== null),
+    reviewed_block_count:
+      positiveFeedbackBlockCount + negativeFeedbackBlockCount,
+    positive_feedback_block_count: positiveFeedbackBlockCount,
+    negative_feedback_block_count: negativeFeedbackBlockCount,
     is_starter_dashboard: targetView.id === STARTER_DASHBOARD_ID,
   };
+}
+
+function liveViewResultSignature(targetView: ViewDefinition): string | null {
+  const resultVersions = targetView.slots
+    .flatMap((slot) =>
+      slot.value
+        ? [
+            `${slot.id}:${slot.value.artifactOutputId}:${slot.value.artifactVersion}`,
+          ]
+        : [],
+    )
+    .sort();
+  return resultVersions.length > 0 ? resultVersions.join("|") : null;
 }
 
 const COMPONENTS: Array<{
@@ -374,6 +400,10 @@ export function BrainOverview({
   );
   const activationViewedRef = useRef(new Set<string>());
   const lastViewedDashboardRef = useRef<string | null>(null);
+  const lastViewedResultRef = useRef<{
+    viewId: string;
+    signature: string;
+  } | null>(null);
   const lastRefreshOutcomeRef = useRef<number | null>(null);
   const refreshOnboardingActivation = useCallback(
     () => setActivationVersion((version) => version + 1),
@@ -526,7 +556,44 @@ export function BrainOverview({
       ...liveViewAnalyticsProperties(view, views.length),
       entry_method,
       is_onboarding: Boolean(onboardingActivation),
+      onboarding_goal_category:
+        onboardingActivation?.goalCategory ?? "unknown",
     });
+  }, [onboardingActivation, view, views.length]);
+
+  useEffect(() => {
+    if (!view) return;
+    const signature = liveViewResultSignature(view);
+    if (!signature) return;
+
+    const captureVisibleResult = () => {
+      if (document.visibilityState === "hidden") return;
+      const previous = lastViewedResultRef.current;
+      if (
+        previous?.viewId === view.id &&
+        previous.signature === signature
+      ) {
+        return;
+      }
+      const entryMethod = !previous
+        ? "initial"
+        : previous.viewId === view.id
+          ? "result_updated"
+          : "selection";
+      lastViewedResultRef.current = { viewId: view.id, signature };
+      posthog.capture("live_view_result_viewed", {
+        ...liveViewAnalyticsProperties(view, views.length),
+        entry_method: entryMethod,
+        is_onboarding: Boolean(onboardingActivation),
+        onboarding_goal_category:
+          onboardingActivation?.goalCategory ?? "unknown",
+      });
+    };
+
+    captureVisibleResult();
+    document.addEventListener("visibilitychange", captureVisibleResult);
+    return () =>
+      document.removeEventListener("visibilitychange", captureVisibleResult);
   }, [onboardingActivation, view, views.length]);
 
   useEffect(() => {
@@ -896,6 +963,9 @@ export function BrainOverview({
       requested_pipe_count: dataRefresh.pipeNames.length,
       refreshed_block_count: dataRefresh.filled,
       pipe_start_failure_count: dataRefresh.startFailureCount,
+      produced_result: dataRefresh.filled > 0,
+      all_requested_blocks_refreshed:
+        dataRefresh.total > 0 && dataRefresh.filled === dataRefresh.total,
       is_onboarding: dataRefresh.trigger === "onboarding",
     });
   }, [dataRefresh]);
@@ -1203,11 +1273,16 @@ export function BrainOverview({
           : current,
       );
       posthog.capture("live_view_card_feedback", {
-        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        ...liveViewAnalyticsProperties(view, views.length),
         action: rating ?? "clear",
+        previous_action: slot.feedback?.current?.rating ?? "none",
+        is_first_feedback: !slot.feedback?.current,
         component: slot.component,
         has_pipe: Boolean(slot.binding),
         has_correction: Boolean(correction?.trim()),
+        is_onboarding: Boolean(onboardingActivation),
+        onboarding_goal_category:
+          onboardingActivation?.goalCategory ?? "unknown",
       });
       if (rating) finishOnboardingActivation("feedback");
       return true;

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -102,14 +102,28 @@ export type ViewDefinition = BrainViewDefinition;
 
 type DataRefreshState = {
   status: "starting" | "running" | "complete" | "partial" | "error";
+  trigger: LiveViewRefreshTrigger;
   viewId: string;
+  timeRange: BrainViewTimeRange;
   pipeNames: string[];
   slotIds: string[];
   startedAt: number;
+  startFailureCount: number;
   filled: number;
   total: number;
   message?: string;
 };
+
+type LiveViewRefreshTrigger =
+  | "manual"
+  | "onboarding"
+  | "time_range"
+  | "dashboard_saved"
+  | "template_applied"
+  | "dashboard_duplicated"
+  | "undo"
+  | "card_regenerated"
+  | "card_ai_edit";
 
 type PreviewSource =
   | { kind: "ai"; scope: LiveViewGenerationScope }
@@ -120,6 +134,34 @@ type PreviewDestination = "new" | "replace";
 const MAX_DASHBOARDS = 12;
 const STARTER_DASHBOARD_ID = "my-dashboard";
 const STARTER_DASHBOARD_TITLE = "My dashboard";
+const LIVE_VIEW_ANALYTICS_SCHEMA_VERSION = 1;
+
+function analyticsErrorType(error: unknown): string {
+  return error instanceof Error ? error.name : "unknown";
+}
+
+function liveViewAnalyticsProperties(
+  targetView: ViewDefinition,
+  dashboardCount: number,
+) {
+  const boundSlots = targetView.slots.filter((slot) => slot.binding);
+  return {
+    analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+    dashboard_count: dashboardCount,
+    block_count: targetView.slots.length,
+    bound_block_count: boundSlots.length,
+    result_block_count: targetView.slots.filter((slot) => slot.value !== null)
+      .length,
+    source_pipe_count: new Set(
+      boundSlots
+        .map((slot) => slot.binding?.pipeName)
+        .filter((name): name is string => Boolean(name)),
+    ).size,
+    time_range: targetView.timeRange,
+    has_result: targetView.slots.some((slot) => slot.value !== null),
+    is_starter_dashboard: targetView.id === STARTER_DASHBOARD_ID,
+  };
+}
 
 const COMPONENTS: Array<{
   value: ViewComponent;
@@ -331,6 +373,8 @@ export function BrainOverview({
     readActiveAiPresetId,
   );
   const activationViewedRef = useRef(new Set<string>());
+  const lastViewedDashboardRef = useRef<string | null>(null);
+  const lastRefreshOutcomeRef = useRef<number | null>(null);
   const refreshOnboardingActivation = useCallback(
     () => setActivationVersion((version) => version + 1),
     [],
@@ -413,6 +457,12 @@ export function BrainOverview({
           });
           if (starter.status === "ok") {
             loadedViews = [starter.data];
+            posthog.capture("live_view_dashboard_saved", {
+              ...liveViewAnalyticsProperties(starter.data, 1),
+              action: "created",
+              source: "starter",
+              refresh_requested: false,
+            });
           } else {
             // A second mount can win the create race in development or after
             // a fast route change. Read back before treating that as a failure.
@@ -438,6 +488,10 @@ export function BrainOverview({
         });
       } catch (loadError) {
         if (!silent) {
+          posthog.capture("live_view_load_failed", {
+            analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+            failure_type: analyticsErrorType(loadError),
+          });
           setError(
             loadError instanceof Error
               ? loadError.message
@@ -462,6 +516,18 @@ export function BrainOverview({
       return next;
     });
   }, [view]);
+
+  useEffect(() => {
+    if (!view || lastViewedDashboardRef.current === view.id) return;
+    const entry_method =
+      lastViewedDashboardRef.current === null ? "initial" : "selection";
+    lastViewedDashboardRef.current = view.id;
+    posthog.capture("live_view_viewed", {
+      ...liveViewAnalyticsProperties(view, views.length),
+      entry_method,
+      is_onboarding: Boolean(onboardingActivation),
+    });
+  }, [onboardingActivation, view, views.length]);
 
   useEffect(() => {
     onViewCountChange?.(views.length);
@@ -502,7 +568,11 @@ export function BrainOverview({
   }, []);
 
   const refreshConnectedPipes = useCallback(
-    async (targetView: ViewDefinition, requestedSlots?: ViewSlot[]) => {
+    async (
+      targetView: ViewDefinition,
+      requestedSlots?: ViewSlot[],
+      trigger: LiveViewRefreshTrigger = "manual",
+    ) => {
       const boundSlots = (requestedSlots ?? targetView.slots).filter(
         (slot) => slot.binding,
       );
@@ -513,15 +583,37 @@ export function BrainOverview({
             .filter((name): name is string => Boolean(name)),
         ),
       );
-      if (pipeNames.length === 0) return;
+      const analyticsProperties = {
+        ...liveViewAnalyticsProperties(targetView, views.length),
+        trigger,
+        requested_block_count: boundSlots.length,
+        requested_pipe_count: pipeNames.length,
+        is_onboarding: Boolean(
+          getOnboardingLiveViewActivation(targetView.id),
+        ),
+      };
+      posthog.capture("live_view_refresh_requested", analyticsProperties);
+      if (pipeNames.length === 0) {
+        posthog.capture("live_view_refresh_completed", {
+          ...analyticsProperties,
+          status: "not_configured",
+          duration_ms: 0,
+          refreshed_block_count: 0,
+          pipe_start_failure_count: 0,
+        });
+        return;
+      }
 
       const startedAt = Date.now();
       setDataRefresh({
         status: "starting",
+        trigger,
         viewId: targetView.id,
+        timeRange: targetView.timeRange,
         pipeNames,
         slotIds: boundSlots.map((slot) => slot.id),
         startedAt,
+        startFailureCount: 0,
         filled: 0,
         total: boundSlots.length,
       });
@@ -575,6 +667,7 @@ export function BrainOverview({
               ...current,
               status:
                 failures.length === pipeNames.length ? "error" : "running",
+              startFailureCount: failures.length,
               message:
                 failures.length > 0
                   ? `Could not start ${failures.join(", ")}`
@@ -583,7 +676,7 @@ export function BrainOverview({
           : current,
       );
     },
-    [],
+    [views.length],
   );
 
   useEffect(() => {
@@ -784,6 +877,29 @@ export function BrainOverview({
     };
   }, [dataRefresh]);
 
+  useEffect(() => {
+    if (
+      !dataRefresh ||
+      !["complete", "partial", "error"].includes(dataRefresh.status) ||
+      lastRefreshOutcomeRef.current === dataRefresh.startedAt
+    ) {
+      return;
+    }
+    lastRefreshOutcomeRef.current = dataRefresh.startedAt;
+    posthog.capture("live_view_refresh_completed", {
+      analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+      trigger: dataRefresh.trigger,
+      status: dataRefresh.status,
+      time_range: dataRefresh.timeRange,
+      duration_ms: Math.max(0, Date.now() - dataRefresh.startedAt),
+      requested_block_count: dataRefresh.total,
+      requested_pipe_count: dataRefresh.pipeNames.length,
+      refreshed_block_count: dataRefresh.filled,
+      pipe_start_failure_count: dataRefresh.startFailureCount,
+      is_onboarding: dataRefresh.trigger === "onboarding",
+    });
+  }, [dataRefresh]);
+
   const clearTransientState = () => {
     setDraft(null);
     setEditing(false);
@@ -806,6 +922,12 @@ export function BrainOverview({
 
   const beginCreate = () => {
     if (views.length >= MAX_DASHBOARDS) {
+      posthog.capture("live_view_action_blocked", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: "create",
+        reason: "dashboard_limit",
+        dashboard_count: views.length,
+      });
       toast({
         title: "dashboard limit reached",
         description: `Delete a dashboard before creating another. You can keep up to ${MAX_DASHBOARDS}.`,
@@ -813,10 +935,20 @@ export function BrainOverview({
       });
       return;
     }
+    posthog.capture("live_view_creation_started", {
+      analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+      source: "ai",
+      dashboard_count: views.length,
+    });
     setCreateDashboardOpen(true);
   };
 
   const beginManualCreate = () => {
+    posthog.capture("live_view_creation_started", {
+      analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+      source: "manual",
+      dashboard_count: views.length,
+    });
     const now = new Date().toISOString();
     setCreateDashboardOpen(false);
     setDraft({
@@ -838,6 +970,9 @@ export function BrainOverview({
 
   const beginEdit = () => {
     if (!view) return;
+    posthog.capture("live_view_customize_started", {
+      ...liveViewAnalyticsProperties(view, views.length),
+    });
     setDraft(copyViewDefinition(view));
     setAiPreview(false);
     setPreviewSource(null);
@@ -846,6 +981,14 @@ export function BrainOverview({
   };
 
   const previewTemplate = (kit: BrainViewTemplateKit) => {
+    posthog.capture("live_view_template_previewed", {
+      analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+      template_id: kit.id,
+      template_block_count: kit.slots.length,
+      template_pipe_count: kit.pipes.length,
+      dashboard_count: views.length,
+      has_current_view: Boolean(view),
+    });
     const now = new Date().toISOString();
     setDraft({
       id: view?.id ?? "my-overview",
@@ -873,6 +1016,17 @@ export function BrainOverview({
     preset: AIPreset,
     intent: LiveViewGenerationIntent,
   ) => {
+    const startedAt = Date.now();
+    const analyticsProperties = {
+      analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+      scope,
+      intent,
+      prompt_length: prompt.length,
+      has_current_view: Boolean(view),
+      current_block_count: view?.slots.length ?? 0,
+      dashboard_count: views.length,
+    };
+    posthog.capture("live_view_generation_started", analyticsProperties);
     setTemplateGalleryOpen(false);
     setGenerating(true);
     try {
@@ -947,8 +1101,21 @@ export function BrainOverview({
       );
       setEditing(false);
       setAiPreview(true);
+      posthog.capture("live_view_generation_completed", {
+        ...analyticsProperties,
+        duration_ms: Math.max(0, Date.now() - startedAt),
+        generated_block_count: generated.blocks.length,
+        generated_bound_block_count: generated.blocks.filter(
+          (block) => block.pipeName,
+        ).length,
+      });
       return true;
     } catch (generateError) {
+      posthog.capture("live_view_generation_failed", {
+        ...analyticsProperties,
+        duration_ms: Math.max(0, Date.now() - startedAt),
+        failure_type: analyticsErrorType(generateError),
+      });
       toast({
         title: "failed to generate Live View",
         description:
@@ -1036,14 +1203,23 @@ export function BrainOverview({
           : current,
       );
       posthog.capture("live_view_card_feedback", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
         action: rating ?? "clear",
         component: slot.component,
-        pipe: slot.binding?.pipeName ?? null,
+        has_pipe: Boolean(slot.binding),
         has_correction: Boolean(correction?.trim()),
       });
       if (rating) finishOnboardingActivation("feedback");
       return true;
     } catch (feedbackError) {
+      posthog.capture("live_view_card_feedback_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: rating ?? "clear",
+        component: slot.component,
+        has_pipe: Boolean(slot.binding),
+        has_correction: Boolean(correction?.trim()),
+        failure_type: analyticsErrorType(feedbackError),
+      });
       toast({
         title: "failed to save feedback",
         description:
@@ -1069,6 +1245,15 @@ export function BrainOverview({
       return false;
     }
 
+    const startedAt = Date.now();
+    const analyticsProperties = {
+      analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+      prompt_length: prompt.length,
+      component: slot.component,
+      has_pipe: Boolean(slot.binding),
+      time_range: view.timeRange,
+    };
+    posthog.capture("live_view_card_ai_edit_started", analyticsProperties);
     setAiEditingSlotId(slot.id);
     try {
       const previousView = copyViewDefinition(view);
@@ -1129,11 +1314,26 @@ export function BrainOverview({
         (candidate) => candidate.id === slot.id,
       );
       if (refreshedSlot?.binding) {
-        void refreshConnectedPipes(result.data, [refreshedSlot]);
+        void refreshConnectedPipes(
+          result.data,
+          [refreshedSlot],
+          "card_ai_edit",
+        );
       }
+      posthog.capture("live_view_card_ai_edit_completed", {
+        ...analyticsProperties,
+        duration_ms: Math.max(0, Date.now() - startedAt),
+        next_component: replacement.component,
+        next_has_pipe: Boolean(replacement.pipeName),
+      });
       toast({ title: `${replacement.title} updated` });
       return true;
     } catch (editError) {
+      posthog.capture("live_view_card_ai_edit_failed", {
+        ...analyticsProperties,
+        duration_ms: Math.max(0, Date.now() - startedAt),
+        failure_type: analyticsErrorType(editError),
+      });
       toast({
         title: "failed to edit this section",
         description:
@@ -1151,6 +1351,9 @@ export function BrainOverview({
     destination: PreviewDestination = draft?.revision === 0 ? "new" : "replace",
   ) => {
     if (!draft || !draft.title.trim()) return;
+    const saveSource = previewSource?.kind ?? "manual";
+    const intendedAction =
+      destination === "new" || draft.revision === 0 ? "created" : "replaced";
     setSaving(true);
     try {
       const creatingNew = destination === "new" || draft.revision === 0;
@@ -1188,6 +1391,7 @@ export function BrainOverview({
       toast({
         title: creatingNew ? `${result.data.title} created` : "dashboard saved",
       });
+      let slotsToRefresh: ViewSlot[] = [];
       if (refreshData) {
         const previousSlots = new Map(
           previousView?.slots.map((slot) => [slot.id, slot]) ?? [],
@@ -1206,10 +1410,34 @@ export function BrainOverview({
           );
         });
         if (changedSlots.length > 0) {
-          void refreshConnectedPipes(result.data, changedSlots);
+          slotsToRefresh = changedSlots;
         }
       }
+      posthog.capture("live_view_dashboard_saved", {
+        ...liveViewAnalyticsProperties(
+          result.data,
+          creatingNew ? views.length + 1 : views.length,
+        ),
+        action: creatingNew ? "created" : "replaced",
+        source: saveSource,
+        refresh_requested: slotsToRefresh.length > 0,
+      });
+      if (slotsToRefresh.length > 0) {
+        void refreshConnectedPipes(
+          result.data,
+          slotsToRefresh,
+          "dashboard_saved",
+        );
+      }
     } catch (saveError) {
+      posthog.capture("live_view_dashboard_save_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: intendedAction,
+        source: saveSource,
+        block_count: draft.slots.length,
+        dashboard_count: views.length,
+        failure_type: analyticsErrorType(saveError),
+      });
       toast({
         title: "failed to save Live View",
         description:
@@ -1275,8 +1503,31 @@ export function BrainOverview({
           ? `${installedView.title} created`
           : `${installedView.title} replaced`,
       });
-      void refreshConnectedPipes(installedView);
+      posthog.capture("live_view_dashboard_saved", {
+        ...liveViewAnalyticsProperties(
+          installedView,
+          creatingNew ? views.length + 1 : views.length,
+        ),
+        action: creatingNew ? "created" : "replaced",
+        source: "template",
+        template_id: kit.id,
+        refresh_requested: true,
+      });
+      void refreshConnectedPipes(
+        installedView,
+        undefined,
+        "template_applied",
+      );
     } catch (installError) {
+      posthog.capture("live_view_dashboard_save_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: creatingNew ? "created" : "replaced",
+        source: "template",
+        template_id: kit.id,
+        block_count: kit.slots.length,
+        dashboard_count: views.length,
+        failure_type: analyticsErrorType(installError),
+      });
       toast({
         title: "template was not installed",
         description:
@@ -1308,8 +1559,17 @@ export function BrainOverview({
       });
       if (result.status === "error") throw new Error(result.error);
       setView(result.data);
+      posthog.capture("live_view_dashboard_action", {
+        ...liveViewAnalyticsProperties(result.data, views.length),
+        action: "renamed",
+      });
       toast({ title: `renamed to ${result.data.title}` });
     } catch (renameError) {
+      posthog.capture("live_view_dashboard_action_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: "renamed",
+        failure_type: analyticsErrorType(renameError),
+      });
       toast({
         title: "could not rename dashboard",
         description:
@@ -1348,9 +1608,27 @@ export function BrainOverview({
       if (result.status === "error") throw new Error(result.error);
       clearTransientState();
       setView(result.data);
+      posthog.capture("live_view_dashboard_saved", {
+        ...liveViewAnalyticsProperties(result.data, views.length + 1),
+        action: "created",
+        source: "duplicate",
+        refresh_requested: true,
+      });
       toast({ title: `${result.data.title} created` });
-      void refreshConnectedPipes(result.data);
+      void refreshConnectedPipes(
+        result.data,
+        undefined,
+        "dashboard_duplicated",
+      );
     } catch (duplicateError) {
+      posthog.capture("live_view_dashboard_save_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: "created",
+        source: "duplicate",
+        block_count: view.slots.length,
+        dashboard_count: views.length,
+        failure_type: analyticsErrorType(duplicateError),
+      });
       toast({
         title: "could not duplicate dashboard",
         description:
@@ -1378,8 +1656,17 @@ export function BrainOverview({
       setView(next);
       rememberSelectedLiveViewDashboard(next?.id ?? null);
       removeOnboardingLiveViewActivation(deletingId);
+      posthog.capture("live_view_dashboard_deleted", {
+        ...liveViewAnalyticsProperties(view, views.length),
+        dashboard_count_after: nextViews.length,
+      });
       toast({ title: "dashboard deleted" });
     } catch (deleteError) {
+      posthog.capture("live_view_dashboard_action_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: "deleted",
+        failure_type: analyticsErrorType(deleteError),
+      });
       toast({
         title: "could not delete dashboard",
         description:
@@ -1410,9 +1697,20 @@ export function BrainOverview({
       setView(result.data);
       setUndoView(null);
       setUndoRevision(null);
+      posthog.capture("live_view_dashboard_saved", {
+        ...liveViewAnalyticsProperties(result.data, views.length),
+        action: "restored",
+        source: "undo",
+        refresh_requested: true,
+      });
       toast({ title: "previous dashboard restored" });
-      void refreshConnectedPipes(result.data);
+      void refreshConnectedPipes(result.data, undefined, "undo");
     } catch (restoreError) {
+      posthog.capture("live_view_dashboard_action_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: "restored",
+        failure_type: analyticsErrorType(restoreError),
+      });
       toast({
         title: "could not restore the previous dashboard",
         description:
@@ -1457,11 +1755,20 @@ export function BrainOverview({
       setView(result.data);
       setUndoView(previousView);
       setUndoRevision(result.data.revision);
+      posthog.capture("live_view_time_range_changed", {
+        ...liveViewAnalyticsProperties(result.data, views.length),
+        previous_time_range: previousView.timeRange,
+      });
       toast({
         title: `showing ${getLiveViewTimeRangeOption(timeRange).label.toLowerCase()}`,
       });
-      void refreshConnectedPipes(result.data);
+      void refreshConnectedPipes(result.data, undefined, "time_range");
     } catch (rangeError) {
+      posthog.capture("live_view_dashboard_action_failed", {
+        analytics_schema_version: LIVE_VIEW_ANALYTICS_SCHEMA_VERSION,
+        action: "time_range_changed",
+        failure_type: analyticsErrorType(rangeError),
+      });
       toast({
         title: "could not change the time range",
         description:
@@ -2032,7 +2339,7 @@ export function BrainOverview({
               goal_category: onboardingActivation.goalCategory,
               pipe_count: onboardingPipeNames.length,
             });
-            void refreshConnectedPipes(view);
+            void refreshConnectedPipes(view, undefined, "onboarding");
           }}
           onComplete={() => finishOnboardingActivation("confirmed")}
         />
@@ -2076,7 +2383,13 @@ export function BrainOverview({
               onFeedback={(rating, correction) =>
                 recordCardFeedback(slot, rating, correction)
               }
-              onRegenerate={() => void refreshConnectedPipes(view, [slot])}
+              onRegenerate={() =>
+                void refreshConnectedPipes(
+                  view,
+                  [slot],
+                  "card_regenerated",
+                )
+              }
               onAiEdit={(prompt) => editSlotWithAi(slot, prompt)}
             />
           ))}


### PR DESCRIPTION
## What changed

- add versioned Live View events for eligible views, creation, AI generation, customization, templates, saves, time-range changes, deletion, and recovery actions
- measure refresh requests through terminal outcomes, including duration, refreshed Block count, and Pipe start failures
- distinguish a dashboard opening from a source-backed result that was actually visible, and record result completeness without sending artifact IDs
- measure explicit useful/not-useful feedback, prior review state, and AI edits, including failures
- keep properties privacy-safe: no dashboard titles or IDs, prompt text, Pipe names, correction text, or backend error details
- add regression tests for the view, visible result, feedback, generation, and refresh analytics contracts

## Why

Live Views had detailed onboarding telemetry and card feedback, but almost no ongoing product-use funnel. We could see that setup happened without knowing whether someone opened a useful result, customized it, refreshed it successfully, or hit a failure.

This adds the minimum event set needed to measure the retention ladder without sending captured work content:

`eligible view -> populated result visible -> explicit review -> result visible on another day -> recurring successful refresh`

Billing churn remains a separate Stripe measure. PostHog can use these events as product-value signals and join identity-matched, mature cohorts to later paid survival.

## User and developer impact

There is no UI or workflow change. PostHog can now answer how many eligible users open a Live View, actually see a populated result while the app is visible, review it, return to results on another day, refresh successfully, or encounter a failure.

## Validation

- `bunx vitest run --config vitest.config.ts components/settings/__tests__/brain-overview.test.tsx components/settings/__tests__/live-view-card.test.tsx components/settings/__tests__/live-view-dashboard-switcher.test.tsx lib/live-views/__tests__/onboarding-activation.test.ts lib/live-views/__tests__/time-range.test.ts` — 51 passed
- `bun run typecheck` — passed
- focused effects lint on the changed files — 0 errors
- `git diff --check` — passed
