### PR TITLE
feat(engine): stream pipe run progress over SSE

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 30
 - Mapped Rust files: 303
-- Active test blocks: 2829
+- Active test blocks: 2833
 - Ignored/manual test blocks: 133
-- Weighted coverage points: 2329.5
+- Weighted coverage points: 2332.3
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 27 | 2701 | 128 | 2270.8 | 21 | 11 | 100% |
-| macos | 27 | 2752 | 108 | 2280.7 | 22 | 11 | 100% |
-| linux | 23 | 2395 | 102 | 1993.1 | 20 | 11 | 100% |
+| windows | 27 | 2705 | 128 | 2273.6 | 21 | 11 | 100% |
+| macos | 27 | 2756 | 108 | 2283.5 | 22 | 11 | 100% |
+| linux | 23 | 2399 | 102 | 1995.9 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio-eval"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -8460,7 +8460,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8561,11 +8561,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.34"
+version = "0.4.35"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8674,7 +8674,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-gateway"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "async-trait",
  "axum",
@@ -8722,7 +8722,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-meeting-eval"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -8734,7 +8734,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -8773,7 +8773,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-resource"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "serde",
  "sysinfo",
@@ -8793,7 +8793,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8875,7 +8875,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "libsqlite3-sys",
  "sqlx",
@@ -8886,7 +8886,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8908,7 +8908,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-team-memory"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -8917,7 +8917,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-telemetry-wire"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "serde",
  "serde_json",
@@ -8927,7 +8927,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.34"
+version = "0.4.35"
 authors = ["louis030195 <hi@louis030195.com>"]
 description = ""
 repository = "https://github.com/screenpipe/screenpipe"

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11279,7 +11279,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -11356,7 +11356,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -11369,7 +11369,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -11415,7 +11415,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -11467,11 +11467,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.34"
+version = "0.4.35"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11568,7 +11568,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11584,7 +11584,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11621,7 +11621,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-resource"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "serde",
  "sysinfo",
@@ -11641,7 +11641,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -11709,7 +11709,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "libsqlite3-sys",
  "sqlx",
@@ -11719,7 +11719,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11739,7 +11739,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-telemetry-wire"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "serde",
  "serde_json",
@@ -11749,7 +11749,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/crates/screenpipe-engine/src/pipe_stream.rs
+++ b/crates/screenpipe-engine/src/pipe_stream.rs
@@ -10,26 +10,28 @@
 //! polling `/pipes/:id/executions` saw `stdout` stay empty for the whole run and
 //! then arrive as one blob.
 //!
-//! This module fans those lines out to HTTP subscribers in two shapes:
+//! This module fans those lines out to authenticated HTTP subscribers:
 //!
 //! * `GET  /pipes/:id/stream`      — the raw agent events, one SSE frame per line
-//! * `POST /v1/chat/completions`   — OpenAI-compatible, so any OpenAI SDK can
-//!                                   stream a pipe run with no custom client code
+//!
+//! The OpenAI-shaped translation helpers below are intentionally not registered
+//! as a route yet. They do not start a run or apply hosted-AI admission controls,
+//! so exposing them would promise an incomplete API surface.
 //!
 //! Persistence is untouched: the completed-run blob is still written and read
 //! exactly as before.
 
 use axum::extract::{Path, State};
+use axum::http::{header::RETRY_AFTER, StatusCode};
 use axum::response::sse::{Event, Sse};
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
-use futures::stream::Stream;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, OwnedSemaphorePermit, Semaphore};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 
@@ -49,7 +51,10 @@ pub struct PipeLine {
 #[derive(Clone)]
 pub struct PipeStreamHub {
     tx: broadcast::Sender<PipeLine>,
+    subscriber_slots: Arc<Semaphore>,
 }
+
+const DEFAULT_MAX_SUBSCRIBERS: usize = 32;
 
 impl Default for PipeStreamHub {
     fn default() -> Self {
@@ -59,8 +64,15 @@ impl Default for PipeStreamHub {
 
 impl PipeStreamHub {
     pub fn new() -> Self {
+        Self::with_max_subscribers(DEFAULT_MAX_SUBSCRIBERS)
+    }
+
+    pub fn with_max_subscribers(max_subscribers: usize) -> Self {
         let (tx, _) = broadcast::channel(1024);
-        Self { tx }
+        Self {
+            tx,
+            subscriber_slots: Arc::new(Semaphore::new(max_subscribers)),
+        }
     }
 
     pub fn publish(&self, pipe: &str, exec_id: i64, line: &str) {
@@ -74,6 +86,14 @@ impl PipeStreamHub {
 
     pub fn subscribe(&self) -> broadcast::Receiver<PipeLine> {
         self.tx.subscribe()
+    }
+
+    fn try_subscribe(
+        &self,
+    ) -> Result<(broadcast::Receiver<PipeLine>, OwnedSemaphorePermit), tokio::sync::TryAcquireError>
+    {
+        let permit = self.subscriber_slots.clone().try_acquire_owned()?;
+        Ok((self.tx.subscribe(), permit))
     }
 }
 
@@ -95,33 +115,53 @@ fn is_done(line: &str) -> bool {
 pub async fn stream_pipe(
     State(hub): State<SharedPipeStreamHub>,
     Path(id): Path<String>,
-) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let rx = hub.subscribe();
-    let wanted = id;
+) -> Response {
+    let (rx, permit) = match hub.try_subscribe() {
+        Ok(subscription) => subscription,
+        Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(RETRY_AFTER, "1")],
+                "too many active pipe streams",
+            )
+                .into_response();
+        }
+    };
 
-    let stream = BroadcastStream::new(rx)
-        .filter_map(move |item| match item {
-            // a lagged subscriber has already missed events; ending the stream is
-            // honest, resuming it would serve a gap the client cannot detect
-            Err(_) => Some(Err(())),
-            Ok(l) if l.pipe == wanted => Some(Ok(l)),
-            Ok(_) => None,
-        })
-        .take_while(|item| item.is_ok())
-        .filter_map(|item| item.ok())
-        .map(|l| {
-            let done = is_done(&l.line);
-            let event = Event::default().id(l.exec_id.to_string()).data(l.line);
-            (done, event)
-        })
-        .take_while(|(done, _)| !*done)
-        .map(|(_, event)| Ok(event));
+    // Keep the admission permit in the stream state for the full connection
+    // lifetime. The terminal pipe_done event is emitted before the stream ends
+    // so clients have an explicit, observable completion signal.
+    let stream = futures::stream::unfold(
+        (BroadcastStream::new(rx), id, permit, false),
+        |(mut rx, wanted, permit, finished)| async move {
+            if finished {
+                return None;
+            }
+            loop {
+                match rx.next().await {
+                    Some(Ok(line)) if line.pipe == wanted => {
+                        let done = is_done(&line.line);
+                        let event = Event::default()
+                            .id(line.exec_id.to_string())
+                            .data(line.line);
+                        return Some((Ok::<_, Infallible>(event), (rx, wanted, permit, done)));
+                    }
+                    Some(Ok(_)) => continue,
+                    // A lagged subscriber has missed data. Ending the stream is
+                    // safer than silently serving a gap the client cannot detect.
+                    Some(Err(_)) | None => return None,
+                }
+            }
+        },
+    );
 
-    Sse::new(stream).keep_alive(
-        axum::response::sse::KeepAlive::new()
-            .interval(Duration::from_secs(15))
-            .text("keep-alive"),
-    )
+    Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("keep-alive"),
+        )
+        .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -265,6 +305,11 @@ pub async fn openai_chat_completions(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::{to_bytes, Body};
+    use axum::http::Request;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
 
     #[test]
     fn text_delta_becomes_openai_content() {
@@ -304,5 +349,75 @@ mod tests {
         let got = rx.try_recv().expect("subscriber should receive");
         assert_eq!(got.pipe, "ios-chat");
         assert_eq!(got.exec_id, 7);
+    }
+
+    #[test]
+    fn hub_caps_long_lived_subscribers_and_recovers_capacity() {
+        let hub = PipeStreamHub::with_max_subscribers(1);
+        let (_rx, permit) = hub.try_subscribe().expect("first subscriber admitted");
+        assert!(
+            hub.try_subscribe().is_err(),
+            "second subscriber must be rejected"
+        );
+        drop(permit);
+        assert!(
+            hub.try_subscribe().is_ok(),
+            "disconnect must release capacity"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_route_emits_pipe_done_before_closing() {
+        let hub = Arc::new(PipeStreamHub::new());
+        let app = Router::new()
+            .route("/pipes/:id/stream", get(stream_pipe))
+            .with_state(hub.clone());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/pipes/time-tracker/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        hub.publish("time-tracker", 42, r#"{"type":"turn_start"}"#);
+        hub.publish("time-tracker", 42, r#"{"type":"pipe_done"}"#);
+        let body = to_bytes(response.into_body(), 16 * 1024).await.unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body.contains(r#"data: {"type":"turn_start"}"#));
+        assert!(body.contains(r#"data: {"type":"pipe_done"}"#));
+    }
+
+    #[tokio::test]
+    async fn raw_route_returns_retry_after_when_stream_slots_are_full() {
+        let hub = Arc::new(PipeStreamHub::with_max_subscribers(1));
+        let app = Router::new()
+            .route("/pipes/:id/stream", get(stream_pipe))
+            .with_state(hub);
+        let first = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/pipes/one/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let second = app
+            .oneshot(
+                Request::builder()
+                    .uri("/pipes/two/stream")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(second.headers().get(RETRY_AFTER).unwrap(), "1");
+        drop(first);
     }
 }

--- a/crates/screenpipe-engine/src/server.rs
+++ b/crates/screenpipe-engine/src/server.rs
@@ -1074,6 +1074,15 @@ impl SCServer {
 
         // Pipe API routes (if pipe manager is available)
         let router = if let Some(ref pm) = self.pipe_manager {
+            let pipe_stream_hub = Arc::new(crate::pipe_stream::PipeStreamHub::new());
+            {
+                let hub = pipe_stream_hub.clone();
+                pm.lock()
+                    .await
+                    .set_on_output_line(Arc::new(move |pipe, exec_id, line| {
+                        hub.publish(pipe, exec_id, line)
+                    }));
+            }
             let pipe_routes = Router::new()
                 .route("/", axum::routing::get(crate::pipes_api::list_pipes))
                 .route(
@@ -1175,7 +1184,14 @@ impl SCServer {
             } else {
                 pipe_routes
             };
-            let router = router.nest("/pipes", pipe_routes);
+            let router = router.nest("/pipes", pipe_routes).merge(
+                Router::new()
+                    .route(
+                        "/pipes/:id/stream",
+                        axum::routing::get(crate::pipe_stream::stream_pipe),
+                    )
+                    .with_state(pipe_stream_hub),
+            );
 
             // Plain chat, no pipe: served locally using the user's own AI preset
             // so clients can stream without going through the hosted gateway.
@@ -1568,6 +1584,11 @@ mod tests {
         ] {
             assert!(!is_api_auth_exempt_path(path));
         }
+    }
+
+    #[test]
+    fn pipe_stream_is_not_api_auth_exempt() {
+        assert!(!is_api_auth_exempt_path("/pipes/daily-summary/stream"));
     }
 
     #[test]

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 30
 - Mapped Rust files: 303
-- Active test blocks: 2829
+- Active test blocks: 2833
 - Ignored/manual test blocks: 133
-- Declared test blocks: 2962
-- Weighted coverage points: 2329.5
+- Declared test blocks: 2966
+- Weighted coverage points: 2332.3
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 27 | 2701 | 128 | 2270.8 | 21 | 11 | 100% |
-| macos | 27 | 2752 | 108 | 2280.7 | 22 | 11 | 100% |
-| linux | 23 | 2395 | 102 | 1993.1 | 20 | 11 | 100% |
+| windows | 27 | 2705 | 128 | 2273.6 | 21 | 11 | 100% |
+| macos | 27 | 2756 | 108 | 2283.5 | 22 | 11 | 100% |
+| linux | 23 | 2399 | 102 | 1995.9 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 9 | 18 | 97 | 1344 | 42 | 1033.7 | 10 |
+| screenpipe-engine | 9 | 18 | 97 | 1348 | 42 | 1036.5 | 10 |
 | screenpipe-db | 5 | 48 | 13 | 402 | 16 | 384.4 | 9 |
 | screenpipe-audio | 6 | 23 | 47 | 524 | 39 | 454.6 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 229 | 9 | 210.6 | 4 |
@@ -67,8 +67,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | database | 4 suites / 301 active / 12 ignored / 283.4 pts | 4 suites / 301 active / 12 ignored / 283.4 pts | 4 suites / 301 active / 12 ignored / 283.4 pts |
 | db-search | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts |
 | engine-lifecycle | 4 suites / 184 active / 1 ignored / 159.6 pts | 4 suites / 184 active / 1 ignored / 159.6 pts | 3 suites / 178 active / 1 ignored / 157.9 pts |
-| local-api | 2 suites / 290 active / 9 ignored / 204.2 pts | 2 suites / 290 active / 9 ignored / 204.2 pts | 2 suites / 290 active / 9 ignored / 204.2 pts |
-| meeting | 6 suites / 1282 active / 15 ignored / 1045.9 pts | 6 suites / 1282 active / 15 ignored / 1045.9 pts | 4 suites / 1011 active / 12 ignored / 795.3 pts |
+| local-api | 2 suites / 294 active / 9 ignored / 207.0 pts | 2 suites / 294 active / 9 ignored / 207.0 pts | 2 suites / 294 active / 9 ignored / 207.0 pts |
+| meeting | 6 suites / 1286 active / 15 ignored / 1048.7 pts | 6 suites / 1286 active / 15 ignored / 1048.7 pts | 4 suites / 1015 active / 12 ignored / 798.1 pts |
 | ocr | 4 suites / 120 active / 7 ignored / 114.3 pts | 4 suites / 124 active / 7 ignored / 119.8 pts | 3 suites / 115 active / 6 ignored / 110.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1297 active / 67 ignored / 1150.2 pts | 14 suites / 1392 active / 70 ignored / 1188.2 pts | 13 suites / 1297 active / 67 ignored / 1150.2 pts |
@@ -78,8 +78,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | speaker | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts |
 | storage | 3 suites / 436 active / 29 ignored / 354.4 pts | 3 suites / 436 active / 29 ignored / 354.4 pts | 3 suites / 436 active / 29 ignored / 354.4 pts |
 | sync | 1 suites / 433 active / 3 ignored / 303.1 pts | 1 suites / 433 active / 3 ignored / 303.1 pts | 1 suites / 433 active / 3 ignored / 303.1 pts |
-| timeline | 4 suites / 860 active / 33 ignored / 704.0 pts | 4 suites / 860 active / 33 ignored / 704.0 pts | 4 suites / 860 active / 33 ignored / 704.0 pts |
-| transcription | 5 suites / 617 active / 37 ignored / 482.2 pts | 5 suites / 617 active / 37 ignored / 482.2 pts | 5 suites / 617 active / 37 ignored / 482.2 pts |
+| timeline | 4 suites / 864 active / 33 ignored / 706.8 pts | 4 suites / 864 active / 33 ignored / 706.8 pts | 4 suites / 864 active / 33 ignored / 706.8 pts |
+| transcription | 5 suites / 621 active / 37 ignored / 485.0 pts | 5 suites / 621 active / 37 ignored / 485.0 pts | 5 suites / 621 active / 37 ignored / 485.0 pts |
 | ui-events | 4 suites / 668 active / 28 ignored / 511.5 pts | 3 suites / 620 active / 5 ignored / 477.9 pts | 3 suites / 620 active / 5 ignored / 477.9 pts |
 | vision-capture | 5 suites / 454 active / 32 ignored / 365.3 pts | 5 suites / 458 active / 32 ignored / 370.8 pts | 4 suites / 449 active / 31 ignored / 361.8 pts |
 
@@ -94,7 +94,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | Local API search and indexing | local-api, db-search | covered (strong; engine-local-api-search-integration) | covered (strong; engine-local-api-search-integration) | covered (strong; engine-local-api-search-integration) |
 | Audio record, transcribe, and reconcile | audio, transcription | covered (strong; audio-meetings-speakers-dedup, audio-transcription-pipeline) | covered (strong; audio-meetings-speakers-dedup, audio-transcription-pipeline) | covered (strong; audio-meetings-speakers-dedup, audio-transcription-pipeline) |
 | Audio device and stream health | audio-device | covered (strong; audio-device-stream-health, audio-platform-output-capture) | covered (strong; audio-device-stream-health, audio-platform-output-capture) | covered (strong; audio-device-stream-health) |
-| Meeting detection and live transcript merge | meeting | covered (strong; engine-meeting-privacy-sync, engine-meeting-watcher) | covered (strong; engine-meeting-privacy-sync, engine-meeting-watcher) | covered (strong; engine-meeting-privacy-sync, engine-api-routes) |
+| Meeting detection and live transcript merge | meeting | covered (strong; engine-meeting-privacy-sync, engine-api-routes) | covered (strong; engine-meeting-privacy-sync, engine-api-routes) | covered (strong; engine-meeting-privacy-sync, engine-api-routes) |
 | Privacy filters, DRM guards, and redaction | privacy | covered (strong; engine-meeting-privacy-sync, screen-capture-windowing) | covered (strong; engine-meeting-privacy-sync, screen-capture-windowing) | covered (strong; engine-meeting-privacy-sync, screen-capture-windowing) |
 | Accessibility tree and UI event capture | accessibility, ui-events | covered (strong; a11y-core-tree-cross-platform, a11y-windows-tree) | covered (strong; a11y-core-tree-cross-platform, db-accessibility-ui-events) | covered (strong; a11y-core-tree-cross-platform, db-accessibility-ui-events) |
 | Performance, backpressure, and liveness | performance | covered (strong; screen-capture-windowing, db-timeline-frames) | covered (strong; screen-capture-windowing, db-timeline-frames) | covered (strong; screen-capture-windowing, db-timeline-frames) |
@@ -132,7 +132,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 10 | 18 | 6 | SQLite hard-fault classification, failpoint VFS injection, query cancellation surviving dropped futures, close-severs-connections wedge regression, multi-pool WAL parity/corruption coverage, runtime version pinning, and manual WAL chaos plus memory-pressure probes (several ignored by default). |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 101 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 164 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
-| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 28 | 286 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
+| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 28 | 290 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 234 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
@@ -363,7 +363,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-config-lifecycle | screenpipe-engine | src/permission_monitor.rs | source | 1 | 0 | 1 |
 | engine-telemetry-observability | screenpipe-engine | src/piggyback_telemetry.rs | source | 1 | 0 | 1 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/pipe_store.rs | source | 32 | 0 | 32 |
-| engine-api-routes | screenpipe-engine | src/pipe_stream.rs | source | 5 | 0 | 5 |
+| engine-api-routes | screenpipe-engine | src/pipe_stream.rs | source | 8 | 0 | 8 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/pipes_api.rs | source | 9 | 0 | 9 |
 | engine-config-lifecycle | screenpipe-engine | src/power/manager.rs | source | 2 | 0 | 2 |
 | engine-config-lifecycle | screenpipe-engine | src/power/monitor.rs | source | 3 | 0 | 3 |
@@ -397,7 +397,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-api-routes | screenpipe-engine | src/routes/websocket.rs | source | 1 | 0 | 1 |
 | engine-config-lifecycle | screenpipe-engine | src/schedule_monitor.rs | source | 8 | 0 | 8 |
 | engine-capture-timeline | screenpipe-engine | src/semantic_worker.rs | source | 6 | 0 | 6 |
-| engine-api-routes | screenpipe-engine | src/server.rs | source | 10 | 0 | 10 |
+| engine-api-routes | screenpipe-engine | src/server.rs | source | 11 | 0 | 11 |
 | engine-config-lifecycle | screenpipe-engine | src/sleep_monitor.rs | source | 11 | 1 | 12 |
 | engine-capture-timeline | screenpipe-engine | src/snapshot_compaction.rs | source | 18 | 0 | 18 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/structured_outputs.rs | source | 8 | 0 | 8 |

--- a/packages/sdk/Cargo.lock
+++ b/packages/sdk/Cargo.lock
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6993,11 +6993,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.34"
+version = "0.4.35"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "libsqlite3-sys",
  "sqlx",
@@ -7168,7 +7168,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
+++ b/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -7126,11 +7126,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.34"
+version = "0.4.35"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7158,7 +7158,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7262,7 +7262,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "libsqlite3-sys",
  "sqlx",
@@ -7296,7 +7296,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "argon2",
  "chacha20poly1305",


### PR DESCRIPTION
## Summary
- register the authenticated raw pipe SSE route and wire live agent output into it
- bound long-lived subscribers, fail honestly on lag, and emit an explicit terminal event
- bump the CLI workspace to 0.4.35 for managed-runner rollout

## Verification
- `cargo test -p screenpipe-engine pipe_stream --lib` (9 passed)
- `cargo check -p screenpipe-engine --lib`
- `cargo fmt --check`
- `git diff --check`