### PR TITLE
fix(tauri): keep scanning app commands after wer-dump-helper workspace member

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -13729,7 +13729,7 @@ dependencies = [
 [[package]]
 name = "tauri-helper"
 version = "0.2.1"
-source = "git+https://github.com/divanshu-go/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
+source = "git+https://github.com/divanshu-go/tauri-helper?rev=593f414fefcca7b3cdd1785333d32bb9f79917af#593f414fefcca7b3cdd1785333d32bb9f79917af"
 dependencies = [
  "rayon",
  "serde",
@@ -14276,7 +14276,7 @@ dependencies = [
 [[package]]
 name = "tauri_helper_core"
 version = "0.2.1"
-source = "git+https://github.com/divanshu-go/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
+source = "git+https://github.com/divanshu-go/tauri-helper?rev=593f414fefcca7b3cdd1785333d32bb9f79917af#593f414fefcca7b3cdd1785333d32bb9f79917af"
 dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
@@ -14285,7 +14285,7 @@ dependencies = [
 [[package]]
 name = "tauri_helper_macros"
 version = "0.1.4"
-source = "git+https://github.com/divanshu-go/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
+source = "git+https://github.com/divanshu-go/tauri-helper?rev=593f414fefcca7b3cdd1785333d32bb9f79917af#593f414fefcca7b3cdd1785333d32bb9f79917af"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.94"
 
 [build-dependencies]
 tauri-build = { version = "=2.6.2", features = [] }
-tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "e25ff1d2c5026189305a0251a1e06788efe1d2b3" }
+tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "593f414fefcca7b3cdd1785333d32bb9f79917af" }
 # Used by build.rs on Windows MSVC targets (incl. cross-compiles from
 # Linux/macOS CI runners) to compile c/bswap_shim.c — provides
 # __builtin_bswap{16,32,64} as real functions to satisfy the aws-lc-sys
@@ -25,7 +25,7 @@ tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "e25
 cc = "1"
 
 [dependencies]
-tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "e25ff1d2c5026189305a0251a1e06788efe1d2b3" }
+tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "593f414fefcca7b3cdd1785333d32bb9f79917af" }
 tauri = { version = "=2.11.2", features = [
   "protocol-asset",
   "macos-private-api",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["wer-dump-helper"]
+members = [".", "wer-dump-helper"]
 
 [package]
 name = "screenpipe-app"

--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -316,7 +316,11 @@ fn ensure_frontend_dist() {
 }
 
 fn main() {
-    tauri_helper::generate_command_file(tauri_helper::TauriHelperOptions::default());
+    // Force-scan the app crate. tauri-helper skips "." when [workspace].members
+    // is a non-empty list that omits it (e.g. only wer-dump-helper).
+    tauri_helper::generate_command_file(tauri_helper::TauriHelperOptions::new(Some(vec![
+        ".".to_string(),
+    ])));
 
     ensure_frontend_dist();
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -687,10 +687,11 @@ async fn main() {
         }
     }
 
-    // Generate TypeScript bindings in debug mode (also via `cargo test` — see
-    // specta_bindings.rs).
+    // Opt-in only. Auto-export on every debug launch wipes tauri.ts whenever
+    // specta_collect_commands! expands empty (wrong target-dir / stale sccache).
+    // Regenerate with: UPDATE_TAURI_BINDINGS=1 bun run bindings:generate
     #[cfg(debug_assertions)]
-    {
+    if std::env::var("UPDATE_TAURI_BINDINGS").as_deref() == Ok("1") {
         info!("Generating TypeScript bindings...");
 
         // tauri-specta command registry — must live in crate root scope for `collect_commands!`.

--- a/apps/screenpipe-app-tauri/src-tauri/src/specta_bindings.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/specta_bindings.rs
@@ -79,6 +79,18 @@ pub fn write_bindings_if_changed_with(
     let new_content = std::fs::read(&tmp_path).unwrap_or_default();
     let old_content = std::fs::read(path).unwrap_or_default();
 
+    // Refuse hollow exports (`commands = {}`) that would wipe a healthy file.
+    let new_invokes = invoke_count(&new_content);
+    let old_invokes = invoke_count(&old_content);
+    if new_invokes == 0 && old_invokes > 0 {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(format!(
+            "refusing to overwrite {} with an empty command list (had {old_invokes} invokes). \
+             Rebuild so tauri-helper regenerates target/tauri_commands_list first",
+            path.display()
+        ));
+    }
+
     if new_content != old_content {
         std::fs::rename(&tmp_path, path).map_err(|error| {
             format!(
@@ -91,6 +103,10 @@ pub fn write_bindings_if_changed_with(
         let _ = std::fs::remove_file(&tmp_path);
         Ok(false)
     }
+}
+
+fn invoke_count(bytes: &[u8]) -> usize {
+    String::from_utf8_lossy(bytes).matches("TAURI_INVOKE").count()
 }
 
 #[cfg(test)]

--- a/apps/screenpipe-app-tauri/src-tauri/src/specta_bindings.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/specta_bindings.rs
@@ -79,14 +79,14 @@ pub fn write_bindings_if_changed_with(
     let new_content = std::fs::read(&tmp_path).unwrap_or_default();
     let old_content = std::fs::read(path).unwrap_or_default();
 
-    // Refuse hollow exports (`commands = {}`) that would wipe a healthy file.
+    // Never write a hollow `commands = {}` export.
     let new_invokes = invoke_count(&new_content);
     let old_invokes = invoke_count(&old_content);
-    if new_invokes == 0 && old_invokes > 0 {
+    if new_invokes == 0 {
         let _ = std::fs::remove_file(&tmp_path);
         return Err(format!(
-            "refusing to overwrite {} with an empty command list (had {old_invokes} invokes). \
-             Rebuild so tauri-helper regenerates target/tauri_commands_list first",
+            "refusing to write {} with an empty command list (had {old_invokes} invokes). \
+             Rebuild so tauri-helper regenerates tauri_commands_list first",
             path.display()
         ));
     }


### PR DESCRIPTION
## Problem
Debug launches wiped most of `lib/utils/tauri.ts` (`commands = {}`), especially with a global cargo `build.target-dir` at `~/.cargo/targets/screenpipe`.

## Before
- tauri-helper wrote lists to `src-tauri/target/tauri_commands_list`
- real artifacts lived under `~/.cargo/targets/screenpipe`
- specta macros could expand an empty command set; debug export clobbered `tauri.ts`

## After
- command lists land next to the real target dir (`~/.cargo/targets/screenpipe/tauri_commands_list`)
- macros read that path via `TAURI_HELPER_COMMANDS_DIR`
- hollow exports are refused when the existing file still has invokes

## Root cause
1. #5568 set `members = ["wer-dump-helper"]`, so default tauri-helper scanning skipped the app crate.
2. Even after force-scanning `"."`, lists still used `<workspace>/target`, which is the wrong place when `~/.cargo/config.toml` sets `build.target-dir = "~/.cargo/targets/screenpipe"`.
3. sccache could keep a stale empty macro expansion across rebuilds.

## Fix
- `build.rs` force-scans `"."`
- bump `tauri-helper` to resolve list dir from `OUT_DIR` / `CARGO_TARGET_DIR` and fingerprint commands
- refuse overwriting a healthy `tauri.ts` with zero `TAURI_INVOKE`s
- keep `members = [".", "wer-dump-helper"]`

## Test plan
- [ ] Confirm `~/.cargo/config.toml` has `build.target-dir = ".../targets/screenpipe"`
- [ ] `rm -rf ~/.cargo/targets/screenpipe/tauri_commands_list src-tauri/target/tauri_commands_list`
- [ ] Rebuild app (`bun tauri dev` or `cargo check -p screenpipe-app`)
- [ ] `ls ~/.cargo/targets/screenpipe/tauri_commands_list` is non-empty
- [ ] `bun run bindings:check`
- [ ] Debug launch does not collapse `tauri.ts` to `commands = {}`