### PR TITLE
fix(windows): bypass Excel UIA filter-menu stalls

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -584,7 +584,8 @@ These apps are common on Windows but have **never been tested** with the event-d
 | **Productivity** | | | |
 | Notion | ? | unknown | Electron |
 | Obsidian | ? | unknown | Electron |
-| Word / Excel / PowerPoint | ? | unknown | native Win32, historically good UIA |
+| Excel | OCR-NEEDED | full-tree UIA stalls filter menus | bypass full subtree and preserve visible content through OCR |
+| Word / PowerPoint | ? | unknown | native Win32, historically good UIA |
 | Outlook | ? | unknown | mixed native/web |
 | OneNote | ? | unknown | UWP, should have good UIA |
 | **Media / Creative** | | | |
@@ -608,6 +609,12 @@ These apps are common on Windows but have **never been tested** with the event-d
 4. Edge / Firefox — browser is primary use
 5. Notion / Obsidian — knowledge workers
 6. Office apps — enterprise users
+
+**Excel responsiveness regression:** With recording active and Enhanced AI both on
+and off, open a worksheet with column filters and repeatedly open different filter
+menus. Each menu must appear without a multi-second stall. Logs should show
+`provider prefers OCR`, and a search for visible worksheet text should return OCR-backed
+frames rather than a cached full-tree UIA capture.
 
 **How to verify an app:**
 ```bash

--- a/crates/screenpipe-a11y/src/platform/windows_uia.rs
+++ b/crates/screenpipe-a11y/src/platform/windows_uia.rs
@@ -1098,11 +1098,25 @@ fn refresh_focused_element(
 /// with a different provider and is unaffected.
 const FRAGILE_UIA_TREE_PROVIDERS: &[&str] = &["outlook.exe"];
 
+/// Process names whose full cached UIA subtree is too disruptive to materialize.
+///
+/// Excel's virtualized worksheet/filter provider can service a
+/// `TreeScope_Subtree` cache request on Excel's UI thread for several seconds.
+/// The cached request is one synchronous COM call, so the normal mid-walk deadline
+/// cannot interrupt it. The paired-capture path uses OCR for these apps instead.
+const OCR_PREFERRED_UIA_TREE_PROVIDERS: &[&str] = &["excel.exe"];
+
 /// Returns true if `app_name` is a process whose UIA provider can crash when we capture
 /// its full accessibility tree. See [`FRAGILE_UIA_TREE_PROVIDERS`].
 pub(crate) fn is_fragile_uia_tree_provider(app_name: &str) -> bool {
     let lower = app_name.to_ascii_lowercase();
     FRAGILE_UIA_TREE_PROVIDERS.iter().any(|p| lower == *p)
+}
+
+/// Returns true when full-subtree UIA capture should be replaced by screenshot OCR.
+pub(crate) fn prefers_ocr_over_uia_tree(app_name: &str) -> bool {
+    let lower = app_name.to_ascii_lowercase();
+    OCR_PREFERRED_UIA_TREE_PROVIDERS.iter().any(|p| lower == *p)
 }
 
 /// Capture a window tree and send it through the channel if it changed.
@@ -1138,6 +1152,14 @@ fn capture_and_send(
     if is_fragile_uia_tree_provider(&app_name) {
         trace!(
             "Skipping a11y tree capture for fragile UIA provider '{}' (crash-prone)",
+            app_name
+        );
+        return;
+    }
+
+    if prefers_ocr_over_uia_tree(&app_name) {
+        trace!(
+            "Skipping full a11y tree capture for '{}' (OCR-preferred provider)",
             app_name
         );
         return;
@@ -1349,6 +1371,19 @@ mod tests {
         assert!(!is_fragile_uia_tree_provider("chrome.exe"));
         assert!(!is_fragile_uia_tree_provider("notepad.exe"));
         assert!(!is_fragile_uia_tree_provider(""));
+    }
+
+    #[test]
+    fn test_ocr_preferred_uia_provider_detection() {
+        assert!(prefers_ocr_over_uia_tree("EXCEL.EXE"));
+        assert!(prefers_ocr_over_uia_tree("excel.exe"));
+        assert!(prefers_ocr_over_uia_tree("Excel.exe"));
+
+        assert!(!prefers_ocr_over_uia_tree("excel"));
+        assert!(!prefers_ocr_over_uia_tree("excel-helper.exe"));
+        assert!(!prefers_ocr_over_uia_tree("powerpnt.exe"));
+        assert!(!prefers_ocr_over_uia_tree("winword.exe"));
+        assert!(!prefers_ocr_over_uia_tree(""));
     }
 
     #[test]

--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -655,6 +655,17 @@ pub enum SkipReason {
     NotInIncludeList,
     /// Focused browser tab's URL matched a user-configured ignored URL.
     BlockedUrl,
+    /// The app's full accessibility provider is known to block its foreground UI.
+    /// Continue the frame capture with OCR instead of dropping the frame.
+    OcrPreferred,
+}
+
+impl SkipReason {
+    /// Whether a skipped tree walk should continue through the screenshot OCR path.
+    /// Privacy and user-filter skips must never fall back to pixels.
+    pub fn uses_ocr_fallback(&self) -> bool {
+        matches!(self, Self::OcrPreferred)
+    }
 }
 
 impl std::fmt::Display for SkipReason {
@@ -665,6 +676,9 @@ impl std::fmt::Display for SkipReason {
             SkipReason::UserIgnored => write!(f, "user-configured ignored window"),
             SkipReason::NotInIncludeList => write!(f, "not in included windows list"),
             SkipReason::BlockedUrl => write!(f, "user-configured ignored URL"),
+            SkipReason::OcrPreferred => {
+                write!(f, "accessibility provider bypassed in favor of OCR")
+            }
         }
     }
 }
@@ -1311,5 +1325,15 @@ mod tests {
         );
         let json = serde_json::to_string(&node).expect("serialize");
         assert!(!json.contains("\"lines\""));
+    }
+
+    #[test]
+    fn only_ocr_preferred_skip_allows_pixel_fallback() {
+        assert!(SkipReason::OcrPreferred.uses_ocr_fallback());
+        assert!(!SkipReason::Incognito.uses_ocr_fallback());
+        assert!(!SkipReason::ExcludedApp.uses_ocr_fallback());
+        assert!(!SkipReason::UserIgnored.uses_ocr_fallback());
+        assert!(!SkipReason::NotInIncludeList.uses_ocr_fallback());
+        assert!(!SkipReason::BlockedUrl.uses_ocr_fallback());
     }
 }

--- a/crates/screenpipe-a11y/src/tree/windows.rs
+++ b/crates/screenpipe-a11y/src/tree/windows.rs
@@ -328,6 +328,20 @@ impl TreeWalkerPlatform for WindowsTreeWalker {
             return Ok(TreeWalkResult::Skipped(SkipReason::NotInIncludeList));
         }
 
+        // Excel's cached full-subtree provider can block the foreground UI for
+        // several seconds while a worksheet filter menu is opening. That cache
+        // call is synchronous and cannot be interrupted by the walk deadline.
+        // Preserve the frame through the explicit OCR fallback instead.
+        if crate::platform::windows_uia::prefers_ocr_over_uia_tree(&app_name) {
+            debug!(
+                app = %app_name,
+                pid,
+                title = %window_name,
+                "a11y: skipped full tree — provider prefers OCR"
+            );
+            return Ok(TreeWalkResult::Skipped(SkipReason::OcrPreferred));
+        }
+
         debug!(app = %app_name, pid, title = %window_name, "a11y: capturing window tree");
 
         // Use adaptive budget overrides when set

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2548,11 +2548,20 @@ async fn do_capture(
             crate::ui_recorder::record_tree_walk(crate::ui_recorder::TreeWalkOutcome::Error);
         }
         // Skipped: user filter / incognito — not a walk attempt, don't count.
+        // OCR-preferred providers also skip the tree intentionally and continue
+        // through the screenshot path below.
         TreeWalkResult::Skipped(_) => {}
     }
 
     let tree_snapshot = match tree_walk_result {
         TreeWalkResult::Found(snap) => Some(snap),
+        TreeWalkResult::Skipped(reason) if reason.uses_ocr_fallback() => {
+            debug!(
+                "tree walk skipped ({}); continuing with screenshot OCR on monitor {}",
+                reason, params.monitor_id
+            );
+            None
+        }
         TreeWalkResult::Skipped(reason) => {
             debug!(
                 "skipping capture: window filtered ({}) on monitor {}",

--- a/packages/sdk/recorder-core/src/platform/recorder.rs
+++ b/packages/sdk/recorder-core/src/platform/recorder.rs
@@ -832,12 +832,20 @@ fn focus_filter_needs_tree(ignored_urls: &[String]) -> bool {
 }
 
 fn skip_verdict(reason: SkipReason) -> (bool, Option<String>) {
+    if reason.uses_ocr_fallback() {
+        // This is a capture-strategy hint, not a privacy verdict. In particular,
+        // Excel bypasses its blocking UIA provider in favor of screenshot OCR;
+        // the SDK's MP4 recorder must remain unpaused while that window is focused.
+        return (false, None);
+    }
+
     let tag = match reason {
         SkipReason::Incognito => "incognito",
         SkipReason::ExcludedApp => "excluded_app",
         SkipReason::UserIgnored => "ignored_window",
         SkipReason::NotInIncludeList => "included_window_mismatch",
         SkipReason::BlockedUrl => "blocked_url",
+        SkipReason::OcrPreferred => unreachable!("handled above"),
     };
     (true, Some(tag.to_string()))
 }
@@ -1632,5 +1640,18 @@ mod tests {
     #[test]
     fn url_filters_require_tree_metadata() {
         assert!(focus_filter_needs_tree(&["bank.example".to_string()]));
+    }
+
+    #[test]
+    fn ocr_preferred_does_not_pause_sdk_recording() {
+        assert_eq!(skip_verdict(SkipReason::OcrPreferred), (false, None));
+    }
+
+    #[test]
+    fn privacy_skip_still_pauses_sdk_recording() {
+        assert_eq!(
+            skip_verdict(SkipReason::Incognito),
+            (true, Some("incognito".to_string()))
+        );
     }
 }


### PR DESCRIPTION
## Scope

Split from #5541. This PR detects Excel on Windows before the synchronous UI Automation subtree walk and asks the capture path to use screenshot OCR instead. Recording remains active.

It does not change crash dumps, audio recovery, OCR cache hashing, or pipe execution tracking.

## Before / after

```text
before: focus Excel -> synchronous full UIA subtree walk -> filter-menu interaction can stall
after:  focus Excel -> OCR-preferred verdict -> skip UIA tree -> continue screenshot capture/OCR
```

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p screenpipe-a11y --lib` — 248 passed
- `cargo test --manifest-path packages/sdk/recorder-core/Cargo.toml ocr_preferred_does_not_pause_sdk_recording --lib` — 1 passed
- `cargo test --manifest-path packages/sdk/recorder-core/Cargo.toml privacy_skip_still_pauses_sdk_recording --lib` — 1 passed
- testing contract documents physical Windows Excel validation

## Remaining validation

Keep this draft until a physical Windows Excel smoke test confirms filter-menu responsiveness, OCR search quality, and metadata scoping. The fallback can use monitor-level OCR when no accessibility tree is available, so CI alone is not enough to validate result relevance.

## Sibling splits

- #5557 — Windows fail-fast dumps and OCR hash allocation
- #5558 — unsupported audio-device backoff
- #5560 — exact automation execution tracking

Supersedes the corresponding scope in #5541.
