### PR TITLE
fix(pi): write tagged credentials so pi 0.83 can resolve provider auth

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1141,8 +1141,8 @@ impl PiExecutor {
 
         // -- auth.json: merge/remove screenpipe token, preserve other providers --
         // Only manage screenpipe auth when screenpipe provider is actually being used.
+        let auth_path = config_dir.join("auth.json");
         if should_add_screenpipe {
-            let auth_path = config_dir.join("auth.json");
             if let Some(token) = user_token.filter(|token| !token.is_empty()) {
                 let mut auth: serde_json::Value = if auth_path.exists() {
                     let content = std::fs::read_to_string(&auth_path).unwrap_or_default();
@@ -1151,31 +1151,21 @@ impl PiExecutor {
                     json!({})
                 };
 
+                upgrade_legacy_pi_credentials(&mut auth);
+
                 if let Some(obj) = auth.as_object_mut() {
-                    obj.insert("screenpipe".to_string(), json!(token));
+                    obj.insert("screenpipe".to_string(), api_key_credential(token));
                 }
 
-                let auth_tmp = config_dir.join(format!(
-                    "auth.json.{}.{}.tmp",
-                    std::process::id(),
-                    format!("{:?}", std::thread::current().id())
-                        .chars()
-                        .filter(|c| c.is_ascii_digit())
-                        .collect::<String>()
-                ));
-                std::fs::write(&auth_tmp, serde_json::to_string_pretty(&auth)?)?;
-                std::fs::rename(&auth_tmp, &auth_path)?;
-
-                // Set restrictive permissions (user read/write only)
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let perms = std::fs::Permissions::from_mode(0o600);
-                    let _ = std::fs::set_permissions(&auth_path, perms);
-                }
+                write_auth_json(&auth_path, &auth)?;
             } else {
                 remove_screenpipe_auth_from_path(&auth_path)?;
             }
+        } else {
+            // BYOK-only users never reach the screenpipe branch, but their
+            // auth.json can still hold legacy entries seeded from the user's
+            // global `~/.pi/agent/auth.json` — upgrade those too.
+            upgrade_legacy_pi_credentials_at_path(&auth_path)?;
         }
 
         debug!("pi config written at {:?}", models_path);
@@ -2377,6 +2367,102 @@ fn seed_from_global(global: &Path, dest: &Path, data_dir: &Path) -> bool {
     true
 }
 
+/// A pi credential in the tagged form pi >=0.83 requires.
+fn api_key_credential(key: &str) -> serde_json::Value {
+    json!({ "type": "api_key", "key": key })
+}
+
+/// Upgrade one legacy `auth.json` entry to pi >=0.83's tagged form.
+///
+/// pi 0.83 rejects any stored credential it cannot tag. `resolveProviderAuth`
+/// (pi-ai `auth/resolve.js`) short-circuits on *any* stored entry and returns
+/// `undefined` unless it matches `{"type": "oauth"|"api_key", …}` — there is no
+/// fallback to the provider's `apiKey` in models.json once a credential exists.
+/// Screenpipe wrote the cloud token as a bare string, which pi <=0.80 accepted,
+/// so after the 0.83 bump every signed-in user's hosted AI (chat *and* every
+/// background pipe) fails with "Provider is not configured: screenpipe".
+/// Legacy `{"apiKey": …}` entries — seeded from a user's global
+/// `~/.pi/agent/auth.json` for BYOK providers — fail identically.
+///
+/// Returns `None` for entries that are already tagged, so oauth credentials and
+/// anything pi writes itself are left untouched.
+fn upgrade_legacy_pi_credential(value: &serde_json::Value) -> Option<serde_json::Value> {
+    match value {
+        // pi <=0.80 screenpipe format: the bare token string.
+        serde_json::Value::String(key) => Some(api_key_credential(key)),
+        // Legacy BYOK format: `{"apiKey": "…"}` with no discriminant.
+        serde_json::Value::Object(obj) if !obj.contains_key("type") => {
+            let key = obj.get("apiKey").or_else(|| obj.get("key"))?.as_str()?;
+            let mut upgraded = api_key_credential(key);
+            // `env` drives pi's `resolveConfigValue` indirection — preserve it.
+            if let Some(env) = obj.get("env") {
+                upgraded["env"] = env.clone();
+            }
+            Some(upgraded)
+        }
+        _ => None,
+    }
+}
+
+/// Upgrade every legacy entry in an `auth.json` value. Returns whether
+/// anything changed.
+fn upgrade_legacy_pi_credentials(auth: &mut serde_json::Value) -> bool {
+    let Some(obj) = auth.as_object_mut() else {
+        return false;
+    };
+    let upgrades: Vec<(String, serde_json::Value)> = obj
+        .iter()
+        .filter_map(|(provider, value)| {
+            upgrade_legacy_pi_credential(value).map(|upgraded| (provider.clone(), upgraded))
+        })
+        .collect();
+    if upgrades.is_empty() {
+        return false;
+    }
+    for (provider, upgraded) in upgrades {
+        obj.insert(provider, upgraded);
+    }
+    true
+}
+
+/// Rewrite `auth.json` in place if it holds any legacy credential shape.
+fn upgrade_legacy_pi_credentials_at_path(auth_path: &Path) -> Result<()> {
+    if !auth_path.exists() {
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(auth_path)?;
+    let mut auth: serde_json::Value = serde_json::from_str(&content).unwrap_or_else(|_| json!({}));
+    if !upgrade_legacy_pi_credentials(&mut auth) {
+        return Ok(());
+    }
+
+    write_auth_json(auth_path, &auth)
+}
+
+/// Atomically write `auth.json` with owner-only permissions.
+fn write_auth_json(auth_path: &Path, auth: &serde_json::Value) -> Result<()> {
+    let auth_tmp = auth_path.with_file_name(format!(
+        "auth.json.{}.{}.tmp",
+        std::process::id(),
+        format!("{:?}", std::thread::current().id())
+            .chars()
+            .filter(|c| c.is_ascii_digit())
+            .collect::<String>()
+    ));
+    std::fs::write(&auth_tmp, serde_json::to_string_pretty(auth)?)?;
+    std::fs::rename(&auth_tmp, auth_path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = std::fs::set_permissions(auth_path, perms);
+    }
+
+    Ok(())
+}
+
 fn remove_screenpipe_auth_from_path(auth_path: &Path) -> Result<()> {
     if !auth_path.exists() {
         return Ok(());
@@ -2388,30 +2474,14 @@ fn remove_screenpipe_auth_from_path(auth_path: &Path) -> Result<()> {
         .as_object_mut()
         .map(|obj| obj.remove("screenpipe").is_some())
         .unwrap_or(false);
+    // Signed-out users keep their BYOK credentials — upgrade those too.
+    let upgraded = upgrade_legacy_pi_credentials(&mut auth);
 
-    if !removed {
+    if !removed && !upgraded {
         return Ok(());
     }
 
-    let auth_tmp = auth_path.with_file_name(format!(
-        "auth.json.{}.{}.tmp",
-        std::process::id(),
-        format!("{:?}", std::thread::current().id())
-            .chars()
-            .filter(|c| c.is_ascii_digit())
-            .collect::<String>()
-    ));
-    std::fs::write(&auth_tmp, serde_json::to_string_pretty(&auth)?)?;
-    std::fs::rename(&auth_tmp, auth_path)?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        let _ = std::fs::set_permissions(auth_path, perms);
-    }
-
-    Ok(())
+    write_auth_json(auth_path, &auth)
 }
 
 pub fn find_bun_executable() -> Option<String> {
@@ -3606,11 +3676,77 @@ mod tests {
         let auth: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&auth_path).unwrap()).unwrap();
         assert!(auth.get("screenpipe").is_none());
-        assert_eq!(auth["openai"], serde_json::json!("sk-keep"));
+        // Preserved, and upgraded to the tagged form pi >=0.83 accepts.
         assert_eq!(
-            auth["anthropic"]["apiKey"],
-            serde_json::json!("anthropic-keep")
+            auth["openai"],
+            serde_json::json!({"type": "api_key", "key": "sk-keep"})
         );
+        assert_eq!(
+            auth["anthropic"],
+            serde_json::json!({"type": "api_key", "key": "anthropic-keep"})
+        );
+    }
+
+    /// pi >=0.83 returns `undefined` from `resolveProviderAuth` for any stored
+    /// credential that is not tagged, with no fallback to models.json — so a
+    /// bare-string token makes hosted AI fail with
+    /// "Provider is not configured: screenpipe".
+    #[test]
+    fn legacy_credentials_upgrade_to_tagged_api_key() {
+        let mut auth = serde_json::json!({
+            "screenpipe": "bare-jwt",
+            "anthropic": {"apiKey": "sk-ant"},
+            "openai": {"apiKey": "sk-oai", "env": {"FOO": "BAR"}},
+        });
+
+        assert!(upgrade_legacy_pi_credentials(&mut auth));
+
+        assert_eq!(
+            auth["screenpipe"],
+            serde_json::json!({"type": "api_key", "key": "bare-jwt"})
+        );
+        assert_eq!(
+            auth["anthropic"],
+            serde_json::json!({"type": "api_key", "key": "sk-ant"})
+        );
+        // `env` drives pi's resolveConfigValue indirection — must survive.
+        assert_eq!(
+            auth["openai"],
+            serde_json::json!({"type": "api_key", "key": "sk-oai", "env": {"FOO": "BAR"}})
+        );
+    }
+
+    #[test]
+    fn already_tagged_credentials_are_left_alone() {
+        let original = serde_json::json!({
+            "screenpipe": {"type": "api_key", "key": "jwt"},
+            "anthropic": {"type": "oauth", "access": "a", "refresh": "r", "expires": 1},
+        });
+        let mut auth = original.clone();
+
+        assert!(!upgrade_legacy_pi_credentials(&mut auth));
+        assert_eq!(auth, original);
+    }
+
+    #[test]
+    fn upgrade_at_path_rewrites_legacy_file_and_skips_clean_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let auth_path = dir.path().join("auth.json");
+        std::fs::write(&auth_path, r#"{"screenpipe":"bare-jwt"}"#).expect("write auth");
+
+        upgrade_legacy_pi_credentials_at_path(&auth_path).expect("upgrade");
+
+        let auth: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&auth_path).unwrap()).unwrap();
+        assert_eq!(
+            auth["screenpipe"],
+            serde_json::json!({"type": "api_key", "key": "bare-jwt"})
+        );
+
+        // Second pass is a no-op: already tagged, file must not be rewritten.
+        let before = std::fs::read_to_string(&auth_path).unwrap();
+        upgrade_legacy_pi_credentials_at_path(&auth_path).expect("second upgrade");
+        assert_eq!(std::fs::read_to_string(&auth_path).unwrap(), before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The pi 0.83.0 bump (#5692, first shipped in the unpublished **2.5.160** draft) breaks hosted AI for **every signed-in user** — chat and every background pipe fail with:

```
pi exited 0 but LLM returned error: Provider is not configured: screenpipe
```

2.5.158 (currently live) is unaffected; it runs pi 0.80.6.

## Root cause

pi 0.83 rejects any stored credential it cannot tag. In `pi-ai/dist/auth/resolve.js`, a stored credential **owns** the provider — there is no fallback to the provider's `apiKey` in `models.json` once *any* entry exists:

```js
const stored = await readCredential(credentials, provider.id);
if (stored) {
    if (stored.type === "oauth"   && provider.auth.oauth)  { ... }
    if (stored.type === "api_key" && provider.auth.apiKey) { ... }
    return undefined;   // <-- bare string / untagged object lands here
}
// Ambient (env vars, ...) — only reached when nothing is stored
```

`undefined` then throws `Provider is not configured: ${provider}` from `applyAuth`.

Screenpipe writes the cloud token as a **bare string** (`{"screenpipe":"<jwt>"}`), which pi <=0.80 accepted. `AuthStorage.read()` does no coercion, so `stored.type` is `undefined` and every request dies before it leaves the machine. Legacy `{"apiKey": ...}` entries — seeded from a user's global `~/.pi/agent/auth.json` for BYOK providers — fail identically.

```
2.5.158 / pi 0.80.6        2.5.160 / pi 0.83.0        this PR
auth.json: "<jwt>"         auth.json: "<jwt>"         auth.json: {type,key}
      |                          |                          |
   accepted                  untagged                    tagged
      |                          |                          |
  -> gateway              -> return undefined          -> gateway
                          -> "Provider is not
                              configured"
```

## Evidence

Against the **real pi 0.83.0 binary** with the **live `~/.screenpipe/pi-config`**, varying only `auth.json` (BOM-free — a UTF-8 BOM makes `JSON.parse` throw, which silently drops the stored credential and masks the bug):

| `auth.json` entry | shipped in | pi 0.83.0 result |
|---|---|---|
| `"<jwt>"` bare string | 2.5.160, screenpipe provider | **REJECTED** — `Provider is not configured` |
| `{"apiKey": "<jwt>"}` | legacy seed, BYOK providers | **REJECTED** — `Provider is not configured` |
| `{"type":"api_key","key":"<jwt>"}` | **this PR** | ACCEPTED — request reaches the gateway |
| `{}` (no entry) | — | ACCEPTED — falls back to `models.json` |

Live A/B on the same config dir, back to back:

```
BEFORE — 2.5.160 bare-string auth.json       => REJECTED (Provider is not configured)
AFTER  — patched tagged auth.json            => ACCEPTED (reached gateway, 429 quota)
```

(The `429` is an unrelated, pre-existing daily-allowance state on this account — it proves the request left the machine and was answered by the gateway, which is exactly what the bug prevented.)

Corroborating field evidence from the same box, across the 158 -> 160 boundary:

```
# 2.5.158 / pi 0.80.6 — auth resolves, gateway answers
00:31:10  pipe 'random-fun-pipe' completed successfully
01:30:59  pipe 'random-fun-pipe' failed: 429 daily_cost_limit_exceeded   <- real, actionable

# 2.5.160 / pi 0.83.0 — never reaches the gateway
02:31:27  pipe 'random-fun-pipe'      failed: Provider is not configured: screenpipe
02:32:28  pipe 'todo-list-assistant'  failed: Provider is not configured: screenpipe
02:34:29  pipe 'obsidian-daily-summary' failed: Provider is not configured: screenpipe
```

## Changes

- Write the screenpipe token in pi's tagged form: `{"type":"api_key","key":...}`.
- Upgrade legacy entries (bare string, and untagged `{"apiKey"|"key", env?}`) in place on every config write, preserving `env` so pi's `resolveConfigValue` indirection keeps working.
- Run the upgrade for **BYOK-only** users too, who never reach the screenpipe branch.
- Already-tagged entries (`oauth`, and anything pi writes itself) are left untouched, so the migration is idempotent and does not clobber pi-managed credentials.
- Deduplicate three copies of the atomic `auth.json` write into one `write_auth_json` helper.

## Verification

- `cargo check -p screenpipe-core` — clean (3 pre-existing warnings, none from this change)
- `cargo test -p screenpipe-core --lib agents::pi::` — **25 passed, 0 failed**
- New tests: `legacy_credentials_upgrade_to_tagged_api_key`, `already_tagged_credentials_are_left_alone`, `upgrade_at_path_rewrites_legacy_file_and_skips_clean_one`
- Updated `clear_screenpipe_auth_preserves_other_provider_tokens` — it asserted the old untagged shapes were preserved verbatim, which is precisely the state pi 0.83 rejects; it now asserts they are preserved *and* upgraded.
- End-to-end against the real pi 0.83.0 binary, as above.

## Note on release

**2.5.160 should not be published with this bug.** The fix is not in any built draft, and no post-160 commit touched this writer — #5713 addresses pi *extension* failures and context limits, not credential shape. This needs to land and be picked up by a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
