### PR TITLE
fix(app): make meeting sharing action discoverable

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -1105,8 +1105,9 @@ export function NoteView({
               size="sm"
               onClick={handleCopy}
               disabled={copying}
-              title="copy meeting + transcript to clipboard"
-              className="h-8 w-8 p-0 rounded-none"
+              title="copy meeting and transcript to share"
+              aria-label="copy meeting and transcript to share"
+              className="h-8 gap-1.5 px-2 rounded-none"
             >
               {copying ? (
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -1115,6 +1116,9 @@ export function NoteView({
               ) : (
                 <Copy className="h-3.5 w-3.5" />
               )}
+              <span className="text-xs">
+                {copying ? "copying" : copied ? "copied" : "copy to share"}
+              </span>
             </Button>
             {!isLive && (
               <>


### PR DESCRIPTION
## summary

- replace the icon-only meeting copy control with a visible `copy to share` label
- make the action's accessible name explicit
- preserve the existing local-only behavior: the complete meeting note and transcript are copied to the clipboard

## verification

- `bun run typecheck`
- `NODE_OPTIONS=--no-experimental-webstorage bun run test:vitest` — 189 files and 1,857 tests passed

Node 26's experimental global web-storage shim causes the unflagged test command to fail before tests can use jsdom's `localStorage`; disabling that shim is the replacement test gate above.

## visual

```text
before: [<]                       [copy icon] [summarize] [retranscribe] [export]
after:  [<]              [COPY TO SHARE]     [summarize] [retranscribe] [export]
```
