### PR TITLE
fix(chat): prevent duplicate steering sends

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
@@ -234,7 +234,7 @@ export function useChatComposerShellActions({
   const handleSteerShortcut = useCallback(() => {
     if ((input.trim() || pastedImages.length > 0) && !steerShortcutInFlightRef.current) {
       steerShortcutInFlightRef.current = true;
-      void Promise.resolve(steerMessage(input.trim())).finally(() => {
+      void steerMessage(input.trim()).finally(() => {
         steerShortcutInFlightRef.current = false;
       });
       return;
@@ -248,7 +248,7 @@ export function useChatComposerShellActions({
       !steerShortcutInFlightRef.current
     ) {
       steerShortcutInFlightRef.current = true;
-      void Promise.resolve(steerQueuedPrompt(queuedPrompts[0])).finally(() => {
+      void steerQueuedPrompt(queuedPrompts[0]).finally(() => {
         steerShortcutInFlightRef.current = false;
       });
     }

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-steering-transport.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-steering-transport.ts
@@ -453,7 +453,7 @@ export function usePiSteeringTransport(
         const interruptedAssistantId =
           latest.interruptedAssistantId ?? null;
 
-        void commands
+        await commands
           .piSteer(
             sid,
             prompt,


### PR DESCRIPTION
## Summary
- keep the Cmd/Ctrl+Enter steering single-flight guard active until the steering promise settles
- await the native `piSteer` IPC call instead of returning before transport completes
- prevent rapid repeated shortcut events from enqueueing the same steer multiple times

## Root cause
The shortcut used `Promise.resolve(steerMessage(...))`, but the transport path launched `commands.piSteer(...)` without awaiting it. The handler therefore cleared its in-flight guard immediately, allowing repeated key events to send duplicate steering messages.

## Validation
- `git diff --check` ✅
- targeted Vitest/typecheck attempted, but this clean worktree has no installed frontend dependencies (`vitest/config` and `@vitejs/plugin-react` unavailable)

## Reproduction evidence
The same queued steer was persisted with the same queued prompt ID and timestamp in three chat JSON files, confirming duplicate sends across the chat persistence path.
