### PR TITLE
Bump app to v2.5.151 - release-app

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.150"
+version = "2.5.151"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "screenpipe-app"
-version = "2.5.150"
+version = "2.5.151"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
## Summary

- bump the desktop app manifest from 2.5.150 to 2.5.151
- keep the app-local Cargo.lock version synchronized
- trigger the standard five-platform Release App workflow after protected merge
- use the same merge SHA for the manual Enterprise release

## Validation

- `cargo metadata --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --no-deps --format-version 1 --locked`
- `git diff --check`

Public app and Enterprise release state will be verified independently from their exact workflow runs and live manifests.