### PR TITLE
fix(app): recognize Business capacity plans

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,14 +32,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 30
 - Mapped Rust files: 301
-- Active test blocks: 2815
+- Active test blocks: 2816
 - Ignored/manual test blocks: 133
-- Weighted coverage points: 2319.4
+- Weighted coverage points: 2319.8
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | windows | 27 | 2688 | 128 | 2261.1 | 21 | 11 | 100% |
-| macos | 27 | 2738 | 108 | 2270.6 | 22 | 11 | 100% |
+| macos | 27 | 2739 | 108 | 2271.0 | 22 | 11 | 100% |
 | linux | 23 | 2382 | 102 | 1983.4 | 20 | 11 | 100% |
 
 ## Refresh

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -833,6 +833,37 @@ describe("AppEntitlementGate", () => {
     expect(mocks.stopScreenpipe).not.toHaveBeenCalled();
   });
 
+  it.each(["pro_max", "pro_ultra"] as const)(
+    "does not route an enterprise workspace admin with a %s consumer plan away",
+    (plan) => {
+      mocks.state.user = baseUser({
+        app_entitled: true,
+        cloud_subscribed: true,
+        subscription_plan: plan,
+        enterprise_account: {
+          org_name: "Screenpipe",
+          role: "admin",
+          requires_enterprise_app: true,
+        },
+        entitlement: {
+          active: true,
+          plan,
+          source: "manual",
+          checked_at: minsAgo(1),
+          features: { app: true, cloud: true, enterprise: false },
+        },
+      });
+
+      render(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
+
+      expect(
+        screen.queryByText(/enterprise app required/i),
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("protected-app")).toBeInTheDocument();
+      expect(mocks.stopScreenpipe).not.toHaveBeenCalled();
+    },
+  );
+
   it("does not show the consumer-app warning inside the enterprise build", () => {
     mocks.enterprise.isManagedDeployment = true;
     mocks.state.user = baseUser({

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -285,6 +285,32 @@ describe("app entitlement", () => {
     ).toBe(false);
   });
 
+  it.each(["pro_max", "pro_ultra"] as const)(
+    "recognizes %s as a consumer plan when the user also belongs to an enterprise workspace",
+    (plan) => {
+      const capacityUser = user({
+        cloud_subscribed: true,
+        app_entitled: true,
+        subscription_plan: plan,
+        entitlement: {
+          active: true,
+          plan,
+          checked_at: "2026-06-05T11:00:00.000Z",
+          source: "manual",
+          features: { app: true, cloud: true, enterprise: false },
+        },
+        enterprise_account: {
+          org_name: "Screenpipe",
+          role: "admin",
+          requires_enterprise_app: true,
+        },
+      });
+
+      expect(getLocalPlanPolicy(capacityUser)).toBe("verified-paid");
+      expect(hasConsumerAppSubscription(capacityUser)).toBe(true);
+    },
+  );
+
   it("does not unlock new cloud features from stale entitlement data", () => {
     expect(
       hasCloudEntitlement(user({ cloud_subscribed: true, entitlement: null })),

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -9,6 +9,8 @@ export type AppEntitlementPlan =
   | "none"
   | "standard"
   | "pro"
+  | "pro_max"
+  | "pro_ultra"
   | "team"
   | "enterprise"
   | "lifetime";
@@ -72,6 +74,8 @@ export const ENTERPRISE_DOWNLOAD_URL = screenpipeWebUrl("/api/download", "https:
 const VERIFIED_PAID_PLAN_IDS = new Set([
   "standard",
   "pro",
+  "pro_max",
+  "pro_ultra",
   "team",
   "enterprise",
   "lifetime",

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1226,6 +1226,19 @@ fn entitlement_is_lifetime(entitlement: &serde_json::Value) -> bool {
     field("plan") == "lifetime" || field("source") == "lifetime"
 }
 
+fn is_verified_paid_plan_id(plan: &str) -> bool {
+    matches!(
+        plan.trim().to_ascii_lowercase().as_str(),
+        "standard"
+            | "pro"
+            | "pro_max"
+            | "pro_ultra"
+            | "team"
+            | "enterprise"
+            | "lifetime"
+    )
+}
+
 fn entitlement_feature(entitlement: &serde_json::Value, feature: &str) -> bool {
     entitlement
         .get("features")
@@ -1699,11 +1712,7 @@ impl SettingsStore {
         else {
             return false;
         };
-        let account_plan_is_paid = matches!(
-            account_plan.to_ascii_lowercase().as_str(),
-            "standard" | "pro" | "team" | "enterprise" | "lifetime"
-        );
-        if !account_plan_is_paid {
+        if !is_verified_paid_plan_id(account_plan) {
             return false;
         }
         let Some(entitlement) = self.user.entitlement.as_ref() else {
@@ -1720,11 +1729,7 @@ impl SettingsStore {
         else {
             return false;
         };
-        let entitlement_plan_is_paid = matches!(
-            entitlement_plan.to_ascii_lowercase().as_str(),
-            "standard" | "pro" | "team" | "enterprise" | "lifetime"
-        );
-        if !entitlement_plan_is_paid {
+        if !is_verified_paid_plan_id(entitlement_plan) {
             return false;
         }
         if !account_plan.eq_ignore_ascii_case(entitlement_plan) {
@@ -2492,6 +2497,31 @@ mod tests {
             "features": { "app": true }
         }));
         assert!(!store.requires_enterprise_app_for_consumer());
+    }
+
+    #[test]
+    fn business_capacity_plans_override_enterprise_app_requirement() {
+        for plan in ["pro_max", "pro_ultra"] {
+            let mut store = SettingsStore::default();
+            store.user.id = Some("consumer_capacity_paid".to_string());
+            store.user.app_entitled = Some(true);
+            store.user.cloud_subscribed = Some(true);
+            store.user.subscription_plan = Some(plan.to_string());
+            store.user.enterprise_account = Some(json!({ "requires_enterprise_app": true }));
+            store.user.entitlement = Some(json!({
+                "active": true,
+                "plan": plan,
+                "source": "manual",
+                "checked_at": chrono::Utc::now().to_rfc3339(),
+                "features": { "app": true, "cloud": true, "enterprise": false }
+            }));
+
+            assert_eq!(store.local_plan_policy(), LocalPlanPolicy::VerifiedPaid);
+            assert!(!store.restricts_paid_local_features());
+            assert!(!store.requires_enterprise_app_for_consumer());
+            let config = store.to_recording_config(std::path::PathBuf::from("/tmp/screenpipe"));
+            assert_eq!(config.max_non_template_pipes, None);
+        }
     }
 
     #[test]

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 30
 - Mapped Rust files: 301
-- Active test blocks: 2815
+- Active test blocks: 2816
 - Ignored/manual test blocks: 133
-- Declared test blocks: 2948
-- Weighted coverage points: 2319.4
+- Declared test blocks: 2949
+- Weighted coverage points: 2319.8
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -24,7 +24,7 @@ are explicitly enabled in a runtime lane.
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | windows | 27 | 2688 | 128 | 2261.1 | 21 | 11 | 100% |
-| macos | 27 | 2738 | 108 | 2270.6 | 22 | 11 | 100% |
+| macos | 27 | 2739 | 108 | 2271.0 | 22 | 11 | 100% |
 | linux | 23 | 2382 | 102 | 1983.4 | 20 | 11 | 100% |
 
 ## Crate Summary
@@ -35,7 +35,7 @@ are explicitly enabled in a runtime lane.
 | screenpipe-db | 5 | 48 | 13 | 400 | 16 | 382.4 | 9 |
 | screenpipe-audio | 6 | 23 | 47 | 523 | 39 | 453.9 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 229 | 9 | 210.6 | 4 |
-| screenpipe-a11y | 4 | 2 | 28 | 329 | 27 | 246.0 | 3 |
+| screenpipe-a11y | 4 | 2 | 28 | 330 | 27 | 246.4 | 3 |
 
 ## Line Coverage
 
@@ -60,7 +60,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 
 | Layer | windows | macos | linux |
 | --- | --- | --- | --- |
-| accessibility | 4 suites / 336 active / 29 ignored / 309.4 pts | 4 suites / 382 active / 9 ignored / 313.4 pts | 4 suites / 312 active / 7 ignored / 287.5 pts |
+| accessibility | 4 suites / 336 active / 29 ignored / 309.4 pts | 4 suites / 383 active / 9 ignored / 313.8 pts | 4 suites / 312 active / 7 ignored / 287.5 pts |
 | audio | 7 suites / 618 active / 40 ignored / 548.9 pts | 7 suites / 618 active / 40 ignored / 548.9 pts | 6 suites / 550 active / 40 ignored / 501.3 pts |
 | audio-device | 2 suites / 193 active / 6 ignored / 172.6 pts | 2 suites / 193 active / 6 ignored / 172.6 pts | 1 suites / 125 active / 6 ignored / 125.0 pts |
 | configuration | 2 suites / 135 active / 3 ignored / 122.8 pts | 2 suites / 135 active / 3 ignored / 122.8 pts | 2 suites / 135 active / 3 ignored / 122.8 pts |
@@ -71,10 +71,10 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1272 active / 15 ignored / 1038.9 pts | 6 suites / 1272 active / 15 ignored / 1038.9 pts | 4 suites / 1001 active / 12 ignored / 788.3 pts |
 | ocr | 4 suites / 120 active / 7 ignored / 114.3 pts | 4 suites / 124 active / 7 ignored / 119.8 pts | 3 suites / 115 active / 6 ignored / 110.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1294 active / 67 ignored / 1147.5 pts | 14 suites / 1388 active / 70 ignored / 1185.1 pts | 13 suites / 1294 active / 67 ignored / 1147.5 pts |
+| performance | 13 suites / 1294 active / 67 ignored / 1147.5 pts | 14 suites / 1389 active / 70 ignored / 1185.5 pts | 13 suites / 1294 active / 67 ignored / 1147.5 pts |
 | pipes | 1 suites / 433 active / 3 ignored / 303.1 pts | 1 suites / 433 active / 3 ignored / 303.1 pts | 1 suites / 433 active / 3 ignored / 303.1 pts |
-| privacy | 5 suites / 840 active / 36 ignored / 685.5 pts | 5 suites / 886 active / 16 ignored / 689.5 pts | 5 suites / 816 active / 14 ignored / 663.7 pts |
-| real-app | - | 1 suites / 94 active / 3 ignored / 37.6 pts | - |
+| privacy | 5 suites / 840 active / 36 ignored / 685.5 pts | 5 suites / 887 active / 16 ignored / 689.9 pts | 5 suites / 816 active / 14 ignored / 663.7 pts |
+| real-app | - | 1 suites / 95 active / 3 ignored / 38.0 pts | - |
 | speaker | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts |
 | storage | 3 suites / 434 active / 29 ignored / 352.4 pts | 3 suites / 434 active / 29 ignored / 352.4 pts | 3 suites / 434 active / 29 ignored / 352.4 pts |
 | sync | 1 suites / 433 active / 3 ignored / 303.1 pts | 1 suites / 433 active / 3 ignored / 303.1 pts | 1 suites / 433 active / 3 ignored / 303.1 pts |
@@ -119,7 +119,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | a11y-core-tree-cross-platform | screenpipe-a11y | windows, macos, linux | accessibility, ui-events, privacy, performance | accessibility-ui-events, privacy-and-redaction, performance-liveness | high | strong | unit | 14 | 163 | 0 | Cross-platform accessibility config, tree normalization, cache, privacy title matching, events, budget, and activity feed units. |
 | a11y-linux-tree | screenpipe-a11y | linux | accessibility, privacy | accessibility-ui-events, privacy-and-redaction | medium | partial | unit | 4 | 24 | 1 | Linux-specific accessibility/incognito normalization tests. |
-| a11y-macos-tree | screenpipe-a11y | macos | accessibility, privacy, real-app, performance | accessibility-ui-events, privacy-and-redaction, performance-liveness | high | conditional | mixed | 6 | 94 | 3 | macOS AX unit coverage plus real TextEdit/Finder/Obsidian probes. Obsidian tests are ignored by default because they require a local app install and AX permission. |
+| a11y-macos-tree | screenpipe-a11y | macos | accessibility, privacy, real-app, performance | accessibility-ui-events, privacy-and-redaction, performance-liveness | high | conditional | mixed | 6 | 95 | 3 | macOS AX unit coverage plus real TextEdit/Finder/Obsidian probes. Obsidian tests are ignored by default because they require a local app install and AX permission. |
 | a11y-windows-tree | screenpipe-a11y | windows | accessibility, privacy, ui-events | accessibility-ui-events, privacy-and-redaction | high | partial | unit | 6 | 48 | 23 | Windows UIA/accessibility parsing and privacy matching; some UIA tests are ignored where they require a live desktop. |
 | audio-device-stream-health | screenpipe-audio | windows, macos, linux | audio-device, audio, performance | audio-device-health, audio-record-transcribe, performance-liveness | high | strong | mixed | 14 | 125 | 6 | Device monitor, device manager, stream buffering, source lag, audio metrics, Bluetooth gap/hallucination regressions, and cross-platform process-tap watchdog counters (process_tap.rs split into src/core/process_tap/ modules). |
 | audio-meetings-speakers-dedup | screenpipe-audio | windows, macos, linux | audio, meeting, speaker, transcription | audio-record-transcribe, meeting-live-notes, performance-liveness | high | strong | mixed | 22 | 197 | 4 | Meeting streaming config/controller logic, speaker embedding state, cross-device dedupe simulations, and overlap cleanup coverage. |
@@ -175,7 +175,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | a11y-linux-tree | screenpipe-a11y | src/tree/linux_lines.rs | source | 3 | 0 | 3 |
 | a11y-linux-tree | screenpipe-a11y | src/tree/linux.rs | source | 10 | 0 | 10 |
 | a11y-macos-tree | screenpipe-a11y | src/tree/macos_lines.rs | source | 12 | 0 | 12 |
-| a11y-macos-tree | screenpipe-a11y | src/tree/macos.rs | source | 47 | 0 | 47 |
+| a11y-macos-tree | screenpipe-a11y | src/tree/macos.rs | source | 48 | 0 | 48 |
 | a11y-core-tree-cross-platform | screenpipe-a11y | src/tree/mod.rs | source | 36 | 0 | 36 |
 | a11y-windows-tree | screenpipe-a11y | src/tree/windows_lines.rs | source | 2 | 0 | 2 |
 | a11y-windows-tree | screenpipe-a11y | src/tree/windows.rs | source | 9 | 0 | 9 |


### PR DESCRIPTION
## Summary

- recognize `pro_max` and `pro_ultra` as verified paid plans in both the desktop UI and native policy
- prevent consumer capacity plans from falling through to the enterprise-app gate when the account also belongs to an enterprise workspace
- keep recording and pipe enforcement aligned with the visible entitlement gate

## Tests

- `bunx vitest run --config vitest.config.ts lib/app-entitlement.test.ts components/app-entitlement-gate.test.tsx`
- `bun run typecheck`
- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml business_capacity_plans_override_enterprise_app_requirement`
- `bun run coverage:all:check`

## Reproduction

An active consumer `pro_ultra` entitlement was treated as unknown because the desktop allowlist only recognized the older plan IDs. The unrelated enterprise workspace membership then selected the enterprise-only gate. This patch adds exact regression coverage for both `pro_max` and `pro_ultra` with that mixed account state.

## Existing compatibility bridge

[website#660](https://github.com/screenpipe/website/pull/660) is already merged and downmaps Max/Ultra to the stable `pro` app-access contract for installed desktop versions while preserving the canonical tier as `billing_plan`. Keep that bridge until a fixed signed desktop release has sufficient adoption. This PR makes exact plan IDs safe when the server later becomes capability/version-aware; exact purchased-tier display can separately consume `billing_plan`.
