### PR TITLE
fix(app): recover from hung enterprise build check

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
   loadUser: vi.fn().mockResolvedValue(undefined),
   updateSettings: vi.fn().mockResolvedValue(undefined),
   state: { isSettingsLoaded: true, user: null as any },
+  enterpriseResolutionError: false,
   enterprise: {
     isManagedDeployment: false,
     isManagedDeploymentResolved: true,
@@ -65,6 +66,7 @@ vi.mock("@/lib/hooks/use-managed-policy", () => ({
   useManagedPolicy: () => ({
     isManagedDeployment: mocks.enterprise.isManagedDeployment,
     isManagedDeploymentResolved: mocks.enterprise.isManagedDeploymentResolved,
+    managedDeploymentResolutionError: mocks.enterpriseResolutionError,
     authenticationState: mocks.enterprise.authenticationState,
     authenticationError: mocks.enterprise.authenticationError,
     isManagedAuthenticated: mocks.enterprise.isManagedAuthenticated,
@@ -126,6 +128,7 @@ describe("AppEntitlementGate", () => {
     vi.stubEnv("TAURI_ENV_DEBUG", "false");
     vi.stubEnv("NEXT_PUBLIC_SCREENPIPE_DEV_BILLING_BYPASS", "false");
     mocks.state = { isSettingsLoaded: true, user: null };
+    mocks.enterpriseResolutionError = false;
     mocks.windowLabel = "home";
     mocks.enterprise = {
       isManagedDeployment: false,
@@ -174,6 +177,19 @@ describe("AppEntitlementGate", () => {
     mocks.enterprise.isManagedDeploymentResolved = true;
     rerender(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
     await waitFor(() => expect(mocks.stopScreenpipe).toHaveBeenCalled());
+  });
+
+  it("surfaces a recoverable error when build detection cannot finish", () => {
+    mocks.enterprise.isManagedDeploymentResolved = false;
+    mocks.enterpriseResolutionError = true;
+
+    render(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
+
+    expect(screen.getByText(/couldn't check access/i)).toBeInTheDocument();
+    expect(screen.getByText(/retry automatically/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /reload and retry/i }),
+    ).toBeInTheDocument();
   });
 
   it("keeps recording while enterprise authentication is still checking", async () => {

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -109,6 +109,7 @@ export function AppEntitlementGate({
   const {
     isManagedDeployment,
     isManagedDeploymentResolved,
+    managedDeploymentResolutionError,
     authenticationState,
     authenticationError,
     isManagedAuthenticated,
@@ -669,6 +670,22 @@ export function AppEntitlementGate({
   }
 
   if (!isManagedDeploymentResolved) {
+    if (managedDeploymentResolutionError) {
+      return (
+        <EntitlementShell
+          title="couldn't check access"
+          description="screenpipe could not confirm which build is installed. it will retry automatically."
+        >
+          <Button
+            onClick={() => window.location.reload()}
+            variant="secondary"
+            className="w-full"
+          >
+            reload and retry
+          </Button>
+        </EntitlementShell>
+      );
+    }
     return (
       <EntitlementShell
         title="checking access"

--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-is-enterprise-build.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-is-enterprise-build.test.tsx
@@ -15,12 +15,15 @@ vi.mock("@/lib/utils/tauri", () => ({
   },
 }));
 
-import { useEnterpriseBuildStatus } from "@/lib/hooks/use-is-enterprise-build";
+let useEnterpriseBuildStatus: (typeof import("@/lib/hooks/use-is-enterprise-build"))["useEnterpriseBuildStatus"];
 
 describe("useEnterpriseBuildStatus", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
     mocks.isEnterpriseBuildCmd.mockReset();
+    vi.resetModules();
+    ({ useEnterpriseBuildStatus } =
+      await import("@/lib/hooks/use-is-enterprise-build"));
   });
 
   afterEach(() => {
@@ -60,5 +63,32 @@ describe("useEnterpriseBuildStatus", () => {
       error: false,
     });
     expect(mocks.isEnterpriseBuildCmd).toHaveBeenCalledTimes(4);
+  });
+
+  it("abandons a hung startup IPC and recovers on a fresh invoke", async () => {
+    mocks.isEnterpriseBuildCmd
+      .mockImplementationOnce(() => new Promise<boolean>(() => {}))
+      .mockResolvedValueOnce(false);
+
+    const { result } = renderHook(() => useEnterpriseBuildStatus());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3_000);
+    });
+    expect(result.current).toEqual({
+      isEnterprise: false,
+      resolved: false,
+      error: false,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(result.current).toEqual({
+      isEnterprise: false,
+      resolved: true,
+      error: false,
+    });
+    expect(mocks.isEnterpriseBuildCmd).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/hooks/use-is-enterprise-build.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-is-enterprise-build.ts
@@ -11,6 +11,31 @@ import { commands } from "@/lib/utils/tauri";
 let cachedResult: boolean | null = null;
 let pendingPromise: Promise<boolean> | null = null;
 
+// Tauri invokes can remain pending when WebKit's content process is replaced
+// during startup. A bounded attempt lets the shared promise clear so the next
+// invoke can reach the new content process instead of wedging every consumer.
+const ENTERPRISE_BUILD_IPC_TIMEOUT_MS = 3_000;
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("enterprise build policy check timed out")),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export const E2E_FORCE_ENTERPRISE_BUILD_KEY =
   "screenpipe_e2e_force_enterprise_build";
 
@@ -39,7 +64,10 @@ async function resolveEnterpriseBuild(): Promise<boolean> {
   const attempt = (async () => {
     for (let i = 0; i < 3; i++) {
       try {
-        const result = await commands.isEnterpriseBuildCmd();
+        const result = await withTimeout(
+          commands.isEnterpriseBuildCmd(),
+          ENTERPRISE_BUILD_IPC_TIMEOUT_MS,
+        );
         cachedResult = result;
         if (i === 0) {
           console.log(`[enterprise] isEnterpriseBuild = ${result}`);


### PR DESCRIPTION
## What broke

After restarting v2.5.155, the native app and recorder reached healthy state, but the frontend never emitted the expected `isEnterpriseBuild = false` log. The first Tauri build-policy invoke remained pending. Because `use-is-enterprise-build` shared that promise globally and only retried rejected calls, all consumers stayed unresolved forever and `AppEntitlementGate` rendered the permanent `checking access` screen.

The failure became possible when #5082 changed build detection to fail closed on July 10, then #5253 made unresolved detection a full-window entitlement gate on July 16. Fail-closed is correct for managed policy, but the pending IPC had no terminal path.

## Fix

- Bound each enterprise-build IPC attempt to 3 seconds so a hung invoke releases the shared promise and a fresh invoke can recover.
- Keep policy fail-closed: a timeout is never cached as a consumer build.
- After repeated failures, replace the endless skeleton with an honest recovery state, automatic background retry, and a `reload and retry` action.
- Add regressions for a never-settling IPC and the visible gate error state.

## Verification

- `bun run test:vitest --run lib/hooks/__tests__/use-is-enterprise-build.test.tsx components/app-entitlement-gate.test.tsx` — 39 passed
- `bunx tsc --noEmit --pretty false` — passed
- `git diff --check` — passed
- Repository-wide effects lint is currently blocked by an unrelated existing config error in `components/meeting-notes/attendees-pill.tsx`: missing `jsx-a11y/no-autofocus` rule definition.