### PR TITLE
fix(live-views): preserve chart size on first resize

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-canvas.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-canvas.test.tsx
@@ -179,6 +179,75 @@ describe("LiveViewCanvas", () => {
     expect(onPersist).not.toHaveBeenCalled();
   });
 
+  it("resizes a Block from its current size on the first drag", async () => {
+    const onPersist = vi.fn();
+    render(<CanvasHarness onPersist={onPersist} />);
+
+    const block = screen.getByTestId("canvas-block-focus-time");
+    fireEvent.pointerDown(block, { pointerId: 11 });
+    const resizeHandle = await waitFor(() => {
+      const handle = block.querySelector<HTMLElement>(
+        ".react-flow__resize-control.handle.bottom.right",
+      );
+      expect(handle).toBeTruthy();
+      return handle!;
+    });
+
+    const testWindow = resizeHandle.ownerDocument.defaultView!;
+    const mouseEvent = (
+      type: string,
+      init: ConstructorParameters<typeof MouseEvent>[1],
+    ) => {
+      const event = new testWindow.MouseEvent(type, init);
+      Object.defineProperty(event, "view", { value: testWindow });
+      return event;
+    };
+    fireEvent(
+      resizeHandle,
+      mouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: 300,
+        clientY: 260,
+      }),
+    );
+    fireEvent(
+      testWindow,
+      mouseEvent("mousemove", {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        clientX: 396,
+        clientY: 324,
+      }),
+    );
+    fireEvent(
+      testWindow,
+      mouseEvent("mouseup", {
+        bubbles: true,
+        button: 0,
+        buttons: 0,
+        clientX: 396,
+        clientY: 324,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          blocks: expect.arrayContaining([
+            expect.objectContaining({
+              slotId: "focus-time",
+              width: 544,
+              height: 352,
+            }),
+          ]),
+        }),
+      );
+    });
+  });
+
   it("adds, edits, persists, and deletes a note", async () => {
     const onPersist = vi.fn();
     render(<CanvasHarness onPersist={onPersist} />);

--- a/apps/screenpipe-app-tauri/components/settings/live-view-canvas.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-canvas.tsx
@@ -545,6 +545,7 @@ export function LiveViewCanvas({
           position: { x: block.x, y: block.y },
           initialWidth: block.width,
           initialHeight: block.height,
+          measured: { width: block.width, height: block.height },
           style: { width: block.width, height: block.height },
           handles: [
             {
@@ -597,6 +598,7 @@ export function LiveViewCanvas({
         position: { x: note.x, y: note.y },
         initialWidth: note.width,
         initialHeight: note.height,
+        measured: { width: note.width, height: note.height },
         style: { width: note.width, height: note.height },
         handles: [
           {

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -31,7 +31,13 @@ interface BrainView {
 interface CanvasDocument {
   revision: number;
   mode: "dashboard" | "canvas";
-  blocks: Array<{ slotId: string; x: number; y: number }>;
+  blocks: Array<{
+    slotId: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>;
   notes: Array<{ id: string; text: string }>;
   arrows: Array<{ id: string; fromId: string; toId: string }>;
   strokes: Array<{ id: string }>;
@@ -210,6 +216,106 @@ async function pointerPressTestId(testId: string) {
       new PointerEvent("pointerup", { ...init, buttons: 0 }),
     );
   }, testId);
+}
+
+async function resizeCanvasBlockBottomRight(
+  testId: string,
+  delta: { x: number; y: number },
+) {
+  await pointerPressTestId(testId);
+  await browser.waitUntil(
+    async () =>
+      (await browser.execute((id) => {
+        const block = document.querySelector<HTMLElement>(
+          `[data-testid="${id}"]`,
+        );
+        return Boolean(
+          block?.querySelector(
+            ".react-flow__resize-control.handle.bottom.right",
+          ),
+        );
+      }, testId)) as boolean,
+    {
+      timeout: t(10_000),
+      timeoutMsg: `resize handle did not appear for ${testId}`,
+    },
+  );
+
+  const geometry = (await browser.execute((id) => {
+    const block = document.querySelector<HTMLElement>(
+      `[data-testid="${id}"]`,
+    );
+    const handle = block?.querySelector<HTMLElement>(
+      ".react-flow__resize-control.handle.bottom.right",
+    );
+    if (!block || !handle) return null;
+    const blockRect = block.getBoundingClientRect();
+    const handleRect = handle.getBoundingClientRect();
+    return {
+      block: { width: blockRect.width, height: blockRect.height },
+      handle: {
+        x: handleRect.left + handleRect.width / 2,
+        y: handleRect.top + handleRect.height / 2,
+      },
+    };
+  }, testId)) as {
+    block: { width: number; height: number };
+    handle: { x: number; y: number };
+  } | null;
+  expect(geometry).not.toBeNull();
+
+  const dragError = (await browser.execute(
+    (drag: { startX: number; startY: number; endX: number; endY: number }) => {
+      try {
+        const handle = document.elementFromPoint(drag.startX, drag.startY);
+        if (!(handle instanceof HTMLElement)) {
+          return "resize handle is not available at the drag origin";
+        }
+        handle.dispatchEvent(
+          new MouseEvent("mousedown", {
+            bubbles: true,
+            button: 0,
+            buttons: 1,
+            clientX: drag.startX,
+            clientY: drag.startY,
+            view: window,
+          }),
+        );
+        window.dispatchEvent(
+          new MouseEvent("mousemove", {
+            bubbles: true,
+            button: 0,
+            buttons: 1,
+            clientX: drag.endX,
+            clientY: drag.endY,
+            view: window,
+          }),
+        );
+        window.dispatchEvent(
+          new MouseEvent("mouseup", {
+            bubbles: true,
+            button: 0,
+            buttons: 0,
+            clientX: drag.endX,
+            clientY: drag.endY,
+            view: window,
+          }),
+        );
+        return null;
+      } catch (error) {
+        return String(error);
+      }
+    },
+    {
+      startX: Math.round(geometry!.handle.x),
+      startY: Math.round(geometry!.handle.y),
+      endX: Math.round(geometry!.handle.x + delta.x),
+      endY: Math.round(geometry!.handle.y + delta.y),
+    },
+  )) as string | null;
+  expect(dragError).toBeNull();
+
+  return geometry!.block;
 }
 
 describe("Brain Live Views", function () {
@@ -642,6 +748,66 @@ Refresh the assigned Live View output targets from source-backed activity.
     await waitForTestId("canvas-block-focus-time", 10_000);
     expect(await canvas.getText()).toContain("4.5");
     expect(await canvas.getText()).toContain("Automation opportunities");
+
+    const chartBeforeResize = await resizeCanvasBlockBottomRight(
+      "canvas-block-time-by-app",
+      { x: 96, y: 64 },
+    );
+    let chartAfterResize:
+      | CanvasDocument["blocks"][number]
+      | undefined;
+    await browser.waitUntil(
+      async () => {
+        const saved = await invokeOrThrow<CanvasDocument | null>(
+          "load_brain_view_canvas",
+          { viewId: SELECTABLE_VIEW_ID },
+        );
+        chartAfterResize = saved?.blocks.find(
+          (candidate) => candidate.slotId === "time-by-app",
+        );
+        return Boolean(
+          chartAfterResize &&
+            chartAfterResize.width >= chartBeforeResize.width + 80 &&
+            chartAfterResize.height >= chartBeforeResize.height + 48,
+        );
+      },
+      {
+        timeout: t(10_000),
+        interval: 200,
+        timeoutMsg:
+          "the first Canvas resize drag did not persist the intended chart size",
+      },
+    );
+    const chartDomAfterResize = (await browser.execute(() => {
+      const chart = document.querySelector<HTMLElement>(
+        "[data-testid='canvas-block-time-by-app']",
+      );
+      if (!chart) return null;
+      const rect = chart.getBoundingClientRect();
+      return {
+        width: rect.width,
+        height: rect.height,
+        hasResizeHandle: Boolean(
+          chart.querySelector(
+            ".react-flow__resize-control.handle.bottom.right",
+          ),
+        ),
+      };
+    })) as {
+      width: number;
+      height: number;
+      hasResizeHandle: boolean;
+    } | null;
+    expect(chartDomAfterResize).not.toBeNull();
+    expect(chartDomAfterResize!.width).toBeCloseTo(chartAfterResize!.width, 0);
+    expect(chartDomAfterResize!.height).toBeCloseTo(
+      chartAfterResize!.height,
+      0,
+    );
+    const resizedChartScreenshot = await saveScreenshot(
+      "brain-overview-canvas-chart-resized",
+    );
+    expect(existsSync(resizedChartScreenshot)).toBe(true);
 
     const moveHandle = await $("[data-testid='canvas-move-focus-time']");
     await moveHandle.click();


### PR DESCRIPTION
## What changed

- initialize React Flow's measured size from the saved Canvas dimensions for Blocks and notes
- keep the first resize drag anchored to the visible size instead of React Flow's zero-size fallback
- cover the interaction in both the component test and the native WebKit Live View flow

## Root cause

Selecting a Canvas item rebuilds its React Flow node. The rebuilt node had styled dimensions but no measured dimensions, so the first `NodeResizer` drag started from `0 × 0` and immediately clamped the chart to its minimum size. A second drag then worked because React Flow had measured the now-small node.

## Interaction proof

```text
before                                after
440 × 280 -- first corner drag -->    220 × 160 (minimum)
440 × 280 -- first corner drag -->    536 × 344 (saved immediately)
```

The native test resizes the actual `bar-chart.v1` Block through its bottom-right handle, then reads the persisted Canvas document and checks that the DOM matches it. It also captures `brain-overview-canvas-chart-resized.png` after the drag.

## Verification

- `bunx vitest run --config vitest.config.ts components/settings/__tests__/live-view-canvas.test.tsx` — 8 passed
- `bun run typecheck` — passed
- `bun run e2e:coverage:check` — passed
- `NEXT_PUBLIC_SCREENPIPE_E2E=true bun tauri build --no-sign --debug --no-bundle -- --features e2e` — passed
- `SCREENPIPE_PORT=3041 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/brain-overview.spec.ts` — 2 passed in native WebKit
