### PR TITLE
fix(audio): correct i16/i32 sample-to-float conversion (bytemuck cast → numeric divide)

### DIFF
--- a/screenpipe-audio/src/core.rs
+++ b/screenpipe-audio/src/core.rs
@@ -476,7 +476,8 @@ impl AudioStream {
                     .build_input_stream(
                         &config.into(),
                         move |data: &[i16], _: &_| {
-                            let mono = audio_to_mono(bytemuck::cast_slice(data), channels);
+                            let float_data: Vec<f32> = data.iter().map(|&s| s as f32 / i16::MAX as f32).collect();
+                            let mono = audio_to_mono(&float_data, channels);
                             let _ = tx.send(mono);
                         },
                         error_callback,
@@ -487,7 +488,8 @@ impl AudioStream {
                     .build_input_stream(
                         &config.into(),
                         move |data: &[i32], _: &_| {
-                            let mono = audio_to_mono(bytemuck::cast_slice(data), channels);
+                            let float_data: Vec<f32> = data.iter().map(|&s| s as f32 / i32::MAX as f32).collect();
+                            let mono = audio_to_mono(&float_data, channels);
                             let _ = tx.send(mono);
                         },
                         error_callback,


### PR DESCRIPTION
## Problem

`bytemuck::cast_slice` performs a **bit reinterpretation**, not a numeric conversion. When audio devices output `I32` or `I16` PCM samples (which is common — e.g. RØDE Connect Stream reports `32-bit Signed Integer PCM` via CoreAudio), the raw integer bytes are recast as `f32` bit patterns.

A speech sample at `i32 = 1_000_000_000` (0x3B9ACA00) is reinterpreted as `f32 ≈ 0.005` — near silent. Silero VAD sees silence for every chunk and returns `speech_frames: 0` indefinitely, even with active speech on the device.

The `I16` branch has the same issue and additionally changes the sample count (`size_of::<i16>() = 2` bytes reinterpreted as `size_of::<f32>() = 4` bytes = half as many samples).

## Fix

Divide by `i32::MAX` / `i16::MAX` to produce properly normalized `[-1.0, 1.0]` float samples before calling `audio_to_mono`.

```rust
// Before (bit reinterpretation — wrong):
let mono = audio_to_mono(bytemuck::cast_slice(data), channels);

// After (numeric conversion — correct):
let float_data: Vec<f32> = data.iter().map(|&s| s as f32 / i32::MAX as f32).collect();
let mono = audio_to_mono(&float_data, channels);
```

The `F32` and `I8` branches are not modified.

## Reproduction

Any device that CoreAudio reports as `SampleFormat::I32` or `SampleFormat::I16` will have `speech_frames: 0` in logs regardless of microphone activity. Check with `sox -t coreaudio "<device>" -n stat` to confirm the device outputs integer PCM.