### PR TITLE
Default unchanged user goals to work memory

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
@@ -76,6 +76,7 @@ describe("SummaryCards", () => {
 
   it("gives Automate My Work the installed pipe inventory instead of the static fallback prompt", () => {
     const onSendMessage = vi.fn();
+    setUserGoalCategory("default");
 
     render(
       <SummaryCards

--- a/apps/screenpipe-app-tauri/lib/live-views/__tests__/onboarding-activation.test.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/__tests__/onboarding-activation.test.ts
@@ -71,6 +71,19 @@ describe("onboarding Live View activation", () => {
     expect(getUserGoalCategory()).toBe("process_automation");
   });
 
+  it("defaults an untouched existing user to work memory", () => {
+    expect(getUserGoalCategory()).toBe("work_memory");
+    expect(window.localStorage.getItem(USER_GOAL_STORAGE_KEY)).toBe(
+      "work_memory",
+    );
+  });
+
+  it("preserves an explicit No specific goal choice", () => {
+    setUserGoalCategory("default");
+
+    expect(getUserGoalCategory()).toBe("default");
+  });
+
   it("uses the default order for a custom onboarding goal", () => {
     startOnboardingLiveViewActivation("first-dashboard-5", "custom");
 

--- a/apps/screenpipe-app-tauri/lib/live-views/onboarding-activation.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/onboarding-activation.ts
@@ -30,6 +30,8 @@ const USER_GOAL_CATEGORIES = new Set<UserGoalCategory>([
   "process_automation",
 ]);
 
+const DEFAULT_USER_GOAL_CATEGORY: UserGoalCategory = "work_memory";
+
 export type OnboardingLiveViewActivation = {
   viewId: string;
   goalCategory: OnboardingGoalCategory;
@@ -124,7 +126,7 @@ function normalizeUserGoalCategory(value: unknown): UserGoalCategory | null {
 }
 
 export function getUserGoalCategory(): UserGoalCategory {
-  if (typeof window === "undefined") return "default";
+  if (typeof window === "undefined") return DEFAULT_USER_GOAL_CATEGORY;
   try {
     const stored = normalizeUserGoalCategory(
       window.localStorage.getItem(USER_GOAL_STORAGE_KEY),
@@ -144,11 +146,15 @@ export function getUserGoalCategory(): UserGoalCategory {
     const latest = Object.values(readActivations()).sort(
       (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt),
     )[0];
-    return latest && latest.goalCategory !== "custom"
-      ? latest.goalCategory
-      : "default";
+    const migratedGoal = latest
+      ? latest.goalCategory === "custom"
+        ? "default"
+        : latest.goalCategory
+      : DEFAULT_USER_GOAL_CATEGORY;
+    window.localStorage.setItem(USER_GOAL_STORAGE_KEY, migratedGoal);
+    return migratedGoal;
   } catch {
-    return "default";
+    return DEFAULT_USER_GOAL_CATEGORY;
   }
 }
 


### PR DESCRIPTION
## description

Make `remember and resume my work` the one-time default for existing users who have never selected a goal.

- persist `work_memory` when no goal preference or onboarding activation exists
- preserve every explicit saved selection, including `No specific goal`
- preserve migration from prior onboarding and Home focus preferences

## before

Users without a saved goal resolved to `No specific goal`.

## after

Users without a saved goal resolve to `remember and resume my work`; explicit choices are unchanged.

## how to test

1. Clear `screenpipe.user.goal-category.v1`, open General Settings, and confirm `remember and resume my work` is selected.
2. Select `No specific goal`, reopen General Settings, and confirm the choice persists.
3. Run the focused Live View activation and home-card tests.

## desktop app checklist

- [x] `bun run typecheck`
- [x] focused Vitest: 16 tests passed
- [x] focused ESLint and `git diff --check`
