### PR TITLE
fix(ai-gateway): resolve anonymous usage as Free

### DIFF
--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -294,12 +294,20 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 
 		// Usage status endpoint - returns current usage without incrementing
 		if (path === '/v1/usage' && request.method === 'GET') {
+			// Anonymous auth results deliberately carry an `unknown` account plan:
+			// there is no server-verified customer record. The usage endpoint still
+			// represents anonymous traffic as the Free product, so resolve that one
+			// safe fallback explicitly. Keep every authenticated unknown plan
+			// fail-closed instead of accidentally granting paid capacity.
+			const usageAccountPlan = authResult.tier === 'anonymous' && authResult.accountPlan === 'unknown'
+				? 'free'
+				: authResult.accountPlan;
 			const status = await getUsageStatus(
 				env,
 				authResult.deviceId,
 				usageTier,
 				authResult.userId,
-				authResult.accountPlan,
+				usageAccountPlan,
 			);
 			// Enrich with cost-based limit flag (NOT the raw $ numbers — those
 			// are our internal margin and shouldn't leak to any client/user).
@@ -310,12 +318,12 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 			let monthlyCap: number;
 			try {
 				maxCost = getPlanDailyCostCap(
-					authResult.accountPlan,
+					usageAccountPlan,
 					env,
 					authResult.hostedAiTrial === true,
 				);
 				monthlyCap = getPlanMonthlyCostCap(
-					authResult.accountPlan,
+					usageAccountPlan,
 					env,
 					authResult.hostedAiTrial === true,
 				);
@@ -339,7 +347,7 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				// Admission still fails closed. The status route stays available but
 				// marks usage unknown instead of pretending the customer spent zero.
 			}
-			const includedCredits = getHostedAiIncludedCredits(authResult.accountPlan);
+			const includedCredits = getHostedAiIncludedCredits(usageAccountPlan);
 			const usedCredits = monthlyCost === null ? null : Math.ceil(monthlyCost * 100);
 			const enriched = {
 				...status,
@@ -347,14 +355,14 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				upgrade_eligible: isHostedAiUpgradeEligible(authResult),
 				upsell_banner: status.upsell_banner === true && isHostedAiUpgradeEligible(authResult),
 				hosted_ai: {
-					plan: getHostedAiPlan(authResult.accountPlan) ?? 'unknown',
+					plan: getHostedAiPlan(usageAccountPlan) ?? 'unknown',
 					trial: authResult.hostedAiTrial === true,
 					included_credits: includedCredits,
 					used_credits: usedCredits,
 					remaining_credits: usedCredits === null
 						? null
 						: Math.max(0, includedCredits - usedCredits),
-					model_access: [...getHostedAiAllowedModels(authResult.accountPlan)],
+					model_access: [...getHostedAiAllowedModels(usageAccountPlan)],
 					upgrade_url: isHostedAiUpgradeEligible(authResult)
 						? 'https://screenpi.pe/account/billing'
 						: null,

--- a/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
+++ b/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
@@ -97,6 +97,38 @@ describe('/v1/chat/completions free-plan route policy', () => {
 		expect(globalThis.fetch).not.toHaveBeenCalled();
 	});
 
+	it.each([
+		['without credentials', {}],
+		['after an invalid bearer falls back to anonymous', { Authorization: 'Bearer invalid-canary' }],
+	])('returns the Free usage policy %s', async (
+		_label: string,
+		headers: Record<string, string>,
+	) => {
+		const response = await handleRequest(new Request('https://gateway.test/v1/usage', {
+			headers,
+		}), env, ctx);
+		const body = await response.json() as {
+			tier: string;
+			cost_limit_reached: boolean;
+			hosted_ai: {
+				plan: string;
+				included_credits: number;
+				model_access: string[];
+			};
+		};
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({
+			tier: 'anonymous',
+			cost_limit_reached: false,
+			hosted_ai: {
+				plan: 'free',
+				included_credits: 10,
+			},
+		});
+		expect(body.hosted_ai.model_access).toContain('auto');
+	});
+
 	it('lets the trusted runner bearer reach hosted background inference without a human user id', async () => {
 		const response = await handleRequest(
 			request({


### PR DESCRIPTION
## Summary

Fix `/v1/usage` returning `503 cost_control_unavailable` for anonymous requests and invalid bearers that safely fall back to anonymous.

The private cost controls were present and valid. The failure was caused by passing the anonymous auth sentinel `accountPlan: unknown` into the strict cost-control resolver. Authenticated usage remained healthy.

This change resolves only `anonymous + unknown` to the Free product policy at the usage boundary. Authenticated accounts with unknown plan truth continue to fail closed.

```text
anonymous + unknown -> Free usage policy -> 200
logged_in/subscribed + unknown -> unchanged fail-closed behavior
```

## Verification

- `bun test`: 744 passed, 0 failed across 51 files / 2,050 expectations
- focused route suite: 33 passed, 0 failed
- regression coverage for both no credentials and invalid bearer fallback
- missing private-control regression remains fail closed
- authenticated Max route regression remains green
- `bunx wrangler deploy --dry-run`: success
- `git diff --check`: clean

Standalone `bunx tsc --noEmit` remains red on existing package-wide issues (notably absent `bun:test` declarations and unrelated `openrouter.ts` typing); the repository's executable Bun and Wrangler gates are green.

No visual applies: this is a backend response-policy correction with exact route assertions.
