### PR TITLE
fix(ai-gateway): recognize Anthropic geo-403 and stop recommending Auto in blocked regions

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -118,11 +118,14 @@ export function clientPayloadMessage(status: number, msg: string): string | null
   return CLIENT_PAYLOAD_PATTERNS.find((p) => p.re.test(msg))?.message ?? null;
 }
 
-// OpenAI refuses service in some countries/regions based on the egress IP.
-// Nothing the worker or the user's API key can fix — surface which models DO
-// work there instead of the misleading "check your API key" advice, and keep
-// it out of Sentry (SCREENPIPE-AI-PROXY-1C, 14 users). Other 403s stay loud.
-const GEO_BLOCK_PATTERN = /country,? region,? or territory not supported/i;
+// Providers refuse service in some countries/regions based on the egress IP.
+// Nothing the worker or the user's API key can fix, and every hosted chain
+// entry is OpenAI/Anthropic so "pick another model" (or Auto) fails the same
+// way — point at local models instead, and keep it out of Sentry
+// (SCREENPIPE-AI-PROXY-1C, -2S/-1W: 3k+ events). Other 403s stay loud.
+// OpenAI: "Country, region, or territory not supported".
+// Anthropic: {"type":"forbidden","message":"Request not allowed"}.
+const GEO_BLOCK_PATTERN = /country,? region,? or territory not supported|request not allowed/i;
 
 export function isGeoBlocked(status: number, msg: string): boolean {
   return status === 403 && GEO_BLOCK_PATTERN.test(msg);
@@ -258,10 +261,12 @@ async function tryModel(
       throw error;
     }
 
-    // Provider geo-blocks (OpenAI 403 by region) — expected per-region
-    // condition; tell the user what will work, keep Sentry quiet.
+    // Provider geo-blocks (OpenAI/Anthropic 403 by region) — expected
+    // per-region condition; tell the user what will work, keep Sentry quiet.
+    // No model name on purpose: the chain's last entry isn't what the user
+    // picked, and every hosted model fails identically in a blocked region.
     if (isGeoBlocked(status, msg)) {
-      error.userMessage = `${model} isn't available in your country or region (the provider rejected the request). Pick Auto instead.`;
+      error.userMessage = `Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.`;
       console.warn(`${ctx}: ${model} geo-blocked by provider (403)`);
       logModelOutcome(env, { model, outcome: 'error' }).catch(() => {});
       throw error;

--- a/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
+++ b/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
@@ -83,9 +83,14 @@ describe('chat handler — geo-block detection (SCREENPIPE-AI-PROXY-1C)', () => 
 		expect(isGeoBlocked(403, '403 Country, region, or territory not supported')).toBe(true);
 	});
 
+	it('detects the Anthropic geo/policy 403 (SCREENPIPE-AI-PROXY-2S/-1W, 3k+ events)', () => {
+		expect(isGeoBlocked(403, '403 {"error":{"type":"forbidden","message":"Request not allowed"}}')).toBe(true);
+	});
+
 	it('keeps other 403s loud (IAM regressions must still reach Sentry)', () => {
 		expect(isGeoBlocked(403, 'The caller does not have permission')).toBe(false);
 		expect(isGeoBlocked(401, 'Country, region, or territory not supported')).toBe(false);
+		expect(isGeoBlocked(401, 'Request not allowed')).toBe(false);
 	});
 });
 


### PR DESCRIPTION
### Description:

Users in provider-blocked regions (RU etc.) can't use any hosted model — but the gateway's 403 handling gives them wrong or misleading advice, in two ways:

**Before:**
```
# chain dies on OpenAI (matches GEO_BLOCK_PATTERN):
gpt-5.4-mini isn't available in your country or region (the provider
rejected the request). Pick Auto instead.

# chain dies on Anthropic (phrasing NOT matched → generic 403 advice):
Your provider rejected the request for "claude-opus-5" (403). Check that
the API key in your AI preset is valid and has access to this model.
```

**After (both cases):**
```
Cloud AI models aren't available in your country or region (the provider
rejected the request). Connect a local model like Ollama in Settings → AI
to keep using chat.
```

- Add Anthropic's geo/policy rejection phrasing (`{"type":"forbidden","message":"Request not allowed"}`) to `GEO_BLOCK_PATTERN` — Sentry SCREENPIPE-AI-PROXY-2S (2,375 events / 8 days, still firing) and -1W (684 events) confirm the exact string. Still 403-gated, so legit key/IAM errors keep the existing advice and stay loud in Sentry.
- Stop recommending "Pick Auto instead": every hosted chain entry (`AUTO_WATERFALL`, `MODEL_FALLBACKS`, `FREE_PREVIEW_WATERFALL`) is OpenAI/Anthropic, so Auto fails identically — verified in a blocked-region user's log where Auto, claude-opus-5, and gpt-5.6-terra all returned the same geo-403. Point at local models (Ollama) instead, which several affected users already have configured.
- Drop the model name from the geo message: it named the *last chain entry* (always gpt-5.4-mini), not the model the user picked, which read as nonsense to users who had selected claude-opus-5 or gpt-5.6-luna.
- Cascade/transient classification is unchanged — geo-blocked entries still fall through the chain, so supported-region users see zero behavior change.

Context: 5 user feedback reports on 2026-07-30 alone (4 geo-blocked Russian-locale users, verified via their logs), on top of the ~3k Sentry events above.

`bun test`: touched file 20/20 pass; full suite 618 pass / 2 fail — both failures are a pre-existing order-dependent flake in `free-chat-limit.test.ts`, reproduced identically on clean main.

### References:
- Sentry: [SCREENPIPE-AI-PROXY-2S](https://mediar.sentry.io/issues/SCREENPIPE-AI-PROXY-2S), [SCREENPIPE-AI-PROXY-1W](https://mediar.sentry.io/issues/SCREENPIPE-AI-PROXY-1W), SCREENPIPE-AI-PROXY-1C