### PR TITLE
[codex] remove hosted from pricing copy

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -170,7 +170,7 @@ describe("AccountSection subscription/login gating", () => {
     const card = screen.getByTestId(ACTIVE_CARD);
     expect(card).toBeInTheDocument();
     expect(within(card).getByText("active")).toBeInTheDocument();
-    expect(within(card).getByText("400 hosted AI credits / month")).toBeInTheDocument();
+    expect(within(card).getByText("400 AI credits / month")).toBeInTheDocument();
     expect(
       within(card).getByText(
         "frontier Claude + GPT models: Fable, Opus, Sonnet, latest GPT",
@@ -196,6 +196,7 @@ describe("AccountSection subscription/login gating", () => {
 
     render(<AccountSection />);
     const upgrade = screen.getByTestId("account-capacity-upgrade");
+    expect(within(upgrade).getByText("need more AI capacity?")).toBeInTheDocument();
     expect(within(upgrade).getByText(/higher query and request-rate limits/i)).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("account-capacity-upgrade-button"));
 

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -539,7 +539,7 @@ export function AccountSection() {
               data-testid="account-capacity-upgrade"
             >
               <div className="min-w-0">
-                <p className="text-sm font-medium">need more hosted AI capacity?</p>
+                <p className="text-sm font-medium">need more AI capacity?</p>
                 <p className="text-xs text-muted-foreground">
                   {capacityUpgrade.name} adds higher query and request-rate
                   limits for ${capacityUpgrade.monthlyPrice}/month.

--- a/apps/screenpipe-app-tauri/components/settings/business-upgrade-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/business-upgrade-card.test.tsx
@@ -157,7 +157,7 @@ describe("BusinessUpgradeCard", () => {
     );
 
     expect(
-      await screen.findByText("400 hosted AI credits / month"),
+      await screen.findByText("400 AI credits / month"),
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/apps/screenpipe-app-tauri/lib/business-upgrade-offer.test.ts
+++ b/apps/screenpipe-app-tauri/lib/business-upgrade-offer.test.ts
@@ -20,7 +20,7 @@ describe("business upgrade offer", () => {
       ...BUSINESS_PLAN_FEATURES,
     ]);
     expect(DEFAULT_BUSINESS_UPGRADE_OFFER.copy.features.join(" ")).not.toMatch(
-      /cloud transcription|100x more AI queries/i,
+      /cloud transcription|100x more AI queries|hosted/i,
     );
   });
 

--- a/apps/screenpipe-app-tauri/lib/business-upgrade-offer.ts
+++ b/apps/screenpipe-app-tauri/lib/business-upgrade-offer.ts
@@ -44,10 +44,10 @@ export const BUSINESS_PLAN_DESCRIPTION =
   "For power users and small teams who live across devices.";
 
 export const BUSINESS_PLAN_FEATURES = [
-  "400 hosted AI credits / month",
+  "400 AI credits / month",
   "frontier Claude + GPT models: Fable, Opus, Sonnet, latest GPT",
   "cloud sync across your devices",
-  "hosted automations on efficient models",
+  "automations on efficient models",
   "use your own provider key for unlimited provider usage",
   "team workspace: one bill, managed seats",
   "priority support",


### PR DESCRIPTION
## What changed

- changes the desktop Business offer from “hosted AI credits” to “AI credits”
- changes “hosted automations” to “automations”
- simplifies the active-plan capacity prompt to “need more AI capacity?”
- updates focused regression coverage

## Why

The desktop pricing surface should use the same direct language as the website and avoid implementation jargon.

## Checks

- `bunx vitest run --config vitest.config.ts lib/business-upgrade-offer.test.ts components/settings/business-upgrade-card.test.tsx components/settings/__tests__/account-section.subscription-gate.test.tsx` (22 passed)
- `bun run typecheck`
- targeted ESLint on all changed files
- `git diff --check`
