### PR TITLE
fix(app): bypass build IPC in E2E bundles

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-is-enterprise-build.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-is-enterprise-build.test.tsx
@@ -17,17 +17,75 @@ vi.mock("@/lib/utils/tauri", () => ({
 
 let useEnterpriseBuildStatus: (typeof import("@/lib/hooks/use-is-enterprise-build"))["useEnterpriseBuildStatus"];
 
+const localStorageMock = (() => {
+  let values = new Map<string, string>();
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    get length() {
+      return values.size;
+    },
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, String(value)),
+  } satisfies Storage;
+})();
+
 describe("useEnterpriseBuildStatus", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
+    vi.stubEnv("NEXT_PUBLIC_SCREENPIPE_E2E", "false");
     mocks.isEnterpriseBuildCmd.mockReset();
+    localStorageMock.clear();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: localStorageMock,
+    });
     vi.resetModules();
     ({ useEnterpriseBuildStatus } =
       await import("@/lib/hooks/use-is-enterprise-build"));
   });
 
   afterEach(() => {
+    localStorageMock.clear();
+    vi.unstubAllEnvs();
     vi.useRealTimers();
+  });
+
+  it("uses consumer mode in E2E without waiting for startup IPC", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SCREENPIPE_E2E", "true");
+    mocks.isEnterpriseBuildCmd.mockImplementation(
+      () => new Promise<boolean>(() => {}),
+    );
+
+    const { result } = renderHook(() => useEnterpriseBuildStatus());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual({
+      isEnterprise: false,
+      resolved: true,
+      error: false,
+    });
+    expect(mocks.isEnterpriseBuildCmd).not.toHaveBeenCalled();
+  });
+
+  it("preserves the explicit enterprise E2E override", async () => {
+    vi.stubEnv("NEXT_PUBLIC_SCREENPIPE_E2E", "true");
+    window.localStorage.setItem("screenpipe_e2e_force_enterprise_build", "1");
+
+    const { result } = renderHook(() => useEnterpriseBuildStatus());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual({
+      isEnterprise: true,
+      resolved: true,
+      error: false,
+    });
+    expect(mocks.isEnterpriseBuildCmd).not.toHaveBeenCalled();
   });
 
   it("stays unresolved on IPC failure and recovers on a later retry", async () => {

--- a/apps/screenpipe-app-tauri/lib/hooks/use-is-enterprise-build.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-is-enterprise-build.ts
@@ -39,24 +39,30 @@ async function withTimeout<T>(
 export const E2E_FORCE_ENTERPRISE_BUILD_KEY =
   "screenpipe_e2e_force_enterprise_build";
 
-function isE2eEnterpriseForced(): boolean {
+function getE2eEnterpriseBuildOverride(): boolean | null {
   if (
     process.env.NEXT_PUBLIC_SCREENPIPE_E2E !== "true" ||
     typeof window === "undefined"
   ) {
-    return false;
+    return null;
   }
   try {
+    // E2E builds are consumer builds by default. Dedicated enterprise specs
+    // opt in before reloading the webview; no test build should depend on a
+    // startup IPC round trip merely to render its first page.
     return window.localStorage?.getItem(E2E_FORCE_ENTERPRISE_BUILD_KEY) === "1";
   } catch {
+    // The E2E-only override is compiled out of production bundles. If a test
+    // webview cannot access storage, keep the documented consumer default.
     return false;
   }
 }
 
 async function resolveEnterpriseBuild(): Promise<boolean> {
-  if (isE2eEnterpriseForced()) {
-    cachedResult = true;
-    return true;
+  const e2eOverride = getE2eEnterpriseBuildOverride();
+  if (e2eOverride !== null) {
+    cachedResult = e2eOverride;
+    return e2eOverride;
   }
   if (cachedResult !== null) return cachedResult;
   if (pendingPromise) return pendingPromise;


### PR DESCRIPTION
## Summary
- resolve E2E builds as consumer by default without a startup Tauri IPC round trip
- retain the explicit enterprise E2E override
- leave production build-policy behavior unchanged

## Why
Windows E2E could remain on the startup access-check screen when the native build-policy command never answered, so `home-page` never rendered. E2E bundles already bypass billing and should not require this startup IPC call.

## Tests
- `bunx vitest run lib/hooks/__tests__/use-is-enterprise-build.test.tsx` (4 pass)
- `bun run typecheck`
- `bunx biome check lib/hooks/use-is-enterprise-build.ts lib/hooks/__tests__/use-is-enterprise-build.test.tsx`
- `git diff --check origin/main...HEAD`

Full app suites and GitHub Windows E2E are running.