### PR TITLE
fix(ai): allow bounded trial incident resets

### DIFF
--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -567,8 +567,24 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				authResult.hostedAiTrial === true,
 			);
 			if (!costReservation.allowed) {
+				let rejectionReason: string | undefined;
+				try {
+					const payload = await costReservation.response.clone().json() as { error?: unknown };
+					if (typeof payload.error === 'string') {
+						rejectionReason = payload.error;
+						try {
+							const nested = JSON.parse(payload.error) as { error?: unknown };
+							if (typeof nested.error === 'string') rejectionReason = nested.error;
+						} catch {
+							// The error was already a plain code.
+						}
+					}
+				} catch {
+					// Preserve the original response even if diagnostic decoding fails.
+				}
 				console.warn('hosted AI admission rejected', {
 					gate: 'cost_reservation',
+					reason: rejectionReason,
 					tier: authResult.tier,
 					accountPlan: authResult.accountPlan,
 					hostedAiTrial: authResult.hostedAiTrial === true,

--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -29,6 +29,7 @@ import { loadHostedAiReservationControls } from './hosted-ai-reservation-control
 
 const COST_BASELINE_TIER = 'daily_cost_baseline_v1';
 const MONTHLY_COST_BASELINE_TIER = 'monthly_cost_baseline_v1';
+const TRIAL_COST_BASELINE_TIER = 'trial_cost_baseline_v1';
 const COST_RESERVATION_TIER_PREFIX = 'daily_cost_reservation_v3';
 
 export type DailyCostHold = {
@@ -63,6 +64,11 @@ function utcDay(now: Date = new Date()): string {
 
 function configuredCostCapEpoch(env: Env): string | null {
 	const epoch = env.PRIVATE_COST_CAP_EPOCH?.trim();
+	return epoch && epoch.length <= 128 ? epoch : null;
+}
+
+function configuredTrialCostCapEpoch(env: Env): string | null {
+	const epoch = env.PRIVATE_TRIAL_COST_CAP_EPOCH?.trim();
 	return epoch && epoch.length <= 128 ? epoch : null;
 }
 
@@ -161,6 +167,39 @@ async function getMonthlyUserCostForCapOrThrow(
 		currentCost,
 	).first<{ baseline: number }>();
 	if (!baselineRow) throw new Error('monthly cost baseline unavailable');
+
+	return Math.max(0, currentCost - Number(baselineRow.baseline || 0));
+}
+
+/** Return trial spend incurred after an explicit one-time incident reset. */
+async function getTrialUserCostForCapOrThrow(
+	env: Env,
+	deviceId: string,
+): Promise<number> {
+	const currentCost = await getCostAccumulatorOrThrow(env, trialCostKey(deviceId), 'trial');
+	const epoch = configuredTrialCostCapEpoch(env);
+	if (!epoch) return currentCost;
+
+	const baselineKey = `trial-cost:baseline:v1:${await sha256Hex(`${epoch}:${deviceId}`)}`;
+	const baselineRow = await env.DB.prepare(`
+		INSERT INTO usage
+			(device_id, user_id, daily_count, last_reset, tier, cost_day, daily_cost_usd)
+		VALUES (?, ?, 0, 'trial', ?, 'trial', ?)
+		ON CONFLICT(device_id) DO UPDATE SET
+			user_id = excluded.user_id,
+			daily_count = 0,
+			last_reset = excluded.last_reset,
+			tier = excluded.tier,
+			daily_cost_usd = usage.daily_cost_usd,
+			cost_day = 'trial'
+		RETURNING daily_cost_usd AS baseline
+	`).bind(
+		baselineKey,
+		deviceId,
+		TRIAL_COST_BASELINE_TIER,
+		currentCost,
+	).first<{ baseline: number }>();
+	if (!baselineRow) throw new Error('trial cost baseline unavailable');
 
 	return Math.max(0, currentCost - Number(baselineRow.baseline || 0));
 }
@@ -320,9 +359,8 @@ export async function reserveDailyCostCap(
 		const reservationControls = loadHostedAiReservationControls(env);
 		// Establish immutable incident-epoch baselines before admission.
 		await getDailyUserCostForCapOrThrow(env, deviceId, now);
-		if (!hostedAiTrial) {
-			await getMonthlyUserCostForCapOrThrow(env, deviceId, now);
-		}
+		if (hostedAiTrial) await getTrialUserCostForCapOrThrow(env, deviceId);
+		else await getMonthlyUserCostForCapOrThrow(env, deviceId, now);
 
 		const day = utcDay(now);
 		const month = utcMonth(now);
@@ -339,9 +377,14 @@ export async function reserveDailyCostCap(
 		const baselineKey = baselineEpoch
 			? `daily-cost:baseline:v1:${await sha256Hex(`${baselineEpoch}:${deviceId}`)}`
 			: '__no_daily_cost_baseline__';
-		const monthlyBaselineKey = baselineEpoch && !hostedAiTrial
-			? `monthly-cost:baseline:v1:${await sha256Hex(`${baselineEpoch}:${deviceId}`)}`
-			: '__no_monthly_cost_baseline__';
+		const trialBaselineEpoch = configuredTrialCostCapEpoch(env);
+		const monthlyBaselineKey = hostedAiTrial
+			? trialBaselineEpoch
+				? `trial-cost:baseline:v1:${await sha256Hex(`${trialBaselineEpoch}:${deviceId}`)}`
+				: '__no_trial_cost_baseline__'
+			: baselineEpoch
+				? `monthly-cost:baseline:v1:${await sha256Hex(`${baselineEpoch}:${deviceId}`)}`
+				: '__no_monthly_cost_baseline__';
 		// Non-Business Auto is constrained to the efficient waterfall. Reserving it
 		// against Sol would reject legitimate requests before the provider runs.
 		const reservationModel = model === 'auto' && getHostedAiPlan(accountPlan) !== 'business'
@@ -524,7 +567,7 @@ export async function reserveDailyCostCap(
 		const [dailyCost, monthlyCost, globalDailyCost, globalHourlyCost, accountHolds, globalHolds] = await Promise.all([
 			getDailyUserCostForCapOrThrow(env, deviceId, now),
 			hostedAiTrial
-				? getCostAccumulatorOrThrow(env, monthKey, monthPeriod)
+				? getTrialUserCostForCapOrThrow(env, deviceId)
 				: getMonthlyUserCostForCapOrThrow(env, deviceId, now),
 			getCostAccumulatorOrThrow(env, GLOBAL_DAILY_COST_KEY, day),
 			getCostAccumulatorOrThrow(env, GLOBAL_HOURLY_COST_KEY, hour),

--- a/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
@@ -1039,6 +1039,79 @@ describe('usage reservations against workerd D1', () => {
 		}
 	});
 
+	it('allows an explicit one-time trial incident reset while preserving its bounded cap', async () => {
+		const deviceId = 'user-d1-trial-incident-epoch';
+		const now = new Date();
+		const holdUsd = getCostReservationMicroUsd('claude-sonnet-5') / 1_000_000;
+		const trialCap = holdUsd * 4;
+		const incidentSpend = 0.9;
+		env.PRIVATE_TRIAL_COST_CAP_EPOCH = 'trial-incident-v1';
+		setTrialTextWindows(env, {
+			request: holdUsd,
+			daily: holdUsd * 4,
+			total: trialCap,
+		});
+		await env.DB.prepare(`
+			INSERT INTO usage (device_id, user_id, last_reset, tier, cost_day, daily_cost_usd)
+			VALUES (?, ?, 'trial', 'trial_cost_v1', 'trial', ?)
+		`).bind(trialCostKey(deviceId), deviceId, incidentSpend).run();
+
+		const first = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			'claude-sonnet-5',
+			now,
+			'interactive',
+			{},
+			'business',
+			true,
+		);
+		expect(first.allowed).toBe(true);
+		if (!first.allowed || !first.reservation) throw new Error('expected fresh trial epoch reservation');
+		await releaseDailyCostReservation(env, first.reservation);
+
+		const preserved = await env.DB.prepare(
+			'SELECT daily_cost_usd FROM usage WHERE device_id = ?',
+		).bind(trialCostKey(deviceId)).first<{ daily_cost_usd: number }>();
+		expect(preserved?.daily_cost_usd).toBe(incidentSpend);
+
+		await env.DB.prepare('UPDATE usage SET daily_cost_usd = ? WHERE device_id = ?')
+			.bind(incidentSpend + trialCap, trialCostKey(deviceId)).run();
+		const atCap = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			'claude-sonnet-5',
+			now,
+			'interactive',
+			{},
+			'business',
+			true,
+		);
+		expect(atCap.allowed).toBe(false);
+		if (!atCap.allowed) {
+			expect(await atCap.response.text()).toContain('trial_cost_limit_exceeded');
+		}
+
+		env.PRIVATE_TRIAL_COST_CAP_EPOCH = 'trial-incident-v2';
+		const secondEpoch = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			'claude-sonnet-5',
+			now,
+			'interactive',
+			{},
+			'business',
+			true,
+		);
+		expect(secondEpoch.allowed).toBe(true);
+		if (secondEpoch.allowed && secondEpoch.reservation) {
+			await releaseDailyCostReservation(env, secondEpoch.reservation);
+		}
+	});
+
 	it('preserves incident spend while enforcing a fresh post-epoch cash budget', async () => {
 		const deviceId = 'user-d1-cost-epoch';
 		const day = new Date().toISOString().slice(0, 10);

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -219,6 +219,8 @@ export interface Env {
 	 * the new cap only on spend incurred after that snapshot.
 	 */
 	PRIVATE_COST_CAP_EPOCH?: string;
+	/** One-time incident reset for the otherwise lifetime/non-resetting trial allowance. */
+	PRIVATE_TRIAL_COST_CAP_EPOCH?: string;
 	PRIVATE_COST_RESERVATION_TTL_SECONDS?: string;
 	PRIVATE_CAPACITY_ACTIVITY_SECONDS?: string;
 	PRIVATE_MAX_ACTIVE_INTERACTIVE_RESERVATIONS?: string;


### PR DESCRIPTION
Follow-up for #5765.

Adds a separate operator-controlled one-time baseline for the otherwise non-resetting trial allowance. Historical trial spend remains intact; request, daily, trial-total, background, monthly, and global safeguards continue to apply after the reset. Also restores rejection-reason telemetry so incident handling can distinguish the active gate.

Production evidence:
- original reporter confirmed the monthly reset works
- remaining Discord reporter was on a Business trial
- pre-reset tail: 97/97 cost-reservation rejects were Business trial traffic
- trial reset initialized 15 fresh trial baselines
- restored telemetry identified the next active gate as `daily_cost_limit_exceeded`; bounded daily incident epoch then rotated

Validation:
- 771/771 gateway tests passed
- focused trial-epoch D1 regression passes
- 33/33 route tests pass after telemetry change
- Wrangler dry build passes
- production release `a86c071de`, with trial and daily incident epochs active at 100% traffic