### PR TITLE
chore(pi): bump runtime to v0.83.0

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
-pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.80.6";
-pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.80.6";
+pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.83.0";
+pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.83.0";
 pub const PI_NAMESPACE_DIR: &str = "@earendil-works";
 pub const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
 


### PR DESCRIPTION
## Summary

- bump `@earendil-works/pi-coding-agent` from 0.80.6 to 0.83.0
- bump the directly pinned `@earendil-works/pi-ai` runtime in lockstep to 0.83.0

## Version map

```text
pi-coding-agent  0.80.6  ──▶  0.83.0
pi-ai            0.80.6  ──▶  0.83.0
```

## Shared-pin audit

- `crates/screenpipe-core/src/agents/pi.rs` — authoritative coding-agent and pi-ai pins; updated
- background pipe installer/executor — consumes the shared constants; no separate pin
- desktop Pi installer/integrity checks — imports the shared constants; no separate pin
- repository-wide `0.80.6` search — no remaining Pi version references

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p screenpipe-core agents::pi --lib` — 20 passed, 1 ignored
- `bunx --bun @earendil-works/pi-coding-agent@0.83.0 --version` — reports 0.83.0
- confirmed both 0.83.0 artifacts are published through the package registry

Desktop install-integrity tests were attempted through the app manifest, but the local Tauri build stops before tests because the untracked bundled resource `bun-aarch64-apple-darwin` is absent. CI bootstraps that resource.
