### PR TITLE
Bump CLI to v0.4.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8342,7 +8342,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio-eval"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -8460,7 +8460,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -8508,7 +8508,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -8561,11 +8561,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.35"
+version = "0.4.36"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -8676,7 +8676,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8694,7 +8694,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-gateway"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "async-trait",
  "axum",
@@ -8724,7 +8724,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-meeting-eval"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "clap",
@@ -8736,7 +8736,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -8775,7 +8775,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-resource"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "serde",
  "sysinfo",
@@ -8795,7 +8795,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -8877,7 +8877,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "libsqlite3-sys",
  "serde",
@@ -8891,7 +8891,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-recovery"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "cc",
  "libsqlite3-sys",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-team-memory"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "serde",
  "serde_yaml",
@@ -8932,7 +8932,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-telemetry-wire"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "serde",
  "serde_json",
@@ -8942,7 +8942,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.35"
+version = "0.4.36"
 authors = ["louis030195 <hi@louis030195.com>"]
 description = ""
 repository = "https://github.com/screenpipe/screenpipe"

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11279,7 +11279,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-audio"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "audiopipe",
@@ -11356,7 +11356,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -11369,7 +11369,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -11415,7 +11415,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -11467,11 +11467,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.35"
+version = "0.4.36"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11499,7 +11499,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-engine"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -11570,7 +11570,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11586,7 +11586,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-redact"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -11623,7 +11623,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-resource"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "serde",
  "sysinfo",
@@ -11643,7 +11643,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -11711,7 +11711,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "libsqlite3-sys",
  "serde",
@@ -11724,7 +11724,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-recovery"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "cc",
  "libsqlite3-sys",
@@ -11732,7 +11732,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sync"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -11752,7 +11752,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-telemetry-wire"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "serde",
  "serde_json",
@@ -11762,7 +11762,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/crates/screenpipe-redact/src/adapters/rfdetr.rs
+++ b/crates/screenpipe-redact/src/adapters/rfdetr.rs
@@ -25,8 +25,10 @@
 //! recall@IoU0.5 on a 150-state real-app suite of planted PII that no
 //! model here trained on:
 //!
-//!     v27 (previous): recall 92.9 %, secrets 74/76, 1.04 strays/shot
-//!     v34 (this):     recall 95.3 %, secrets 75/76, 1.03 strays/shot
+//! ```text
+//! v27 (previous): recall 92.9 %, secrets 74/76, 1.04 strays/shot
+//! v34 (this):     recall 95.3 %, secrets 75/76, 1.03 strays/shot
+//! ```
 //!   Both: 0 decoy false fires. For scale, an RFDETR-**Large** trained on
 //!   the same data scores 95.7 % — i.e. +0.4 over this nano model, so
 //!   accuracy here is data-limited, not capacity-limited.

--- a/packages/sdk/Cargo.lock
+++ b/packages/sdk/Cargo.lock
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -6993,11 +6993,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.35"
+version = "0.4.36"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7142,7 +7142,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "libsqlite3-sys",
  "serde",
@@ -7171,7 +7171,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "argon2",
  "chacha20poly1305",

--- a/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
+++ b/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-config"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "dirs 6.0.0",
  "screenpipe-cpu-features",
@@ -7039,7 +7039,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-connect"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -7084,7 +7084,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-core"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility",
  "accessibility-sys",
@@ -7126,11 +7126,11 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-cpu-features"
-version = "0.4.35"
+version = "0.4.36"
 
 [[package]]
 name = "screenpipe-db"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7158,7 +7158,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-events"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-screen"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "accessibility-sys",
  "anyhow",
@@ -7262,7 +7262,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-sqlite-coordinator"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "libsqlite3-sys",
  "serde",
@@ -7299,7 +7299,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-vault"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "argon2",
  "chacha20poly1305",


### PR DESCRIPTION
## Summary

- fix the new RF-DETR benchmark prose so Rustdoc treats it as text instead of executable Rust
- bump the CLI workspace from `0.4.35` to `0.4.36`
- regenerate every affected checked-in Cargo lockfile
- pair the CLI release with app `2.5.165`, already staged on `main` at `cf3989588bc290644c6789c2a20972add078c0da`

## Release behavior

This PR remains draft until its current-base CI is complete. It must be rebase-merged so `Bump CLI to v0.4.36` remains the final commit and the CLI release workflow publishes npm packages plus the rolling CLI GitHub release. The app artifact build is already running separately from `cf3989588`.

## Validation

- `cargo test -p screenpipe-redact --doc`
- `./scripts/regenerate-locks.sh --check`
- root and app `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

## App promotion boundary

Signed app artifacts will be canaried before creating the public `app-v2.5.165` release and moving the stable updater.