### PR TITLE
[codex] simplify Live View action hierarchy

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -163,7 +163,16 @@ import {
 
 beforeAll(() => {
   Element.prototype.scrollIntoView ||= () => {};
+  globalThis.PointerEvent ||= MouseEvent as typeof PointerEvent;
 });
+
+async function openDashboardMenu(): Promise<void> {
+  fireEvent.pointerDown(await screen.findByTestId("overview-dashboard-menu"), {
+    button: 0,
+    ctrlKey: false,
+    pointerType: "mouse",
+  });
+}
 
 function setDocumentVisibility(state: "visible" | "hidden"): () => void {
   const original = Object.getOwnPropertyDescriptor(
@@ -678,6 +687,7 @@ describe("BrainOverview", () => {
     }));
     render(<BrainOverview />);
 
+    await openDashboardMenu();
     fireEvent.click(await screen.findByTestId("overview-new-dashboard"));
     const createDialog = await screen.findByTestId(
       "live-view-create-dashboard-dialog",
@@ -730,6 +740,7 @@ describe("BrainOverview", () => {
     });
     render(<BrainOverview />);
 
+    await openDashboardMenu();
     fireEvent.click(await screen.findByTestId("overview-new-dashboard"));
     const createDialog = await screen.findByTestId(
       "live-view-create-dashboard-dialog",
@@ -784,7 +795,7 @@ describe("BrainOverview", () => {
     expect(generationProperties).not.toHaveProperty("prompt");
   });
 
-  it("keeps one stable visible refresh label while data is loading", async () => {
+  it("keeps one stable refresh control while data is loading", async () => {
     mocks.listBrainViews.mockResolvedValue({
       status: "ok",
       data: [populatedView],
@@ -797,7 +808,7 @@ describe("BrainOverview", () => {
       name: "loading data",
     });
     expect(loadingButton).toBeDisabled();
-    expect(loadingButton.textContent).toBe("refresh data");
+    expect(loadingButton.textContent).toBe("");
     expect(screen.queryByText("loading data")).toBeNull();
   });
 
@@ -840,7 +851,7 @@ describe("BrainOverview", () => {
     expect(JSON.stringify(properties)).not.toContain("private failure detail");
   });
 
-  it("keeps the dashboard controls aligned as one responsive control group", async () => {
+  it("keeps primary controls visible and moves setup actions into More", async () => {
     mocks.listBrainViews.mockResolvedValue({
       status: "ok",
       data: [populatedView],
@@ -856,8 +867,20 @@ describe("BrainOverview", () => {
       "h-9",
     );
     expect(screen.getByTestId("overview-refresh-data").className).toContain(
-      "h-9",
+      "w-9",
     );
+    expect(screen.getByTestId("overview-refresh-data").textContent).toBe("");
+    expect(screen.queryByTestId("overview-edit")).toBeNull();
+    const prompt = screen.getByTestId(
+      "live-view-ai-prompt",
+    ) as HTMLTextAreaElement;
+    expect(prompt.rows).toBe(1);
+    expect(screen.queryByTestId("live-view-ai-options")).toBeNull();
+    fireEvent.focus(prompt);
+    expect(screen.getByTestId("live-view-ai-options")).toBeTruthy();
+
+    await openDashboardMenu();
+    expect(await screen.findByTestId("overview-new-dashboard")).toBeTruthy();
     expect(screen.getByTestId("overview-edit").textContent).toContain(
       "customize",
     );
@@ -879,13 +902,12 @@ describe("BrainOverview", () => {
     await screen.findByTestId("overview-dashboard-selector");
     expect(screen.queryByTestId("overview-fixed-period")).toBeNull();
     expect(screen.queryByTestId("overview-time-range")).toBeNull();
-    expect(
-      screen.getByText(
-        /Pipes fill these Blocks for today\. Data changes when you refresh or a connected Pipe runs\./,
-      ),
-    ).toBeTruthy();
+    expect(screen.getByTestId("overview-data-status").textContent).toMatch(
+      /^Updated /,
+    );
 
-    fireEvent.click(screen.getByTestId("overview-edit"));
+    await openDashboardMenu();
+    fireEvent.click(await screen.findByTestId("overview-edit"));
     expect(screen.queryByText("Time window")).toBeNull();
   });
 
@@ -971,9 +993,9 @@ describe("BrainOverview", () => {
     fireEvent.change(selector, { target: { value: otherView.id } });
 
     await waitFor(() => expect(selector.value).toBe(otherView.id));
-    expect(
-      screen.getByText(/Pipes fill these Blocks for last 30 days/),
-    ).toBeTruthy();
+    expect(screen.getByTestId("overview-data-status").textContent).toBe(
+      "No data yet",
+    );
   });
 
   it("keeps vertical scrolling on the dashboard while dense tables can scroll sideways", async () => {
@@ -1163,6 +1185,7 @@ describe("BrainOverview", () => {
     }));
     render(<BrainOverview />);
 
+    await openDashboardMenu();
     fireEvent.click(await screen.findByTestId("overview-edit"));
     expect(screen.getByText("4.5")).toBeTruthy();
     fireEvent.keyDown(screen.getByTestId("overview-drag-focus-time"), {
@@ -1226,6 +1249,7 @@ describe("BrainOverview", () => {
     }));
     render(<BrainOverview />);
 
+    await openDashboardMenu();
     fireEvent.click(await screen.findByTestId("overview-edit"));
     const target = screen.getByTestId("overview-editor-card-second-block");
     const originalElementFromPoint = document.elementFromPoint;
@@ -1314,6 +1338,7 @@ describe("BrainOverview", () => {
     }));
     render(<BrainOverview />);
 
+    await openDashboardMenu();
     fireEvent.click(await screen.findByTestId("overview-templates"));
     expect(await screen.findByText("Starter templates")).toBeTruthy();
     expect(screen.getByText("Sets up 2 built-in helpers")).toBeTruthy();
@@ -1614,8 +1639,7 @@ describe("BrainOverview", () => {
       expect(mocks.generateLiveViewWithPi).toHaveBeenCalledTimes(1),
     );
     expect(screen.getByTestId("overview-dashboard-selector")).toBeDisabled();
-    expect(screen.getByTestId("overview-new-dashboard")).toBeDisabled();
-    expect(screen.getByTestId("overview-edit")).toBeDisabled();
+    expect(screen.getByTestId("overview-dashboard-menu")).toBeDisabled();
 
     await act(async () => {
       finishGeneration?.({
@@ -1678,6 +1702,7 @@ describe("BrainOverview", () => {
     }));
     render(<BrainOverview />);
 
+    await openDashboardMenu();
     fireEvent.click(await screen.findByTestId("overview-new-dashboard"));
     const dialog = await screen.findByTestId(
       "live-view-create-dashboard-dialog",
@@ -2185,6 +2210,7 @@ describe("BrainOverview", () => {
     }));
     const firstRender = render(<BrainOverview />);
 
+    fireEvent.focus(await screen.findByTestId("live-view-ai-prompt"));
     const modelSelector = await screen.findByTestId("model-selector");
     expect(modelSelector.textContent).toBe("auto");
     fireEvent.click(modelSelector);
@@ -2211,6 +2237,7 @@ describe("BrainOverview", () => {
 
     firstRender.unmount();
     render(<BrainOverview />);
+    fireEvent.focus(await screen.findByTestId("live-view-ai-prompt"));
     await waitFor(() =>
       expect(screen.getByTestId("model-selector").textContent).toBe("quality"),
     );

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-dashboard-switcher.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-dashboard-switcher.test.tsx
@@ -34,9 +34,11 @@ const dashboards: BrainViewDefinition[] = [
 ];
 
 describe("LiveViewDashboardSwitcher", () => {
-  it("switches, creates, renames, duplicates, and confirms deletion", async () => {
+  it("keeps management actions in More", async () => {
     const onSelect = vi.fn();
     const onCreate = vi.fn();
+    const onCustomize = vi.fn();
+    const onOpenTemplates = vi.fn();
     const onRename = vi.fn();
     const onDuplicate = vi.fn();
     const onDelete = vi.fn();
@@ -47,6 +49,8 @@ describe("LiveViewDashboardSwitcher", () => {
         busy={false}
         onSelect={onSelect}
         onCreate={onCreate}
+        onCustomize={onCustomize}
+        onOpenTemplates={onOpenTemplates}
         onRename={onRename}
         onDuplicate={onDuplicate}
         onDelete={onDelete}
@@ -60,8 +64,30 @@ describe("LiveViewDashboardSwitcher", () => {
     fireEvent.change(selector, { target: { value: "weekly-review" } });
     expect(onSelect).toHaveBeenCalledWith("weekly-review");
 
-    fireEvent.click(screen.getByTestId("overview-new-dashboard"));
+    expect(screen.queryByTestId("overview-new-dashboard")).toBeNull();
+    fireEvent.pointerDown(screen.getByTestId("overview-dashboard-menu"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    fireEvent.click(await screen.findByTestId("overview-new-dashboard"));
     expect(onCreate).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerDown(screen.getByTestId("overview-dashboard-menu"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    fireEvent.click(await screen.findByTestId("overview-edit"));
+    expect(onCustomize).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerDown(screen.getByTestId("overview-dashboard-menu"), {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
+    fireEvent.click(await screen.findByTestId("overview-templates"));
+    expect(onOpenTemplates).toHaveBeenCalledTimes(1);
 
     fireEvent.pointerDown(screen.getByTestId("overview-dashboard-menu"), {
       button: 0,

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -17,11 +17,9 @@ import {
   AlertCircle,
   CheckCircle2,
   LayoutDashboard,
-  LayoutTemplate,
   Loader2,
   Network,
   RefreshCw,
-  SlidersHorizontal,
   Undo2,
   X,
 } from "lucide-react";
@@ -2555,9 +2553,6 @@ export function BrainOverview({
   const slots = normalizedSlots(view.slots);
   const boundSlotCount = slots.filter((slot) => slot.binding).length;
   const periodRanges = allowedLiveViewTimeRanges(view.periodPolicy);
-  const selectedPeriod =
-    periodRanges.find((range) => range.value === view.timeRange) ??
-    getLiveViewTimeRangeOption(view.timeRange);
   const latestDataTimestamp = slots.reduce<number | null>((latest, slot) => {
     const timestamp = slot.value?.updatedAt
       ? Date.parse(slot.value.updatedAt)
@@ -2594,6 +2589,12 @@ export function BrainOverview({
             selectionDisabled={dashboardSelectionDisabled}
             onSelect={selectDashboard}
             onCreate={beginCreate}
+            onCustomize={onboardingColdStart ? undefined : beginEdit}
+            onOpenTemplates={
+              !onboardingColdStart && templateKits.length > 0
+                ? () => setTemplateGalleryOpen(true)
+                : undefined
+            }
             onRename={renameDashboard}
             onDuplicate={duplicateDashboard}
             onDelete={deleteDashboard}
@@ -2609,15 +2610,15 @@ export function BrainOverview({
             }
             onCreateBlank={beginManualCreate}
           />
-          <p className="mt-2 text-xs text-muted-foreground">
+          <p
+            data-testid="overview-data-status"
+            className="mt-2 text-xs text-muted-foreground"
+          >
             {onboardingColdStart
               ? "This view will appear when Screenpipe has enough real activity for your outcome."
-              : `Pipes fill these Blocks for ${selectedPeriod.label.toLowerCase()}. Data changes when you refresh or a connected Pipe runs.`}
-            {latestDataTimestamp !== null && (
-              <span className="ml-1">
-                Last data {new Date(latestDataTimestamp).toLocaleString()}.
-              </span>
-            )}
+              : latestDataTimestamp !== null
+                ? `Updated ${new Date(latestDataTimestamp).toLocaleString()}`
+                : "No data yet"}
           </p>
         </div>
         <div
@@ -2697,46 +2698,22 @@ export function BrainOverview({
               </SelectContent>
             </Select>
           )}
-          {!onboardingColdStart && templateKits.length > 0 && (
-            <Button
-              data-testid="overview-templates"
-              variant="outline"
-              size="sm"
-              className="h-9 flex-1 rounded-none px-3 sm:flex-none"
-              disabled={dashboardBusy}
-              onClick={() => setTemplateGalleryOpen((open) => !open)}
-            >
-              <LayoutTemplate className="mr-1.5 h-3.5 w-3.5" /> templates
-            </Button>
-          )}
           {boundSlotCount > 0 && !onboardingColdStart && (
             <Button
               data-testid="overview-refresh-data"
               variant="outline"
-              size="sm"
-              className="h-9 flex-1 rounded-none px-3 sm:flex-none"
+              size="icon"
+              className="h-9 w-9 shrink-0 rounded-none"
               aria-label={refreshIsActive ? "loading data" : "refresh data"}
+              title={refreshIsActive ? "loading data" : "refresh data"}
               disabled={dashboardBusy}
               onClick={() => void refreshConnectedPipes(view)}
             >
               <RefreshCw
-                className={`mr-1.5 h-3.5 w-3.5 ${
+                className={`h-3.5 w-3.5 ${
                   refreshIsActive ? "animate-spin" : ""
                 }`}
               />
-              <span aria-hidden="true">refresh data</span>
-            </Button>
-          )}
-          {!onboardingColdStart && (
-            <Button
-              data-testid="overview-edit"
-              variant="outline"
-              size="sm"
-              className="h-9 flex-1 rounded-none px-3 sm:flex-none"
-              disabled={dashboardBusy}
-              onClick={beginEdit}
-            >
-              <SlidersHorizontal className="mr-1.5 h-3.5 w-3.5" /> customize
             </Button>
           )}
         </div>

--- a/apps/screenpipe-app-tauri/components/settings/live-view-ai-composer.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-ai-composer.tsx
@@ -75,6 +75,7 @@ export function LiveViewAiComposer({
   );
   const [prompt, setPrompt] = useState("");
   const [generationStep, setGenerationStep] = useState(0);
+  const [compactFocused, setCompactFocused] = useState(false);
 
   useEffect(() => {
     if (!busy) return;
@@ -90,6 +91,8 @@ export function LiveViewAiComposer({
     (preset) => preset.id === selectedPresetId,
   );
   const canSubmit = Boolean(prompt.trim() && selectedPreset && !busy);
+  const compactExpanded =
+    compact && (compactFocused || Boolean(prompt.trim()) || busy);
   const intent = inferLiveViewGenerationIntent(
     prompt,
     Boolean(currentViewTitle),
@@ -103,6 +106,11 @@ export function LiveViewAiComposer({
       : intent === "replace-dashboard"
         ? `will edit “${currentViewTitle}”`
         : "will create a new dashboard";
+  const actionLabel = busy
+    ? "creating"
+    : intent === "pipe-agent"
+      ? "open agent"
+      : "generate";
 
   const submit = () => {
     if (!canSubmit || !selectedPreset) return;
@@ -113,6 +121,9 @@ export function LiveViewAiComposer({
   return (
     <div
       data-testid="live-view-ai-composer"
+      onFocusCapture={() => {
+        if (compact) setCompactFocused(true);
+      }}
       className={
         compact
           ? "border border-border bg-background"
@@ -127,70 +138,124 @@ export function LiveViewAiComposer({
           </p>
         </div>
       )}
-      <Textarea
-        data-testid="live-view-ai-prompt"
-        autoFocus={autoFocus}
-        value={prompt}
-        disabled={busy}
-        rows={compact ? 2 : 3}
-        maxLength={1_500}
-        className="min-h-16 resize-none rounded-none border-0 px-4 py-3 text-sm shadow-none focus-visible:ring-0"
-        placeholder={
-          compact
-            ? "Ask AI to change this Live View..."
-            : "For example: show how I spend my time and what changed this week"
-        }
-        onChange={(event) => setPrompt(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && !event.shiftKey) {
-            event.preventDefault();
-            submit();
-          }
-        }}
-      />
-      <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border px-2 py-2">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <AIPresetsSelector
-            controlledPresetId={selectedPresetId}
-            onControlledSelect={onSelectedPresetIdChange}
+      <div className={compact ? "flex items-stretch" : undefined}>
+        <Textarea
+          data-testid="live-view-ai-prompt"
+          autoFocus={autoFocus}
+          value={prompt}
+          disabled={busy}
+          rows={compactExpanded ? 2 : compact ? 1 : 3}
+          maxLength={1_500}
+          className={
             compact
-            showModelOnly
-            showLoginCta
-            containerClassName="w-auto min-w-36"
-            triggerClassName="h-8 rounded-none"
-          />
-          {prompt.trim() && (
-            <span
-              data-testid="live-view-generation-intent"
-              className="max-w-72 truncate text-[11px] text-muted-foreground"
-            >
-              {intentLabel}
-            </span>
-          )}
-        </div>
-        <Button
-          data-testid="live-view-ai-generate"
-          type="button"
-          size="sm"
-          className="h-8 rounded-none"
-          disabled={!canSubmit}
-          onClick={submit}
-        >
-          {busy ? (
-            <>
-              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              <span>creating</span>
-            </>
-          ) : (
-            <>
-              <span className="mr-1.5">
-                {intent === "pipe-agent" ? "open agent" : "generate"}
-              </span>
+              ? `resize-none rounded-none border-0 px-4 text-sm shadow-none transition-[min-height] duration-150 focus-visible:ring-0 ${
+                  compactExpanded ? "min-h-16 py-3" : "h-10 min-h-10 py-2.5"
+                }`
+              : "min-h-16 resize-none rounded-none border-0 px-4 py-3 text-sm shadow-none focus-visible:ring-0"
+          }
+          placeholder={
+            compact
+              ? "Ask AI to change this Live View..."
+              : "For example: show how I spend my time and what changed this week"
+          }
+          onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              submit();
+            }
+          }}
+        />
+        {compact && (
+          <Button
+            data-testid="live-view-ai-generate"
+            type="button"
+            size="icon"
+            className="h-10 w-10 shrink-0 rounded-none"
+            aria-label={actionLabel}
+            title={actionLabel}
+            disabled={!canSubmit}
+            onClick={submit}
+          >
+            {busy ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
               <ArrowUp className="h-3.5 w-3.5" />
-            </>
-          )}
-        </Button>
+            )}
+            <span className="sr-only">{actionLabel}</span>
+          </Button>
+        )}
       </div>
+      {compact ? (
+        compactExpanded && (
+          <div
+            data-testid="live-view-ai-options"
+            className="flex min-w-0 flex-wrap items-center gap-2 border-t border-border px-2 py-2"
+          >
+            <AIPresetsSelector
+              controlledPresetId={selectedPresetId}
+              onControlledSelect={onSelectedPresetIdChange}
+              compact
+              showModelOnly
+              showLoginCta
+              containerClassName="w-auto min-w-36"
+              triggerClassName="h-8 rounded-none"
+            />
+            {prompt.trim() && (
+              <span
+                data-testid="live-view-generation-intent"
+                className="max-w-72 truncate text-[11px] text-muted-foreground"
+              >
+                {intentLabel}
+              </span>
+            )}
+          </div>
+        )
+      ) : (
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-border px-2 py-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <AIPresetsSelector
+              controlledPresetId={selectedPresetId}
+              onControlledSelect={onSelectedPresetIdChange}
+              compact
+              showModelOnly
+              showLoginCta
+              containerClassName="w-auto min-w-36"
+              triggerClassName="h-8 rounded-none"
+            />
+            {prompt.trim() && (
+              <span
+                data-testid="live-view-generation-intent"
+                className="max-w-72 truncate text-[11px] text-muted-foreground"
+              >
+                {intentLabel}
+              </span>
+            )}
+          </div>
+          <Button
+            data-testid="live-view-ai-generate"
+            type="button"
+            size="sm"
+            className="h-8 rounded-none"
+            disabled={!canSubmit}
+            onClick={submit}
+          >
+            {busy ? (
+              <>
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                <span>creating</span>
+              </>
+            ) : (
+              <>
+                <span className="mr-1.5">
+                  {intent === "pipe-agent" ? "open agent" : "generate"}
+                </span>
+                <ArrowUp className="h-3.5 w-3.5" />
+              </>
+            )}
+          </Button>
+        </div>
+      )}
       {busy && (
         <div
           data-testid="live-view-generation-progress"

--- a/apps/screenpipe-app-tauri/components/settings/live-view-dashboard-switcher.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-dashboard-switcher.tsx
@@ -4,7 +4,15 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import { Copy, MoreHorizontal, Pencil, Plus, Trash2 } from "lucide-react";
+import {
+  Copy,
+  LayoutTemplate,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  SlidersHorizontal,
+  Trash2,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -43,6 +51,8 @@ export function LiveViewDashboardSwitcher({
   selectionDisabled = busy,
   onSelect,
   onCreate,
+  onCustomize,
+  onOpenTemplates,
   onRename,
   onDuplicate,
   onDelete,
@@ -53,6 +63,8 @@ export function LiveViewDashboardSwitcher({
   selectionDisabled?: boolean;
   onSelect: (id: string) => void;
   onCreate: () => void;
+  onCustomize?: () => void;
+  onOpenTemplates?: () => void;
   onRename: (title: string) => void | Promise<void>;
   onDuplicate: () => void | Promise<void>;
   onDelete: () => void | Promise<void>;
@@ -97,19 +109,6 @@ export function LiveViewDashboardSwitcher({
               </option>
             ))}
           </select>
-          <Button
-            data-testid="overview-new-dashboard"
-            type="button"
-            variant="outline"
-            size="icon"
-            className="h-9 w-9 shrink-0 rounded-none"
-            aria-label="create dashboard with AI"
-            title="create dashboard with AI"
-            disabled={busy || views.length >= MAX_DASHBOARDS}
-            onClick={onCreate}
-          >
-            <Plus className="h-3.5 w-3.5" />
-          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -119,12 +118,38 @@ export function LiveViewDashboardSwitcher({
                 size="icon"
                 className="h-9 w-9 shrink-0 rounded-none"
                 aria-label="dashboard actions"
+                title="dashboard actions"
                 disabled={busy}
               >
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-44 rounded-none">
+              <DropdownMenuItem
+                data-testid="overview-new-dashboard"
+                disabled={views.length >= MAX_DASHBOARDS}
+                onSelect={onCreate}
+              >
+                <Plus className="mr-2 h-3.5 w-3.5" /> new dashboard
+              </DropdownMenuItem>
+              {onCustomize && (
+                <DropdownMenuItem
+                  data-testid="overview-edit"
+                  onSelect={onCustomize}
+                >
+                  <SlidersHorizontal className="mr-2 h-3.5 w-3.5" />
+                  customize
+                </DropdownMenuItem>
+              )}
+              {onOpenTemplates && (
+                <DropdownMenuItem
+                  data-testid="overview-templates"
+                  onSelect={onOpenTemplates}
+                >
+                  <LayoutTemplate className="mr-2 h-3.5 w-3.5" /> templates
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
               <DropdownMenuItem onSelect={() => setRenameOpen(true)}>
                 <Pencil className="mr-2 h-3.5 w-3.5" /> rename
               </DropdownMenuItem>

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -90,6 +90,11 @@ async function selectDashboard(viewId: string) {
   );
 }
 
+async function openDashboardMenu() {
+  await pointerPressTestId("overview-dashboard-menu");
+  await waitForTestId("overview-new-dashboard", 10_000);
+}
+
 async function openHomeWithDiagnostics() {
   try {
     await openHomeWindow();
@@ -671,7 +676,8 @@ Refresh the assigned Live View output targets from source-backed activity.
     if (await collapseSidebar.isExisting()) {
       await collapseSidebar.click();
     }
-    const customize = await $("[data-testid='overview-edit']");
+    await openDashboardMenu();
+    const customize = await waitForTestId("overview-edit", 10_000);
     await customize.moveTo({
       xOffset: 10,
       yOffset: 10,
@@ -695,6 +701,7 @@ Refresh the assigned Live View output targets from source-backed activity.
     expect(selectedDashboardTitle).toBe("How I worked today");
     const screenshot = await saveScreenshot("brain-overview-pipe-filled");
     expect(existsSync(screenshot)).toBe(true);
+    await browser.keys(["Escape"]);
 
     const timeRange = await waitForTestId("overview-time-range", 10_000);
     await timeRange.click();
@@ -726,14 +733,13 @@ Refresh the assigned Live View output targets from source-backed activity.
     const fixedDashboardText = (await browser.execute(
       () => document.body?.innerText || "",
     )) as string;
-    expect(fixedDashboardText).toContain(
-      "Pipes fill these Blocks for today. Data changes when you refresh or a connected Pipe runs.",
-    );
+    expect(fixedDashboardText).toContain("Updated");
     const fixedScreenshot = await saveScreenshot(
       "brain-overview-fixed-range-hidden",
     );
     expect(existsSync(fixedScreenshot)).toBe(true);
 
+    await openDashboardMenu();
     const fixedCustomize = await waitForTestId("overview-edit", 10_000);
     await fixedCustomize.click();
     await waitForTestId("brain-overview-editor", 10_000);
@@ -978,7 +984,10 @@ Refresh the assigned Live View output targets from source-backed activity.
     await dashboardMode.click();
     await waitForTestId("brain-overview-grid", 10_000);
 
-    await $("[data-testid='overview-edit']").click();
+    await openDashboardMenu();
+    await waitForTestId("overview-edit", 10_000).then((element) =>
+      element.click(),
+    );
     await waitForTestId("brain-overview-editor", 10_000);
     const editorText = (await browser.execute(
       () => document.body?.innerText || "",


### PR DESCRIPTION
## description

Simplify the Live View header around one clear action hierarchy:

- keep dashboard/canvas, time range, refresh, and the AI command visible
- make refresh and AI submit compact icon actions with accessible labels
- move new, customize, templates, rename, duplicate, and delete into the existing More menu
- replace the instructional paragraph with a compact data freshness status
- collapse the AI editor to one line until it receives focus or text

This reduces the number of equally weighted controls without removing any existing capability.

Related issue: n/a

## before

```text
[ dashboard | canvas ] [ today ] [ templates ] [ refresh data ] [ customize ]

[ Ask AI to change this Live View...                                  ]
[ auto model                                      ] [ generate ↑ ]
```

## after

```text
DASHBOARDS 11/12
[ Todo Commitments Tracker ▾ ] [ ⋯ ]      [ dashboard | canvas ] [ today ] [ ↻ ]
Updated just now

[ Ask AI to change this Live View...                              ] [ ↑ ]

⋯  new dashboard
   customize
   templates
   ─────────────
   rename
   duplicate
   ─────────────
   delete
```

Focusing or typing in the AI command reveals its model and intent details.

## how to test

1. Open Brain → Live Views and confirm the AI command starts as one line.
2. Focus the command and confirm model/intent controls expand; submit still works with Enter or the arrow button.
3. Open the dashboard More menu and exercise New, Customize, Templates, Rename, Duplicate, and Delete.
4. Change the time range and refresh data; confirm the dashboard selector remains usable and freshness status updates.

## checks

- `bunx vitest run --config vitest.config.ts components/settings/__tests__/brain-overview.test.tsx components/settings/__tests__/live-view-dashboard-switcher.test.tsx` — 53 passed
- `bun run typecheck` — passed
- `bunx --bun @biomejs/biome check --write ...` — passed for the changed frontend files
- Native `brain-overview.spec.ts` was updated for the More-menu path but not executed locally.

## desktop app checklist

- [x] TypeScript-only UI change; no Tauri command or binding changes
- [x] `bun run typecheck`
