### PR TITLE
add lean Tauri debug profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,3 +183,61 @@ opt-level = 0
 [profile.dev.package."*"]
 opt-level = 2      # Optimize all dependencies (faster runtime, same compile time)
 debug = false      # deps don't need debug symbols — keeps target/ from ballooning
+
+# Space-efficient debugging: retain complete symbols for Screenpipe while
+# omitting DWARF from third-party crates. Use `cargo … --profile dev-debug`.
+[profile.dev-debug]
+inherits = "dev"
+debug = true
+split-debuginfo = "packed"
+incremental = false
+
+[profile.dev-debug.package."*"]
+opt-level = 2
+debug = false
+
+# The wildcard above deliberately strips third-party dependencies. Restore
+# complete symbols for every first-party crate so stepping through the
+# Screenpipe stack still works.
+[profile.dev-debug.package.screenpipe-a11y]
+debug = true
+[profile.dev-debug.package.screenpipe-audio]
+debug = true
+[profile.dev-debug.package.screenpipe-audio-eval]
+debug = true
+[profile.dev-debug.package.screenpipe-capture]
+debug = true
+[profile.dev-debug.package.screenpipe-config]
+debug = true
+[profile.dev-debug.package.screenpipe-connect]
+debug = true
+[profile.dev-debug.package.screenpipe-core]
+debug = true
+[profile.dev-debug.package.screenpipe-db]
+debug = true
+[profile.dev-debug.package.screenpipe-engine]
+debug = true
+[profile.dev-debug.package.screenpipe-events]
+debug = true
+[profile.dev-debug.package.screenpipe-gateway]
+debug = true
+[profile.dev-debug.package.screenpipe-meeting-eval]
+debug = true
+[profile.dev-debug.package.screenpipe-redact]
+debug = true
+[profile.dev-debug.package.screenpipe-resource]
+debug = true
+[profile.dev-debug.package.screenpipe-screen]
+debug = true
+[profile.dev-debug.package.screenpipe-secrets]
+debug = true
+[profile.dev-debug.package.screenpipe-sqlite-coordinator]
+debug = true
+[profile.dev-debug.package.screenpipe-sync]
+debug = true
+[profile.dev-debug.package.screenpipe-team-memory]
+debug = true
+[profile.dev-debug.package.screenpipe-telemetry-wire]
+debug = true
+[profile.dev-debug.package.screenpipe-vault]
+debug = true

--- a/apps/screenpipe-app-tauri/package.json
+++ b/apps/screenpipe-app-tauri/package.json
@@ -41,6 +41,7 @@
     "predev": "bun scripts/gen-skill-content.js && bun scripts/pre_build.js",
     "prebuild": "bun scripts/gen-skill-content.js && bun scripts/pre_build.js",
     "tauri": "tauri",
+    "tauri:dev:debug": "tauri dev -- --profile dev-debug",
     "tauri:build": "scripts/build_macos.sh",
     "clean": "rm -rf out && cargo clean --manifest-path src-tauri/Cargo.toml && rm -rf src-tauri/{screenpipe-*,tesseract-*,ffmpeg*,openblas*,bun*,ollama*,ui_monitor*} node_modules"
   },

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -371,3 +371,57 @@ debug = false
 [profile.dev.build-override]
 opt-level = 0
 debug = false
+
+# Space-efficient debugging: the app and Screenpipe retain complete symbols,
+# while third-party crates carry no debuginfo. Invoke through
+# `bun run tauri:dev:debug` (or `tauri dev -- --profile dev-debug`).
+[profile.dev-debug]
+inherits = "dev"
+debug = true
+split-debuginfo = "packed"
+incremental = false
+
+[profile.dev-debug.package."*"]
+opt-level = 2
+debug = false
+
+# Preserve complete debugging across the first-party runtime
+# stack without paying for third-party dependency symbols.
+[profile.dev-debug.package.screenpipe-a11y]
+debug = true
+[profile.dev-debug.package.screenpipe-audio]
+debug = true
+[profile.dev-debug.package.screenpipe-capture]
+debug = true
+[profile.dev-debug.package.screenpipe-config]
+debug = true
+[profile.dev-debug.package.screenpipe-connect]
+debug = true
+[profile.dev-debug.package.screenpipe-core]
+debug = true
+[profile.dev-debug.package.screenpipe-db]
+debug = true
+[profile.dev-debug.package.screenpipe-engine]
+debug = true
+[profile.dev-debug.package.screenpipe-events]
+debug = true
+[profile.dev-debug.package.screenpipe-redact]
+debug = true
+[profile.dev-debug.package.screenpipe-resource]
+debug = true
+[profile.dev-debug.package.screenpipe-screen]
+debug = true
+[profile.dev-debug.package.screenpipe-secrets]
+debug = true
+[profile.dev-debug.package.screenpipe-sqlite-coordinator]
+debug = true
+[profile.dev-debug.package.screenpipe-sync]
+debug = true
+[profile.dev-debug.package.screenpipe-vault]
+debug = true
+
+# Build scripts/proc macros are not part of the shipped app, so do not retain
+# their debuginfo either.
+[profile.dev-debug.build-override]
+opt-level = 0
+debug = false


### PR DESCRIPTION
## Summary

- add a `dev-debug` Cargo profile to both the root workspace and the separate Tauri workspace
- retain full symbols for Screenpipe and `screenpipe-app`, while stripping debuginfo from third-party dependencies
- add `bun run tauri:dev:debug` to launch the Tauri app with the new profile
- disable incremental artifacts and use packed split debuginfo to limit per-worktree storage

## Profile layout

```text
dev-debug
├── screenpipe-app + screenpipe-*  -> full symbols
├── tauri / plugins / crates.io    -> stripped debuginfo
└── incremental state              -> disabled
```

## First-party profile audit

The root workspace profile restores symbols for all 21 `screenpipe-*` workspace packages.
The Tauri workspace profile restores symbols for every first-party package in its resolved dependency graph: a11y, audio, capture, config, connect, core, db, engine, events, redact, resource, screen, secrets, sqlite-coordinator, sync, and vault. `screenpipe-app` inherits the profile's full-symbol setting directly.

All other packages—including Tauri, Tauri plugins, and crates.io dependencies—remain stripped by the wildcard package override.

## Measured footprint (Apple Silicon)

A complete `screenpipe-app` build under `dev-debug` completed successfully at **5.4 GiB**:

| Area | Size |
| --- | ---: |
| `deps/` | 4.3 GiB |
| native/build-script output | 634 MiB |
| app binary | 206 MiB |
| app dSYM | ~663 MiB |
| incremental state | 0 B |

## Validation

- `cargo metadata --manifest-path Cargo.toml --format-version 1 --no-deps`
- `cargo metadata --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --format-version 1`
- `cargo check -p screenpipe-telemetry-wire --profile dev-debug -vv` (verified first-party `debuginfo=2`; dependencies use `strip=debuginfo`)
- `bun scripts/pre_build.js`
- `cargo build --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml -p screenpipe-app --profile dev-debug`
