### PR TITLE
[codex] fix Windows post-login recorder recovery

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -26,7 +26,7 @@ const mocks = vi.hoisted(() => ({
   piUpdateConfig: vi.fn().mockResolvedValue(undefined),
   platform: vi.fn(() => "windows"),
   arch: vi.fn(() => "x86_64"),
-  windowLabel: "main",
+  windowLabel: "home",
   loadUser: vi.fn().mockResolvedValue(undefined),
   updateSettings: vi.fn().mockResolvedValue(undefined),
   state: { isSettingsLoaded: true, user: null as any },
@@ -81,7 +81,7 @@ vi.mock("@tauri-apps/plugin-os", () => ({
 }));
 
 // The resume effect only restarts the engine from the primary window, which it
-// detects via getCurrentWindow().label. Stand in as the primary "main" window so
+// detects via getCurrentWindow().label. Stand in as the primary "home" window so
 // the sequenced stop -> settle -> spawn actually runs under test.
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({ label: mocks.windowLabel }),
@@ -126,7 +126,7 @@ describe("AppEntitlementGate", () => {
     vi.stubEnv("TAURI_ENV_DEBUG", "false");
     vi.stubEnv("NEXT_PUBLIC_SCREENPIPE_DEV_BILLING_BYPASS", "false");
     mocks.state = { isSettingsLoaded: true, user: null };
-    mocks.windowLabel = "main";
+    mocks.windowLabel = "home";
     mocks.enterprise = {
       isManagedDeployment: false,
       isManagedDeploymentResolved: true,
@@ -218,22 +218,25 @@ describe("AppEntitlementGate", () => {
     expect(mocks.spawnScreenpipe).not.toHaveBeenCalled();
   });
 
-  it("never lets a secondary enterprise webview stop the shared recorder", async () => {
-    mocks.windowLabel = "search";
-    mocks.enterprise = {
-      isManagedDeployment: true,
-      isManagedDeploymentResolved: true,
-      authenticationState: "account",
-      authenticationError: null,
-      isManagedAuthenticated: false,
-    };
+  it.each(["main", "main-window", "search"])(
+    "never lets the %s webview stop the shared recorder",
+    async (windowLabel) => {
+      mocks.windowLabel = windowLabel;
+      mocks.enterprise = {
+        isManagedDeployment: true,
+        isManagedDeploymentResolved: true,
+        authenticationState: "account",
+        authenticationError: null,
+        isManagedAuthenticated: false,
+      };
 
-    render(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
+      render(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
 
-    expect(screen.queryByTestId("protected-app")).not.toBeInTheDocument();
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(mocks.stopScreenpipe).not.toHaveBeenCalled();
-  });
+      expect(screen.queryByTestId("protected-app")).not.toBeInTheDocument();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mocks.stopScreenpipe).not.toHaveBeenCalled();
+    },
+  );
 
   it("resumes recording when a real enterprise gate authenticates", async () => {
     mocks.enterprise = {
@@ -271,6 +274,26 @@ describe("AppEntitlementGate", () => {
     fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
     expect(mocks.openLoginWindow).toHaveBeenCalled();
   });
+
+  it.each(["main", "main-window", "search"])(
+    "never lets the %s webview own consumer recorder recovery",
+    async (windowLabel) => {
+      mocks.windowLabel = windowLabel;
+      mocks.state.user = null;
+      const { rerender } = render(
+        <AppEntitlementGate>{protectedApp}</AppEntitlementGate>,
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mocks.stopScreenpipe).not.toHaveBeenCalled();
+
+      mocks.state.user = baseUser();
+      rerender(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mocks.spawnScreenpipe).not.toHaveBeenCalled();
+    },
+  );
 
   it("offers account and enterprise-key routes in the fallback gate", () => {
     mocks.enterprise = {

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -33,8 +33,8 @@ import {
 } from "@/lib/app-entitlement";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { useManagedPolicy } from "@/lib/hooks/use-managed-policy";
+import { isPrimaryWindow } from "@/lib/utils/is-primary-window";
 import { commands } from "@/lib/utils/tauri";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { EnterpriseLicensePrompt } from "@/components/enterprise-license-prompt";
 
 const E2E_ACCOUNT_USER_KEY = "screenpipe_e2e_account_user";
@@ -44,27 +44,6 @@ const E2E_ACCOUNT_USER_EVENT = "screenpipe-e2e-seed-account-user";
 const E2E_ACCOUNT_SEED_ENABLED =
   process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
 const POLICY_CLOCK_CHECK_INTERVAL_MS = 60_000;
-
-// Drive the resume from exactly ONE window — the main CONTENT window — so
-// multiple webviews don't fire overlapping spawns that race each other (and a
-// reconnect teardown) and wedge the recorder at "Starting capture session".
-//
-// The content-window label differs by platform: on macOS it is "home" (the
-// "main" window there is the NSPanel overlay, which must NOT drive recording —
-// gating on "main" was why macOS never resumed after login). On Windows/Linux
-// the content window is "main-window" (window overlay mode) or "main". This
-// must match the window that actually handles the sign-in deep link, so its
-// gate observes the entitled flip.
-function isPrimaryWindow(): boolean {
-  try {
-    const label = getCurrentWindow().label;
-    const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
-    if (/Mac/i.test(ua)) return label === "home";
-    return label === "main-window" || label === "main";
-  } catch {
-    return false;
-  }
-}
 
 function getDownloadPlatform(): string | null {
   try {

--- a/apps/screenpipe-app-tauri/lib/utils/is-primary-window.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/is-primary-window.ts
@@ -11,17 +11,13 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
  * without this guard global UI would render once per window and analytics
  * would multi-count.
  *
- * The label differs by platform — this mirrors `isPrimaryWindow` in
- * `components/app-entitlement-gate.tsx`: macOS uses "home" (its "main" window
- * is the NSPanel overlay), Windows/Linux use "main"/"main-window". Keep the two
- * in sync. Returns false off-Tauri (getCurrentWindow throws).
+ * The app creates its content window as `home` on every platform. Labels such
+ * as `main` and `main-window` belong to overlays and must not own global UI or
+ * recorder lifecycle. Returns false off-Tauri (getCurrentWindow throws).
  */
 export function isPrimaryWindow(): boolean {
   try {
-    const label = getCurrentWindow().label;
-    const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
-    if (/Mac/i.test(ua)) return label === "home";
-    return label === "main-window" || label === "main";
+    return getCurrentWindow().label === "home";
   } catch {
     return false;
   }


### PR DESCRIPTION
## What

- make the `home` webview the single app-wide owner of recorder lifecycle on every platform
- centralize the entitlement gate on the shared primary-window helper
- prevent `main`, `main-window`, and `search` overlays from stopping or restarting the shared recorder
- add regression coverage for consumer and enterprise sign-in recovery

## Why

A Windows 2.5.148 diagnostic session showed that the login callback succeeded and the native process accepted the account, but the recorder did not restart until the app itself was restarted. The content route was running in the `home` webview, while the entitlement gate only treated `main`/`main-window` as primary on Windows.

Those labels are overlays. As a result, the real content window observed the signed-out to signed-in transition but was not allowed to run the sequenced recorder recovery.

## Root cause and fix

```mermaid
flowchart LR
  A[Login callback succeeds] --> B[Home webview receives account]
  B --> C{Primary recorder owner?}
  C -- Before: no --> D[Local recorder stays stopped]
  C -- After: yes --> E[Stop, settle, then spawn]
  E --> F[Local API becomes healthy]
```

The app creates the content window as `home` across platforms. Keeping that as the sole owner also avoids overlapping stop/spawn races from overlay webviews.

## Impact

- Windows sign-in can recover capture without requiring an app restart
- macOS behavior is unchanged
- overlay windows no longer render app-wide announcement/advisory owners or control recorder lifecycle
- no data model, capture format, or authentication persistence changes

## Checks

- `bunx vitest run --config vitest.config.ts components/app-entitlement-gate.test.tsx` — 36/36 passed
- `bun run typecheck` — passed
- scoped ESLint on all three changed files — passed
- `git diff --check` — passed

## Live evidence

In the sanitized Windows reproduction, the sign-in callback completed without session, token-persistence, or authorization errors. Native signed-out warnings stopped immediately, but the local recorder API remained absent until restart. After restart, the stored account was accepted and the local API returned healthy, isolating the failure to post-login recorder ownership rather than login persistence.
