### PR TITLE
Bump app to v2.5.149 - release-app

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.148"
+version = "2.5.149"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "screenpipe-app"
-version = "2.5.148"
+version = "2.5.149"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
## Summary

- bump desktop app version from `2.5.148` to `2.5.149`
- keep the app manifest and app lockfile package entry aligned
- base the release on merged parser/search change `e37d6fb9`

## Verification

- `cargo metadata --locked --format-version 1 --no-deps` reports `screenpipe-app@2.5.149`
- `git diff --check`

Merging this PR triggers the signed Release App workflow. Artifact completion, public updater promotion, GitHub release publication, and Enterprise rollout remain separately verified release surfaces.