### PR TITLE
fix(app): stop DB recovery respawn loop

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/db_relaunch.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_relaunch.rs
@@ -25,13 +25,20 @@ use tracing::{error, warn};
 const DB_BOOT_FAILURES_BEFORE_RECOVERY_ALERT: u32 = 2;
 
 static DB_BOOT_FAILURES: AtomicU32 = AtomicU32::new(0);
-/// Dedupe for the recovery notification (once per process lifetime is plenty —
-/// the state only clears with the restart or recovery the user must perform).
+/// Dedupe for the recovery notification and gate for automatic engine
+/// respawns. A confirmed healthy server clears it after recovery.
 static GAVE_UP_NOTIFIED: AtomicBool = AtomicBool::new(false);
 
 /// Call when an engine respawn succeeds — a healthy boot ends the episode.
 pub fn reset_db_boot_failures() {
     DB_BOOT_FAILURES.store(0, Ordering::SeqCst);
+    GAVE_UP_NOTIFIED.store(false, Ordering::SeqCst);
+}
+
+/// Whether automatic engine restarts must stay disabled until a manual repair
+/// produces a confirmed healthy server (or the app process restarts).
+pub fn manual_recovery_required() -> bool {
+    GAVE_UP_NOTIFIED.load(Ordering::SeqCst)
 }
 
 /// Does this spawn error look like the DB layer failing to open/init (the
@@ -81,7 +88,9 @@ pub async fn surface_manual_recovery(reason: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::is_db_shaped;
+    use super::{
+        is_db_shaped, manual_recovery_required, reset_db_boot_failures, surface_manual_recovery,
+    };
 
     #[test]
     fn db_shaped_errors_match() {
@@ -94,5 +103,15 @@ mod tests {
         ));
         assert!(!is_db_shaped("Failed to bind port 3030: address in use"));
         assert!(!is_db_shaped("screen recording permission denied"));
+    }
+
+    #[tokio::test]
+    async fn recovery_alert_gates_retries_until_a_healthy_boot_resets_it() {
+        reset_db_boot_failures();
+        surface_manual_recovery("test hard fault").await;
+        assert!(manual_recovery_required());
+
+        reset_db_boot_failures();
+        assert!(!manual_recovery_required());
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/health.rs
@@ -682,6 +682,9 @@ struct EngineRespawnCheck {
     recently_woke: bool,
     /// A start/respawn is already in flight.
     start_in_progress: bool,
+    /// DB recovery was surfaced; automatic retries must stop to preserve the
+    /// quarantined generation until a deliberate repair succeeds.
+    manual_recovery_required: bool,
     /// Consecutive connection failures, vs `down_threshold`.
     consecutive_failures: u32,
     down_threshold: u32,
@@ -708,6 +711,7 @@ impl EngineRespawnCheck {
             && !self.in_restart_grace
             && !self.recently_woke
             && !self.start_in_progress
+            && !self.manual_recovery_required
             && self.consecutive_failures >= self.down_threshold
             && self.respawns_in_window < self.max_respawns
     }
@@ -749,6 +753,15 @@ fn respawn_engine_if_crashed(
     // fresh respawn attempts. (Nothing to respawn while it's up.)
     if health_ok {
         server_respawns.clear();
+        return;
+    }
+
+    // Once DB recovery has been surfaced, preserve the quarantined database
+    // and stop every automatic restart path (including the port-conflict
+    // shortcut below). A deliberate start that proves the server healthy
+    // clears this gate via `reset_db_boot_failures`.
+    let manual_recovery_required = crate::db_relaunch::manual_recovery_required();
+    if manual_recovery_required {
         return;
     }
 
@@ -849,6 +862,7 @@ fn respawn_engine_if_crashed(
             .unwrap_or(false),
         recently_woke: screenpipe_engine::sleep_monitor::recently_woke_from_sleep(),
         start_in_progress,
+        manual_recovery_required,
         consecutive_failures,
         down_threshold: SERVER_DOWN_THRESHOLD,
         respawns_in_window: server_respawns.len() as u32,
@@ -3388,6 +3402,7 @@ mod tests {
             in_restart_grace: false,
             recently_woke: false,
             start_in_progress: false,
+            manual_recovery_required: false,
             consecutive_failures: SERVER_DOWN_THRESHOLD,
             down_threshold: SERVER_DOWN_THRESHOLD,
             respawns_in_window: 0,
@@ -3466,6 +3481,15 @@ mod tests {
     fn never_respawns_while_a_start_is_in_flight() {
         assert!(!EngineRespawnCheck {
             start_in_progress: true,
+            ..crash_baseline()
+        }
+        .should_respawn());
+    }
+
+    #[test]
+    fn never_respawns_after_manual_db_recovery_is_required() {
+        assert!(!EngineRespawnCheck {
+            manual_recovery_required: true,
             ..crash_baseline()
         }
         .should_respawn());

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -1222,6 +1222,7 @@ async fn spawn_screenpipe_inner(
     match result_rx.await {
         Ok(Ok(())) => {
             info!("Screenpipe started successfully");
+            crate::db_relaunch::reset_db_boot_failures();
             state.is_starting.store(false, Ordering::SeqCst);
             state.is_starting_capture.store(false, Ordering::SeqCst);
             let spawn_epoch = std::time::SystemTime::now()

--- a/crates/screenpipe-db/src/failpoint_vfs.rs
+++ b/crates/screenpipe-db/src/failpoint_vfs.rs
@@ -417,6 +417,24 @@ mod tests {
             .await
             .expect("write succeeds before the wedge");
 
+        // Make the failure boundary deterministic. The pre-wedge write warms
+        // whichever pooled connection handled it; without clearing every pool
+        // member's page cache, the first armed batch can occasionally commit
+        // entirely from cached pages before any xRead observes the failpoint.
+        // Hold both max_connections slots at once so both caches are emptied.
+        let mut cold_connection_a = write_pool.acquire().await.unwrap();
+        let mut cold_connection_b = write_pool.acquire().await.unwrap();
+        sqlx::query("PRAGMA shrink_memory")
+            .execute(&mut *cold_connection_a)
+            .await
+            .unwrap();
+        sqlx::query("PRAGMA shrink_memory")
+            .execute(&mut *cold_connection_b)
+            .await
+            .unwrap();
+        drop(cold_connection_a);
+        drop(cold_connection_b);
+
         // --- ARM the wedge: every write now hits a hard disk I/O error.
         arm();
 


### PR DESCRIPTION
## What changed

- expose the existing manual-DB-recovery state to the health watchdog
- stop every automatic engine respawn path after that state is surfaced
- clear the gate only after a deliberate full server start succeeds
- cold-cache both SQLite failpoint-test pool members so the hard-fault boundary is deterministic instead of scheduler-dependent

## Why

After Screenpipe had already emitted needs_recovery, the health watchdog continued retrying the same broken database every five minutes. This patch stops that retry loop and preserves the database for deliberate recovery.

The Ubuntu gate also exposed a test-only race: the failpoint was armed while a warm pooled connection could complete the first batch without a disk read. The test now clears both connection caches before arming; production database behavior is unchanged.

## Verification

- desktop health tests: 90 passed
- desktop DB-relaunch tests: 2 passed
- hard-fault failpoint regression: 50 consecutive local passes
- cargo fmt --all -- --check
- git diff --check
- prior revision platform E2E: Linux, Linux Wayland, Windows, and macOS passed

## Scope boundary

This is containment plus deterministic test setup. It does not change SQLite pools, writers, checkpoints, redaction, recovery, database files, or app version, and it does not claim to prevent the initial corruption.