### PR TITLE
fix(docs): repair Granola comparison links

### DIFF
--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-granola.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-granola.mdx
@@ -46,7 +46,7 @@ screenpipe works with any email provider, any calendar, any meeting tool. no Goo
 
 ## more comparisons
 
-- [screenpipe vs Granola (full comparison)](https://screenpi.pe/blog/screenpipe-vs-granola-2026) - in-depth analysis
+- [screenpipe vs Granola (full comparison)](https://screenpipe.com/compare/granola) - in-depth analysis
 - [screenpipe vs Otter.ai](https://screenpi.pe/blog/screenpipe-vs-otter-ai-2026) - cloud transcription comparison
 - [screenpipe vs Fathom](https://screenpi.pe/blog/screenpipe-vs-fathom-2026) - meeting tool comparison
 - [all comparisons](https://screenpi.pe/compare) - see how screenpipe stacks up

--- a/docs/mintlify/docs-mintlify-mig-tmp/vs-otter.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/vs-otter.mdx
@@ -48,7 +48,7 @@ all data stays on your device. source-available with 17k+ GitHub stars. 45+ app 
 
 - [screenpipe vs Otter.ai (full comparison)](https://screenpi.pe/blog/screenpipe-vs-otter-ai-2026) - in-depth analysis
 - [screenpipe vs Fireflies](https://screenpi.pe/blog/screenpipe-vs-fireflies-2026) - another cloud meeting bot comparison
-- [screenpipe vs Granola](https://screenpi.pe/blog/screenpipe-vs-granola-2026) - meeting notepad comparison
+- [screenpipe vs Granola](https://screenpipe.com/compare/granola) - meeting notepad comparison
 - [all comparisons](https://screenpi.pe/compare) - see how screenpipe stacks up
 
 ## frequently asked questions


### PR DESCRIPTION
## summary

- replace the dead Granola blog URL in the Otter and Granola comparison docs
- route both links to the live Granola comparison page

## verification

- `git diff --check`
- confirmed the stale URL is absent from both edited docs
- confirmed `https://screenpipe.com/compare/granola` returns HTTP 200

## visual

```text
before: comparison docs -> /blog/screenpipe-vs-granola-2026 -> 404
after:  comparison docs -> /compare/granola                    -> 200
```
