### PR TITLE
test(engine): stop migrating through read pool

### DIFF
--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -57,10 +57,6 @@ async fn setup_db() -> (tempfile::TempDir, DatabaseManager) {
     let db = DatabaseManager::new(&path, Default::default())
         .await
         .unwrap();
-    sqlx::migrate!("../screenpipe-db/src/migrations")
-        .run(&db.pool)
-        .await
-        .unwrap();
     (dir, db)
 }
 


### PR DESCRIPTION
## Why

Current `main` Ubuntu Rust CI fails `meeting_watcher::audio_process::tests::active_meeting_blocks_audio_process_insert` with `attempt to write a readonly database`. `DatabaseManager::new` already runs migrations through the dedicated writer; this file-backed test redundantly reruns them through `db.pool`, which is now intentionally read-only.

Primary evidence: main run `30713968970`, job `91406257515`.

## Fix

Remove only the redundant manual migration from this test fixture. No product code changes.

## Verification

- `cargo test --locked -p screenpipe-engine meeting_watcher::audio_process::tests::active_meeting_blocks_audio_process_insert -- --nocapture`
- 1 passed, 0 failed
- `git diff --check`