### PR TITLE
fix(ci): remove flaky SQLite teardown oracles

### DIFF
--- a/crates/screenpipe-db/src/db/setup.rs
+++ b/crates/screenpipe-db/src/db/setup.rs
@@ -173,10 +173,14 @@ impl DatabaseManager {
         // Run migrations after establishing the connection
         Self::run_migrations(&db_manager.pool).await?;
 
-        // Surface corruption proactively at boot with a recovery hint,
-        // instead of only discovering it later via worker query errors
-        // (which used to spin a CPU core retrying a malformed DB).
-        db_manager.spawn_startup_integrity_check(Arc::from(database_path));
+        // Surface persistent-file corruption proactively at boot with a recovery
+        // hint, instead of only discovering it later via worker query errors.
+        // An in-memory database cannot carry corruption across startups, and a
+        // quick_check on SQLite's shared in-memory cache takes table read locks
+        // that can make concurrent writes fail immediately with SQLITE_LOCKED.
+        if !database_path.contains("mode=memory") && database_path != ":memory:" {
+            db_manager.spawn_startup_integrity_check(Arc::from(database_path));
+        }
 
         // Periodic WAL checkpoint so the write-ahead log can't grow unbounded
         // when passive auto-checkpoint is blocked by long-lived readers. An

--- a/crates/screenpipe-db/tests/close_severs_connections_test.rs
+++ b/crates/screenpipe-db/tests/close_severs_connections_test.rs
@@ -11,10 +11,14 @@
 //! These tests model the incident directly:
 //!  * a "leaked" pool clone must be SEVERED by `DatabaseManager::close()`
 //!    (fail fast, not pin the WAL-index),
-//!  * after `close()` SQLite must have dropped the `-wal`/`-shm` sidecars —
-//!    the file-level proof that zero connections survived teardown,
 //!  * a fresh `DatabaseManager` on the same file must then init and write,
 //!  * repeated restart cycles (the engine-respawn path) must stay clean.
+//!
+//! Do not use `-wal`/`-shm` file existence as a connection-leak oracle here.
+//! SQLite may retain both files when the last connection to disconnect is
+//! read-only; this manager closes independent read and write pools concurrently.
+//! A closed leaked clone plus a successful same-process reopen and write tests
+//! the recovery invariant directly.
 
 use screenpipe_config::{DbConfig, DeviceTier};
 use screenpipe_db::DatabaseManager;
@@ -24,29 +28,6 @@ fn temp_db_path(tag: &str) -> String {
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
     dir.join("db.sqlite").to_string_lossy().into_owned()
-}
-
-/// Wait (bounded) for SQLite to unlink the WAL sidecars after the last
-/// connection closes. `close()` resolves when the pools are closed; the OS
-/// unlink is usually immediate after that, but Linux CI can lag under load.
-async fn assert_wal_sidecars_gone(db_path: &str) {
-    let wal_path = format!("{db_path}-wal");
-    let shm_path = format!("{db_path}-shm");
-    for _ in 0..200 {
-        let wal = std::path::Path::new(&wal_path).exists();
-        let shm = std::path::Path::new(&shm_path).exists();
-        if !wal && !shm {
-            return;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-    let wal = std::path::Path::new(&wal_path).exists();
-    let shm = std::path::Path::new(&shm_path).exists();
-    panic!(
-        "-wal/-shm still present after close() — a SQLite connection survived teardown \
-         (the exact leak that made the 2026-07-02 wedge unrecoverable in-process); \
-         wal={wal}, shm={shm}"
-    );
 }
 
 #[tokio::test]
@@ -75,10 +56,6 @@ async fn close_severs_leaked_pool_clones_and_allows_reinit() {
         err.is_err(),
         "leaked pool clone must be unusable after DatabaseManager::close()"
     );
-
-    // File-level proof that ZERO connections survived: SQLite only deletes
-    // -wal/-shm when the LAST connection to the db closes.
-    assert_wal_sidecars_gone(&db_path).await;
 
     // And the same process can re-open the db cleanly — the step that failed
     // with (code: 522) disk I/O error for hours on 2026-07-02.
@@ -113,7 +90,6 @@ async fn repeated_restart_cycles_reopen_cleanly() {
             .await
             .unwrap_or_else(|e| panic!("cycle {cycle}: write failed: {e}"));
         db.close().await;
-        assert_wal_sidecars_gone(&db_path).await;
     }
 
     // All five cycles' writes survived the churn.

--- a/crates/screenpipe-redact/tests/worker_integration.rs
+++ b/crates/screenpipe-redact/tests/worker_integration.rs
@@ -371,7 +371,16 @@ async fn worker_skips_already_redacted_rows() {
     let worker = Worker::new(pool.clone(), redactor, cfg);
     let handle = worker.clone().spawn();
 
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    wait_until("unredacted frame watermark", || async {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM frames WHERE id = 2 AND full_text_redacted_at IS NOT NULL",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+            == 1
+    })
+    .await;
     handle.abort();
 
     let status = worker.status().await;


### PR DESCRIPTION
## Root causes

- The WAL teardown regression tests treated `-wal`/`-shm` filename presence as proof that a connection survived. SQLite may retain both when the last disconnect is read-only; `DatabaseManager` closes its read/write pools concurrently. This produced alternating 20-second Linux failures even though leaked clones were closed and same-process reopen/write succeeded.
- The timeline performance suite uses shared in-memory SQLite databases. The delayed startup `quick_check` acquired shared-cache table locks after 10 seconds, causing concurrent frame writes to fail with SQLite code 262. In-memory databases cannot carry corruption across startups, so the scan is now limited to persistent databases.

## Preserved regression coverage

- leaked pool clone rejects queries after `DatabaseManager::close()`
- same-process reopen and query succeeds
- five restart cycles preserve all writes
- persistent databases still run the startup corruption scan

## Verification

- `cargo fmt --check --all`
- `cargo test -p screenpipe-db --test close_severs_connections_test --test timeline_performance_test` (13 passed, 1 ignored)
- close/reopen regression binary stress-run 50 times (50/50 passed)