### PR TITLE
restore headed UI for consumer installs

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -10,7 +10,7 @@ import { Switch } from "@/components/ui/switch";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Rocket, Moon, Sun, Monitor, FlaskConical, ExternalLink, Layers, RefreshCw, MonitorOff } from "lucide-react";
+import { Rocket, Moon, Sun, Monitor, FlaskConical, ExternalLink, Layers, RefreshCw } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,8 +42,6 @@ export const searchIndex: SettingsField[] = [
   { label: "Auto-Update Pipes" },
   { label: "Reset Onboarding", keywords: ["setup"] },
   { label: "Your goal", keywords: ["onboarding", "purpose", "personalization"] },
-  { label: "Headless", keywords: ["low resource", "tray only", "memory", "webview"] },
-  { label: "Record only", keywords: ["headless", "pipes", "scheduler", "automation"] },
 ];
 import { useManagedPolicy } from "@/lib/hooks/use-managed-policy";
 import { screenpipeWebUrl } from "@/lib/web-url";
@@ -441,49 +439,6 @@ export default function GeneralSettings() {
               {isResettingOnboarding ? "resetting..." : "reset"}
             </Button>
           </div>
-        </CardContent>
-      </Card>
-
-      <Card className="border-border bg-card" data-testid="headless-setting">
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <MonitorOff className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground">Headless</h3>
-                <p className="text-xs text-muted-foreground">
-                  Close the app UI completely while recording continues in the tray
-                </p>
-                <p className="text-[10px] text-muted-foreground/60 mt-0.5">
-                  App shortcuts and the UI are unavailable until you open screenpipe from the tray.
-                </p>
-              </div>
-            </div>
-            <Switch
-              id="headless-toggle"
-              checked={settings?.headless ?? false}
-              onCheckedChange={(checked) => handleSettingsChange({ headless: checked })}
-              className="ml-4"
-            />
-          </div>
-          {settings?.headless && (
-            <div className="ml-6 mt-2 border-l border-border pl-3 pt-2 flex items-center justify-between">
-              <div>
-                <h4 className="text-xs font-medium text-foreground">Record only</h4>
-                <p className="text-[10px] text-muted-foreground mt-0.5">
-                  Skip scheduled pipe runs while the UI is headless
-                </p>
-              </div>
-              <Switch
-                id="headless-record-only-toggle"
-                checked={settings?.headlessRecordOnly ?? false}
-                onCheckedChange={(checked) =>
-                  handleSettingsChange({ headlessRecordOnly: checked })
-                }
-                className="ml-4"
-              />
-            </div>
-          )}
         </CardContent>
       </Card>
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1845,6 +1845,25 @@ impl SettingsStore {
     }
 }
 
+/// Consumer builds no longer support the legacy tray-only UI preference. Reset
+/// both fields together so installs that used it reopen headed and resume their
+/// normal scheduled-pipe behavior on the first launch after upgrading.
+///
+/// Enterprise builds retain the fields because a managed deployment may still
+/// use the dormant-UI lifecycle independently of the consumer settings page.
+fn restore_headed_mode_for_consumer(
+    settings: &mut SettingsStore,
+    is_enterprise_build: bool,
+) -> bool {
+    if is_enterprise_build || (!settings.headless && !settings.headless_record_only) {
+        return false;
+    }
+
+    settings.headless = false;
+    settings.headless_record_only = false;
+    true
+}
+
 pub fn init_store(app: &AppHandle) -> Result<SettingsStore, String> {
     println!("Initializing settings store");
 
@@ -1952,6 +1971,13 @@ pub fn init_store(app: &AppHandle) -> Result<SettingsStore, String> {
             );
             should_save = true;
         }
+    }
+
+    if restore_headed_mode_for_consumer(&mut store, cfg!(feature = "enterprise-build")) {
+        tracing::info!(
+            "settings migration: restored headed UI and scheduled pipe runs for consumer install"
+        );
+        should_save = true;
     }
 
     if should_save {
@@ -2160,6 +2186,29 @@ mod tests {
         .unwrap();
 
         assert!(settings.headless_record_only);
+    }
+
+    #[test]
+    fn consumer_headless_migration_restores_headed_mode() {
+        let mut consumer = SettingsStore {
+            headless: true,
+            headless_record_only: true,
+            ..Default::default()
+        };
+
+        assert!(restore_headed_mode_for_consumer(&mut consumer, false));
+        assert!(!consumer.headless);
+        assert!(!consumer.headless_record_only);
+        assert!(!restore_headed_mode_for_consumer(&mut consumer, false));
+
+        let mut enterprise = SettingsStore {
+            headless: true,
+            headless_record_only: true,
+            ..Default::default()
+        };
+        assert!(!restore_headed_mode_for_consumer(&mut enterprise, true));
+        assert!(enterprise.headless);
+        assert!(enterprise.headless_record_only);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove the Headless and Record only controls, including their Settings search entries.
- Migrate consumer settings before window startup: reset `headless` and `headlessRecordOnly` to `false`, then persist the headed state.
- Preserve existing settings on enterprise builds.

Closes #5469.

## Why

The legacy consumer Headless preference can make completed installs start tray-only, which makes the app appear not to be running. A frontend-only migration would not reach users whose UI is already dormant, so the migration runs in Rust during store initialization before startup window decisions.

## Validation

- `bun run test:vitest -- lib/hooks/__tests__/default-settings-headless.test.ts`
- `bun run typecheck`
- `cargo test -p screenpipe-app consumer_headless_migration_restores_headed_mode --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml -- --nocapture`

## Migration audit

- Settings UI toggle and nested Record only control: removed.
- Settings search entries: removed.
- Consumer startup state: reset and persisted before dormant-window logic executes.
- Enterprise policy and unrelated headless browser runtime paths: retained.