### PR TITLE
fix(a11y): incognito windows captured on macOS when enhanced detection is enabled

### DIFF
--- a/crates/screenpipe-a11y/src/incognito/macos.rs
+++ b/crates/screenpipe-a11y/src/incognito/macos.rs
@@ -292,6 +292,27 @@ mod tests {
         );
     }
 
+    /// Chrome answers the AppleScript query with tab titles, while the AX
+    /// window title the tree walk passes in carries a " - Google Chrome
+    /// (Incognito)" suffix. The exact-match lookup therefore says "not
+    /// private" for a window that is, and the localized title check has to
+    /// catch it.
+    #[test]
+    fn test_incognito_window_with_browser_suffix_is_detected() {
+        let detector = isolated_detector(true);
+        detector.cache.store(
+            "com.google.Chrome".to_ascii_lowercase(),
+            Some(HashSet::from(["Privacy - Wikipedia".to_string()])),
+        );
+
+        assert!(detector.is_incognito(
+            "Google Chrome",
+            0,
+            "Privacy - Wikipedia - Google Chrome (Incognito)"
+        ));
+        assert!(!detector.is_incognito("Google Chrome", 0, "Privacy - Wikipedia - Google Chrome"));
+    }
+
     #[test]
     fn test_fallback_to_title_for_firefox() {
         let detector = MacOSIncognitoDetector::new(false);

--- a/crates/screenpipe-a11y/src/incognito/macos.rs
+++ b/crates/screenpipe-a11y/src/incognito/macos.rs
@@ -227,10 +227,15 @@ impl IncognitoDetector for MacOSIncognitoDetector {
         // Strategy 1: explicit opt-in AppleScript query for Chromium browsers
         // (not Arc). This is the only path that can require Automation access.
         if self.enhanced_detection && Self::is_chromium_browser(app_name) {
-            if let Some(is_private) = self.check_with_cache(app_name, window_title) {
-                return is_private;
+            if let Some(true) = self.check_with_cache(app_name, window_title) {
+                return true;
             }
-            // AppleScript failed — fall through to title check.
+            // A negative answer is not final: the AppleScript query returns
+            // tab titles, while the AX title carries a " - App (Incognito)"
+            // suffix, so the exact-match lookup misses windows that really
+            // are private. Let the localized title check have the last word;
+            // a false positive skips one window, a false negative records
+            // private browsing.
         }
 
         // Strategy 2: Localized title matching (all browsers).


### PR DESCRIPTION
Fixes the incognito capture gap reported in the issue.

## Problem

With `enhanced_detection` enabled on macOS, Chrome incognito windows are captured even though `ignore_incognito_windows` is on. `is_incognito()` treats any answer from the AppleScript strategy as final, and `check_with_cache` compares titles by exact match: the AppleScript query returns tab titles (`Privacy - Wikipedia`) while the AX window title carries a suffix (`Privacy - Wikipedia - Google Chrome (Incognito)`). The lookup misses, `Some(false)` is returned, and the localized title fallback never runs, even though it would have matched the `(Incognito)` marker in that same title.

Reproduced three times on macOS 26 with Chrome: 6 to 9 frame rows per run with `(Incognito)` in `window_name`, page text extracted through the accessibility path.

## Change

Only a positive AppleScript answer is final. Anything else falls through to `is_title_private()`, which already handles the localized markers for every browser.

The asymmetry is deliberate: a false positive skips one window, a false negative records private browsing.

## Before / after

```text
BEFORE
AppleScript title cache -> exact match misses -> Some(false) -> capture private window

AFTER
AppleScript title cache -> exact match misses -> title fallback -> detect (Incognito) -> skip window
```

## Verification

- `cargo test -p screenpipe-a11y incognito -- --nocapture` — 46 passed
- `cargo test -p screenpipe-a11y` — 247 unit, 8 end-to-end, and 2 doc tests passed; 3 unrelated Obsidian tests ignored
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`

The new regression test models the exact mismatch between the AppleScript tab title and the suffixed AX window title. A screen recording is intentionally omitted because demonstrating the failure would expose private-browsing content; the source-backed reproduction is in #5531.

## Alternative considered

Making the cache lookup tolerant (`window_title.contains(title)` alongside the exact match) also closes the gap, but it changes the semantics of the cache for every caller. Falling through keeps the change local to the strategy chain.

Closes #5531
