### PR TITLE
fix(ai): restore Max identity and preserve Chat headroom

### DIFF
--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -193,6 +193,9 @@ async function handleMeteredTinfoilRequest(
 		),
 		endpoint: `/v1/tinfoil${subPath}`,
 		stream: usage === null,
+		lane: reservation.reservation?.lane,
+		cost_ledger_epoch: reservation.reservation?.ledgerEpoch,
+		cost_total_ledger_epoch: reservation.reservation?.totalLedgerEpoch,
 	}) : logReservedCost(env, reservation.reservation, attribution);
 	return withDailyCostSettlement(response, env, reservation.reservation, settlement);
 }
@@ -249,6 +252,9 @@ async function handleMeteredVoiceAiRequest(
 		),
 		endpoint,
 		stream: false,
+		lane: reservation.reservation?.lane,
+		cost_ledger_epoch: reservation.reservation?.ledgerEpoch,
+		cost_total_ledger_epoch: reservation.reservation?.totalLedgerEpoch,
 	}) : logReservedCost(env, reservation.reservation, attribution);
 	return withDailyCostSettlement(response, env, reservation.reservation, settlement);
 }
@@ -678,6 +684,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 						stream: true,
 						latency_ms: latencyMs,
 						router_tier: routerTier,
+						lane: dailyCostReservation?.lane,
+						cost_ledger_epoch: dailyCostReservation?.ledgerEpoch,
+						cost_total_ledger_epoch: dailyCostReservation?.totalLedgerEpoch,
 					}));
 				} else {
 					costSettlement = settleActualOrReservedCost(
@@ -718,6 +727,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 								stream: false,
 								latency_ms: latencyMs,
 								router_tier: routerTier,
+								lane: dailyCostReservation?.lane,
+								cost_ledger_epoch: dailyCostReservation?.ledgerEpoch,
+								cost_total_ledger_epoch: dailyCostReservation?.totalLedgerEpoch,
 							});
 						},
 					);
@@ -809,6 +821,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				),
 				endpoint: '/v1/web-search',
 				stream: false,
+				lane: costReservation.reservation?.lane,
+				cost_ledger_epoch: costReservation.reservation?.ledgerEpoch,
+				cost_total_ledger_epoch: costReservation.reservation?.totalLedgerEpoch,
 			}) : logReservedCost(env, costReservation.reservation, attribution);
 			return withDailyCostSettlement(
 				webSearchResponse,
@@ -1042,6 +1057,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 					}, costReservation.reservation?.reservedMicroUsd),
 					endpoint: '/v1/messages',
 					stream: true,
+					lane: costReservation.reservation?.lane,
+					cost_ledger_epoch: costReservation.reservation?.ledgerEpoch,
+					cost_total_ledger_epoch: costReservation.reservation?.totalLedgerEpoch,
 				}));
 			} else {
 				costSettlement = settleActualOrReservedCost(
@@ -1075,6 +1093,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 							}, costReservation.reservation?.reservedMicroUsd),
 							endpoint: '/v1/messages',
 							stream: false,
+							lane: costReservation.reservation?.lane,
+							cost_ledger_epoch: costReservation.reservation?.ledgerEpoch,
+							cost_total_ledger_epoch: costReservation.reservation?.totalLedgerEpoch,
 						});
 					},
 				);
@@ -1190,6 +1211,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 					}, costReservation.reservation?.reservedMicroUsd),
 					endpoint: '/anthropic/v1/messages',
 					stream: true,
+					lane: costReservation.reservation?.lane,
+					cost_ledger_epoch: costReservation.reservation?.ledgerEpoch,
+					cost_total_ledger_epoch: costReservation.reservation?.totalLedgerEpoch,
 				}));
 			} else {
 				costSettlement = settleActualOrReservedCost(
@@ -1223,6 +1247,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 							}, costReservation.reservation?.reservedMicroUsd),
 							endpoint: '/anthropic/v1/messages',
 							stream: false,
+							lane: costReservation.reservation?.lane,
+							cost_ledger_epoch: costReservation.reservation?.ledgerEpoch,
+							cost_total_ledger_epoch: costReservation.reservation?.totalLedgerEpoch,
 						});
 					},
 				);

--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -6,6 +6,8 @@ import { Env, type AccountPlan } from '../types';
 import { addCorsHeaders, createErrorResponse } from '../utils/cors';
 import { withResponseLifecycle } from '../utils/response-finalizer';
 import {
+	costLedgerEpoch,
+	dailyLaneCostKey,
 	getCostReservationMicroUsd,
 	getCostAccumulatorOrThrow,
 	getDailyUserCost,
@@ -13,11 +15,14 @@ import {
 	GLOBAL_DAILY_COST_KEY,
 	GLOBAL_HOURLY_COST_KEY,
 	monthlyCostKey,
+	totalCostLedgerEpoch,
+	totalLaneCostKey,
 	trialCostKey,
 	utcHour,
 	utcMonth,
 	isZeroCostModel,
 	type CostReservationShape,
+	type HostedAiCostLane,
 } from './cost-tracker';
 import {
 	accountPlanFromTier,
@@ -37,12 +42,15 @@ export type DailyCostHold = {
 	deviceId: string;
 	tier: string;
 	reservedMicroUsd: number;
+	lane: DailyCostLane;
+	ledgerEpoch: string;
+	totalLedgerEpoch: string;
 	expiresAt: string;
 	reservationTtlSeconds: number;
 	capacityActivitySeconds: number;
 };
 
-export type DailyCostLane = 'interactive' | 'background';
+export type DailyCostLane = HostedAiCostLane;
 
 export type DailyCostReservation =
 	| { allowed: true; reservation: DailyCostHold | null }
@@ -246,6 +254,30 @@ function capResponse(accountPlan: AccountPlan, period: 'request' | 'day' | 'mont
 	})));
 }
 
+function backgroundCapResponse(
+	accountPlan: AccountPlan,
+	period: 'day' | 'month' | 'trial',
+): Response {
+	const resetsAt = new Date();
+	if (period === 'month') {
+		resetsAt.setUTCMonth(resetsAt.getUTCMonth() + 1, 1);
+		resetsAt.setUTCHours(0, 0, 0, 0);
+	} else {
+		resetsAt.setUTCHours(24, 0, 0, 0);
+	}
+	const periodLabel = period === 'month' ? 'monthly' : period === 'trial' ? 'trial' : 'daily';
+	return addCorsHeaders(createErrorResponse(429, JSON.stringify({
+		error: 'background_cost_limit_exceeded',
+		message: `Scheduled pipes reached their ${periodLabel} hosted AI budget. Foreground chat remains available.`,
+		resets_at: period === 'trial' ? null : resetsAt.toISOString(),
+		plan: accountPlan,
+		required_plan: null,
+		upgrade_url: null,
+		can_buy_credits: false,
+		byok_supported: true,
+	})));
+}
+
 function globalCapResponse(period: 'hour' | 'day'): Response {
 	const response = addCorsHeaders(createErrorResponse(503, JSON.stringify({
 		error: 'hosted_ai_global_spend_limit',
@@ -404,8 +436,24 @@ export async function reserveDailyCostCap(
 			: reservationControls.maxActiveInteractive;
 		const lanePrefix = `${reservationKeyPrefix(lane)}%`;
 		const backgroundPrefix = `${reservationKeyPrefix('background')}%`;
+		const ledgerEpoch = costLedgerEpoch(env);
+		const totalLedgerEpoch = totalCostLedgerEpoch(env, hostedAiTrial);
+		const backgroundCostKey = dailyLaneCostKey(
+			deviceId,
+			'background',
+			ledgerEpoch,
+		);
+		const backgroundTotalCostKey = totalLaneCostKey(
+			deviceId,
+			'background',
+			hostedAiTrial,
+			totalLedgerEpoch,
+		);
 		const backgroundBudgetMicroUsd = Math.floor(
-			dailyCapMicroUsd * reservationControls.maxBackgroundReservedFraction,
+			dailyCapMicroUsd * reservationControls.maxBackgroundBudgetFraction,
+		);
+		const backgroundTotalBudgetMicroUsd = Math.floor(
+			monthlyCapMicroUsd * reservationControls.maxBackgroundBudgetFraction,
 		);
 		const key = `${reservationKeyPrefix(lane)}${crypto.randomUUID()}`;
 
@@ -488,11 +536,30 @@ export async function reserveDailyCostCap(
 			), 0) < ?
 			AND (
 				? = 'interactive'
-				OR COALESCE((
-					SELECT SUM(daily_count) FROM usage
-					WHERE user_id = ? AND tier = ? AND last_reset > ?
-						AND device_id LIKE ?
-				), 0) + ? <= ?
+				OR (
+					(
+						COALESCE((
+							SELECT CASE WHEN cost_day = ? THEN daily_cost_usd ELSE 0 END
+							FROM usage WHERE device_id = ?
+						), 0) * 1000000
+						+ COALESCE((
+							SELECT SUM(daily_count) FROM usage
+							WHERE user_id = ? AND tier = ? AND last_reset > ?
+								AND device_id LIKE ?
+						), 0) + ?
+					) <= ?
+					AND (
+						COALESCE((
+							SELECT CASE WHEN cost_day = ? THEN daily_cost_usd ELSE 0 END
+							FROM usage WHERE device_id = ?
+						), 0) * 1000000
+						+ COALESCE((
+							SELECT SUM(daily_count) FROM usage
+							WHERE user_id = ? AND tier = ? AND last_reset > ?
+								AND device_id LIKE ?
+						), 0) + ?
+					) <= ?
+				)
 			)
 			RETURNING device_id AS reservation_key
 		`).bind(
@@ -541,12 +608,22 @@ export async function reserveDailyCostCap(
 			lanePrefix,
 			laneLimit,
 			lane,
+			day,
+			backgroundCostKey,
 			deviceId,
 			holdTier,
 			nowIso,
 			backgroundPrefix,
 			reservedMicroUsd,
 			backgroundBudgetMicroUsd,
+			monthPeriod,
+			backgroundTotalCostKey,
+			deviceId,
+			holdTier,
+			nowIso,
+			backgroundPrefix,
+			reservedMicroUsd,
+			backgroundTotalBudgetMicroUsd,
 		).first<{ reservation_key: string }>();
 
 		if (claimed?.reservation_key === key) {
@@ -557,6 +634,9 @@ export async function reserveDailyCostCap(
 					deviceId,
 					tier: holdTier,
 					reservedMicroUsd,
+					lane,
+					ledgerEpoch,
+					totalLedgerEpoch,
 					expiresAt,
 					reservationTtlSeconds: reservationControls.reservationTtlSeconds,
 					capacityActivitySeconds: reservationControls.capacityActivitySeconds,
@@ -564,17 +644,23 @@ export async function reserveDailyCostCap(
 			};
 		}
 
-		const [dailyCost, monthlyCost, globalDailyCost, globalHourlyCost, accountHolds, globalHolds] = await Promise.all([
+		const [
+			dailyCost,
+			monthlyCost,
+			globalDailyCost,
+			globalHourlyCost,
+			backgroundCost,
+			backgroundTotalCost,
+			globalHolds,
+		] = await Promise.all([
 			getDailyUserCostForCapOrThrow(env, deviceId, now),
 			hostedAiTrial
 				? getTrialUserCostForCapOrThrow(env, deviceId)
 				: getMonthlyUserCostForCapOrThrow(env, deviceId, now),
 			getCostAccumulatorOrThrow(env, GLOBAL_DAILY_COST_KEY, day),
 			getCostAccumulatorOrThrow(env, GLOBAL_HOURLY_COST_KEY, hour),
-			env.DB.prepare(`
-				SELECT COALESCE(SUM(daily_count), 0) AS reserved
-				FROM usage WHERE user_id = ? AND tier = ? AND last_reset > ?
-			`).bind(deviceId, holdTier, nowIso).first<{ reserved: number }>(),
+			getCostAccumulatorOrThrow(env, backgroundCostKey, day),
+			getCostAccumulatorOrThrow(env, backgroundTotalCostKey, monthPeriod),
 			env.DB.prepare(`
 				SELECT COALESCE(SUM(daily_count), 0) AS reserved
 				FROM usage WHERE tier = ? AND last_reset > ?
@@ -584,18 +670,39 @@ export async function reserveDailyCostCap(
 		const monthlyCostMicroUsd = Math.max(0, Math.ceil(monthlyCost * 1_000_000));
 		const globalDailyCostMicroUsd = Math.max(0, Math.ceil(globalDailyCost * 1_000_000));
 		const globalHourlyCostMicroUsd = Math.max(0, Math.ceil(globalHourlyCost * 1_000_000));
-		const accountReservedMicroUsd = Math.max(0, Number(accountHolds?.reserved ?? 0));
+		const backgroundCostMicroUsd = Math.max(0, Math.ceil(backgroundCost * 1_000_000));
+		const backgroundTotalCostMicroUsd = Math.max(0, Math.ceil(backgroundTotalCost * 1_000_000));
 		const globalReservedMicroUsd = Math.max(0, Number(globalHolds?.reserved ?? 0));
 		let response: Response;
+		// Settled spend is a durable quota failure. Active holds are temporary and
+		// fall through to the retryable capacity response below.
 		if (reservedMicroUsd > requestCapMicroUsd) {
 			response = capResponse(accountPlan, 'request');
-		} else if (dailyCostMicroUsd + accountReservedMicroUsd + reservedMicroUsd > dailyCapMicroUsd) {
+		} else if (
+			lane === 'background'
+			&& backgroundCostMicroUsd + reservedMicroUsd > backgroundBudgetMicroUsd
+		) {
+			response = backgroundCapResponse(accountPlan, 'day');
+		} else if (
+			lane === 'background'
+			&& backgroundTotalCostMicroUsd + reservedMicroUsd > backgroundTotalBudgetMicroUsd
+		) {
+			response = backgroundCapResponse(accountPlan, hostedAiTrial ? 'trial' : 'month');
+		} else if (dailyCostMicroUsd + reservedMicroUsd > dailyCapMicroUsd) {
 			response = capResponse(accountPlan, 'day');
-		} else if (monthlyCostMicroUsd + accountReservedMicroUsd + reservedMicroUsd > monthlyCapMicroUsd) {
+		} else if (monthlyCostMicroUsd + reservedMicroUsd > monthlyCapMicroUsd) {
 			response = capResponse(accountPlan, hostedAiTrial ? 'trial' : 'month');
-		} else if (globalHourlyCostMicroUsd + globalReservedMicroUsd + reservedMicroUsd > globalHourlyCapMicroUsd) {
+		} else if (globalHourlyCostMicroUsd + reservedMicroUsd > globalHourlyCapMicroUsd) {
 			response = globalCapResponse('hour');
-		} else if (globalDailyCostMicroUsd + globalReservedMicroUsd + reservedMicroUsd > globalDailyCapMicroUsd) {
+		} else if (globalDailyCostMicroUsd + reservedMicroUsd > globalDailyCapMicroUsd) {
+			response = globalCapResponse('day');
+		} else if (
+			globalHourlyCostMicroUsd + globalReservedMicroUsd + reservedMicroUsd > globalHourlyCapMicroUsd
+		) {
+			response = globalCapResponse('hour');
+		} else if (
+			globalDailyCostMicroUsd + globalReservedMicroUsd + reservedMicroUsd > globalDailyCapMicroUsd
+		) {
 			response = globalCapResponse('day');
 		} else {
 			response = capacityResponse(accountPlan, lane);

--- a/packages/ai-gateway/src/services/cost-tracker.ts
+++ b/packages/ai-gateway/src/services/cost-tracker.ts
@@ -367,7 +367,15 @@ export interface CostLogEntry {
   // A/B baseline), or null (router N/A: vision/background/explicit/off).
   latency_ms?: number | null;
   router_tier?: string | null;
+  /** Admission lane for priced text AI. Missing legacy callers default to interactive. */
+  lane?: HostedAiCostLane;
+  /** Daily incident namespace captured when the request was admitted. */
+  cost_ledger_epoch?: string;
+  /** Monthly or trial incident namespace captured when the request was admitted. */
+  cost_total_ledger_epoch?: string;
 }
+
+export type HostedAiCostLane = 'interactive' | 'background';
 
 /** UTC day string (YYYY-MM-DD) — same convention as usage.last_reset. */
 function utcToday(): string {
@@ -394,6 +402,42 @@ export function transcriptionCostKey(deviceId: string): string {
   return `hosted-transcription-cost:day:v1:${deviceId}`;
 }
 
+/** Share the incident epoch with lane ledgers so an authorized reset is complete. */
+export function costLedgerEpoch(env?: Pick<Env, 'PRIVATE_COST_CAP_EPOCH'>): string {
+	const epoch = env?.PRIVATE_COST_CAP_EPOCH?.trim();
+	return epoch && epoch.length <= 128 ? epoch : 'default';
+}
+
+/** Use the matching monthly/trial epoch for the cumulative background ledger. */
+export function totalCostLedgerEpoch(
+	env?: Pick<Env, 'PRIVATE_COST_CAP_EPOCH' | 'PRIVATE_TRIAL_COST_CAP_EPOCH'>,
+	hostedAiTrial = false,
+): string {
+	const epoch = hostedAiTrial
+		? env?.PRIVATE_TRIAL_COST_CAP_EPOCH?.trim()
+		: env?.PRIVATE_COST_CAP_EPOCH?.trim();
+	return epoch && epoch.length <= 128 ? epoch : 'default';
+}
+
+/** Bounded per-account daily lane accumulator used to preserve chat headroom. */
+export function dailyLaneCostKey(
+	deviceId: string,
+	lane: HostedAiCostLane,
+	epoch = 'default',
+): string {
+	return `hosted-ai-cost:lane-day:v1:${epoch}:${lane}:${deviceId}`;
+}
+
+/** Bounded per-account monthly (or permanent trial) lane accumulator. */
+export function totalLaneCostKey(
+	deviceId: string,
+	lane: HostedAiCostLane,
+	hostedAiTrial = false,
+	epoch = 'default',
+): string {
+	return `hosted-ai-cost:lane-total:v1:${hostedAiTrial ? 'trial' : 'month'}:${epoch}:${lane}:${deviceId}`;
+}
+
 export const GLOBAL_DAILY_COST_KEY = 'hosted-ai-cost:global-day:v1';
 export const GLOBAL_HOURLY_COST_KEY = 'hosted-ai-cost:global-hour:v1';
 
@@ -413,6 +457,9 @@ async function bumpCostAccumulators(
   deviceId: string,
   cost: number,
   hostedAiTrial: boolean,
+  lane: HostedAiCostLane,
+  ledgerEpoch: string,
+  totalLedgerEpoch: string,
 ): Promise<boolean> {
   const now = new Date();
   const today = utcToday();
@@ -429,12 +476,20 @@ async function bumpCostAccumulators(
   try {
     // D1 batches are transactional: a request is either visible in every
     // account/global budget window or in none of them.
+    const backgroundStatements = lane === 'background' ? [
+      statement(dailyLaneCostKey(deviceId, lane, ledgerEpoch), today),
+      statement(
+        totalLaneCostKey(deviceId, lane, hostedAiTrial, totalLedgerEpoch),
+        hostedAiTrial ? 'trial' : month,
+      ),
+    ] : [];
     const statements = [
       statement(deviceId, today),
       statement(
         hostedAiTrial ? trialCostKey(deviceId) : monthlyCostKey(deviceId),
         hostedAiTrial ? 'trial' : month,
       ),
+      ...backgroundStatements,
       statement(GLOBAL_DAILY_COST_KEY, today),
       statement(GLOBAL_HOURLY_COST_KEY, hour),
     ];
@@ -525,6 +580,10 @@ export async function logCost(env: Env, entry: CostLogEntry): Promise<boolean> {
       entry.device_id,
       entry.estimated_cost_usd,
       entry.hosted_ai_trial === true,
+      entry.lane ?? 'interactive',
+      entry.cost_ledger_epoch?.trim() || costLedgerEpoch(env),
+      entry.cost_total_ledger_epoch?.trim()
+        || totalCostLedgerEpoch(env, entry.hosted_ai_trial === true),
     );
   }
 

--- a/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.integration.test.ts
@@ -12,12 +12,16 @@ import {
 } from './cost-cap';
 import { loadHostedAiReservationControls } from './hosted-ai-reservation-controls';
 import {
+	costLedgerEpoch,
+	dailyLaneCostKey,
 	GLOBAL_DAILY_COST_KEY,
 	GLOBAL_HOURLY_COST_KEY,
 	getCostReservationMicroUsd,
 	getStreamSettlementCost,
 	logCost,
 	monthlyCostKey,
+	totalCostLedgerEpoch,
+	totalLaneCostKey,
 	trialCostKey,
 	utcHour,
 	utcMonth,
@@ -438,7 +442,7 @@ describe('usage reservations against workerd D1', () => {
 		const controls = loadHostedAiReservationControls(env);
 		const holdUsd = getCostReservationMicroUsd('claude-sonnet-5') / 1_000_000;
 		const dailyForOneBackgroundHold = holdUsd * 1.5
-			/ controls.maxBackgroundReservedFraction;
+			/ controls.maxBackgroundBudgetFraction;
 		setUniformTextWindows(env, {
 			request: dailyForOneBackgroundHold,
 			daily: dailyForOneBackgroundHold,
@@ -480,9 +484,132 @@ describe('usage reservations against workerd D1', () => {
 		);
 		expect(largePipe.allowed).toBe(false);
 		if (!largePipe.allowed) {
-			expect(await largePipe.response.text()).toContain('hosted_ai_capacity_reserved');
+			expect(await largePipe.response.text()).toContain('background_cost_limit_exceeded');
 		}
 		expect(separateChat.allowed).toBe(true);
+	});
+
+	it('bounds cumulative Pipe spend while preserving foreground Chat headroom', async () => {
+		const now = new Date();
+		const deviceId = 'user-d1-cumulative-pipe-headroom';
+		const controls = loadHostedAiReservationControls(env);
+		const holdUsd = getCostReservationMicroUsd('claude-sonnet-5') / 1_000_000;
+		const dailyCap = 1;
+		const monthlyCap = 2;
+		const backgroundSpend = dailyCap * controls.maxBackgroundBudgetFraction - holdUsd / 2;
+		setUniformTextWindows(env, {
+			request: holdUsd * 2,
+			daily: dailyCap,
+			monthly: monthlyCap,
+		});
+
+		expect(await logCost(env, {
+			device_id: deviceId,
+			tier: 'subscribed',
+			provider: 'anthropic',
+			model: 'claude-sonnet-5',
+			input_tokens: 1_000,
+			output_tokens: 100,
+			estimated_cost_usd: backgroundSpend,
+			endpoint: '/v1/chat/completions',
+			stream: false,
+			lane: 'background',
+		})).toBe(true);
+
+		const pipe = await reserveDailyCostCap(
+			env, deviceId, 'subscribed', 'claude-sonnet-5', now, 'background',
+		);
+		expect(pipe.allowed).toBe(false);
+		if (!pipe.allowed) {
+			const body = await pipe.response.text();
+			expect(body).toContain('background_cost_limit_exceeded');
+			expect(body).toContain('Foreground chat remains available');
+		}
+
+		const chat = await reserveDailyCostCap(
+			env, deviceId, 'subscribed', 'claude-sonnet-5', now, 'interactive',
+		);
+		expect(chat.allowed).toBe(true);
+		if (chat.allowed && chat.reservation) {
+			await releaseDailyCostReservation(env, chat.reservation);
+		}
+
+		const laneRow = await env.DB.prepare(
+			'SELECT cost_day, daily_cost_usd FROM usage WHERE device_id = ?',
+		).bind(dailyLaneCostKey(deviceId, 'background', costLedgerEpoch(env)))
+			.first<{ cost_day: string; daily_cost_usd: number }>();
+		expect(laneRow).toEqual({
+			cost_day: now.toISOString().slice(0, 10),
+			daily_cost_usd: backgroundSpend,
+		});
+	});
+
+	it('resets daily and monthly Pipe ledgers together with the incident epoch', async () => {
+		const now = new Date();
+		const deviceId = 'user-d1-pipe-incident-epoch';
+		const controls = loadHostedAiReservationControls(env);
+		const holdUsd = getCostReservationMicroUsd('claude-sonnet-5') / 1_000_000;
+		const dailyCap = 1;
+		const monthlyCap = 1;
+		const backgroundSpend = monthlyCap * controls.maxBackgroundBudgetFraction - holdUsd / 2;
+		setUniformTextWindows(env, {
+			request: holdUsd * 2,
+			daily: dailyCap,
+			monthly: monthlyCap,
+		});
+
+		expect(await logCost(env, {
+			device_id: deviceId,
+			tier: 'subscribed',
+			provider: 'anthropic',
+			model: 'claude-sonnet-5',
+			input_tokens: 1_000,
+			output_tokens: 100,
+			estimated_cost_usd: backgroundSpend,
+			endpoint: '/v1/chat/completions',
+			stream: false,
+			lane: 'background',
+		})).toBe(true);
+
+		const blocked = await reserveDailyCostCap(
+			env, deviceId, 'subscribed', 'claude-sonnet-5', now, 'background',
+		);
+		expect(blocked.allowed).toBe(false);
+
+		env.PRIVATE_COST_CAP_EPOCH = 'chat-headroom-recovery-v1';
+		const fresh = await reserveDailyCostCap(
+			env, deviceId, 'subscribed', 'claude-sonnet-5', now, 'background',
+		);
+		expect(fresh.allowed).toBe(true);
+		if (!fresh.allowed || !fresh.reservation) throw new Error('expected fresh Pipe reservation');
+		expect(fresh.reservation.ledgerEpoch).toBe(costLedgerEpoch(env));
+		expect(fresh.reservation.totalLedgerEpoch).toBe(totalCostLedgerEpoch(env, false));
+
+		expect(await logCost(env, {
+			device_id: deviceId,
+			tier: 'subscribed',
+			provider: 'anthropic',
+			model: 'claude-sonnet-5',
+			input_tokens: 1_000,
+			output_tokens: 100,
+			estimated_cost_usd: holdUsd,
+			endpoint: '/v1/chat/completions',
+			stream: false,
+			lane: fresh.reservation.lane,
+			cost_ledger_epoch: fresh.reservation.ledgerEpoch,
+			cost_total_ledger_epoch: fresh.reservation.totalLedgerEpoch,
+		})).toBe(true);
+		await releaseDailyCostReservation(env, fresh.reservation);
+
+		const resetTotal = await env.DB.prepare(
+			'SELECT cost_day, daily_cost_usd FROM usage WHERE device_id = ?',
+		).bind(totalLaneCostKey(
+			deviceId,
+			'background',
+			false,
+			totalCostLedgerEpoch(env, false),
+		)).first<{ cost_day: string; daily_cost_usd: number }>();
+		expect(resetTotal).toEqual({ cost_day: utcMonth(now), daily_cost_usd: holdUsd });
 	});
 
 	it('rejects a request whose own measured shape cannot fit the cash cap', async () => {
@@ -694,6 +821,63 @@ describe('usage reservations against workerd D1', () => {
 			'SELECT daily_cost_usd FROM usage WHERE device_id = ?',
 		).bind(deviceId).first<{ daily_cost_usd: number }>();
 		expect(account?.daily_cost_usd).toBeCloseTo(expectedCost, 8);
+		expect(await env.DB.prepare(
+			'SELECT device_id FROM usage WHERE device_id = ?',
+		).bind(result.reservation.key).first()).toBeNull();
+	});
+
+	it('attributes a failed background request to its admitted budget epoch', async () => {
+		const now = new Date();
+		const deviceId = 'user-d1-provider-exception-background';
+		const model = 'claude-sonnet-5';
+		env.PRIVATE_COST_CAP_EPOCH = 'provider-exception-background-v1';
+		const result = await reserveDailyCostCap(
+			env,
+			deviceId,
+			'subscribed',
+			model,
+			now,
+			'background',
+			{},
+			'business',
+		);
+		if (!result.allowed || !result.reservation) {
+			throw new Error('expected background provider-exception reservation');
+		}
+
+		await settleProviderException(env, result.reservation, reservedCostAttribution({
+			isValid: true,
+			tier: 'subscribed',
+			accountPlan: 'business',
+			deviceId,
+			userId: deviceId,
+		}, model, '/v1/chat/completions', false));
+
+		const expectedCost = result.reservation.reservedMicroUsd / 1_000_000;
+		const dailyLane = await env.DB.prepare(
+			'SELECT cost_day, daily_cost_usd FROM usage WHERE device_id = ?',
+		).bind(dailyLaneCostKey(
+			deviceId,
+			'background',
+			result.reservation.ledgerEpoch,
+		)).first<{ cost_day: string; daily_cost_usd: number }>();
+		expect(dailyLane).toEqual({
+			cost_day: now.toISOString().slice(0, 10),
+			daily_cost_usd: expectedCost,
+		});
+
+		const monthlyLane = await env.DB.prepare(
+			'SELECT cost_day, daily_cost_usd FROM usage WHERE device_id = ?',
+		).bind(totalLaneCostKey(
+			deviceId,
+			'background',
+			false,
+			result.reservation.totalLedgerEpoch,
+		)).first<{ cost_day: string; daily_cost_usd: number }>();
+		expect(monthlyLane).toEqual({
+			cost_day: utcMonth(now),
+			daily_cost_usd: expectedCost,
+		});
 		expect(await env.DB.prepare(
 			'SELECT device_id FROM usage WHERE device_id = ?',
 		).bind(result.reservation.key).first()).toBeNull();

--- a/packages/ai-gateway/src/services/hosted-ai-cost-settlement.ts
+++ b/packages/ai-gateway/src/services/hosted-ai-cost-settlement.ts
@@ -65,6 +65,9 @@ export function logReservedCost(
 		stream: attribution.stream,
 		latency_ms: attribution.latencyMs,
 		router_tier: attribution.routerTier,
+		lane: reservation.lane,
+		cost_ledger_epoch: reservation.ledgerEpoch,
+		cost_total_ledger_epoch: reservation.totalLedgerEpoch,
 	});
 }
 

--- a/packages/ai-gateway/src/services/hosted-ai-reservation-controls.ts
+++ b/packages/ai-gateway/src/services/hosted-ai-reservation-controls.ts
@@ -17,7 +17,8 @@ export type HostedAiReservationControls = {
 	capacityActivitySeconds: number;
 	maxActiveInteractive: number;
 	maxActiveBackground: number;
-	maxBackgroundReservedFraction: number;
+	/** Maximum cumulative-plus-in-flight share available to background work. */
+	maxBackgroundBudgetFraction: number;
 };
 
 export class PrivateReservationControlError extends Error {
@@ -80,7 +81,8 @@ export function loadHostedAiReservationControls(
 			env.PRIVATE_MAX_ACTIVE_BACKGROUND_RESERVATIONS,
 			'PRIVATE_MAX_ACTIVE_BACKGROUND_RESERVATIONS',
 		),
-		maxBackgroundReservedFraction: requiredPrivateFraction(
+		// Keep the existing production binding name for a no-config migration.
+		maxBackgroundBudgetFraction: requiredPrivateFraction(
 			env.PRIVATE_MAX_BACKGROUND_RESERVED_FRACTION,
 			'PRIVATE_MAX_BACKGROUND_RESERVED_FRACTION',
 		),

--- a/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
+++ b/packages/ai-gateway/src/test/free-chat-route.unit.test.ts
@@ -444,33 +444,40 @@ describe('/v1/chat/completions free-plan route policy', () => {
 		expect(await errorCode(response)).toBe('cost_control_unavailable');
 	});
 
-	it('returns the Max capacity tier from the authenticated usage route', async () => {
-		verifyTokenMock.mockImplementation(async () => ({ sub: 'user_pro_max' }) as any);
-		globalThis.fetch = mock(async () => new Response(JSON.stringify({
-			success: true,
-			user: {
-				clerk_id: 'user_pro_max',
-				cloud_subscribed: true,
-				app_entitled: true,
-				subscription_plan: 'pro_max',
-				entitlement: { active: true, plan: 'pro_max', features: { app: true } },
-			},
-		}), { status: 200 })) as typeof fetch;
+	it('returns canonical Max and Ultra capacity from desktop-compatible user responses', async () => {
+		for (const [billingPlan, usageTier, dailyLimit] of [
+			['pro_max', 'business_max', 120],
+			['pro_ultra', 'business_ultra', 240],
+		] as const) {
+			const clerkId = `user_${billingPlan}`;
+			verifyTokenMock.mockImplementation(async () => ({ sub: clerkId }) as any);
+			globalThis.fetch = mock(async () => new Response(JSON.stringify({
+				success: true,
+				user: {
+					clerk_id: clerkId,
+					cloud_subscribed: true,
+					app_entitled: true,
+					subscription_plan: 'pro',
+					billing_plan: billingPlan,
+					entitlement: { active: true, plan: 'pro', features: { app: true } },
+				},
+			}), { status: 200 })) as typeof fetch;
 
-		const response = await handleRequest(new Request('https://gateway.test/v1/usage', {
-			headers: { Authorization: 'Bearer eyJ.pro-max.paid' },
-		}), env, ctx);
-		const body = await response.json() as Record<string, unknown>;
+			const response = await handleRequest(new Request('https://gateway.test/v1/usage', {
+				headers: { Authorization: `Bearer eyJ.${billingPlan}.paid` },
+			}), env, ctx);
+			const body = await response.json() as Record<string, unknown>;
 
-		expect(response.status).toBe(200);
-		expect(body).toMatchObject({
-			tier: 'business_max',
-			limit_today: 120,
-			remaining: 120,
-			upsell_banner: false,
-			upgrade_eligible: false,
-			cost_limit_reached: false,
-		});
+			expect(response.status).toBe(200);
+			expect(body).toMatchObject({
+				tier: usageTier,
+				limit_today: dailyLimit,
+				remaining: dailyLimit,
+				upsell_banner: false,
+				upgrade_eligible: false,
+				cost_limit_reached: false,
+			});
+		}
 	});
 
 	it('normalizes a removed model before gating and reaches the fallback provider', async () => {

--- a/packages/ai-gateway/src/test/hosted-ai-reservation-controls.unit.test.ts
+++ b/packages/ai-gateway/src/test/hosted-ai-reservation-controls.unit.test.ts
@@ -15,8 +15,8 @@ describe('private hosted AI reservation controls', () => {
 		expect(controls.reservationTtlSeconds).toBeGreaterThan(controls.capacityActivitySeconds);
 		expect(controls.maxActiveInteractive).toBeGreaterThan(0);
 		expect(controls.maxActiveBackground).toBeGreaterThan(0);
-		expect(controls.maxBackgroundReservedFraction).toBeGreaterThan(0);
-		expect(controls.maxBackgroundReservedFraction).toBeLessThanOrEqual(1);
+		expect(controls.maxBackgroundBudgetFraction).toBeGreaterThan(0);
+		expect(controls.maxBackgroundBudgetFraction).toBeLessThanOrEqual(1);
 	});
 
 	it('fails closed when any private value is missing', () => {

--- a/packages/ai-gateway/src/utils/auth.test.ts
+++ b/packages/ai-gateway/src/utils/auth.test.ts
@@ -475,7 +475,7 @@ describe('validateAuth — verified identities only', () => {
 		});
 	});
 
-  it('keeps Max and Ultra on subscribed model access with separate capacity tiers', async () => {
+  it('uses canonical Max and Ultra billing plans with desktop-compatible access labels', async () => {
     for (const [plan, accountPlan, usageTier] of [
       ['pro_max', 'business_max', 'business_max'],
       ['pro_ultra', 'business_ultra', 'business_ultra'],
@@ -489,8 +489,9 @@ describe('validateAuth — verified identities only', () => {
           clerk_id: clerkId,
           cloud_subscribed: true,
           app_entitled: true,
-          subscription_plan: plan,
-          entitlement: { active: true, plan, features: { app: true } },
+          subscription_plan: 'pro',
+          billing_plan: plan,
+          entitlement: { active: true, plan: 'pro', features: { app: true } },
         },
       }), { status: 200 })) as typeof fetch;
 
@@ -502,6 +503,72 @@ describe('validateAuth — verified identities only', () => {
         deviceId: clerkId,
         userId: clerkId,
       });
+    }
+  });
+
+  it('continues accepting exact legacy power-plan entitlement tuples', async () => {
+    for (const [plan, accountPlan, usageTier] of [
+      ['pro_max', 'business_max', 'business_max'],
+      ['pro_ultra', 'business_ultra', 'business_ultra'],
+    ] as const) {
+      __resetAuthEntitlementCacheForTests();
+      const clerkId = `user_legacy_${plan}`;
+      verifyTokenMock.mockImplementation(async () => ({ sub: clerkId }) as any);
+      globalThis.fetch = mock(async () => new Response(JSON.stringify({
+        success: true,
+        user: {
+          clerk_id: clerkId,
+          cloud_subscribed: true,
+          app_entitled: true,
+          subscription_plan: plan,
+          entitlement: { active: true, plan, features: { app: true } },
+        },
+      }), { status: 200 })) as typeof fetch;
+
+      expect(await validateAuth(requestFor(`eyJ.legacy.${plan}.clerk`), env)).toEqual({
+        isValid: true,
+        tier: 'subscribed',
+        usageTier,
+        accountPlan,
+        deviceId: clerkId,
+        userId: clerkId,
+      });
+    }
+  });
+
+  it('fails plan truth closed for malformed or contradictory billing plans', async () => {
+    for (const [suffix, accessPlan, billingPlan] of [
+      ['null', 'pro', null],
+      ['unknown', 'pro', 'premium'],
+      ['wrong-access', 'standard', 'pro_max'],
+    ] as const) {
+      __resetAuthEntitlementCacheForTests();
+      const clerkId = `user_bad_billing_${suffix}`;
+      verifyTokenMock.mockImplementation(async () => ({ sub: clerkId }) as any);
+      const fetchMock = mock(async () => new Response(JSON.stringify({
+        success: true,
+        user: {
+          clerk_id: clerkId,
+          cloud_subscribed: true,
+          app_entitled: true,
+          subscription_plan: accessPlan,
+          billing_plan: billingPlan,
+          entitlement: { active: true, plan: accessPlan, features: { app: true } },
+        },
+      }), { status: 200 }));
+      globalThis.fetch = fetchMock as typeof fetch;
+
+      const expected = {
+        isValid: true,
+        tier: 'subscribed',
+        accountPlan: 'unknown',
+        deviceId: clerkId,
+        userId: clerkId,
+      } as const;
+      expect(await validateAuth(requestFor(`eyJ.bad-billing.${suffix}.1`), env)).toEqual(expected);
+      expect(await validateAuth(requestFor(`eyJ.bad-billing.${suffix}.2`), env)).toEqual(expected);
+      // Unknown plan truth must never be cached; the next request revalidates it.
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     }
   });
 

--- a/packages/ai-gateway/src/utils/auth.ts
+++ b/packages/ai-gateway/src/utils/auth.ts
@@ -170,6 +170,7 @@ interface ScreenpipeUserData {
   cloud_subscribed?: boolean;
   app_entitled?: boolean;
   subscription_plan?: string | null;
+  billing_plan?: string | null;
   hosted_ai_trial?: boolean;
   entitlement?: {
     active?: boolean;
@@ -264,26 +265,50 @@ function usageTierField(
   return usageTier === tier ? {} : { usageTier };
 }
 
-function resolveAccountPlan(user: ScreenpipeUserData): AccountPlan {
-	// /api/user is the fresh authenticated source of truth. Free accounts return
-	// an explicit app/cloud denial and no entitlement object; `users.plan` may
-	// still contain a stale pre-cancel label, so do not let that advisory field
-	// turn a refunded account into paid access.
-	if (user.app_entitled === false && user.cloud_subscribed === false) {
-		return 'free';
-	}
+function billingPlanMatchesAccessPlan(
+  billingPlan: Exclude<AccountPlan, 'unknown'>,
+  accessPlan: Exclude<AccountPlan, 'unknown'>,
+): boolean {
+  if (billingPlan === accessPlan) return true;
 
-	const accountPlan = normalizeAccountPlan(user.subscription_plan);
-	const entitlementPlan = normalizeAccountPlan(user.entitlement?.plan);
+  // /api/user keeps the established Business access label for desktop builds
+  // released before Max and Ultra existed. The canonical billing plan is a
+  // capacity refinement of that same access grant, not a separate entitlement.
+  return accessPlan === 'business' &&
+    (billingPlan === 'business_max' || billingPlan === 'business_ultra');
+}
+
+function resolveAccountPlan(user: ScreenpipeUserData): AccountPlan {
+  // /api/user is the fresh authenticated source of truth. Free accounts return
+  // an explicit app/cloud denial and no entitlement object; `users.plan` may
+  // still contain a stale pre-cancel label, so do not let that advisory field
+  // turn a refunded account into paid access.
+  if (user.app_entitled === false && user.cloud_subscribed === false) {
+    return 'free';
+  }
+
+  const accessPlan = normalizeAccountPlan(user.subscription_plan);
+  const entitlementPlan = normalizeAccountPlan(user.entitlement?.plan);
 
   // Plan labels alone are stale advisory data in older rows. Require the fresh
   // /api/user entitlement tuple to agree end-to-end so a refunded account with
-  // users.plan=standard/pro cannot bypass the daily Free limit.
-  if (!accountPlan || !entitlementPlan || accountPlan !== entitlementPlan) {
+  // users.plan=standard/pro cannot bypass the daily Free limit. billing_plan is
+  // deliberately not used to prove app access: it only refines a valid access
+  // tuple into the hosted-AI capacity tier purchased by the customer.
+  if (!accessPlan || !entitlementPlan || accessPlan !== entitlementPlan) {
     return 'unknown';
   }
 
-	if (accountPlan === 'free') return 'unknown';
+  if (accessPlan === 'free') return 'unknown';
+
+  let accountPlan = accessPlan;
+  if (user.billing_plan !== undefined) {
+    const billingPlan = normalizeAccountPlan(user.billing_plan);
+    if (!billingPlan || !billingPlanMatchesAccessPlan(billingPlan, accessPlan)) {
+      return 'unknown';
+    }
+    accountPlan = billingPlan;
+  }
 
   return user.app_entitled === true &&
     user.entitlement?.active === true &&


### PR DESCRIPTION
## What changed

- consume canonical billing plan data while preserving the desktop-compatible entitlement contract
- map paid Max and Ultra subscriptions to their matching hosted-AI capacity tiers
- account for settled background Pipe spend in cumulative daily and monthly or trial lane ledgers
- cap background work independently so foreground Chat retains plan headroom
- preserve lane and incident-epoch attribution when provider usage is unavailable
- fail plan truth and cost accounting closed when source data is contradictory or unavailable

## Why

Two defects combined during the hosted-AI incident tracked in #5765:

1. Paid Business Max accounts could be enforced as ordinary Business because the gateway ignored the canonical billing field.
2. Background Pipes were bounded only by active reservations, not cumulative settled spend, so they could consume the shared account allowance and strand foreground Chat.

This change preserves the existing request, account, trial, and global cash breakers. It only bounds how much of those existing allowances background work can consume.

## Validation

- full AI gateway suite: 776 passed, 0 failed, 2,180 assertions
- includes cumulative background enforcement, foreground Chat headroom, incident-epoch reset, and failed-provider settlement regressions
- git diff check passed
- Wrangler production dry build passed: 1.19 MiB upload, 235 KiB compressed
- exact source commit: 6ac8084ba65a7fb82b24eef1893857c37607f305
- Sentry release: 6ac8084ba

## Production state

The exact source commit is deployed. Code deployment created Worker version 9cde1985-57f0-4845-b2d8-829beb00f63a; the one-time paid and trial incident epoch update created the final serving version 3d6a5eb0-bef5-47b9-96a1-3cc250098e6d at 100%.

Equal 20-second windows:
- before: subscribed Chat 7 x 200, 4 x 429
- after: subscribed Chat 22 x 200, 1 x 429
- following 20-second rejection-classification window: no hosted-AI admission rejection observed

Deployment and aggregate recovery are verified. Fresh affected-user confirmation remains separate and pending. CI on this exact PR head is running; do not merge through pending or failed required checks.