### PR TITLE
fix(ai): reset monthly allowance at incident epoch

### DIFF
--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -28,6 +28,7 @@ import { getHostedAiPlan } from './hosted-ai-policy';
 import { loadHostedAiReservationControls } from './hosted-ai-reservation-controls';
 
 const COST_BASELINE_TIER = 'daily_cost_baseline_v1';
+const MONTHLY_COST_BASELINE_TIER = 'monthly_cost_baseline_v1';
 const COST_RESERVATION_TIER_PREFIX = 'daily_cost_reservation_v3';
 
 export type DailyCostHold = {
@@ -112,6 +113,54 @@ export async function getDailyUserCostForCapOrThrow(
 		baselineKey, deviceId, day, COST_BASELINE_TIER, day, currentCost,
 	).first<{ baseline: number }>();
 	if (!baselineRow) throw new Error('daily cost baseline unavailable');
+
+	return Math.max(0, currentCost - Number(baselineRow.baseline || 0));
+}
+
+/** Return monthly spend incurred after the configured incident epoch. */
+async function getMonthlyUserCostForCapOrThrow(
+	env: Env,
+	deviceId: string,
+	now: Date = new Date(),
+): Promise<number> {
+	const month = utcMonth(now);
+	const currentCost = await getCostAccumulatorOrThrow(
+		env,
+		monthlyCostKey(deviceId),
+		month,
+	);
+	const epoch = configuredCostCapEpoch(env);
+	if (!epoch) return currentCost;
+
+	const baselineKey = `monthly-cost:baseline:v1:${await sha256Hex(`${epoch}:${deviceId}`)}`;
+	const baselineRow = await env.DB.prepare(`
+		INSERT INTO usage
+			(device_id, user_id, daily_count, last_reset, tier, cost_day, daily_cost_usd)
+		VALUES (?, ?, 0, ?, ?, ?, ?)
+		ON CONFLICT(device_id) DO UPDATE SET
+			user_id = excluded.user_id,
+			daily_count = 0,
+			last_reset = excluded.last_reset,
+			tier = excluded.tier,
+			daily_cost_usd = CASE
+				WHEN usage.cost_day = excluded.cost_day THEN usage.daily_cost_usd
+				ELSE excluded.daily_cost_usd
+			END,
+			updated_at = CASE
+				WHEN usage.cost_day = excluded.cost_day THEN usage.updated_at
+				ELSE CURRENT_TIMESTAMP
+			END,
+			cost_day = excluded.cost_day
+		RETURNING daily_cost_usd AS baseline
+	`).bind(
+		baselineKey,
+		deviceId,
+		month,
+		MONTHLY_COST_BASELINE_TIER,
+		month,
+		currentCost,
+	).first<{ baseline: number }>();
+	if (!baselineRow) throw new Error('monthly cost baseline unavailable');
 
 	return Math.max(0, currentCost - Number(baselineRow.baseline || 0));
 }
@@ -269,8 +318,11 @@ export async function reserveDailyCostCap(
 
 	try {
 		const reservationControls = loadHostedAiReservationControls(env);
-		// Establish and read the immutable incident-epoch baseline before admission.
+		// Establish immutable incident-epoch baselines before admission.
 		await getDailyUserCostForCapOrThrow(env, deviceId, now);
+		if (!hostedAiTrial) {
+			await getMonthlyUserCostForCapOrThrow(env, deviceId, now);
+		}
 
 		const day = utcDay(now);
 		const month = utcMonth(now);
@@ -287,6 +339,9 @@ export async function reserveDailyCostCap(
 		const baselineKey = baselineEpoch
 			? `daily-cost:baseline:v1:${await sha256Hex(`${baselineEpoch}:${deviceId}`)}`
 			: '__no_daily_cost_baseline__';
+		const monthlyBaselineKey = baselineEpoch && !hostedAiTrial
+			? `monthly-cost:baseline:v1:${await sha256Hex(`${baselineEpoch}:${deviceId}`)}`
+			: '__no_monthly_cost_baseline__';
 		// Non-Business Auto is constrained to the efficient waterfall. Reserving it
 		// against Sol would reject legitimate requests before the provider runs.
 		const reservationModel = model === 'auto' && getHostedAiPlan(accountPlan) !== 'business'
@@ -343,10 +398,16 @@ export async function reserveDailyCostCap(
 				+ ?
 			) <= ?
 			AND (
-				COALESCE((
-					SELECT CASE WHEN cost_day = ? THEN daily_cost_usd ELSE 0 END
-					FROM usage WHERE device_id = ?
-				), 0) * 1000000
+				MAX(0, (
+					COALESCE((
+						SELECT CASE WHEN cost_day = ? THEN daily_cost_usd ELSE 0 END
+						FROM usage WHERE device_id = ?
+					), 0)
+					- COALESCE((
+						SELECT CASE WHEN cost_day = ? THEN daily_cost_usd ELSE 0 END
+						FROM usage WHERE device_id = ?
+					), 0)
+				) * 1000000)
 				+ COALESCE((
 					SELECT SUM(daily_count) FROM usage
 					WHERE user_id = ? AND tier = ? AND last_reset > ?
@@ -409,6 +470,8 @@ export async function reserveDailyCostCap(
 			dailyCapMicroUsd,
 			monthPeriod,
 			monthKey,
+			monthPeriod,
+			monthlyBaselineKey,
 			deviceId,
 			holdTier,
 			nowIso,
@@ -460,7 +523,9 @@ export async function reserveDailyCostCap(
 
 		const [dailyCost, monthlyCost, globalDailyCost, globalHourlyCost, accountHolds, globalHolds] = await Promise.all([
 			getDailyUserCostForCapOrThrow(env, deviceId, now),
-			getCostAccumulatorOrThrow(env, monthKey, monthPeriod),
+			hostedAiTrial
+				? getCostAccumulatorOrThrow(env, monthKey, monthPeriod)
+				: getMonthlyUserCostForCapOrThrow(env, deviceId, now),
 			getCostAccumulatorOrThrow(env, GLOBAL_DAILY_COST_KEY, day),
 			getCostAccumulatorOrThrow(env, GLOBAL_HOURLY_COST_KEY, hour),
 			env.DB.prepare(`

--- a/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
@@ -1100,4 +1100,74 @@ describe('usage reservations against workerd D1', () => {
 			await releaseDailyCostReservation(env, nextEpoch.reservation);
 		}
 	});
+
+	it('starts a fresh bounded monthly allowance when the cost epoch changes', async () => {
+		const deviceId = 'user-d1-monthly-cost-epoch';
+		const now = new Date();
+		const month = utcMonth(now);
+		const holdUsd = getCostReservationMicroUsd('claude-sonnet-5') / 1_000_000;
+		const monthlyCap = holdUsd * 3;
+		const historicalSpend = 40;
+		env.PRIVATE_COST_CAP_EPOCH = 'monthly-incident-v2';
+		setUniformTextWindows(env, {
+			request: monthlyCap,
+			daily: monthlyCap,
+			monthly: monthlyCap,
+		});
+		await env.DB.prepare(`
+			INSERT INTO usage (device_id, last_reset, tier, cost_day, daily_cost_usd)
+			VALUES (?, ?, 'monthly_cost_test', ?, ?)
+		`).bind(monthlyCostKey(deviceId), month, month, historicalSpend).run();
+
+		const first = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			'claude-sonnet-5',
+			now,
+		);
+		expect(first.allowed).toBe(true);
+		if (!first.allowed || !first.reservation) {
+			throw new Error('expected fresh monthly epoch reservation');
+		}
+		await releaseDailyCostReservation(env, first.reservation);
+
+		const baseline = await env.DB.prepare(`
+			SELECT daily_cost_usd, cost_day FROM usage
+			WHERE tier = 'monthly_cost_baseline_v1' AND user_id = ?
+		`).bind(deviceId).first<{ daily_cost_usd: number; cost_day: string }>();
+		expect(baseline).toEqual({ daily_cost_usd: historicalSpend, cost_day: month });
+
+		await env.DB.prepare('UPDATE usage SET daily_cost_usd = ? WHERE device_id = ?')
+			.bind(historicalSpend + monthlyCap, monthlyCostKey(deviceId)).run();
+		const atCap = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			'claude-sonnet-5',
+			now,
+		);
+		expect(atCap.allowed).toBe(false);
+		if (!atCap.allowed) {
+			expect(await atCap.response.text()).toContain('monthly_cost_limit_exceeded');
+		}
+
+		const preserved = await env.DB.prepare(`
+			SELECT daily_cost_usd FROM usage WHERE device_id = ?
+		`).bind(monthlyCostKey(deviceId)).first<{ daily_cost_usd: number }>();
+		expect(preserved?.daily_cost_usd).toBe(historicalSpend + monthlyCap);
+
+		env.PRIVATE_COST_CAP_EPOCH = 'monthly-incident-v3';
+		const nextEpoch = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			'claude-sonnet-5',
+			now,
+		);
+		expect(nextEpoch.allowed).toBe(true);
+		if (nextEpoch.allowed && nextEpoch.reservation) {
+			await releaseDailyCostReservation(env, nextEpoch.reservation);
+		}
+	});
 });


### PR DESCRIPTION
Closes #5765.

Production incident fix deployed from the prior live release commit. The cost-cap epoch now snapshots both daily and monthly account spend, so an incident reset grants a fresh bounded allowance without deleting historical spend or weakening request, daily, monthly, trial, background, or global caps. Trial spend remains non-resetting.

Production evidence before deploy: 24/24 sampled hosted-AI rejections were `monthly_cost_limit`.

Validation:
- 777/777 AI gateway tests pass
- focused D1 regression verifies monthly baseline, preserved history, cap re-enforcement, and second epoch
- Wrangler production bundle dry-run passes
- deployed release `51a5f28df`, Worker version `1b06e145-3ec9-479d-8d82-8a5b3539aee7`, 100% traffic
- after deploy: 16 fresh monthly baselines observed; bounded tail shifted from 24/24 monthly rejections to 1/35 (remaining rejects were trial/background limits)