### PR TITLE
fix(meetings): stop live transcript stall notification firing on silence

### DIFF
--- a/crates/screenpipe-audio/src/meeting_streaming/controller.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/controller.rs
@@ -938,7 +938,10 @@ mod tests {
     }
 
     /// Frame of constant-amplitude samples, so RMS equals `amplitude`.
-    fn test_frame(amplitude: f32, device_type: crate::core::device::DeviceType) -> MeetingAudioFrame {
+    fn test_frame(
+        amplitude: f32,
+        device_type: crate::core::device::DeviceType,
+    ) -> MeetingAudioFrame {
         MeetingAudioFrame {
             samples: Arc::new(vec![amplitude; 480]),
             device_name: "test device".to_string(),
@@ -972,19 +975,28 @@ mod tests {
         assert!(session.has_recent_voiced_audio(spoke_at));
 
         // The stamp ages out of the recency window rather than latching on.
-        assert!(!session
-            .has_recent_voiced_audio(spoke_at + STALL_VOICED_AUDIO_RECENCY + Duration::from_secs(1)));
+        assert!(!session.has_recent_voiced_audio(
+            spoke_at + STALL_VOICED_AUDIO_RECENCY + Duration::from_secs(1)
+        ));
 
         // Output taps use a lower floor than mics (system audio is quieter at
         // the tap), so the same amplitude counts as speech on one and not the
         // other. A regression here silently changes which meetings can warn.
         let quiet = 0.005;
         let mut output_session = test_session(now, true);
-        note_audio_frame(&mut output_session, &test_frame(quiet, DeviceType::Output), now);
+        note_audio_frame(
+            &mut output_session,
+            &test_frame(quiet, DeviceType::Output),
+            now,
+        );
         assert!(output_session.last_voiced_audio_at.is_some());
 
         let mut input_session = test_session(now, true);
-        note_audio_frame(&mut input_session, &test_frame(quiet, DeviceType::Input), now);
+        note_audio_frame(
+            &mut input_session,
+            &test_frame(quiet, DeviceType::Input),
+            now,
+        );
         assert!(input_session.last_voiced_audio_at.is_none());
 
         // Empty frames are counted but never treated as speech.

--- a/crates/screenpipe-audio/src/meeting_streaming/controller.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/controller.rs
@@ -237,13 +237,7 @@ pub fn start_meeting_streaming_loop(
                     match frame {
                         Ok(frame) => {
                             if let Some(session) = active.as_mut() {
-                                session.audio_frames_seen += 1;
-                                session.audio_samples_seen += frame.samples.len() as u64;
-                                if frame_has_audio_activity(&frame) {
-                                    let now = Instant::now();
-                                    session.last_audio_activity_at = now;
-                                    session.last_voiced_audio_at = Some(now);
-                                }
+                                note_audio_frame(session, &frame, Instant::now());
                                 if session.live_transcription_enabled {
                                     route_frame_to_provider(
                                         &audio_tap,
@@ -700,6 +694,19 @@ fn device_stream_key(frame: &MeetingAudioFrame) -> String {
     format!("{}::{}", frame.device_name, device_type)
 }
 
+/// Fold one captured frame into the session's audio counters, stamping the
+/// voice-activity clock when the frame carries speech. Split out of the
+/// coordinator's `select!` arm so the stall detector's inputs are testable —
+/// the recency check is only as good as this timestamp being written.
+fn note_audio_frame(session: &mut ActiveMeetingStream, frame: &MeetingAudioFrame, now: Instant) {
+    session.audio_frames_seen += 1;
+    session.audio_samples_seen += frame.samples.len() as u64;
+    if frame_has_audio_activity(frame) {
+        session.last_audio_activity_at = now;
+        session.last_voiced_audio_at = Some(now);
+    }
+}
+
 fn frame_has_audio_activity(frame: &MeetingAudioFrame) -> bool {
     if frame.samples.is_empty() {
         return false;
@@ -928,6 +935,65 @@ mod tests {
     fn test_audio_tap() -> MeetingAudioTap {
         let (tx, _) = broadcast::channel(8);
         MeetingAudioTap::new(tx, Arc::new(std::sync::atomic::AtomicBool::new(false)))
+    }
+
+    /// Frame of constant-amplitude samples, so RMS equals `amplitude`.
+    fn test_frame(amplitude: f32, device_type: crate::core::device::DeviceType) -> MeetingAudioFrame {
+        MeetingAudioFrame {
+            samples: Arc::new(vec![amplitude; 480]),
+            device_name: "test device".to_string(),
+            device_type,
+            sample_rate: 16_000,
+            channels: 1,
+            captured_at_unix_ms: 0,
+        }
+    }
+
+    #[test]
+    fn note_audio_frame_stamps_voice_clock_only_for_speech() {
+        use crate::core::device::DeviceType;
+
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+
+        // Silence advances the counters but must not stamp the voice clock —
+        // that is what keeps the stall notification off silent meetings.
+        note_audio_frame(&mut session, &test_frame(0.0, DeviceType::Output), now);
+        assert_eq!(session.audio_frames_seen, 1);
+        assert_eq!(session.audio_samples_seen, 480);
+        assert!(session.last_voiced_audio_at.is_none());
+        assert!(!session.has_recent_voiced_audio(now));
+
+        // Speech stamps it, and the stamp is the time the frame arrived.
+        let spoke_at = now + Duration::from_secs(5);
+        note_audio_frame(&mut session, &test_frame(0.3, DeviceType::Output), spoke_at);
+        assert_eq!(session.audio_frames_seen, 2);
+        assert_eq!(session.last_voiced_audio_at, Some(spoke_at));
+        assert!(session.has_recent_voiced_audio(spoke_at));
+
+        // The stamp ages out of the recency window rather than latching on.
+        assert!(!session
+            .has_recent_voiced_audio(spoke_at + STALL_VOICED_AUDIO_RECENCY + Duration::from_secs(1)));
+
+        // Output taps use a lower floor than mics (system audio is quieter at
+        // the tap), so the same amplitude counts as speech on one and not the
+        // other. A regression here silently changes which meetings can warn.
+        let quiet = 0.005;
+        let mut output_session = test_session(now, true);
+        note_audio_frame(&mut output_session, &test_frame(quiet, DeviceType::Output), now);
+        assert!(output_session.last_voiced_audio_at.is_some());
+
+        let mut input_session = test_session(now, true);
+        note_audio_frame(&mut input_session, &test_frame(quiet, DeviceType::Input), now);
+        assert!(input_session.last_voiced_audio_at.is_none());
+
+        // Empty frames are counted but never treated as speech.
+        let mut empty_session = test_session(now, true);
+        let mut empty = test_frame(0.5, DeviceType::Output);
+        empty.samples = Arc::new(Vec::new());
+        note_audio_frame(&mut empty_session, &empty, now);
+        assert_eq!(empty_session.audio_frames_seen, 1);
+        assert!(empty_session.last_voiced_audio_at.is_none());
     }
 
     // `check_and_emit_stall_notifications` calls `screenpipe_events::send_event`,

--- a/crates/screenpipe-audio/src/meeting_streaming/controller.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/controller.rs
@@ -42,6 +42,11 @@ const LIVE_COVERAGE_WINDOW_SECS: f64 = 15.0;
 /// looks broken" notification (once per session, per condition) so the user
 /// doesn't sit through a silent meeting wondering why nothing is appearing.
 const STALL_NOTIFY_THRESHOLD: Duration = Duration::from_secs(60);
+/// How recently voiced audio must have arrived for a missing transcript to
+/// count as a stall. Sized above `LIVE_INACTIVITY_CHECK_INTERVAL` so voiced
+/// audio landing anywhere between two checks still counts — otherwise the
+/// notification would depend on where the tick happened to fall.
+const STALL_VOICED_AUDIO_RECENCY: Duration = Duration::from_secs(45);
 
 #[derive(Debug)]
 struct ActiveMeetingStream {
@@ -53,18 +58,27 @@ struct ActiveMeetingStream {
     audio_frames_seen: u64,
     audio_samples_seen: u64,
     last_audio_activity_at: Instant,
-    // Latched true the first time a frame's RMS clears the voice-activity
-    // threshold. Used to suppress the "transcript not flowing" notification
-    // when the room is just silent (e.g. user alone waiting for others to
-    // join) — no transcript is expected from silence, so warning the user is
-    // a false positive.
-    voiced_audio_seen: bool,
+    // When a frame's RMS last cleared the voice-activity threshold. Gates the
+    // "transcript not flowing" notification: silence produces no transcript by
+    // design, so warning about it is a false positive. Tracked as a timestamp
+    // rather than a latched bool because a meeting that had speech and then
+    // went quiet is still silence — the latch kept firing on it.
+    last_voiced_audio_at: Option<Instant>,
     live_transcript_seen: bool,
     last_live_transcript_at: Option<Instant>,
     notified_audio_stall: bool,
     notified_transcript_stall: bool,
     device_senders: HashMap<String, mpsc::Sender<MeetingAudioFrame>>,
     device_retry_after: HashMap<String, Instant>,
+}
+
+impl ActiveMeetingStream {
+    /// Whether speech-level audio arrived recently enough that a missing
+    /// transcript means something is broken rather than that nobody is talking.
+    fn has_recent_voiced_audio(&self, now: Instant) -> bool {
+        self.last_voiced_audio_at
+            .is_some_and(|at| now.duration_since(at) <= STALL_VOICED_AUDIO_RECENCY)
+    }
 }
 
 /// Start the meeting-streaming lifecycle coordinator.
@@ -226,8 +240,9 @@ pub fn start_meeting_streaming_loop(
                                 session.audio_frames_seen += 1;
                                 session.audio_samples_seen += frame.samples.len() as u64;
                                 if frame_has_audio_activity(&frame) {
-                                    session.last_audio_activity_at = Instant::now();
-                                    session.voiced_audio_seen = true;
+                                    let now = Instant::now();
+                                    session.last_audio_activity_at = now;
+                                    session.last_voiced_audio_at = Some(now);
                                 }
                                 if session.live_transcription_enabled {
                                     route_frame_to_provider(
@@ -335,7 +350,7 @@ async fn start_streaming_session(
         audio_frames_seen: 0,
         audio_samples_seen: 0,
         last_audio_activity_at: Instant::now(),
-        voiced_audio_seen: false,
+        last_voiced_audio_at: None,
         live_transcript_seen: false,
         last_live_transcript_at: None,
         notified_audio_stall: false,
@@ -735,7 +750,7 @@ fn check_and_emit_stall_notifications(session: &mut ActiveMeetingStream, now: In
         );
     } else if !session.notified_transcript_stall
         && session.audio_frames_seen > 0
-        && session.voiced_audio_seen
+        && session.has_recent_voiced_audio(now)
         && !session.live_transcript_seen
     {
         session.notified_transcript_stall = true;
@@ -900,7 +915,7 @@ mod tests {
             audio_frames_seen: 0,
             audio_samples_seen: 0,
             last_audio_activity_at: now,
-            voiced_audio_seen: false,
+            last_voiced_audio_at: None,
             live_transcript_seen: false,
             last_live_transcript_at: None,
             notified_audio_stall: false,
@@ -939,7 +954,7 @@ mod tests {
         // is the field itself, not a flag we manage from outside).
         let mut session = test_session(now, true);
         session.audio_frames_seen = 42;
-        session.voiced_audio_seen = true;
+        session.last_voiced_audio_at = Some(now + STALL_NOTIFY_THRESHOLD);
         check_and_emit_stall_notifications(&mut session, now + STALL_NOTIFY_THRESHOLD);
         assert!(!session.notified_audio_stall);
         assert!(session.notified_transcript_stall);
@@ -953,10 +968,40 @@ mod tests {
         // there is nothing to transcribe, so warning them is a false positive.
         let mut session = test_session(now, true);
         session.audio_frames_seen = 200;
-        // voiced_audio_seen stays false
+        // last_voiced_audio_at stays None
         check_and_emit_stall_notifications(&mut session, now + STALL_NOTIFY_THRESHOLD * 3);
         assert!(!session.notified_audio_stall);
         assert!(!session.notified_transcript_stall);
+
+        // Speech happened, then the room went quiet past the recency window —
+        // still a false positive. The meeting is silent now, so the absent
+        // transcript says nothing about whether the provider is healthy.
+        let mut session = test_session(now, true);
+        session.audio_frames_seen = 5_000;
+        let last_speech = now + STALL_NOTIFY_THRESHOLD / 2;
+        session.last_voiced_audio_at = Some(last_speech);
+        check_and_emit_stall_notifications(
+            &mut session,
+            last_speech + STALL_VOICED_AUDIO_RECENCY + Duration::from_secs(1),
+        );
+        assert!(!session.notified_transcript_stall);
+
+        // Same session once speech resumes — now it fires, because voiced audio
+        // is producing no transcript in the present.
+        session.last_voiced_audio_at = Some(now + STALL_NOTIFY_THRESHOLD * 2);
+        check_and_emit_stall_notifications(&mut session, now + STALL_NOTIFY_THRESHOLD * 2);
+        assert!(session.notified_transcript_stall);
+
+        // Voiced audio anywhere inside the check interval still counts, so the
+        // notification never depends on where the 30s tick happens to land.
+        let mut session = test_session(now, true);
+        session.audio_frames_seen = 5_000;
+        session.last_voiced_audio_at = Some(now + STALL_NOTIFY_THRESHOLD);
+        check_and_emit_stall_notifications(
+            &mut session,
+            now + STALL_NOTIFY_THRESHOLD + LIVE_INACTIVITY_CHECK_INTERVAL,
+        );
+        assert!(session.notified_transcript_stall);
 
         // Pure background sessions (no live transcription) never fire — their
         // audio tap is intentionally inactive so audio_frames_seen=0 is


### PR DESCRIPTION
### Description:

- `voiced_audio_seen` latched `true` for the rest of the session on the first frame that cleared the VAD threshold, so any meeting with speech early on kept satisfying the transcript-stall condition through arbitrarily long silences afterwards.
- Result: someone who speaks once and then sits quiet gets a "live transcript not flowing" notification at the 60s mark, about audio that had nothing in it to transcribe. The existing silence guard only covered meetings that were silent from the very start.
- Now tracks when speech last arrived (`last_voiced_audio_at`) and requires it within 45s of the check, so the notification describes the present rather than something that happened a minute ago.
- 45s is deliberately above the 30s inactivity tick, so speech landing anywhere between two checks still counts and the notification never depends on where the tick happens to fall.
- Genuine stalls are unaffected: when a provider is broken and someone is actually talking, speech keeps arriving and the notification still fires. A stall that starts during a pause is only delayed to the next tick, not suppressed — the once-per-session latch is untouched.
- Test covers the regression directly (speech, then quiet past the window → no notification; speech resumes → fires) and fails against the old latched behaviour.

Ref #5543