### PR TITLE
Promote daily recap and time breakdown for activation

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
@@ -47,6 +47,43 @@ describe("SummaryCards", () => {
     });
   });
 
+  it("puts the daily recap and time breakdown first for new users", () => {
+    render(
+      <SummaryCards
+        onSendMessage={vi.fn()}
+        customTemplates={[]}
+        onSaveCustomTemplate={vi.fn()}
+        onUpdateCustomTemplate={vi.fn()}
+        onDeleteCustomTemplate={vi.fn()}
+        userGoalCategory="work_memory"
+      />,
+    );
+
+    const cards = screen.getAllByTestId(/^summary-card-/);
+    expect(cards.slice(0, 4).map((card) => card.dataset.testid)).toEqual([
+      "summary-card-day-recap",
+      "summary-card-time-breakdown",
+      "summary-card-missed-todos",
+      "summary-card-automate-my-work",
+    ]);
+    expect(captureMock).toHaveBeenCalledWith("home_card_impression", {
+      schema_version: 1,
+      surface: "chat_home",
+      layout_version: "home_v2",
+      card: "day_recap",
+      position: 1,
+      presentation: "hero",
+    });
+    expect(captureMock).toHaveBeenCalledWith("home_card_impression", {
+      schema_version: 1,
+      surface: "chat_home",
+      layout_version: "home_v2",
+      card: "other_builtin",
+      position: 2,
+      presentation: "secondary",
+    });
+  });
+
   it("reorders an open Home view when the General Settings goal changes", () => {
     const props = {
       onSendMessage: vi.fn(),
@@ -131,8 +168,8 @@ describe("SummaryCards", () => {
       surface: "chat_home",
       layout_version: "home_v2",
       card: "automate_my_work",
-      position: 1,
-      presentation: "hero",
+      position: 3,
+      presentation: "quick_action",
     });
     expect(screen.getByRole("button", { name: /automate my work/i }).closest(".ph-no-capture"))
       .not.toBeNull();

--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
@@ -59,14 +59,14 @@ export interface ConnectionSetupSuggestion {
 }
 
 const HOME_CARD_SLUGS_BY_GOAL: Record<UserGoalCategory, string[]> = {
-  default: ["automate-my-work", "day-recap", "time-breakdown", "missed-todos"],
+  default: ["day-recap", "time-breakdown", "automate-my-work", "missed-todos"],
   process_automation: [
     "automate-my-work",
     "day-recap",
     "missed-todos",
     "time-breakdown",
   ],
-  work_memory: ["day-recap", "missed-todos", "time-breakdown", "automate-my-work"],
+  work_memory: ["day-recap", "time-breakdown", "missed-todos", "automate-my-work"],
   meeting_follow_through: [
     "missed-todos",
     "day-recap",


### PR DESCRIPTION
## Summary

- make Day Recap the hero action for users without a specific goal
- make Time Breakdown the secondary action for default and work-memory users
- keep automation discovery and missed to-dos available as quick actions
- preserve the existing privacy-safe impression and response-feedback contract

## Why

A recent cancellation interview found that the per-application time breakdown was the strongest immediate value, but the user discovered it only after canceling. The same interview asked for a consistent daily debrief before longer-term automation suggestions. Main already contains both capabilities; this PR changes placement instead of adding another feature.

## Before / after

    before                          after
    [ Automate My Work   HERO ]     [ Day Recap          HERO ]
    [ Day Recap      SECONDARY ]    [ Time Breakdown SECONDARY ]
    [ Time Breakdown | Todos ]      [ Automate My Work | Todos ]

## Measurement

This remains an activation experiment. Existing home-card impressions and content-free response feedback can separate exposure from accepted value. Success is useful source-backed output repeated on another day, not card clicks alone.

## Verification

- bun run test:automation-pipe-evals (18 tests passed)
- bun run typecheck
- git diff --check
