### PR TITLE
fix(db): make file query pool read-only

### DIFF
--- a/crates/screenpipe-db/src/db/setup.rs
+++ b/crates/screenpipe-db/src/db/setup.rs
@@ -212,12 +212,28 @@ impl DatabaseManager {
                 .map_err(|error| quarantine_startup_error(database_file, error))?;
         }
 
+        // File-backed query connections have two independent write barriers:
+        // SQLite opens the file with mode=ro, and query_only rejects mutations
+        // at the connection level. In-memory databases cannot use mode=ro and
+        // remain writable for the many isolated test fixtures that seed them
+        // directly; production databases are always file-backed.
+        let is_in_memory =
+            database_path.contains(":memory:") || database_path.contains("mode=memory");
+        let read_connect_options = if is_in_memory {
+            connect_options.clone()
+        } else {
+            connect_options
+                .clone()
+                .read_only(true)
+                .pragma("query_only", "ON")
+        };
+
         // Read pool: handles all SELECT queries (search, timeline, API, pipes).
         let read_pool = SqlitePoolOptions::new()
             .max_connections(config.read_pool_max)
             .min_connections(config.read_pool_min)
             .acquire_timeout(Duration::from_secs(5))
-            .connect_with(connect_options.clone())
+            .connect_with(read_connect_options)
             .await
             .map_err(|error| quarantine_startup_error(database_file, error))?;
 
@@ -767,6 +783,63 @@ impl DatabaseManager {
 mod shutdown_tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn file_query_pool_remains_read_only_when_query_only_is_disabled() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("read-only-query-pool.sqlite");
+        let database = DatabaseManager::new(
+            db_path.to_str().expect("utf-8 temp path"),
+            DbConfig::for_tier(screenpipe_config::DeviceTier::Low),
+        )
+        .await
+        .expect("database init");
+
+        database
+            .execute_raw_sql_write("CREATE TABLE query_pool_probe (value INTEGER NOT NULL)")
+            .await
+            .expect("create probe through writer");
+
+        let mut reader = database.pool.acquire().await.expect("query connection");
+        let query_only: i64 = sqlx::query_scalar("PRAGMA query_only")
+            .fetch_one(&mut *reader)
+            .await
+            .expect("read query_only");
+        assert_eq!(query_only, 1, "query connections must enable query_only");
+
+        sqlx::query("PRAGMA query_only = OFF")
+            .execute(&mut *reader)
+            .await
+            .expect("disable connection-level guard for physical-mode test");
+        let write_error = sqlx::query("INSERT INTO query_pool_probe (value) VALUES (1)")
+            .execute(&mut *reader)
+            .await
+            .expect_err("mode=ro query connection unexpectedly accepted a write");
+        assert!(
+            write_error
+                .to_string()
+                .to_ascii_lowercase()
+                .contains("readonly"),
+            "unexpected query-pool write error: {write_error}"
+        );
+        sqlx::query("PRAGMA query_only = ON")
+            .execute(&mut *reader)
+            .await
+            .expect("restore connection-level guard");
+        drop(reader);
+
+        database
+            .execute_raw_sql_write("INSERT INTO query_pool_probe (value) VALUES (2)")
+            .await
+            .expect("dedicated writer remains writable");
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM query_pool_probe")
+            .fetch_one(&database.pool)
+            .await
+            .expect("query pool remains readable");
+        assert_eq!(count, 1);
+
+        database.close().await;
+    }
 
     #[test]
     fn early_startup_hard_fault_closes_the_process_writer_gate() {

--- a/crates/screenpipe-db/tests/close_severs_connections_test.rs
+++ b/crates/screenpipe-db/tests/close_severs_connections_test.rs
@@ -80,15 +80,21 @@ async fn repeated_restart_cycles_reopen_cleanly() {
         let db = DatabaseManager::new(&db_path, config.clone())
             .await
             .unwrap_or_else(|e| panic!("cycle {cycle}: init failed: {e}"));
+        let writer = db
+            .coordinated_writer()
+            .lock()
+            .await
+            .unwrap_or_else(|e| panic!("cycle {cycle}: writer unavailable: {e}"));
         sqlx::query("CREATE TABLE IF NOT EXISTS restart_probe (n INTEGER)")
-            .execute(&db.pool)
+            .execute(writer.pool())
             .await
             .unwrap_or_else(|e| panic!("cycle {cycle}: ddl failed: {e}"));
         sqlx::query("INSERT INTO restart_probe (n) VALUES (?)")
             .bind(cycle)
-            .execute(&db.pool)
+            .execute(writer.pool())
             .await
             .unwrap_or_else(|e| panic!("cycle {cycle}: write failed: {e}"));
+        drop(writer);
         db.close().await;
     }
 

--- a/crates/screenpipe-db/tests/multi_pool_wal_parity_test.rs
+++ b/crates/screenpipe-db/tests/multi_pool_wal_parity_test.rs
@@ -161,10 +161,11 @@ async fn coordinated_engine_secret_writes_and_checkpoints_keep_integrity_ok() {
             .expect("secret store"),
     );
 
-    sqlx::query("CREATE TABLE IF NOT EXISTS chaos_engine (id INTEGER PRIMARY KEY, v TEXT)")
-        .execute(&db.pool)
-        .await
-        .unwrap();
+    db.execute_raw_sql_write(
+        "CREATE TABLE IF NOT EXISTS chaos_engine (id INTEGER PRIMARY KEY, v TEXT)",
+    )
+    .await
+    .unwrap();
     let mut tasks = Vec::new();
 
     const WRITERS_PER_POOL: usize = 2;

--- a/crates/screenpipe-db/tests/orphan_chunk_null_poisoning_test.rs
+++ b/crates/screenpipe-db/tests/orphan_chunk_null_poisoning_test.rs
@@ -127,26 +127,28 @@ async fn estimate_evictable_bytes_counts_files_despite_out_of_range_null_chunk_f
 
     let old_ts = (Utc::now() - Duration::days(30)).to_rfc3339();
     let recent_ts = Utc::now().to_rfc3339();
+    let writer = db.coordinated_writer().lock().await.unwrap();
 
     sqlx::query("INSERT INTO video_chunks (id, file_path) VALUES (1, ?1)")
         .bind(video_path.to_str().unwrap())
-        .execute(&db.pool)
+        .execute(writer.pool())
         .await
         .unwrap();
     sqlx::query(
         "INSERT INTO frames (id, video_chunk_id, offset_index, timestamp) VALUES (1, 1, 0, ?1)",
     )
     .bind(&old_ts)
-    .execute(&db.pool)
+    .execute(writer.pool())
     .await
     .unwrap();
     sqlx::query(
         "INSERT INTO frames (id, video_chunk_id, offset_index, timestamp) VALUES (2, NULL, 0, ?1)",
     )
     .bind(&recent_ts)
-    .execute(&db.pool)
+    .execute(writer.pool())
     .await
     .unwrap();
+    drop(writer);
 
     let start = Utc::now() - Duration::days(31);
     let end = Utc::now() - Duration::days(29);

--- a/crates/screenpipe-db/tests/timeline_performance_test.rs
+++ b/crates/screenpipe-db/tests/timeline_performance_test.rs
@@ -421,12 +421,6 @@ mod timeline_performance_tests {
         let db = DatabaseManager::new(path, Default::default())
             .await
             .unwrap();
-
-        sqlx::migrate!("./src/migrations")
-            .run(&db.pool)
-            .await
-            .expect("Failed to run migrations");
-
         db
     }
 
@@ -451,10 +445,7 @@ mod timeline_performance_tests {
         println!("Insert time: {:?}", insert_start.elapsed());
 
         // Force flush to disk
-        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-            .execute(&db.pool)
-            .await
-            .ok();
+        db.wal_checkpoint().await.ok();
 
         let query_start = Instant::now();
         let result = db.find_video_chunks(start_time, end_time).await.unwrap();

--- a/crates/screenpipe-engine/tests/retention_lean_test.rs
+++ b/crates/screenpipe-engine/tests/retention_lean_test.rs
@@ -315,28 +315,30 @@ async fn compact_returns_free_pages_to_the_os_after_deletion() {
 
     // Grow the file with sizable rows, then checkpoint into the main file.
     let ts = (Utc::now() - Duration::days(30)).to_rfc3339();
+    let writer = db.coordinated_writer().lock().await.unwrap();
     for _ in 0..500 {
         sqlx::query("INSERT INTO frames (timestamp, full_text) VALUES (?1, ?2)")
             .bind(&ts)
             .bind("x".repeat(2000))
-            .execute(&db.pool)
+            .execute(writer.pool())
             .await
             .unwrap();
     }
     sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-        .execute(&db.pool)
+        .execute(writer.pool())
         .await
         .unwrap();
 
     // Delete everything → pages go on the free list (auto_vacuum=NONE).
     sqlx::query("DELETE FROM frames")
-        .execute(&db.pool)
+        .execute(writer.pool())
         .await
         .unwrap();
     sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-        .execute(&db.pool)
+        .execute(writer.pool())
         .await
         .unwrap();
+    drop(writer);
 
     let freelist_before = count(&db, "PRAGMA freelist_count").await;
     assert!(


### PR DESCRIPTION
## Summary\n\n- open every file-backed query-pool connection in SQLite read-only mode\n- also enable PRAGMA query_only as a connection-level defense\n- retain writable in-memory pools for isolated test fixtures; production databases are file-backed\n- prove the physical barrier by disabling query_only and verifying that a query connection still returns SQLITE_READONLY\n- move the file-backed fixtures exposed by the new barrier onto the coordinated writer capability\n\n## Stack\n\n- stacked on #5740\n- completes the planned SQLite ownership stack that starts at #5737\n\n## Verification\n\n- cargo fmt --all -- --check\n- cargo test -p screenpipe-db\n- cargo test -p screenpipe-engine --test retention_lean_test compact_returns_free_pages_to_the_os_after_deletion -- --nocapture\n- cargo test --manifest-path packages/sdk/recorder-core/Cargo.toml --test sqlite_coordinator -- --nocapture\n- CARGO_BUILD_JOBS=4 cargo check --bin screenpipe-app\n- git diff --check\n