### PR TITLE
fix(onboarding): dedupe login completion analytics

### DIFF
--- a/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
@@ -58,7 +58,12 @@ vi.mock("@/lib/hooks/use-settings", () => ({
   }),
 }));
 vi.mock("@/components/onboarding/login-gate", () => ({
-  default: () => <div>regular sign in</div>,
+  default: ({ handleNextSlide }: { handleNextSlide: () => void }) => (
+    <div>
+      regular sign in
+      <button onClick={handleNextSlide}>complete regular sign in</button>
+    </div>
+  ),
 }));
 vi.mock("@/components/enterprise-license-prompt", () => ({
   EnterpriseLicensePrompt: ({ onSignIn }: { onSignIn?: () => void }) => (
@@ -159,6 +164,29 @@ describe("enterprise onboarding authentication", () => {
       funnel_version: "onboarding_ui_v1",
       step: "started",
     });
+  });
+
+  it("leaves login completion analytics to the login gate", async () => {
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    render(<OnboardingPage />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /complete regular sign in/i }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.setOnboardingStep).toHaveBeenCalledWith("permissions"),
+    );
+    expect(
+      mocks.capture.mock.calls.filter(
+        ([event]) => event === "onboarding_login_completed",
+      ),
+    ).toHaveLength(0);
+    expect(
+      mocks.capture.mock.calls.filter(
+        ([event]) => event === "onboarding_step_reached",
+      ),
+    ).toHaveLength(1);
   });
 
   it("does not start the standard funnel for managed onboarding", () => {

--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -275,7 +275,12 @@ export default function OnboardingPage() {
     transitioningRef.current = true;
     setIsTransitioning(true);
 
-    posthog.capture(`onboarding_${currentSlide}_completed`);
+    // The login gate owns this event because only it can distinguish a fresh
+    // logged-out -> logged-in transition from resuming a persisted session.
+    // Capturing it here as well duplicates every fresh-login completion.
+    if (currentSlide !== "login") {
+      posthog.capture(`onboarding_${currentSlide}_completed`);
+    }
     const currentIdx = SLIDE_ORDER.indexOf(currentSlide);
     posthog.capture("onboarding_step_reached", {
       step_name: `${currentSlide}_completed`,


### PR DESCRIPTION
## description

PR #5375 made the login gate emit `onboarding_login_completed` only for a real logged-out to logged-in transition. The onboarding page still independently built the same event name in its generic slide-completion handler, so a fresh login produced two events and a persisted-session resume produced a false completion.

This PR makes the login gate the sole owner of login-completion analytics. The parent still captures completion for every other onboarding slide and still emits `onboarding_step_reached` for the login transition.

## before

    fresh login
      |-- login gate --------> onboarding_login_completed
      `-- parent transition -> onboarding_login_completed

    persisted session resume
      `-- parent transition -> onboarding_login_completed

## after

    fresh login
      `-- login gate --------> onboarding_login_completed (once)

    persisted session resume -> no login-completion event

No visual UI changes.

## how to test

1. Start onboarding logged out, then sign in.
2. Confirm onboarding advances to permissions and captures one `onboarding_login_completed` event.
3. Resume onboarding with a persisted authenticated session and confirm it advances without capturing a new login-completion event.

Automated verification:

- Focused onboarding suites: 2 files passed, 36 tests passed
- Full Vitest suite: 205 files passed, 1,975 tests passed
- `bun run typecheck`
- `git diff --check`

## desktop app checklist

- [x] `bun run typecheck`
- [x] Tauri bindings unchanged; generation/check not applicable