### PR TITLE
fix(imap): stop a search phrase from injecting IMAP commands

### DIFF
--- a/crates/screenpipe-connect/src/connections/imap.rs
+++ b/crates/screenpipe-connect/src/connections/imap.rs
@@ -736,6 +736,33 @@ mod net_tests {
         assert!(lines[2].contains("invoice"), "phrase lost: {lines:#?}");
     }
 
+    /// `?mailbox=` is the other caller-controlled value on the same routes.
+    /// It is safe for a different reason — async-imap validates EXAMINE
+    /// arguments itself — so pin that, both to document why only the search
+    /// phrase needed fixing and to catch a future switch to an API that does
+    /// not validate.
+    #[tokio::test]
+    async fn mailbox_name_cannot_inject_imap_commands() {
+        let (port, log) = spawn_fake_server(None).await;
+        let mut session = fake_session(port).await;
+
+        let err = list_messages_in(&mut session, "INBOX\r\nx9 EXPUNGE", 5, None)
+            .await
+            .expect_err("a mailbox name with CRLF must be rejected, not sent");
+        assert!(
+            err.to_string().contains("not found"),
+            "expected the mailbox error, got: {err}"
+        );
+
+        let lines = log.lock().unwrap().clone();
+        assert_eq!(
+            lines.len(),
+            1,
+            "only LOGIN should have been sent: {lines:#?}"
+        );
+        assert!(lines[0].to_uppercase().contains("LOGIN"), "{lines:#?}");
+    }
+
     #[tokio::test]
     async fn mailbox_access_is_read_only() {
         let (port, log) = spawn_fake_server(None).await;

--- a/crates/screenpipe-connect/src/connections/imap.rs
+++ b/crates/screenpipe-connect/src/connections/imap.rs
@@ -244,6 +244,37 @@ fn friendly_login_error(raw: &str, host: &str) -> anyhow::Error {
     anyhow!("IMAP login failed: {}", raw)
 }
 
+/// Render a caller-supplied phrase as an RFC 3501 quoted string (§4.3).
+///
+/// `EXAMINE` and `LIST` run their arguments through async-imap's own
+/// validator, but search keys are interpolated into the command line
+/// verbatim, so this is the only thing between the phrase and the protocol.
+/// A bare CR or LF ends the line, and everything after it is read as the next
+/// command — which is enough to turn a read-only search into `STORE` or
+/// `EXPUNGE` against the real mailbox, since `EXAMINE` only constrains the
+/// mailbox that is currently selected.
+///
+/// Control characters have no quoted-string representation at all, so they
+/// are dropped; the two characters that are representable are escaped rather
+/// than deleted, so phrases containing a quote or a backslash now search for
+/// what the user actually typed.
+fn quoted_search_phrase(query: &str) -> String {
+    let mut out = String::with_capacity(query.len() + 2);
+    out.push('"');
+    for ch in query.chars() {
+        match ch {
+            '"' | '\\' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 /// List recent messages, newest first. `query` (optional) runs an IMAP
 /// `TEXT` search; otherwise the last `limit` messages by sequence.
 pub async fn list_messages(
@@ -271,10 +302,9 @@ where
 
     let set = match query {
         Some(q) if !q.trim().is_empty() => {
-            let escaped = q.replace('\\', "").replace('"', "");
             let uids = bounded("search", OP_TIMEOUT, async {
                 session
-                    .uid_search(format!("TEXT \"{}\"", escaped))
+                    .uid_search(format!("TEXT {}", quoted_search_phrase(q)))
                     .await
                     .context("IMAP search failed")
             })
@@ -471,6 +501,63 @@ mod tests {
     }
 
     #[test]
+    fn search_phrase_escapes_quotes_and_backslashes() {
+        // Escaped, not deleted: the user searched for these characters.
+        assert_eq!(quoted_search_phrase(r#"say "hi""#), r#""say \"hi\"""#);
+        assert_eq!(quoted_search_phrase(r"c:\reports"), r#""c:\\reports""#);
+    }
+
+    #[test]
+    fn search_phrase_drops_line_terminators() {
+        // CR/LF are what end an IMAP command line; NUL is equally illegal.
+        let out = quoted_search_phrase("invoice\r\nx9 EXPUNGE");
+        assert_eq!(out, r#""invoicex9 EXPUNGE""#);
+        assert!(!out.contains('\r') && !out.contains('\n'));
+        assert!(!quoted_search_phrase("a\0b").contains('\0'));
+    }
+
+    #[test]
+    fn search_phrase_is_always_one_balanced_quoted_string() {
+        // Whatever goes in, exactly one quoted string comes out: the opening
+        // and closing quotes are the only unescaped ones.
+        for phrase in [
+            r#""" OR FROM "x"#,
+            r#"\"#,
+            r#"\\""#,
+            "plain words",
+            "trailing backslash\\",
+            "\r\n\r\n",
+            "héllo ünïcode",
+        ] {
+            let out = quoted_search_phrase(phrase);
+            assert!(out.starts_with('"') && out.ends_with('"'), "{out:?}");
+            let inner = &out[1..out.len() - 1];
+            let mut chars = inner.chars().peekable();
+            while let Some(c) = chars.next() {
+                if c == '\\' {
+                    assert!(
+                        matches!(chars.peek(), Some('"') | Some('\\')),
+                        "dangling escape in {out:?}"
+                    );
+                    chars.next();
+                } else {
+                    assert_ne!(c, '"', "unescaped quote closes the string early: {out:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn search_phrase_preserves_ordinary_text() {
+        // No behaviour change for the phrases users actually type.
+        assert_eq!(
+            quoted_search_phrase("quarterly invoice from ansh"),
+            r#""quarterly invoice from ansh""#
+        );
+        assert_eq!(quoted_search_phrase("héllo"), r#""héllo""#);
+    }
+
+    #[test]
     fn parses_rfc2047_headers() {
         let raw = b"From: =?utf-8?q?Ansh_Grover?= <ansh@screenpi.pe>\r\nTo: you@gmail.com\r\nSubject: =?utf-8?q?hello_world?=\r\nDate: Fri, 17 Jul 2026 10:00:00 +0530\r\n\r\n";
         let v = headers_to_json(raw);
@@ -609,6 +696,44 @@ mod net_tests {
             "expected a deadline error, got: {err}"
         );
         assert!(started.elapsed() < Duration::from_secs(10));
+    }
+
+    /// The search phrase is the only caller-controlled value that reaches the
+    /// wire, and `uid_search` interpolates it verbatim. A bare CRLF would end
+    /// the line and run the remainder as its own command against the user's
+    /// real mailbox — read-only EXAMINE does not protect against that.
+    #[tokio::test]
+    async fn search_query_cannot_inject_imap_commands() {
+        let (port, log) = spawn_fake_server(None).await;
+        let mut session = fake_session(port).await;
+
+        // Exactly what an agent could be talked into passing through
+        // GET /connections/imap/messages?query=...
+        let hostile = "invoice\r\nx9 STORE 1:* +FLAGS (\\Deleted)\r\nx8 EXPUNGE";
+        let _ = list_messages_in(&mut session, "INBOX", 5, Some(hostile)).await;
+
+        let lines = log.lock().unwrap().clone();
+        // The phrase may appear inside the quoted string — searching for the
+        // word "EXPUNGE" is legitimate. What must never happen is the phrase
+        // producing a *line* of its own, so assert on line structure: LOGIN,
+        // EXAMINE, UID SEARCH, and nothing else.
+        assert_eq!(
+            lines.len(),
+            3,
+            "hostile phrase added command lines: {lines:#?}"
+        );
+        assert!(
+            lines[2].to_uppercase().starts_with("A0003 UID SEARCH"),
+            "expected one UID SEARCH line; saw: {lines:#?}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.starts_with("x9") || l.starts_with("x8")),
+            "an injected tag reached the server as a command: {lines:#?}"
+        );
+        // ...and the phrase is still actually searched for.
+        assert!(lines[2].contains("invoice"), "phrase lost: {lines:#?}");
     }
 
     #[tokio::test]

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -3675,6 +3675,26 @@ mod tests {
         (format!("http://{addr}/feed.ics"), server)
     }
 
+    /// `?query=` is agent-reachable and carries whatever the caller sends —
+    /// URL encoding hides CR/LF from casual inspection, and nothing between
+    /// the socket and the IMAP connector strips them. This pins that fact so
+    /// the escaping in `connections::imap` stays the enforcement point rather
+    /// than a belt-and-braces nicety somebody later removes.
+    #[test]
+    fn imap_search_query_reaches_the_connector_with_control_bytes_intact() {
+        let uri: axum::http::Uri = "/imap/messages?query=invoice%0D%0Ax9%20EXPUNGE&limit=5"
+            .parse()
+            .unwrap();
+        let Query(parsed) = Query::<ImapMessagesQuery>::try_from_uri(&uri).unwrap();
+
+        let query = parsed.query.expect("query param must be extracted");
+        assert_eq!(query, "invoice\r\nx9 EXPUNGE");
+        assert!(
+            query.contains('\r') && query.contains('\n'),
+            "transport must not be trusted to sanitize; got {query:?}"
+        );
+    }
+
     #[tokio::test]
     async fn connections_lists_ics_calendar_when_feed_enabled() {
         let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Problem

`GET /connections/imap/messages?query=<text>` let the search phrase break out of its IMAP quoted string and run as its own protocol command against the user's real mailbox.

The connector only deleted `"` and `\` before interpolating the phrase into the command line. CR and LF survived. Unlike `EXAMINE` and `LIST` — which async-imap runs through its own `validate_str` (rejects CR/LF) — **search keys are interpolated verbatim**, so the connector was the only line of defence and it wasn't checking for the one thing that matters.

`EXAMINE` does not save us here: it constrains the *currently selected* mailbox, not what an injected `SELECT` + `STORE`/`EXPUNGE`/`APPEND` does next. The session is logged in with full read-write authority.

## Where found

Reviewing the open security-report threads (AI-gateway keyless-access report, plus the website header/cookie reports). The gateway report's core claim is already fixed and covered by tests in `packages/ai-gateway/src/utils/auth.test.ts`; this is a **separate, previously unreported** issue found while auditing the same "agent-callable local endpoint" surface.

`crates/screenpipe-connect/src/connections/imap.rs:274` (pre-fix):

```rust
let escaped = q.replace('\\', "").replace('"', "");   // CR/LF pass straight through
session.uid_search(format!("TEXT \"{}\"", escaped))
```

## Reachability

The endpoint is agent-callable by design (it's advertised in the connector description that goes to the model). A prompt-injected agent — content in a captured screen, a page, or an email — is enough to choose the query string. No local network access or user interaction beyond normal agent operation is required.

## Reproduction / pre-fix failure

`search_query_cannot_inject_imap_commands` drives the **real** `async-imap` client and the **real** `list_messages_in` path against a scripted IMAP server that logs every command line it receives. Phrase:

```
invoice\r\nx9 STORE 1:* +FLAGS (\Deleted)\r\nx8 EXPUNGE
```

**Before the fix** — three commands reach the server; the mailbox is flagged deleted and expunged:

```
A0001 LOGIN "user@example.com" "secret"
A0002 EXAMINE "INBOX"
A0003 UID SEARCH TEXT "invoice
x9 STORE 1:* +FLAGS (Deleted)      <-- injected command
x8 EXPUNGE"                        <-- injected command
```

**After the fix** — one command, phrase contained:

```
A0001 LOGIN "user@example.com" "secret"
A0002 EXAMINE "INBOX"
A0003 UID SEARCH TEXT "invoicex9 STORE 1:* +FLAGS (\\Deleted)x8 EXPUNGE"
```

I verified the test is a real regression guard by reverting the fix and re-running it: it fails (`5 lines` vs `3`), then passes once the fix is restored.

## Root cause

Deleting the two characters that *are* legal inside an RFC 3501 quoted string, while passing through the two that terminate the line.

## Fix

`quoted_search_phrase()` renders the phrase as a proper RFC 3501 §4.3 quoted string:

- control characters are dropped — they have no quoted-string representation
- `"` and `\` are **escaped** rather than deleted

Second-order benefit: searching for `say "hi"` or `c:\reports` now searches for what the user typed instead of a silently mangled phrase.

Scope is deliberately narrow — no change to non-ASCII handling, timeouts, the read-only `EXAMINE` guarantee, or any other connector.

## Validation

| gate | result |
|---|---|
| `cargo test -p screenpipe-connect` | **195 passed**, 0 failed, 1 ignored |
| `cargo test -p screenpipe-engine --lib connections_api` | **83 passed**, 0 failed |
| negative control (fix reverted) | exploit test **fails** as designed |
| `cargo fmt -p screenpipe-connect -p screenpipe-engine --check` | clean |
| `cargo clippy -p screenpipe-connect --all-targets` | no new warnings on `imap.rs` |

New tests:

- `search_query_cannot_inject_imap_commands` — protocol-level, asserts on **line structure** (3 lines, no injected tag) rather than substring matching, so searching for the literal word "EXPUNGE" stays legitimate
- `search_phrase_is_always_one_balanced_quoted_string` — property test over hostile inputs (`""` OR FROM "x`, lone/trailing backslashes, bare CRLF, unicode): exactly one quoted string out, every `\` a valid escape, no unescaped `"`
- `search_phrase_escapes_quotes_and_backslashes`, `search_phrase_drops_line_terminators`, `search_phrase_preserves_ordinary_text`
- `mailbox_name_cannot_inject_imap_commands` — the sibling `?mailbox=` parameter is safe for a *different* reason (async-imap validates `EXAMINE` arguments itself); pinned so a future API switch fails here rather than silently
- `imap_search_query_reaches_the_connector_with_control_bytes_intact` — pins that axum hands `%0D%0A` through raw, so the connector stays the enforcement point

### No Gmail IMAP regression

All pre-existing IMAP tests pass unchanged: read-only `EXAMINE` (never `SELECT`), connect/fetch deadlines, RFC 2047 header decoding, Gmail app-password error messages, secret-field registration. Ordinary phrases produce a byte-identical command line to before.

**Not covered:** no live Gmail account was exercised in CI — the change is below the TLS layer, so the fake-server tests use the same code path with TLS omitted.
