### PR TITLE
fix(settings): stop re-selling cloud transcription to paid plans in Business upsell

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -343,6 +343,38 @@ describe("AccountSection subscription/login gating", () => {
     );
   });
 
+  it("pitches premium AI models, not cloud transcription, to paid-plan holders", () => {
+    // Cloud transcription ships with every paid app entitlement (Basic and
+    // Lifetime included), so the Business upsell must not re-sell it to them.
+    mocks.state.user = {
+      id: "u1",
+      email: "lifetime@screenpipe.test",
+      token: "tok",
+      cloud_subscribed: true,
+      app_entitled: true,
+      subscription_plan: "lifetime",
+      entitlement: {
+        active: true,
+        plan: "lifetime",
+        source: "lifetime",
+        status: "active",
+      },
+    };
+
+    render(<AccountSection />);
+
+    expect(screen.getByText(/premium AI models/i)).toBeInTheDocument();
+    expect(screen.queryByText(/cloud transcription/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the cloud transcription bullet for signed-out free users", () => {
+    mocks.state.user = { token: null, cloud_subscribed: false };
+
+    render(<AccountSection />);
+
+    expect(screen.getByText(/cloud transcription/i)).toBeInTheDocument();
+  });
+
   it("shows the login-first layout for a signed-out free user", () => {
     mocks.state.user = { token: null, cloud_subscribed: false };
 

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -761,9 +761,15 @@ export function AccountSection() {
                   <Shield className="h-3.5 w-3.5 shrink-0" />
                   encrypted cloud sync — 50GB, 3 devices
                 </div>
+                {/* Cloud transcription ships with every paid app entitlement
+                    (Basic/Lifetime included — see applyProCloudAudioDefaults),
+                    so it's only a Business delta for free accounts. Showing it
+                    to Lifetime holders reads as double-selling what they own. */}
                 <div className="flex items-center gap-2 text-foreground">
                   <Zap className="h-3.5 w-3.5 shrink-0" />
-                  cloud transcription — higher quality, saves 2-3GB RAM
+                  {hasNamedPlan
+                    ? "premium AI models — Claude Opus, Sonnet & more"
+                    : "cloud transcription — higher quality, saves 2-3GB RAM"}
                 </div>
                 <div className="flex items-center gap-2 text-foreground">
                   <Sparkles className="h-3.5 w-3.5 shrink-0" />


### PR DESCRIPTION
### Description:

- A Lifetime holder asked why the Business upsell lists "cloud transcription — higher quality, saves 2-3GB RAM" when their plan already includes it. They're right: cloud transcription ships with every paid app entitlement (Basic and Lifetime included — `applyProCloudAudioDefaults` in `use-settings.tsx` even enables it by default for them), so the bullet reads as double-selling something they already own.
- The Business card in Settings → Account is shown to both logged-in free users and paid Basic/Lifetime holders. The bullet is now conditional on `hasNamedPlan`: paid holders see the actual Business delta — "premium AI models — Claude Opus, Sonnet & more" — while free users keep the cloud transcription bullet, which is a genuine delta for them.
- The signed-out upsell card is untouched (transcription is a real delta there too).
- Two regression tests added: paid-plan holders see premium-AI-models and never cloud-transcription; signed-out free users keep the transcription bullet. Matches the website's billing picker, which already excludes the transcription bullet in `lifetime-business-addon` mode (#626).

`bunx vitest run` on the touched test file: 11/11 pass; `tsc --noEmit` clean.