### PR TITLE
fix(ai-gateway): classify Anthropic spend-cap 400 as provider outage

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -131,6 +131,17 @@ export function isGeoBlocked(status: number, msg: string): boolean {
   return status === 403 && GEO_BLOCK_PATTERN.test(msg);
 }
 
+// Anthropic's org-level monthly spend cap ("You have reached your specified
+// API usage limits. You will regain access on ... at 00:00 UTC.", 400
+// invalid_request_error) — a provider-wide outage until the cap resets or is
+// raised, not a client bug. 4k+ identical Sentry events on 2026-07-31
+// (SCREENPIPE-AI-PROXY-30/-2P/-2W/-31) for one billing fact.
+const PROVIDER_USAGE_CAP_PATTERN = /reached your specified api usage limits/i;
+
+export function isProviderUsageCapped(status: number, msg: string): boolean {
+  return status === 400 && PROVIDER_USAGE_CAP_PATTERN.test(msg);
+}
+
 export function isUserInputTooLarge(status: number, msg: string): boolean {
   if (status !== 400 && status !== 413) return false;
   return USER_INPUT_TOO_LARGE_PATTERNS.some((re) => re.test(msg));
@@ -257,6 +268,19 @@ async function tryModel(
       error.status = 413;
       error.transient = true;
       console.warn(`${ctx}: ${model} rejected oversized prompt (413), cascading`);
+      logModelOutcome(env, { model, outcome: 'error' }).catch(() => {});
+      throw error;
+    }
+
+    // Provider spend cap (Anthropic monthly limit) — cascade to another
+    // provider's model; if the whole chain is capped, tell the user what
+    // will work instead of leaking the raw provider JSON. One Sentry alert
+    // per request would drown the dashboard for a single billing fact, so
+    // skip it — the cost dashboards and model-health log still see it.
+    if (isProviderUsageCapped(status, msg)) {
+      error.transient = true;
+      error.userMessage = `${model} is temporarily at capacity (the provider's usage limit was reached). Pick Auto or a model from a different provider, or try again later.`;
+      console.warn(`${ctx}: ${model} provider usage cap hit (400), cascading`);
       logModelOutcome(env, { model, outcome: 'error' }).catch(() => {});
       throw error;
     }

--- a/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
+++ b/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
@@ -7,6 +7,7 @@ import {
 	isTransient,
 	isUserInputTooLarge,
 	isGeoBlocked,
+	isProviderUsageCapped,
 	clientPayloadMessage,
 	MODEL_FALLBACKS,
 	TRANSIENT_STATUSES,
@@ -91,6 +92,22 @@ describe('chat handler — geo-block detection (SCREENPIPE-AI-PROXY-1C)', () => 
 		expect(isGeoBlocked(403, 'The caller does not have permission')).toBe(false);
 		expect(isGeoBlocked(401, 'Country, region, or territory not supported')).toBe(false);
 		expect(isGeoBlocked(401, 'Request not allowed')).toBe(false);
+	});
+});
+
+describe('chat handler — provider usage-cap classification (SCREENPIPE-AI-PROXY-30/-2P)', () => {
+	it('detects the Anthropic monthly spend-cap 400', () => {
+		expect(
+			isProviderUsageCapped(
+				400,
+				'400 {"type":"error","error":{"type":"invalid_request_error","message":"You have reached your specified API usage limits. You will regain access on 2026-08-01 at 00:00 UTC."},"request_id":"req_011CdZwqaamihBfwacKwXY4a"}',
+			),
+		).toBe(true);
+	});
+
+	it('leaves other 400s and non-400 statuses unclassified', () => {
+		expect(isProviderUsageCapped(400, 'invalid tool schema')).toBe(false);
+		expect(isProviderUsageCapped(429, 'You have reached your specified API usage limits.')).toBe(false);
 	});
 });
 


### PR DESCRIPTION
### Description:

On 2026-07-31 the Anthropic org monthly spend limit was reached, taking down every claude-* model for all screenpipe-cloud users until the cap reset (2026-08-01 00:00 UTC). The gateway treated the resulting 400 as a generic client error, so users saw either raw provider JSON or misleading advice:

**Before:**
```
# explicit model without a fallback chain (claude-fable-5, gpt-5.5-pro):
Error: 400 data: {"error":{"message":"400 {"type":"error","error":{"type":
"invalid_request_error","message":"You have reached your specified API usage
limits. You will regain access on 2026-08-01 at 00:00 UTC."},...}

# fallback chain exhausted (claude-opus-5 → sonnet → gpt-5.4-mini):
No available model could complete this request (400). It may contain an
unsupported parameter or a malformed tool call, or the models may not be
enabled on your account or API key. ...
```

**After:**
```
claude-opus-5 is temporarily at capacity (the provider's usage limit was
reached). Pick Auto or a model from a different provider, or try again later.
```

- Add `isProviderUsageCapped()` — 400-gated match on Anthropic's exact spend-cap phrasing ("reached your specified API usage limits"), same shape as the existing `isGeoBlocked()` / `isUserInputTooLarge()` classifiers.
- Set a clear `userMessage`, mark the error transient, and keep cascading — a capped Claude entry falls through to OpenAI as before; only a fully-exhausted chain surfaces the message.
- Skip Sentry for these events: the cap generated **4,300+ identical error events in ~23h** across four issues for a single billing fact. Model-health logging and cost dashboards still record every occurrence.
- Zero behavior change outside the exact phrasing match: other 400s keep their existing classification, tests pin the negative cases.

Verified with two user feedback logs from 2026-07-31 (raw-JSON leak on the explicit path, generic 400 on the exhausted-chain path). `bun test` on the touched file: 22/22 pass.

### References:
- Sentry: [SCREENPIPE-AI-PROXY-30](https://mediar.sentry.io/issues/SCREENPIPE-AI-PROXY-30) (3,388 events), [SCREENPIPE-AI-PROXY-2P](https://mediar.sentry.io/issues/SCREENPIPE-AI-PROXY-2P) (691), [SCREENPIPE-AI-PROXY-2W](https://mediar.sentry.io/issues/SCREENPIPE-AI-PROXY-2W) (183), [SCREENPIPE-AI-PROXY-31](https://mediar.sentry.io/issues/SCREENPIPE-AI-PROXY-31) (46)
- Follow-up to #5618 (geo-403 classification)