### PR TITLE
fix(ai-gateway): prove reservation admission with RETURNING

### DIFF
--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -502,6 +502,11 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				freeModel: isFreeModel(body.model),
 			});
 			if (!rateLimit.allowed && rateLimit.response) {
+				console.warn('hosted AI admission rejected', {
+					gate: 'per_minute',
+					tier: authResult.tier,
+					accountPlan: authResult.accountPlan,
+				});
 				return rateLimit.response;
 			}
 
@@ -509,6 +514,11 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 			const ipAddress = request.headers.get('cf-connecting-ip') || undefined;
 			const usage = await trackUsage(env, authResult.deviceId, usageTier, authResult.userId, ipAddress, body.model);
 			if (!usage.allowed) {
+				console.warn('hosted AI admission rejected', {
+					gate: 'daily_query',
+					tier: authResult.tier,
+					accountPlan: authResult.accountPlan,
+				});
 				const creditsExhausted = (usage.creditsRemaining ?? 0) <= 0;
 				return addCorsHeaders(createErrorResponse(429, JSON.stringify({
 					error: creditsExhausted ? 'credits_exhausted' : 'daily_limit_exceeded',
@@ -561,6 +571,13 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				authResult.hostedAiTrial === true,
 			);
 			if (!costReservation.allowed) {
+				console.warn('hosted AI admission rejected', {
+					gate: 'cost_reservation',
+					tier: authResult.tier,
+					accountPlan: authResult.accountPlan,
+					hostedAiTrial: authResult.hostedAiTrial === true,
+					status: costReservation.response.status,
+				});
 				if (freeChatLease) await releaseFreeChatLease(env, freeChatLease);
 				return costReservation.response;
 			}

--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -318,7 +318,9 @@ export async function reserveDailyCostCap(
 
 		// D1/SQLite serializes this write. Every concurrent request observes the
 		// previously committed holds, so global and account caps cannot race open.
-		const claimed = changed(await env.DB.prepare(`
+		// RETURNING is the admission proof; D1 write metadata can report an
+		// ambiguous change count even when the row was inserted.
+		const claimed = await env.DB.prepare(`
 			INSERT OR IGNORE INTO usage
 				(device_id, user_id, daily_count, last_reset, tier, updated_at)
 			SELECT ?, ?, ?, ?, ?, ?
@@ -387,6 +389,7 @@ export async function reserveDailyCostCap(
 						AND device_id LIKE ?
 				), 0) + ? <= ?
 			)
+			RETURNING device_id AS reservation_key
 		`).bind(
 			key,
 			deviceId,
@@ -437,9 +440,9 @@ export async function reserveDailyCostCap(
 			backgroundPrefix,
 			reservedMicroUsd,
 			backgroundBudgetMicroUsd,
-		).run());
+		).first<{ reservation_key: string }>();
 
-		if (claimed) {
+		if (claimed?.reservation_key === key) {
 			return {
 				allowed: true,
 				reservation: {

--- a/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
@@ -281,6 +281,41 @@ describe('usage reservations against workerd D1', () => {
 		)).allowed).toBe(true);
 	});
 
+	it('uses the inserted row instead of ambiguous write metadata to prove admission', async () => {
+		const realDb = env.DB;
+		const dbWithAmbiguousWriteMetadata = {
+			prepare(sql: string) {
+				const statement = realDb.prepare(sql);
+				if (!sql.includes('INSERT OR IGNORE INTO usage')) return statement;
+				return {
+					bind(...values: unknown[]) {
+						const bound = statement.bind(...values);
+						return {
+							first: <T>() => bound.first<T>(),
+							// Reproduce the production symptom: a successful write path whose
+							// metadata cannot be used as the admission source of truth.
+							run: async () => ({ success: true, meta: { changes: 0 }, results: [] }),
+						};
+					},
+				};
+			},
+		} as unknown as D1Database;
+		const result = await reserveDailyCostCap(
+			{ ...env, DB: dbWithAmbiguousWriteMetadata },
+			'user-d1-returning-proof',
+			'subscribed',
+			'gpt-5.6-sol',
+			new Date('2026-07-14T12:00:00.000Z'),
+		);
+
+		expect(result.allowed).toBe(true);
+		if (!result.allowed || !result.reservation) throw new Error('expected reservation');
+		const stored = await realDb.prepare(
+			'SELECT device_id FROM usage WHERE device_id = ?',
+		).bind(result.reservation.key).first<{ device_id: string }>();
+		expect(stored?.device_id).toBe(result.reservation.key);
+	});
+
 	it('stops stale disconnects from occupying capacity while retaining their spend holds', async () => {
 		const start = new Date('2026-07-14T12:00:00.000Z');
 		const controls = loadHostedAiReservationControls(env);

--- a/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
+++ b/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
@@ -38,9 +38,11 @@ describe('/v1/chat/completions free-plan route policy', () => {
 			}),
 		},
 		DB: {
-			prepare: () => ({
-				bind: () => ({
-					first: async () => null,
+			prepare: (sql: string) => ({
+				bind: (...values: unknown[]) => ({
+					first: async () => sql.includes('INSERT OR IGNORE INTO usage')
+						? { reservation_key: values[0] }
+						: null,
 					run: async () => ({ success: true, meta: { changes: 1 } }),
 				}),
 			}),


### PR DESCRIPTION
## Summary
- use the reservation row returned by the atomic D1 insert as admission proof
- stop relying on ambiguous write-change metadata that can falsely reject an inserted hold
- add privacy-safe gate classification without customer identifiers or request content
- add a regression covering successful inserts with ambiguous change metadata

## Validation
- focused reservation and route tests passed
- full AI gateway suite: 754 passed, 0 failed, 2,087 assertions
- `git diff --check` passed
- Wrangler production-bundle dry run passed

## Deployment
Production deployment and live verification are being handled separately under the active incident authorization.