### PR TITLE
fix(audio): bound post-meeting native memory

### DIFF
--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -149,7 +149,7 @@ objc = { workspace = true }
 
 # Apple Silicon: bundle ONNX Runtime via the pyke prebuilt (arm64 xcframework).
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
-ort = { workspace = true, features = ["download-binaries", "tls-native"] }
+ort = { workspace = true, features = ["download-binaries", "tls-native", "coreml"] }
 
 # Intel mac: ort rc.12 ships no x86_64 prebuilt (pyke + upstream ONNX Runtime
 # are arm64-only since ~1.20). load-dynamic links against headers only and

--- a/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
+++ b/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
@@ -2430,6 +2430,31 @@ mod tests {
     }
 
     #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "parakeet-mlx"))]
+    fn physical_footprint_bytes() -> u64 {
+        let mut info: libc::rusage_info_v0 = unsafe { std::mem::zeroed() };
+        let result = unsafe {
+            libc::proc_pid_rusage(
+                std::process::id() as libc::c_int,
+                libc::RUSAGE_INFO_V0,
+                (&mut info as *mut libc::rusage_info_v0).cast(),
+            )
+        };
+        assert_eq!(result, 0, "proc_pid_rusage(RUSAGE_INFO_V0) failed");
+        info.ri_phys_footprint
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "parakeet-mlx"))]
+    fn release_allocator_pages() -> usize {
+        extern "C" {
+            fn malloc_zone_pressure_relief(zone: *mut std::ffi::c_void, goal: usize) -> usize;
+        }
+
+        // Match the production resource monitor: sample memory after asking
+        // macOS to return completely free malloc pages to the operating system.
+        unsafe { malloc_zone_pressure_relief(std::ptr::null_mut(), 0) }
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "parakeet-mlx"))]
     fn mib(bytes: u64) -> f64 {
         bytes as f64 / 1024.0 / 1024.0
     }
@@ -2455,16 +2480,18 @@ mod tests {
     /// temporary SQLite DB, candidate query, ffmpeg decode, per-batch session,
     /// Parakeet MLX transcription, ONNX speaker diarization, and persistence.
     ///
-    /// `cargo test --release -p screenpipe-audio --features parakeet-mlx cached_parakeet_mlx_reconciliation_memory_plateaus -- --ignored --nocapture --test-threads=1`
+    /// `cargo test --release -p screenpipe-audio --features parakeet-mlx cached_parakeet_mlx_post_meeting_backlog_memory_plateaus -- --ignored --nocapture --test-threads=1`
     #[cfg(all(target_os = "macos", target_arch = "aarch64", feature = "parakeet-mlx"))]
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[ignore = "real-model full reconciliation memory plateau regression"]
-    async fn cached_parakeet_mlx_reconciliation_memory_plateaus() {
+    async fn cached_parakeet_mlx_post_meeting_backlog_memory_plateaus() {
         const MODEL_REPO: &str = "mlx-community/parakeet-tdt-0.6b-v3";
         const WARMUP_CALLS: usize = 4;
-        const CANDIDATES_PER_SWEEP: [usize; 4] = [50, 21, 21, 21];
-        const SWEEP_COUNT: usize = CANDIDATES_PER_SWEEP.len();
-        const MAX_POST_WARMUP_ENDPOINT_GROWTH_BYTES: u64 = 64 * 1024 * 1024;
+        // Mirrors the v2.5.151 incident: four immediately-drained capped sweeps
+        // followed by the final partial sweep after the ordinary idle interval.
+        const SYNTHETIC_CANDIDATES_PER_SWEEP: [usize; 5] = [50, 50, 50, 50, 48];
+        const SYNTHETIC_CANDIDATE_COUNT: usize = 248;
+        const MAX_POST_WARMUP_FOOTPRINT_GROWTH_BYTES: u64 = 512 * 1024 * 1024;
 
         if !cached_parakeet_mlx_model_available() {
             eprintln!(
@@ -2479,15 +2506,17 @@ mod tests {
         let thirty_seconds = sample_rate as usize * 30;
         assert!(audio.len() >= thirty_seconds);
 
-        let engine = TranscriptionEngine::new(
-            Arc::new(AudioTranscriptionEngine::ParakeetMlx),
-            None,
-            None,
-            vec![screenpipe_core::Language::English],
-            Vec::new(),
-        )
-        .await
-        .expect("failed to load cached Parakeet MLX model");
+        let engine = Arc::new(
+            TranscriptionEngine::new(
+                Arc::new(AudioTranscriptionEngine::ParakeetMlx),
+                None,
+                None,
+                vec![screenpipe_core::Language::English],
+                Vec::new(),
+            )
+            .await
+            .expect("failed to load cached Parakeet MLX model"),
+        );
 
         for call in 1..=WARMUP_CALLS {
             let mut session = engine
@@ -2504,7 +2533,8 @@ mod tests {
         }
 
         let temp = tempfile::tempdir().expect("create reconciliation repro dir");
-        let db = temp_db(temp.path()).await;
+        let db = Arc::new(temp_db(temp.path()).await);
+        let sweep_count = SYNTHETIC_CANDIDATES_PER_SWEEP.len();
         let model_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("models")
             .join("pyannote");
@@ -2522,16 +2552,22 @@ mod tests {
             segmentation_model_path: tokio::sync::Mutex::new(Some(segmentation_model_path)),
         });
         let base_timestamp = Utc::now() - chrono::Duration::hours(6);
-        let mut sweep_endpoints = Vec::with_capacity(SWEEP_COUNT);
+        let mut rss_endpoints = Vec::with_capacity(sweep_count);
+        let mut footprint_endpoints = Vec::with_capacity(sweep_count);
         let mut next_index = 0usize;
 
-        for (sweep, candidate_count) in CANDIDATES_PER_SWEEP.into_iter().enumerate() {
+        for (sweep, candidate_count) in SYNTHETIC_CANDIDATES_PER_SWEEP.into_iter().enumerate() {
             for offset in 0..candidate_count {
                 let index = next_index;
                 next_index += 1;
-                let duration_step = offset % 21;
+                // A real meeting produces slightly different AAC durations for
+                // nearly every chunk. Exercise 248 distinct MLX tensor shapes
+                // instead of cycling the same 21 shapes (the old regression),
+                // which hid the shape-cache growth seen in v2.5.151.
+                let base_samples = sample_rate as usize * 20;
+                let variable_span_samples = sample_rate as usize * 10;
                 let sample_count =
-                    sample_rate as usize * 20 + duration_step * sample_rate as usize / 2;
+                    base_samples + index * variable_span_samples / (SYNTHETIC_CANDIDATE_COUNT - 1);
                 let path = temp.path().join(format!(
                     "Display (output)_2026-07-23_{sweep:02}-{offset:02}-00.wav"
                 ));
@@ -2553,31 +2589,49 @@ mod tests {
             assert_eq!(candidates.len(), candidate_count);
 
             let sweep_start = resident_size_bytes();
-            let result = reconcile_untranscribed(
-                &db,
-                &engine,
-                None,
-                Arc::new(AudioTranscriptionEngine::Parakeet),
-                Some(segmentation_manager.clone()),
-                Some(temp.path()),
-                None,
-                None,
-            )
-            .await;
+            let footprint_start = physical_footprint_bytes();
+            let result = {
+                let db = db.clone();
+                let engine = engine.clone();
+                let segmentation_manager = segmentation_manager.clone();
+                let data_dir = temp.path().to_path_buf();
+                tokio::spawn(async move {
+                    reconcile_untranscribed(
+                        &db,
+                        &engine,
+                        None,
+                        Arc::new(AudioTranscriptionEngine::ParakeetMlx),
+                        Some(segmentation_manager),
+                        Some(&data_dir),
+                        None,
+                        None,
+                    )
+                    .await
+                })
+                .await
+                .expect("reconciliation worker panicked")
+            };
             let sweep_end = resident_size_bytes();
+            let allocator_bytes_released = release_allocator_pages();
+            let footprint_end = physical_footprint_bytes();
             assert_eq!(result.processed_chunks, candidate_count);
             assert_eq!(
                 result.hit_candidate_limit,
                 candidate_count == RECONCILIATION_CHUNKS_PER_SWEEP as usize
             );
-            sweep_endpoints.push(sweep_end);
+            rss_endpoints.push(sweep_end);
+            footprint_endpoints.push(footprint_end);
             eprintln!(
-                "[mlx-reconciliation-memory] sweep={}/{SWEEP_COUNT} reconciled={}/{candidate_count} rss_start={:.1} MiB rss_end={:.1} MiB working_set_delta={:.1} MiB active_mlx={:.1} MiB",
+                "[mlx-reconciliation-memory] sweep={}/{sweep_count} reconciled={}/{candidate_count} rss_start={:.1} MiB rss_end={:.1} MiB rss_delta={:.1} MiB allocator_released={:.1} MiB footprint_start={:.1} MiB footprint_end={:.1} MiB footprint_delta={:.1} MiB active_mlx={:.1} MiB",
                 sweep + 1,
                 result.processed_chunks,
                 mib(sweep_start),
                 mib(sweep_end),
                 mib(sweep_end.saturating_sub(sweep_start)),
+                mib(allocator_bytes_released as u64),
+                mib(footprint_start),
+                mib(footprint_end),
+                mib(footprint_end.saturating_sub(footprint_start)),
                 crate::transcription::engine::mlx_active_memory_bytes_for_test() as f64
                     / 1024.0
                     / 1024.0,
@@ -2587,19 +2641,25 @@ mod tests {
         // A sweep's start can be lower because macOS reclaims empty malloc pages
         // between passes. Compare completed sweep endpoints instead: a leak keeps
         // raising that high-water mark, while reusable working memory plateaus.
-        let warmup_endpoint = sweep_endpoints[0];
-        let post_warmup_peak = *sweep_endpoints[1..]
+        let warmup_endpoint = footprint_endpoints[0];
+        let post_warmup_peak = *footprint_endpoints[1..]
             .iter()
             .max()
             .expect("at least one measured reconciliation sweep");
-        let endpoint_growth = post_warmup_peak.saturating_sub(warmup_endpoint);
+        let footprint_growth = post_warmup_peak.saturating_sub(warmup_endpoint);
         assert!(
-            endpoint_growth <= MAX_POST_WARMUP_ENDPOINT_GROWTH_BYTES,
-            "Parakeet MLX reconciliation endpoints did not plateau: {SWEEP_COUNT} real backlog \
-             sweeps grew the post-warm-up high-water mark by \
+            footprint_growth <= MAX_POST_WARMUP_FOOTPRINT_GROWTH_BYTES,
+            "Parakeet MLX reconciliation physical footprint did not plateau: {sweep_count} \
+             post-meeting backlog sweeps grew the post-warm-up high-water mark by \
              {:.1} MiB (limit: {:.1} MiB)",
-            mib(endpoint_growth),
-            mib(MAX_POST_WARMUP_ENDPOINT_GROWTH_BYTES),
+            mib(footprint_growth),
+            mib(MAX_POST_WARMUP_FOOTPRINT_GROWTH_BYTES),
+        );
+
+        eprintln!(
+            "[mlx-reconciliation-memory] completed rss_endpoints={:?} footprint_endpoints={:?}",
+            rss_endpoints.into_iter().map(mib).collect::<Vec<_>>(),
+            footprint_endpoints.into_iter().map(mib).collect::<Vec<_>>(),
         );
     }
 }

--- a/crates/screenpipe-audio/src/speaker/embedding.rs
+++ b/crates/screenpipe-audio/src/speaker/embedding.rs
@@ -32,7 +32,7 @@ pub struct EmbeddingExtractor {
 
 impl EmbeddingExtractor {
     pub fn new<P: AsRef<Path>>(model_path: P) -> Result<Self> {
-        let session = super::create_session(&model_path)?;
+        let session = super::create_embedding_session(&model_path)?;
         let output_name =
             super::resolve_output_name(&super::session_output_names(&session), "embs")?;
         Ok(Self {

--- a/crates/screenpipe-audio/src/speaker/mod.rs
+++ b/crates/screenpipe-audio/src/speaker/mod.rs
@@ -8,6 +8,23 @@ use std::path::Path;
 use anyhow::{anyhow, Result};
 
 pub fn create_session<P: AsRef<Path>>(path: P) -> Result<ort::session::Session> {
+    create_session_with_embedding_ep(path, false)
+}
+
+/// Speaker turns produce a different fbank time dimension on almost every run.
+/// On Apple Silicon the CPU execution path retained several gigabytes of native
+/// activation memory while a meeting backlog drained. CoreML's NeuralNetwork
+/// backend accepts the original dynamic tensor (so embeddings are unchanged)
+/// and keeps that repeated inference working set bounded. CPU remains fallback
+/// for unsupported nodes, without its retaining arena.
+pub(crate) fn create_embedding_session<P: AsRef<Path>>(path: P) -> Result<ort::session::Session> {
+    create_session_with_embedding_ep(path, true)
+}
+
+fn create_session_with_embedding_ep<P: AsRef<Path>>(
+    path: P,
+    embedding_ep: bool,
+) -> Result<ort::session::Session> {
     let path = path.as_ref().to_path_buf();
     // ort 2.0.0-rc.10 panics from inside its global OnceLock when the ONNX
     // Runtime API can't be initialized (Windows DLL/version mismatch hits
@@ -36,6 +53,20 @@ pub fn create_session<P: AsRef<Path>>(path: P) -> Result<ort::session::Session> 
                     .map_err(|e| oe(&e))?;
                 let b = b.with_intra_threads(1).map_err(|e| oe(&e))?;
                 let mut b = b.with_inter_threads(1).map_err(|e| oe(&e))?;
+                if embedding_ep {
+                    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+                    {
+                        b = b
+                            .with_execution_providers([
+                                ort::ep::CoreML::default()
+                                    .with_static_input_shapes(false)
+                                    .with_subgraphs(true)
+                                    .build(),
+                                ort::ep::CPU::default().with_arena_allocator(false).build(),
+                            ])
+                            .map_err(|e| oe(&e))?;
+                    }
+                }
                 let session = b.commit_from_file(&path).map_err(|e| oe(&e))?;
                 Ok(session)
             })

--- a/crates/screenpipe-audio/src/transcription/engine.rs
+++ b/crates/screenpipe-audio/src/transcription/engine.rs
@@ -754,12 +754,12 @@ impl TranscriptionSession {
                 // as of audiopipe#14 (shallow fusion, same as the ONNX path).
                 let keyterms = parakeet_keyterms(vocabulary);
 
-                // Chunk to 30s like the CPU Parakeet path above. The Metal backend
-                // panics with command-buffer / GPU-memory-pressure errors on long
-                // variable-length tensors — historically the top transcription crash
-                // in the field (~61 hits/2wk, "mlx transcription panic"). Bounding
-                // each transcribe to a fixed 30s tensor removes that pressure, and
-                // isolating the panic guard *per chunk* means a single bad chunk drops
+                // Chunk to 30s like the CPU Parakeet path above, and zero-pad the
+                // final chunk to that exact shape. Real meeting chunks have subtly
+                // different AAC durations; passing each length through MLX causes
+                // shape-specific CPU allocations to accumulate even after its GPU
+                // cache is cleared. A stable input shape keeps that memory bounded.
+                // Isolating the panic guard *per chunk* means a single bad chunk drops
                 // only its own ~30s instead of the entire batch's transcript.
                 let chunk_samples = (sample_rate as usize) * 30;
                 let chunks: Vec<&[f32]> = if audio.len() <= chunk_samples {
@@ -771,7 +771,16 @@ impl TranscriptionSession {
                 let mut texts = Vec::new();
                 let mut had_success = false;
                 let mut last_err: Option<anyhow::Error> = None;
+                let mut padded_chunk = Vec::with_capacity(chunk_samples);
                 for chunk in chunks {
+                    let inference_chunk = if chunk.len() == chunk_samples {
+                        chunk
+                    } else {
+                        padded_chunk.clear();
+                        padded_chunk.extend_from_slice(chunk);
+                        padded_chunk.resize(chunk_samples, 0.0);
+                        padded_chunk.as_slice()
+                    };
                     // Clear GPU cache before/after each chunk to reduce Metal command
                     // buffer errors from memory pressure (prevents abort in the MLX
                     // completion handler) and to release resources held by a panic.
@@ -781,7 +790,7 @@ impl TranscriptionSession {
                         ..Default::default()
                     };
                     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        engine.transcribe_with_sample_rate(chunk, sample_rate, opts)
+                        engine.transcribe_with_sample_rate(inference_chunk, sample_rate, opts)
                     }));
                     mlx_memory::clear_cache();
                     match outcome {


### PR DESCRIPTION
## Summary

- zero-pad each short Parakeet MLX chunk to the existing 30-second boundary so MLX sees one input tensor shape
- run the unchanged dynamic speaker-embedding tensor through CoreML NeuralNetwork on Apple Silicon, with CPU fallback arena disabled
- expand the ignored release-mode reconciliation E2E to 248 variable-duration chunks across the same five-sweep post-meeting drain pattern and measure macOS physical footprint

## Root cause

The 15.7 GB process was not SQLite or WebKit. VM allocation evidence showed dirty `MALLOC_SMALL` growth while MLX active memory stayed at 2.431 GB. The exact backlog reproduced two native retention paths:

1. variable final Parakeet MLX tensor lengths
2. repeated dynamic speaker-embedding inference on ONNX Runtime's CPU path

## Red / green evidence

Before:

- generated 248-chunk repro: post-warm physical footprint grew 1.08 GB
- exact local 242-chunk backlog: 5.23 GB -> 13.87 GB (+8.64 GB)
- MLX active memory stayed flat at 2.431 GB

After:

- committed generated E2E endpoints: 3.107, 3.124, 3.124, 3.125, 3.125 GB
- exact local 242-chunk endpoints: 3.212, 3.315, 3.256, 2.798, 3.191 GB
- existing six-speaker identity E2E passes unchanged
- private local audio was used only for validation and is not included in this branch

## Tests

- `cargo test --release -p screenpipe-audio --features parakeet-mlx --lib cached_parakeet_mlx_post_meeting_backlog_memory_plateaus -- --ignored --nocapture --test-threads=1`
- `cargo test --release -p screenpipe-audio --features parakeet-mlx --test speaker_identification test_audio_speaker_identification -- --ignored --nocapture --test-threads=1`
- `cargo test --release -p screenpipe-audio --features parakeet-mlx --lib audio_manager::reconciliation::tests -- --test-threads=1` (21 passed)
- `cargo test --release -p screenpipe-audio --features parakeet-mlx --lib speaker:: -- --test-threads=1` (28 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
