### PR TITLE
test(e2e): follow focused notification inbox view

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -76,6 +76,20 @@ async function openPipesView(): Promise<void> {
   await navPipes.click();
 }
 
+async function showAllNotifications(): Promise<void> {
+  const allNotifications = await $('[data-testid="notification-bell-view-all"]');
+  await allNotifications.waitForDisplayed({ timeout: t(10_000) });
+  await allNotifications.click();
+  await browser.waitUntil(
+    async () => (await allNotifications.getAttribute("aria-selected")) === "true",
+    {
+      timeout: t(10_000),
+      interval: 250,
+      timeoutMsg: "Notification inbox did not switch to the All view",
+    },
+  );
+}
+
 async function clickFirstDisplayed(selector: string, timeoutMs = t(15_000)): Promise<void> {
   const deadline = Date.now() + timeoutMs;
 
@@ -729,6 +743,11 @@ describe("Windows user journey", function () {
       await bell.waitForDisplayed({ timeout: t(20_000) });
       await bell.click();
 
+      // This fixture is an ordinary pipe update, so the focused inbox keeps it
+      // out of the default Priority view. Exercise the real user path to All
+      // before looking for the seeded history row.
+      await showAllNotifications();
+
       const item = await $(itemSelector);
       await item.waitForDisplayed({ timeout: t(20_000) });
 
@@ -810,6 +829,7 @@ describe("Windows user journey", function () {
       const reopenedBell = await $(bellSelector);
       await reopenedBell.waitForDisplayed({ timeout: t(20_000) });
       await reopenedBell.click();
+      await showAllNotifications();
 
       const reopenedItem = await $(itemSelector);
       await reopenedItem.waitForDisplayed({ timeout: t(20_000) });


### PR DESCRIPTION
## Why

PR #5698 made the notification inbox open on **Priority** by default. The Windows user journey seeds an ordinary `pipe` notification, then waits for that row without switching to **All**. The row is persisted correctly but intentionally hidden, so the required Windows E2E now fails after every retry.

This reproduced independently on two exact-current branches:

- rollback PR #5690, run `30675790646`: 7/8 journey tests passed; notification row hidden
- meetings PR #5695, run `30675721887`: the same notification row hidden

## Fix

Add one E2E helper that switches the inbox to **All**, and use it both when the bell first opens and after returning from Notification Settings (when the inbox remounts on Priority).

## Scope

- one test file
- 20 insertions
- no production UI or notification behavior change
- no generated coverage change

## Verification

- TypeScript typecheck: passed
- E2E/core/unified coverage freshness: passed
- diff whitespace check: passed
- hosted Windows `Run E2E Tests` step: passed on runs `30678242391` and `30679897546`
- exact head: `3301a9092d22cafd694be22c99e55db3a9779afd`

The required Windows hosted E2E is the final platform proof for this Windows-only journey correction.