### PR TITLE
fix(ai-gateway): allow trusted runner chat

### DIFF
--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -188,7 +188,10 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 			// body. Otherwise an anonymous or unverifiable-plan request could make
 			// the Worker parse an arbitrarily large JSON payload just to return the
 			// same 401/503 policy decision.
-			if (authResult.tier === 'anonymous' || !authResult.userId) {
+			if (
+				authResult.tier === 'anonymous' ||
+				(!authResult.userId && authResult.service !== true)
+			) {
 				return freeChatErrorResponse({
 					status: 401,
 					code: 'authentication_required',

--- a/packages/ai-gateway/src/services/free-chat-limit.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.test.ts
@@ -218,11 +218,28 @@ const businessAuth: AuthResult = {
 	userId: 'user_paid',
 };
 
+const serviceAuth: AuthResult = {
+	isValid: true,
+	tier: 'subscribed',
+	accountPlan: 'business',
+	deviceId: 'cloud-runner',
+	service: true,
+};
+
 function metered(userId: string, turnKey: string): Extract<FreeChatPreflight, { mode: 'metered' }> {
 	return { mode: 'metered', userId, turnKey };
 }
 
 describe('prepareFreeChatTurn', () => {
+	it('bypasses Free chat metering for a trusted machine identity without a human user id', async () => {
+		const result = await prepareFreeChatTurn(
+			requestFor(undefined, { 'x-screenpipe-latency': 'background' }),
+			bodyWith([{ role: 'user', content: 'scheduled runner request' }]),
+			serviceAuth,
+		);
+		expect(result).toEqual({ mode: 'bypass' });
+	});
+
 	it.each([
 		['Basic', basicAuth],
 		['Business', businessAuth],

--- a/packages/ai-gateway/src/services/free-chat-limit.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.ts
@@ -360,6 +360,10 @@ export async function prepareFreeChatTurn(
 	auth: AuthResult,
 	rawRequestBytes?: number,
 ): Promise<FreeChatPreflight> {
+	// Trusted backend runners are paid machine identities, not human accounts.
+	// They intentionally have no userId and must bypass Free chat metering.
+	if (auth.service === true && hasPaidHostedAiPlan(auth)) return { mode: 'bypass' };
+
 	if (auth.tier === 'anonymous' || !auth.userId) {
 		return blocked(
 			401,

--- a/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
+++ b/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
@@ -19,6 +19,7 @@ describe('/v1/chat/completions free-plan route policy', () => {
 	const originalFetch = globalThis.fetch;
 	const env = {
 		NODE_ENV: 'production',
+		AI_GATEWAY_SERVICE_TOKEN: 'runner-service-secret',
 		CLERK_SECRET_KEY: 'clerk-test-secret',
 		SUPABASE_URL: 'https://supabase.test',
 		SUPABASE_ANON_KEY: 'supabase-test-key',
@@ -92,6 +93,22 @@ describe('/v1/chat/completions free-plan route policy', () => {
 		expect(response.status).toBe(401);
 		expect(await errorCode(response)).toBe('authentication_required');
 		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it('lets the trusted runner bearer reach hosted background inference without a human user id', async () => {
+		const response = await handleRequest(
+			request({
+				Authorization: 'Bearer runner-service-secret',
+				'x-screenpipe-latency': 'background',
+			}, '/v1/chat/completions', 'gpt-5.6-sol'),
+			env,
+			ctx,
+		);
+
+		// The unit env has no provider credential. Reaching provider setup proves
+		// the machine identity cleared both human-user guards and paid-model gates.
+		expect(response.status).toBe(503);
+		expect(await response.text()).not.toContain('authentication_required');
 	});
 
 	it('blocks a free hosted background request instead of trusting its header', async () => {


### PR DESCRIPTION
## Summary

- allow the authenticated cloud-runner service identity through the hosted chat preflight without inventing a human user id
- keep anonymous and unverifiable human callers fail-closed
- add unit and route regressions for paid background machine traffic

## Request flow

```text
runner bearer -> service auth -> paid bypass -> model/rate/cost gates -> GPT provider
anonymous      -> anonymous auth -> 401 before body/provider work
```

## Verification

- `bun test src/services/free-chat-limit.test.ts src/test/free-chat-route.unit.test.ts src/utils/auth.test.ts` (78 passed)
- deployed Worker release `63ee13573`; production canary returned HTTP 200 with `x-screenpipe-model: gpt-5.6-sol`
- full package `tsc` remains blocked by pre-existing Bun test typings and provider type errors on `main`