### PR TITLE
test(e2e): wait for dashboard mode after canvas reload

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -967,7 +967,9 @@ Refresh the assigned Live View output targets from source-backed activity.
     expect(await $("[data-testid^='canvas-arrow-']").isExisting()).toBe(true);
 
     await setCssWindowSize(1440, 900);
-    await $("[data-testid='overview-mode-dashboard']").click();
+    const dashboardMode = await $("[data-testid='overview-mode-dashboard']");
+    await dashboardMode.waitForEnabled({ timeout: t(15_000) });
+    await dashboardMode.click();
     await waitForTestId("brain-overview-grid", 10_000);
 
     await $("[data-testid='overview-edit']").click();


### PR DESCRIPTION
## What

Wait for the Dashboard layout toggle to be enabled after navigating away from and back to Brain before clicking it.

## Failure path

    return to Brain
         |
         v
    Canvas is visible while its persisted document reloads
         |
         v
    Dashboard toggle is temporarily disabled
         |
         v
    old test clicked too early -> click dropped -> grid timeout

    new test: waitForEnabled -> click -> wait for grid

## Evidence

- Windows E2E run 30501605261, job 90742267409
- The artifact showed Dashboard and Canvas rendering correctly before the final post-navigation mode switch
- All four attempts failed at brain-overview.spec.ts:971 after the Canvas reload, not during initial rendering

## Verification

- git diff --check
- E2E TypeScript project check accepted this file; it still reports only the existing unrelated updater-harness, pipes, and SCK recovery errors

No product/runtime behavior changes.