### PR TITLE
fix: align Gmail connected status with token recoverability

### DIFF
--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -649,7 +649,8 @@ async fn list_instances(
         .is_some();
 
     if is_oauth {
-        let instances = oauth_store::list_connected_oauth_instances(state.secret_store.as_deref(), &id).await;
+        let instances =
+            oauth_store::list_connected_oauth_instances(state.secret_store.as_deref(), &id).await;
         let mut items = Vec::new();
         for inst in instances {
             let token =

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -649,7 +649,7 @@ async fn list_instances(
         .is_some();
 
     if is_oauth {
-        let instances = oauth_store::list_oauth_instances(state.secret_store.as_deref(), &id).await;
+        let instances = oauth_store::list_connected_oauth_instances(state.secret_store.as_deref(), &id).await;
         let mut items = Vec::new();
         for inst in instances {
             let token =


### PR DESCRIPTION
## Summary
- Use the recoverability-aware OAuth instance list for `/connections/:id/instances`.
- Prevent stale or unusable Gmail token rows from being advertised as connected.

## Validation
- `git diff --check`
- `cargo check -p screenpipe-engine` started; dependency compilation exceeded the local 180s timeout without an error.

## Scope
Preserves unrelated existing worktree changes.