### PR TITLE
fix(ai-gateway): stop advertising gpt-5.3-codex, unservable via chat completions

### DIFF
--- a/packages/ai-gateway/src/handlers/models.ts
+++ b/packages/ai-gateway/src/handlers/models.ts
@@ -194,23 +194,10 @@ const CURATED_MODELS: ModelEntry[] = [
     warning: 'very expensive — avoid for pipes unless the task truly needs pro-level accuracy',
     requires_env: 'OPENAI_API_KEY',
   },
-  {
-    id: 'gpt-5.3-codex',
-    object: 'model',
-    owned_by: 'openai',
-    name: 'GPT-5.3 Codex',
-    description: 'openai coding specialist for agentic code changes and long-horizon engineering tasks',
-    tags: ['premium', 'coding', 'agentic', 'vision'],
-    free: false,
-    context_window: 400000,
-    best_for: ['agentic coding', 'code review', 'large refactors', 'debugging'],
-    speed: 'medium',
-    intelligence: 'highest',
-    cost_tier: 'medium',
-    recommended_for: ['coding', 'analysis'],
-    warning: 'coding-specialized model — use gpt-5.4-mini or a free model for ordinary chat/pipes',
-    requires_env: 'OPENAI_API_KEY',
-  },
+  // gpt-5.3-codex is deliberately NOT listed: codex models are served only via
+  // OpenAI's Responses API, and this worker speaks Chat Completions — every
+  // request 404s upstream ("model not found"). Codex stays available through
+  // ChatGPT-subscription connections in the app, which use a different backend.
   {
     id: 'gpt-5.4-mini',
     object: 'model',

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -50,9 +50,13 @@ describe('OpenAI API model catalog', () => {
 		expect(ids).toContain('gpt-5.5-pro');
 		expect(ids).toContain('gpt-5.4');
 		expect(ids).toContain('gpt-5.4-pro');
-		expect(ids).toContain('gpt-5.3-codex');
 		expect(ids).toContain('gpt-5.4-mini');
 		expect(ids).toContain('gpt-5.4-nano');
+	});
+
+	it('never advertises Responses-API-only codex models (chat-completions 404s them)', async () => {
+		const ids = await listedModelIds();
+		expect(ids).not.toContain('gpt-5.3-codex');
 	});
 
 	it('hides OpenAI models until OPENAI_API_KEY is configured', async () => {


### PR DESCRIPTION
### Description:

`gpt-5.3-codex` is listed in the gateway's `/models` catalog, but codex models are served only through OpenAI's **Responses API** — and the worker's OpenAI provider speaks **Chat Completions**. Every screenpipe-cloud request for it 404s upstream ("model not found"), so the catalog advertises a model that can never work. It also has no `MODEL_FALLBACKS` entry, so users hit the failure raw instead of cascading.

**Before (user feedback, 2026-07-31 — user retried 5×):**
```
Error: 404 data: {"error":{"message":""gpt-5.3-codex" couldn't complete this
request (404) — it may contain an unsupported parameter or tool call, or not
be enabled on your account or API key. Pick a different model, or check your
provider access.","type":"api_error","code":"404"}}
```

**After:** the model no longer appears in the screenpipe-cloud model list, so it can't be selected there.

- Remove the `gpt-5.3-codex` entry from `models.ts`, with a comment explaining why it must not be re-added while the worker is chat-completions-only.
- **ChatGPT-subscription connections are untouched**: the app's `openai-chatgpt` picker fallbacks (`ai-presets.tsx`, `ai-presets-selector.tsx`) keep codex models — that path uses the ChatGPT backend where they work.
- Pricing (`cost-tracker.ts`) and weight (`usage-tracker.ts`) entries are kept defensively so requests from clients holding a cached model list still cost-log correctly.
- Alternative considered: routing codex models through the Responses API in the worker — that's a feature, not a fix; can follow up if codex demand justifies it.

No Sentry issue exists for this one by design — 404s are in `SENTRY_SKIP_STATUSES` — which is exactly why it only surfaced via user feedback. Root cause verified from the reporting user's log (5 gateway requests for `gpt-5.3-codex`, all 404).

`bun test`: full ai-gateway suite 668 pass / 0 fail, including a new regression test pinning that the catalog never advertises the model.

### References:
- Follow-up to #5618 / #5653 (gateway error-classification series)