### PR TITLE
Bump app to v2.5.148 - release-app

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.147"
+version = "2.5.148"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "screenpipe-app"
-version = "2.5.147"
+version = "2.5.148"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
## summary

- bump the desktop app from `2.5.147` to `2.5.148`
- keep the app lockfile synchronized
- trigger the signed multi-platform Release App workflow after merge

## validation

- `cargo metadata --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --locked --no-deps --format-version 1`
- `git diff --check`

This prepares signed release artifacts only; it does not promote public updater or GitHub latest pointers.