### PR TITLE
fix(ci): repair coverage and cross-platform E2E regressions

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -160,8 +160,13 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       : opts.selectedPreset;
   const componentUnmountedRef = useRef(false);
   const currentMessagesRef = useRef(messages);
+  // Keep cross-window listeners mounted while chats switch. Re-registering
+  // them on every conversationId change leaves a gap where sibling saves can
+  // be dropped, so handlers read the current id through this stable ref.
+  const currentConversationIdRef = useRef(conversationId);
   const latestSavedEventAtRef = useRef(new Map<string, number>());
   currentMessagesRef.current = messages;
+  currentConversationIdRef.current = conversationId;
 
   const [showHistory, setShowHistoryRaw] = useState(() => {
     try { return localStorage.getItem("screenpipe:chat-history-open") === "true"; } catch { return false; }
@@ -396,7 +401,7 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
           if (!id) return;
           invalidateConversationListCache();
           setFileConversations((prev) => prev.filter((c) => c.id !== id));
-          if (conversationId === id) {
+          if (currentConversationIdRef.current === id) {
             setMessages([]);
             setConversationId(null);
           }
@@ -446,7 +451,10 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
           // panel still renders a blank canvas. Hydrate only when disk is
           // strictly more complete so a stale save never rolls back a live
           // foreground stream.
-          if (id === conversationId || id === piSessionIdRef.current) {
+          if (
+            id === currentConversationIdRef.current ||
+            id === piSessionIdRef.current
+          ) {
             // Publish the stable assistant identity before any disk/title
             // awaits below. Pi can echo the user prompt within milliseconds;
             // without this synchronous handoff a sibling treats that echo as
@@ -585,7 +593,6 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       for (const unlisten of unlistenFns) unlisten();
     };
   }, [
-    conversationId,
     piContentBlocksRef,
     piMessageIdRef,
     piSessionIdRef,

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -561,9 +561,6 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
         },
       );
       unlistenFns.push(unlistenSaved);
-      (window as unknown as {
-        __e2eChatConversationSavedListenerReady?: boolean;
-      }).__e2eChatConversationSavedListenerReady = true;
 
       const unlistenRenamed = await listen<{ id: string; title: string }>(
         "chat-renamed",
@@ -593,9 +590,6 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
 
     return () => {
       cancelled = true;
-      (window as unknown as {
-        __e2eChatConversationSavedListenerReady?: boolean;
-      }).__e2eChatConversationSavedListenerReady = false;
       for (const unlisten of unlistenFns) unlisten();
     };
   }, [

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -561,6 +561,9 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
         },
       );
       unlistenFns.push(unlistenSaved);
+      (window as unknown as {
+        __e2eChatConversationSavedListenerReady?: boolean;
+      }).__e2eChatConversationSavedListenerReady = true;
 
       const unlistenRenamed = await listen<{ id: string; title: string }>(
         "chat-renamed",
@@ -590,6 +593,9 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
 
     return () => {
       cancelled = true;
+      (window as unknown as {
+        __e2eChatConversationSavedListenerReady?: boolean;
+      }).__e2eChatConversationSavedListenerReady = false;
       for (const unlisten of unlistenFns) unlisten();
     };
   }, [

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-cross-window-transcript-sync.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-cross-window-transcript-sync.spec.ts
@@ -219,9 +219,9 @@ async function expectSynchronizedActiveTurn(): Promise<void> {
 async function expectActiveToolState(): Promise<void> {
   const summary = await $('[data-testid="tool-activity-summary"]');
   await summary.waitForDisplayed({ timeout: t(10_000) });
-  expect((await summary.getText()).toLowerCase()).not.toContain("done");
   const indicator = await summary.$('[data-testid="tool-activity-running-indicator"]');
   await indicator.waitForDisplayed({ timeout: t(10_000) });
+  expect((await summary.getText()).toLowerCase()).not.toContain("done");
   expect(await $('[aria-label="stop reply"]').isDisplayed()).toBe(true);
 }
 

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-cross-window-transcript-sync.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-cross-window-transcript-sync.spec.ts
@@ -162,6 +162,18 @@ async function loadConversationInForeground(
       timeoutMsg: `${await browser.getWindowHandle()} did not foreground ${id}`,
     },
   );
+  await browser.waitUntil(
+    async () => Boolean(await browser.execute(
+      () => (window as unknown as {
+        __e2eChatConversationSavedListenerReady?: boolean;
+      }).__e2eChatConversationSavedListenerReady,
+    )),
+    {
+      timeout: t(10_000),
+      interval: 100,
+      timeoutMsg: `${await browser.getWindowHandle()} did not register the conversation save listener`,
+    },
+  );
 }
 
 async function expectActiveEmptyState(): Promise<void> {

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-cross-window-transcript-sync.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-cross-window-transcript-sync.spec.ts
@@ -11,6 +11,7 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { E2E_DATA_DIR } from "../helpers/app-launcher.js";
+import { PiConversationHarness } from "../helpers/pi-conversation-harness.js";
 import { saveScreenshot } from "../helpers/screenshot-utils.js";
 import { openHomeWindow, t, waitForAppReady } from "../helpers/test-utils.js";
 import {
@@ -25,6 +26,7 @@ const CHATS_DIR = join(E2E_DATA_DIR, "chats");
 const CHAT_FILE = join(CHATS_DIR, `${CHAT_ID}.json`);
 const USER_MARKER = "E2E-CROSS-WINDOW-USER-7Q3M9K";
 const ASSISTANT_MARKER = "E2E-CROSS-WINDOW-ANSWER-4P8V2N";
+const piConversation = new PiConversationHarness(CHAT_ID);
 
 function writeConversation(
   updatedAt: number,
@@ -162,18 +164,6 @@ async function loadConversationInForeground(
       timeoutMsg: `${await browser.getWindowHandle()} did not foreground ${id}`,
     },
   );
-  await browser.waitUntil(
-    async () => Boolean(await browser.execute(
-      () => (window as unknown as {
-        __e2eChatConversationSavedListenerReady?: boolean;
-      }).__e2eChatConversationSavedListenerReady,
-    )),
-    {
-      timeout: t(10_000),
-      interval: 100,
-      timeoutMsg: `${await browser.getWindowHandle()} did not register the conversation save listener`,
-    },
-  );
 }
 
 async function expectActiveEmptyState(): Promise<void> {
@@ -246,9 +236,14 @@ describe("Cross-window chat transcript sync", function () {
     await openHomeWindow();
     await showWindow("Chat");
     await waitForWindowHandle("chat", t(15_000));
+    await browser.switchToWindow("home");
+    await piConversation.initialize();
+    await piConversation.configureAppPreset();
+    await piConversation.restartPi();
   });
 
   after(async () => {
+    await piConversation.dispose().catch(() => {});
     rmSync(CHAT_FILE, { force: true });
     const handles = await browser.getWindowHandles();
     if (handles.includes("chat")) {
@@ -261,10 +256,12 @@ describe("Cross-window chat transcript sync", function () {
   });
 
   it("shows pending feedback, then hydrates the completed disk turn in both WebViews", async () => {
-    let lastFixtureUpdatedAt = Date.now();
+    // The fixture owns this synthetic save stream. Keep its logical clock well
+    // ahead of unrelated title/settings saves from sibling WebViews so the
+    // production stale-event guard evaluates only the ordering under test.
+    let lastFixtureUpdatedAt = Date.now() + 60 * 60 * 1000;
     const nextFixtureUpdatedAt = () => {
-      lastFixtureUpdatedAt = Math.max(Date.now(), lastFixtureUpdatedAt + 1);
-      return lastFixtureUpdatedAt;
+      return ++lastFixtureUpdatedAt;
     };
     writeConversation(lastFixtureUpdatedAt);
 
@@ -301,6 +298,7 @@ describe("Cross-window chat transcript sync", function () {
       titleSource: "fallback",
       updatedAt: activeAt,
       turnState: { isLoading: true, isStreaming: true },
+      activeAssistantMessageId: "cross-window-assistant",
     });
     await expectSynchronizedActiveTurn();
 
@@ -331,6 +329,7 @@ describe("Cross-window chat transcript sync", function () {
       titleSource: "fallback",
       updatedAt: toolAt,
       turnState: { isLoading: true, isStreaming: true },
+      activeAssistantMessageId: "cross-window-assistant",
     });
     await expectActiveToolState();
 

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -77,6 +77,20 @@ async function openPipesView(): Promise<void> {
   await navPipes.click();
 }
 
+async function showAllNotifications(): Promise<void> {
+  const allNotifications = await $('[data-testid="notification-bell-view-all"]');
+  await allNotifications.waitForDisplayed({ timeout: t(10_000) });
+  await allNotifications.click();
+  await browser.waitUntil(
+    async () => (await allNotifications.getAttribute("aria-selected")) === "true",
+    {
+      timeout: t(10_000),
+      interval: 250,
+      timeoutMsg: "Notification inbox did not switch to the All view",
+    },
+  );
+}
+
 async function clickFirstDisplayed(selector: string, timeoutMs = t(15_000)): Promise<void> {
   const deadline = Date.now() + timeoutMs;
 
@@ -730,6 +744,11 @@ describe("Windows user journey", function () {
       await bell.waitForDisplayed({ timeout: t(20_000) });
       await bell.click();
 
+      // This fixture is an ordinary pipe update, so the focused inbox keeps it
+      // out of the default Priority view. Exercise the real user path to All
+      // before looking for the seeded history row.
+      await showAllNotifications();
+
       const item = await $(itemSelector);
       await item.waitForDisplayed({ timeout: t(20_000) });
 
@@ -811,6 +830,7 @@ describe("Windows user journey", function () {
       const reopenedBell = await $(bellSelector);
       await reopenedBell.waitForDisplayed({ timeout: t(20_000) });
       await reopenedBell.click();
+      await showAllNotifications();
 
       const reopenedItem = await $(itemSelector);
       await reopenedItem.waitForDisplayed({ timeout: t(20_000) });


### PR DESCRIPTION
## Summary
- regenerate the core and unified coverage dashboards after the SQLite quarantine tests landed
- make the Windows notification journey switch from the default Priority inbox to All before asserting a normal-priority notification
- keep the cross-window chat save listener mounted across conversation switches so sibling saves cannot fall into a listener re-registration gap

## Root causes
- `docs/coverage/CORE.md` and `COVERAGE.md` were stale after five new core tests
- the Windows fixture creates an ordinary notification, but the E2E searched the Priority-only view
- the chat sync effect depended on `conversationId`, tearing down its listener during each switch; Linux exposed the event-loss window

## Verification
- `bun test lib/chat/__tests__/cross-window-transcript-sync.test.ts` (12/12)
- `bun run typecheck`
- `bun run coverage:all:check`
- prior combined head: all required checks green; Windows notification journey passed on canary and strict-head runs
- final strict-main CI rerunning with the listener fix