### PR TITLE
fix(build): restore generated Tauri command registry

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/build.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/build.rs
@@ -315,8 +315,44 @@ fn ensure_frontend_dist() {
         .expect("write frontendDist placeholder");
 }
 
+fn generate_and_validate_tauri_commands() {
+    // This Cargo.toml is both the app package and a workspace containing the
+    // Windows WER helper. The helper defaults to scanning workspace members;
+    // once `wer-dump-helper` was added, that excluded the root app package and
+    // silently produced `tauri::generate_handler![]` in release builds.
+    let options = tauri_helper::TauriHelperOptions {
+        members: Some(vec![".".to_string()]),
+    };
+    tauri_helper::generate_command_file(options);
+
+    // Never publish another native binary with an empty or partial command
+    // registry. These sentinels cover startup, authentication, and build-policy
+    // checks that the frontend needs before it can render the normal app.
+    let manifest_dir = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let commands_path = manifest_dir
+        .join("target")
+        .join("tauri_commands_list")
+        .join("screenpipe_app.txt");
+    let commands = std::fs::read_to_string(&commands_path).unwrap_or_else(|error| {
+        panic!(
+            "missing generated Tauri command registry at {}: {error}",
+            commands_path.display()
+        )
+    });
+    for required in [
+        "screenpipe_app::config::get_screenpipe_base_dir",
+        "screenpipe_app::commands::get_cloud_token",
+        "screenpipe_app::commands::is_enterprise_build_cmd",
+    ] {
+        assert!(
+            commands.lines().any(|command| command == required),
+            "generated Tauri command registry is missing required command {required}"
+        );
+    }
+}
+
 fn main() {
-    tauri_helper::generate_command_file(tauri_helper::TauriHelperOptions::default());
+    generate_and_validate_tauri_commands();
 
     ensure_frontend_dist();
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -273,6 +273,15 @@ async fn is_server_running(app: AppHandle) -> Result<bool, String> {
     Ok(response.is_ok())
 }
 
+// `tauri_collect_commands!` historically degraded to an empty handler when
+// its generated registry was missing. Make the same compile-time view a hard
+// build invariant so a commandless native app can never be published again.
+const TAURI_COMMAND_COUNT: usize = tauri_helper::array_collect_commands!(false).len();
+const _: () = assert!(
+    TAURI_COMMAND_COUNT > 0,
+    "generated Tauri command registry must not be empty"
+);
+
 /// Shared tauri-specta registry body.
 macro_rules! define_specta_builder {
     () => {{


### PR DESCRIPTION
## Root cause

Adding `wer-dump-helper` as a member of the nested app workspace changed `tauri-helper` default discovery: it scanned the helper workspace member instead of the root Screenpipe app. Release builds then logged `no commands collected` and silently compiled `tauri::generate_handler![]`. The v155/v156 native binaries therefore lacked frontend-required commands such as `get_screenpipe_base_dir`, `get_cloud_token`, and `is_enterprise_build_cmd`.

## Fix

- explicitly scan the root app package when generating Tauri commands
- fail the build if the generated registry is missing critical startup/auth/build-policy commands
- add a compile-time assertion that the collected command registry is non-empty

## Before / after

```text
v156:  WER workspace member -> 0 collected commands -> Command ... not found -> access gate blocks
fixed: root app scan       -> 247 commands          -> policy returns false    -> /home renders
```

## Verification

- `cargo check -p screenpipe-app --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml`
- full `cargo build -p screenpipe-app` completed
- generated registry contains 247 commands
- rebuilt binary contains `get_screenpipe_base_dir`, `get_cloud_token`, `is_enterprise_build_cmd`, and `get_app_identifier`
- full `bun tauri dev` launch completed on macOS
  - Next `/home`, `/chat`, and `/search` returned 200
  - home, chat, and search each logged `[enterprise] isEnterpriseBuild = false`
  - native health reached `ready`; ports 3030 and 11435 listened
  - `/health` returned `all systems are functioning normally.`
  - no `Command ... not found`, build-policy failure, or access-gate screen
  - normal Chat UI visually confirmed
- dev process shut down cleanly; ports closed; worktree clean
- `git diff --check`

This PR does not publish a release.