### PR TITLE
[codex] add prominent README download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<h1 align="center"><a href="https://screenpipe.com/how-to-install?download=1">DOWNLOAD SCREENPIPE</a></h1>
 
 <img width="1500" height="500" alt="image" src="https://github.com/user-attachments/assets/058a44b8-fcad-4a37-92d8-830167dbd400" />
 
@@ -21,12 +22,6 @@
 
 <p align="center">
 <a align="center" href="https://trendshift.io/repositories/20386" target="_blank"><img align="center" src="https://trendshift.io/api/badge/repositories/20386" alt="screenpipe%2Fscreenpipe | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
-</p>
-
-<p align="center">
-  <a href="https://screenpi.pe/onboarding" target="_blank">
-    <img src="https://img.shields.io/badge/download-desktop%20app-black?style=for-the-badge" alt="download">
-  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## what changed

- added a centered `DOWNLOAD SCREENPIPE` link as the first element in the README
- linked it to `https://screenpipe.com/how-to-install?download=1`
- removed the lower badge that still pointed to the old onboarding URL

## why

The primary download action was below the hero content and used the old onboarding destination. This makes the current explicit-download route the first and most prominent action for README visitors.

## impact

Visitors can start the platform-aware desktop download flow immediately from the top of the repository README. The existing install section remains available for context and CLI instructions.

## visual

```text
before                              after
┌───────────────────────────┐       ┌───────────────────────────┐
│        hero banner        │       │    DOWNLOAD SCREENPIPE    │
│        logo + copy        │       ├───────────────────────────┤
│    old download badge     │       │        hero banner        │
└───────────────────────────┘       │        logo + copy        │
                                    └───────────────────────────┘
```

## verification

- `git diff --check`
- rendered the README through GitHub's Markdown API and confirmed the top heading preserves the exact link
- confirmed `https://screenpipe.com/how-to-install?download=1` responds with HTTP 200
- confirmed only `README.md` changed
