### PR TITLE
Bump app to v2.5.151 - release-app

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11059,7 +11059,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.150"
+version = "2.5.151"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "screenpipe-app"
-version = "2.5.150"
+version = "2.5.151"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
Bumps the desktop app version from 2.5.150 to 2.5.151.

This triggers signed release artifact production after merge. It does not publish the updater, create a GitHub release/tag, or change Enterprise rollout state.