### PR TITLE
fix(ai-gateway): restore paid chat after spend containment

### DIFF
--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -15,6 +15,7 @@ import {
 const COST_LEASE_TIER = 'daily_cost_in_flight_v1';
 const COST_BASELINE_TIER = 'daily_cost_baseline_v1';
 export const DAILY_COST_LEASE_SECONDS = 10 * 60;
+export const FAILED_SETTLEMENT_LEASE_SECONDS = 60;
 
 export type DailyCostLease = {
 	key: string;
@@ -141,6 +142,26 @@ export async function releaseDailyCostLease(env: Env, lease: DailyCostLease): Pr
 }
 
 /**
+ * Keep a short fail-closed quarantine after accounting fails without blocking
+ * the account for the full active-request TTL. Match the exact generation so a
+ * delayed finalizer can never shorten a newer request's lease.
+ */
+async function shortenFailedSettlementLease(env: Env, lease: DailyCostLease): Promise<void> {
+	try {
+		const retryAt = new Date(Date.now() + FAILED_SETTLEMENT_LEASE_SECONDS * 1000).toISOString();
+		await env.DB.prepare(`
+			UPDATE usage
+			SET last_reset = ?, updated_at = CURRENT_TIMESTAMP
+			WHERE device_id = ? AND user_id = ? AND tier = ?
+				AND daily_count = 1 AND last_reset = ?
+		`).bind(retryAt, lease.key, lease.deviceId, COST_LEASE_TIER, lease.expiresAt).run();
+	} catch (error) {
+		// If shortening fails, preserve the original bounded fail-closed lease.
+		console.error('failed settlement lease shortening failed', error);
+	}
+}
+
+/**
  * Atomically serialize priced upstream work for an account, then read its cap.
  *
  * The old check read daily spend before inference and logged it after inference;
@@ -224,9 +245,10 @@ export function withDailyCostSettlement(
 		if (recorded) {
 			await releaseDailyCostLease(env, lease);
 		} else {
-			// Keep the bounded lease closed after an accounting failure. Its TTL is
-			// the crash-recovery escape hatch; do not immediately allow unmetered work.
-			console.error('daily cost was not recorded; retaining spend lease until expiry');
+			// Keep a short fail-closed quarantine after an accounting failure, but do
+			// not strand every chat for the full active-request crash-recovery TTL.
+			console.error('daily cost was not recorded; shortening spend lease quarantine');
+			await shortenFailedSettlementLease(env, lease);
 		}
 	};
 	return withResponseFinalizer(response, finalize, (error) => {

--- a/packages/ai-gateway/src/services/cost-tracker.ts
+++ b/packages/ai-gateway/src/services/cost-tracker.ts
@@ -416,7 +416,7 @@ function getMaxDailyTextCostPerUser(env?: Env): number {
 export function getTierDailyCostCap(tier: string, env?: Env): number {
   const baseCap = getMaxDailyTextCostPerUser(env);
   switch (tier) {
-    case 'subscribed': return baseCap * 7;   // $35
+    case 'subscribed': return parseFloat(env?.MAX_DAILY_SUBSCRIBED_TEXT_COST || '') || baseCap * 7;
     case 'logged_in':  return baseCap * 0.64; // $3.20
     default:           return baseCap * 0.32; // $1.60 (anonymous)
   }

--- a/packages/ai-gateway/src/test/cost-cap.unit.test.ts
+++ b/packages/ai-gateway/src/test/cost-cap.unit.test.ts
@@ -19,6 +19,7 @@
 
 import { describe, it, expect } from 'bun:test';
 import {
+	FAILED_SETTLEMENT_LEASE_SECONDS,
 	enforceDailyCostCap,
 	releaseDailyCostLease,
 	reserveDailyCostCap,
@@ -150,6 +151,18 @@ class LeaseD1 {
 						}
 						return { meta: { changes: 0 } };
 					}
+					if (normalized.includes('SET last_reset = ?')) {
+						const [retryAt, key, userId, tier, expiresAt] = args;
+						const row = this.rows.get(key);
+						if (
+							row && row.userId === userId && row.tier === tier &&
+							row.dailyCount === 1 && row.lastReset === expiresAt
+						) {
+							row.lastReset = retryAt;
+							return { meta: { changes: 1 } };
+						}
+						return { meta: { changes: 0 } };
+					}
 					return { meta: { changes: 0 } };
 				},
 				first: async () => {
@@ -261,10 +274,10 @@ describe('reserveDailyCostCap', () => {
 		)).allowed).toBe(true);
 	});
 
-	it('retains the lease when the accumulator write fails', async () => {
+	it('uses a short quarantine when the accumulator write fails', async () => {
 		const db = new LeaseD1();
 		const env = leaseEnv(db);
-		const now = new Date('2026-07-30T12:00:00Z');
+		const now = new Date();
 		const first = await reserveDailyCostCap(env, 'user_7', 'subscribed', 'gpt-5.6-sol', now);
 		if (!first.allowed || !first.lease) throw new Error('expected lease');
 
@@ -275,9 +288,18 @@ describe('reserveDailyCostCap', () => {
 			Promise.resolve(false),
 		).text();
 		const overlap = await reserveDailyCostCap(
-			env, 'user_7', 'subscribed', 'gpt-5.6-sol', new Date('2026-07-30T12:00:01Z'),
+			env, 'user_7', 'subscribed', 'gpt-5.6-sol', new Date(now.getTime() + 1000),
 		);
 		expect(overlap.allowed).toBe(false);
 		if (!overlap.allowed) expect(await overlap.response.text()).toContain('priced_request_in_flight');
+
+		const retry = await reserveDailyCostCap(
+			env,
+			'user_7',
+			'subscribed',
+			'gpt-5.6-sol',
+			new Date(now.getTime() + (FAILED_SETTLEMENT_LEASE_SECONDS + 1) * 1000),
+		);
+		expect(retry.allowed).toBe(true);
 	});
 });

--- a/packages/ai-gateway/src/test/transcription-cost.unit.test.ts
+++ b/packages/ai-gateway/src/test/transcription-cost.unit.test.ts
@@ -81,8 +81,12 @@ describe('daily cost cap', () => {
   });
 
   it('keeps emergency text caps separate from transcription', () => {
-    const env = { MAX_DAILY_TEXT_COST_PER_USER: '0.5' } as any;
-    expect(getTierDailyCostCap('subscribed', env)).toBe(3.5);
+    const env = {
+      MAX_DAILY_TEXT_COST_PER_USER: '0.5',
+      MAX_DAILY_SUBSCRIBED_TEXT_COST: '35',
+    } as any;
+    expect(getTierDailyCostCap('logged_in', env)).toBe(0.32);
+    expect(getTierDailyCostCap('subscribed', env)).toBe(35);
     expect(getMaxDailyCostPerUser(env)).toBe(5.0);
   });
 });

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -216,6 +216,7 @@ export interface Env {
 	 */
 	COST_CAP_EPOCH?: string;
 	MAX_DAILY_TEXT_COST_PER_USER?: string;
+	MAX_DAILY_SUBSCRIBED_TEXT_COST?: string;
 	// Legacy/transcription base cap. Text falls back to this only when its
 	// dedicated override is absent.
 	MAX_DAILY_COST_PER_USER?: string;

--- a/packages/ai-gateway/wrangler.toml
+++ b/packages/ai-gateway/wrangler.toml
@@ -61,9 +61,10 @@ GEMINI_FLEX_INTERACTIVE = "false"
 # 2026-07-31 emergency spend containment. Fable and Opus are rerouted to Sonnet
 # in code; reject frontier-priced background work. The epoch preserves today's
 # incident ledger while giving legitimate chats a fresh post-containment budget.
-# Effective text-AI caps: $0.16 anonymous / $0.32 Free+Basic / $3.50 Business.
+# Effective text-AI caps: $0.16 anonymous / $0.32 Free+Basic / $35 Business.
 COST_CAP_EPOCH = "anthropic-incident-2026-07-31-v2"
 MAX_DAILY_TEXT_COST_PER_USER = "0.5"
+MAX_DAILY_SUBSCRIBED_TEXT_COST = "35"
 MODEL_GATING_ENABLED = "true"
 PIPE_FRONTIER_POLICY = "reject"
 
@@ -75,6 +76,8 @@ PIPE_FRONTIER_POLICY = "reject"
 #   latency hurts user-facing chat.
 # - MAX_DAILY_TEXT_COST_PER_USER ("5"): base per-user daily text-AI $ cap; ×7 subscribed,
 #   ×0.64 logged_in, ×0.32 anonymous (getTierDailyCostCap).
+# - MAX_DAILY_SUBSCRIBED_TEXT_COST: optional absolute Business/Team/Enterprise
+#   text-AI cap. This keeps paid users available without raising Free/Basic.
 # - MAX_DAILY_COST_PER_USER ("5"): legacy transcription base cap. Keep this
 #   separate from text containment so chat policy cannot disrupt audio capture.
 # - ROUTER_MODE ("off"): interactive auto difficulty router. "off" = GPT-5.6 Luna


### PR DESCRIPTION
Emergency follow-up to #5656.

- keeps the low Free/Basic text cap while setting an explicit $35/day paid-account ceiling
- shortens failed cost-settlement quarantine from the 10-minute active-request TTL to 60 seconds
- matches the exact lease generation so delayed finalizers cannot alter a newer request
- leaves the separate $5 transcription cap unchanged

Validated before deploy:
- 671 gateway tests pass (0 failures)
- focused cap/lease regression tests pass
- wrangler deploy dry-run passes
- parent incident PR #5656 has green Windows, macOS, and Linux E2E

Already deployed as emergency Worker version 79b35726-69bf-4764-8a79-ff5e02b7447e; catalog read-back shows zero Fable/Opus entries.