### PR TITLE
[codex] let Lifetime users add Business in desktop billing

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -23,6 +23,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 
@@ -273,7 +274,7 @@ describe("AccountSection subscription/login gating", () => {
     expect(screen.getByText("active")).toBeInTheDocument();
   });
 
-  it("sends existing Basic subscribers to billing instead of creating a second checkout", () => {
+  it("sends existing Basic subscribers to billing even with a stale cloud flag", () => {
     const checkoutFetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ url: "https://checkout.stripe.test/session" }), {
         status: 200,
@@ -285,7 +286,7 @@ describe("AccountSection subscription/login gating", () => {
       id: "u1",
       email: "basic@screenpipe.test",
       token: "tok",
-      cloud_subscribed: false,
+      cloud_subscribed: true,
       app_entitled: true,
       subscription_plan: "standard",
     };
@@ -298,6 +299,48 @@ describe("AccountSection subscription/login gating", () => {
       expect.anything(),
     );
     expect(mocks.openUrl).toHaveBeenCalledWith("https://screenpipe.com/account/billing");
+  });
+
+  it("offers Lifetime users Business and starts a separate subscription checkout", async () => {
+    const checkoutFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "test stop" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", checkoutFetch);
+    mocks.state.user = {
+      id: "u1",
+      email: "lifetime@screenpipe.test",
+      token: "tok",
+      cloud_subscribed: true,
+      app_entitled: true,
+      subscription_plan: "lifetime",
+      entitlement: {
+        active: true,
+        plan: "lifetime",
+        source: "lifetime",
+        status: "active",
+      },
+    };
+
+    render(<AccountSection />);
+
+    expect(screen.queryByTestId(ACTIVE_CARD)).not.toBeInTheDocument();
+    expect(screen.getByText("Screenpipe Lifetime")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /upgrade to business/i }));
+
+    await waitFor(() => expect(checkoutFetch).toHaveBeenCalledTimes(1));
+    const [url, request] = checkoutFetch.mock.calls[0];
+    expect(url).toContain("/api/subscription/checkout");
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      plan: "pro",
+      token: "tok",
+      origin: "app-account-section",
+    });
+    expect(mocks.openUrl).not.toHaveBeenCalledWith(
+      "https://screenpipe.com/account/billing",
+    );
   });
 
   it("shows the login-first layout for a signed-out free user", () => {

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -71,6 +71,18 @@ function hasExistingStripeSubscriptionPlan(plan: string | null | undefined): boo
   return normalized !== "none" && normalized !== "lifetime";
 }
 
+function isBusinessSubscriptionPlan(plan: string | null | undefined): boolean {
+  // `cloud_subscribed` can remain true in persisted settings after the server
+  // resolves an old one-time license as Lifetime. Explicit plan truth must win
+  // or Lifetime/Basic users land in the Business-active branch with no upgrade
+  // action. Keep the no-plan fallback for older Business responses that only
+  // carried the cloud flag.
+  if (!plan) return true;
+  return ["pro", "business", "team", "enterprise", "monthly", "annual"].includes(
+    plan.toLowerCase(),
+  );
+}
+
 async function openExternalUrl(url: string): Promise<void> {
   const e2eWindow =
     typeof window !== "undefined"
@@ -119,6 +131,9 @@ export function AccountSection() {
   const hasNamedPlan = !!subscriptionPlan && subscriptionPlan !== "none";
   const appUser = settings.user as AppUser | null;
   const hasExpiringProfilePlan = getUserPlanExpiration(appUser) !== null;
+  const isSignedInBusinessSubscriber =
+    isSignedInCloudSubscriber(settings.user) &&
+    isBusinessSubscriptionPlan(subscriptionPlan);
 
   useEffect(() => {
     if (!settings.user?.email) {
@@ -185,8 +200,7 @@ export function AccountSection() {
     if (
       settings.user?.token &&
       hasExistingStripeSubscriptionPlan(subscriptionPlan) &&
-      !hasExpiringProfilePlan &&
-      !settings.user?.cloud_subscribed
+      !hasExpiringProfilePlan
     ) {
       posthog.capture("cloud_plan_upgrade_billing_opened", {
         from_plan: subscriptionPlan,
@@ -196,7 +210,7 @@ export function AccountSection() {
       await openExternalUrl(BILLING_URL);
       return;
     }
-    if (!settings.user?.cloud_subscribed || hasExpiringProfilePlan) {
+    if (!isSignedInBusinessSubscriber || hasExpiringProfilePlan) {
       posthog.capture("cloud_plan_selected", { plan: "pro", interval: annual ? "year" : "month" });
       try {
         // New subscription checkout ($50/mo Pro). Pass the Clerk token so the
@@ -355,7 +369,7 @@ export function AccountSection() {
       {/* Subscribed view — requires a session token, not just cloud_subscribed,
           so a token-hydration failure can't render this "active" card under a
           "not logged in" header (see isSignedInCloudSubscriber). */}
-      {isSignedInCloudSubscriber(settings.user) ? (
+      {isSignedInBusinessSubscriber ? (
         <Card className="p-5" data-testid="account-cloud-active-card">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- use the resolved plan name instead of the stale `cloud_subscribed` flag to decide whether Business is active
- keep existing Basic subscribers on the billing-management path, even when that flag is stale
- let Lifetime users start a separate Business checkout while keeping their Lifetime entitlement
- add regression coverage for stale Basic state and Lifetime checkout routing

## Root cause

The account screen treated every signed-in user with `cloud_subscribed: true` as an active Business subscriber. Lifetime can legitimately carry that persisted flag, so the UI rendered Business as active and removed the upgrade action.

## UX flow

```text
Screenpipe Lifetime · active
core Lifetime access remains available
               |
               v
      [UPGRADE TO BUSINESS]
               |
               v
monthly / annual Business checkout
```

## Verification

- [x] `bunx vitest run --config vitest.config.ts components/settings/__tests__/account-section.subscription-gate.test.tsx` (9 tests)
- [x] `bun run typecheck`
- [x] targeted ESLint on both changed files

## Scope

No release, price, Stripe product, or entitlement precedence changes. Website companion: https://github.com/screenpipe/website/pull/626
