### PR TITLE
fix(gateway-container): stamp the version label and pin the service uid

### DIFF
--- a/.github/workflows/release-gateway-container.yml
+++ b/.github/workflows/release-gateway-container.yml
@@ -89,8 +89,14 @@ jobs:
       # Builds the `runtime` stage (gateway binary only — no seeder, no policy
       # fixture) and fails the job if the result carries anything credential-
       # shaped. Nothing is pushed until this passes.
+      # VERSION stamps org.opencontainers.image.version. Without it the label
+      # keeps the Dockerfile's `dev` default, which is what 0.0.1 shipped with —
+      # a published image that cannot say which release it is.
       - name: Build and scan for secrets
-        run: TAG="$IMAGE:${{ steps.version.outputs.version }}" ./scripts/build-gateway-container.sh
+        run: |
+          TAG="$IMAGE:${{ steps.version.outputs.version }}" \
+          VERSION="${{ steps.version.outputs.version }}" \
+            ./scripts/build-gateway-container.sh
 
       - name: Push
         id: push

--- a/crates/screenpipe-gateway/Dockerfile
+++ b/crates/screenpipe-gateway/Dockerfile
@@ -25,7 +25,15 @@ FROM debian:bookworm-slim AS base
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates curl \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd --system --no-create-home screenpipe \
+    # uid/gid PINNED, not left to useradd's "next free system id". The
+    # customer-facing Fargate template (website
+    # public/enterprise/aws-gateway-fargate.yaml) configures an EFS access point
+    # with PosixUser 999:999 to own /data. An access point's PosixUser overrides
+    # whatever uid the container presents, so a renumber here would not break
+    # the mount — but it would silently desync the two, and the next reader of
+    # either file would have no way to tell 999 was ever deliberate.
+    && groupadd --system --gid 999 screenpipe \
+    && useradd --system --no-create-home --uid 999 --gid 999 screenpipe \
     # Default data dir, owned by the service user so a fresh named volume
     # (which inherits the image directory's ownership) is writable. /policy is
     # the same story for the e2e's fixture-signed policy (SCR-288): a named


### PR DESCRIPTION
## description

Two defects in the published gateway image, both found while building the customer-facing Fargate CloudFormation template against it (website SCR-293).

**1. Every published image is labelled `dev`.** The release workflow never passed `VERSION` to the build script, so `org.opencontainers.image.version` kept the Dockerfile's default. `0.0.1` shipped unable to say which release it is. `scripts/build-gateway-container.sh` has accepted `VERSION` since it was written (it is even in the script's usage header) — only the workflow call site was missing it.

**2. The service uid was incidental, not pinned.** `useradd --system` leaves the uid to "next free system id". It lands on 999 today, and the Fargate template's EFS access point pins `PosixUser` 999:999 to own `/data`. An access point's `PosixUser` *overrides* whatever uid the container presents, so a renumber would not have broken the mount — but it would have silently desynced the two, with nothing on either side recording that 999 was deliberate.

This is the label as published today:

```
$ docker image inspect ghcr.io/screenpipe/screenpipe-gateway:0.0.1 \
    -f '{{index .Config.Labels "org.opencontainers.image.version"}}'
dev
```

related issue: none — fallout from the SCR-293 template work

## before / after

No UI. This is a container build change, so the observable behaviour is the image metadata and the image's passwd entry.

**Label stamping**, exercised against the real `ARG`/`LABEL` lines:

```
--- without VERSION (today) ---
dev
--- with VERSION=0.0.2 (this PR) ---
0.0.2
```

**The uid pin is a no-op on the resulting image** — that is the point. Building the real `--target base` stage before and after gives a byte-identical user:

```
$ docker build -f crates/screenpipe-gateway/Dockerfile --target base -t probe .
$ docker run --rm probe sh -c 'grep screenpipe /etc/passwd; stat -c "/data %u:%g %a" /data'
screenpipe:x:999:999::/home/screenpipe:/bin/sh
/data 999:0 755
```

Same as the published `0.0.1` image, whose `/etc/passwd` I read out of its layers. The change only removes the implicitness.

## how to test

1. `docker build -f crates/screenpipe-gateway/Dockerfile --target base -t probe .` then `docker run --rm probe sh -c 'id screenpipe'` → `uid=999(screenpipe) gid=999(screenpipe)`, and the service user can still write `/data`.
2. `VERSION=9.9.9 TAG=screenpipe-gateway:probe ./scripts/build-gateway-container.sh` → the secret scan passes and the image carries `org.opencontainers.image.version=9.9.9`.
3. Run the same script **without** `VERSION` → still builds (the `[[ -n "${VERSION:-}" ]] && …` lines are errexit-safe in both cases), label falls back to `dev`.

### the one thing worth reviewing

The build script's first secret check exists to reject build args baked into image history, and this PR adds a build arg. It is safe: check 1 only matches *credential-shaped* names (`SECRET|TOKEN|PASSWORD|KEY|CREDENTIAL`), and `VERSION` is not one. Verified against a real built image rather than by reading the regex:

```
$ docker history --no-trunc --format '{{.CreatedBy}}' probe | grep -i 'ARG VERSION'
ARG VERSION=0.0.2
GATE: passes (VERSION is not credential-shaped)
```

The image still reports `Config.User = screenpipe`, so check 4 is unaffected.

## follow-up, not in this PR

`0.0.1` cannot be re-published (the workflow's clobber check refuses to overwrite a version tag, by design), so the label only becomes correct on the next release. That release produces a **new digest**, and the website side pins the current one in two places — `GATEWAY_CONTAINER_IMAGE` in `lib/enterprise/gateway-aws-fargate.ts` and the `ContainerImage` default in `public/enterprise/aws-gateway-fargate.yaml`. A test asserts those two stay equal to each other, but nothing can tell them the registry moved on, so bumping them is a manual step at the next gateway release.

## desktop app checklist

n/a — no Tauri commands or exported Rust types.