### PR TITLE
Bump CLI to v0.4.34 - release-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio-eval"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -8507,7 +8507,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8685,7 +8685,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-gateway"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "async-trait",
  "axum",
@@ -8715,7 +8715,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-meeting-eval"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "clap",
@@ -8727,7 +8727,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -8765,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-resource"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "serde",
  "sysinfo",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8867,7 +8867,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "libsqlite3-sys",
  "tempfile",
@@ -8877,7 +8877,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8899,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-team-memory"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -8908,7 +8908,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-telemetry-wire"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "serde",
  "serde_json",
@@ -8918,7 +8918,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.33"
+version = "0.4.34"
 authors = ["louis030195 <hi@louis030195.com>"]
 description = ""
 repository = "https://github.com/screenpipe/screenpipe"

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11189,7 +11189,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -11266,7 +11266,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -11278,7 +11278,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -11324,7 +11324,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -11375,7 +11375,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11471,7 +11471,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11487,7 +11487,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11523,7 +11523,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-resource"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "serde",
  "sysinfo",
@@ -11543,7 +11543,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -11611,7 +11611,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "libsqlite3-sys",
  "tokio",
@@ -11620,7 +11620,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11640,7 +11640,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-telemetry-wire"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "serde",
  "serde_json",
@@ -11650,7 +11650,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/packages/sdk/Cargo.lock
+++ b/packages/sdk/Cargo.lock
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -6950,7 +6950,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6990,7 +6990,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7018,7 +7018,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7056,7 +7056,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7135,7 +7135,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "libsqlite3-sys",
  "tokio",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
+++ b/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7187,7 +7187,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7255,7 +7255,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "libsqlite3-sys",
  "tokio",
@@ -7288,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.33"
+version = "0.4.34"
 dependencies = [
  "argon2",
  "chacha20poly1305",


### PR DESCRIPTION
## Summary
- bump the workspace/CLI version from 0.4.33 to 0.4.34
- regenerate all tracked Cargo lockfiles
- release the merged CLI cloud-session persistence fix from #5707

## Validation
- `./scripts/regenerate-locks.sh --check`
- `git diff --check`
- verified `screenpipe@0.4.34` and all four platform packages are unused on npm before publication