### PR TITLE
fix(windows): keep Escape registered while overlay is visible

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -925,15 +925,11 @@ impl ShowRewindWindow {
                                         }
                                         #[cfg(not(target_os = "macos"))]
                                         {
-                                            // Only keep Escape when the overlay is still visible.
-                                            // Otherwise Home (or another app window) can hold focus while
-                                            // the overlay is already gone — returning here would skip
-                                            // blur unregister and leave the global Escape hook stuck on.
-                                            if crate::commands::any_screenpipe_webview_has_focus(&app)
-                                                && crate::commands::main_overlay_is_visible(&app)
-                                            {
+                                            // Keep Escape registered whenever the main overlay is visible,
+                                            // even if focus shifts temporarily (#5346).
+                                            if crate::commands::main_overlay_is_visible(&app) {
                                                 info!(
-                                                    "main-window blur: another screenpipe window has focus, keep Escape registered"
+                                                    "main-window blur: main overlay is visible, keeping Escape shortcut registered"
                                                 );
                                                 let _ = app.emit("window-focused", false);
                                                 return;
@@ -1335,11 +1331,11 @@ impl ShowRewindWindow {
                                     }
                                     #[cfg(target_os = "windows")]
                                     {
-                                        if crate::commands::any_screenpipe_webview_has_focus(&app)
-                                            && crate::commands::main_overlay_is_visible(&app)
-                                        {
+                                        // Keep Escape registered whenever the main overlay is visible,
+                                        // even if focus shifts temporarily (#5346).
+                                        if crate::commands::main_overlay_is_visible(&app) {
                                             info!(
-                                                "Main overlay blur: another screenpipe window has focus, keep Escape registered"
+                                                "Main overlay blur: main overlay is visible, keeping Escape shortcut registered"
                                             );
                                             let _ = app.emit("window-focused", false).ok();
                                             return;


### PR DESCRIPTION
## Summary

Fixes #5346 by keeping the global Escape shortcut registered while the Windows timeline overlay remains visible, even after its webview loses focus.

This extracts only the overlay-focus fix from #5614 so it can be reviewed and merged independently from that PR's unrelated UI and generated-file changes.

## Root cause

The blur debounce required both a focused Screenpipe webview and a visible overlay. On Windows, the fullscreen/floating overlay can lose webview focus without closing. The failed focus check then unregistered window shortcuts, leaving Escape unavailable while the overlay was still covering the screen.

## Behavior

```text
before: overlay visible + webview loses focus
        -> unregister window shortcuts
        -> Escape is not received
        -> overlay remains stuck

after:  overlay visible + webview loses focus
        -> keep Escape registered
        -> Escape closes the overlay
```

Both Windows paths are covered:

- regular `main-window` blur handling
- fullscreen overlay blur handling



https://github.com/user-attachments/assets/d2143893-4f57-4775-8843-b2d46361b778


## Testing

- [x] Rebased onto latest upstream `main` (`1cb104b1`)
- [x] Windows Rust app test binary compiled successfully
- [x] `window::show::tests` passed (1 passed, 552 filtered out)
- [x] Changed file passes `rustfmt --check`
- [x] Debug x64 NSIS installer built successfully on Windows with this isolated source fix
- [ ] Manual: open timeline in fullscreen mode, move focus outside the webview, press Escape
- [ ] Manual: repeat in window mode

Repository-wide `cargo fmt --check` currently reports pre-existing formatting differences in unrelated files on `main`; this PR changes only `src/window/show.rs`.