### PR TITLE
fix(app): stop fabricating a subscription_plan that contradicts the entitlement

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -304,13 +304,18 @@ export function AppEntitlementGate({
     gateReportedRef.current = true;
     posthog.capture("app_entitlement_gate_shown", {
       logged_in: Boolean(user?.token),
+      // Must follow the same precedence as the render branches below (and as
+      // `gate_path`). Checking unknown-policy before enterprise-app reported
+      // "plan_verification_required" for users who were actually looking at the
+      // "enterprise app required" screen — both flags are true at once, since an
+      // unknown plan is what clears hasConsumerAppSubscription in the first place.
       reason: shouldGateForEnterpriseLogin
         ? "enterprise_login_required"
-        : shouldGateForConsumerLogin
-          ? "consumer_login_required"
-          : shouldGateForUnknownConsumerPolicy
-            ? "plan_verification_required"
-            : "enterprise_app_required",
+        : shouldGateForEnterpriseApp
+          ? "enterprise_app_required"
+          : shouldGateForConsumerLogin
+            ? "consumer_login_required"
+            : "plan_verification_required",
       plan: user?.subscription_plan ?? null,
       app_entitled: user?.app_entitled ?? null,
       // Diagnostics for the enterprise post-update loop (SCR-132).

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -368,6 +368,96 @@ describe("app entitlement", () => {
     expect(hasCloudEntitlement(normalized)).toBe(true);
   });
 
+  // The server computes `subscription_plan` per request and may omit it while
+  // still returning a complete entitlement. Falling back to an invented label
+  // ("pro"/"standard") then contradicted the entitlement's own plan, and
+  // hasVerifiedPaidPlanAt requires the two to match exactly — so a fully paid
+  // account collapsed to "unknown" policy and was shown the enterprise-app gate.
+  it("adopts entitlement.plan when the API omits subscription_plan", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_lifetime",
+        app_entitled: true,
+        cloud_subscribed: false,
+        entitlement: {
+          active: true,
+          plan: "lifetime",
+          source: "lifetime",
+          checked_at: NOW.toISOString(),
+          features: { app: true },
+        },
+      },
+      "token",
+    );
+
+    expect(normalized.subscription_plan).toBe("lifetime");
+    expect(getLocalPlanPolicy(normalized)).toBe("verified-paid");
+    expect(hasConsumerAppSubscription(normalized)).toBe(true);
+  });
+
+  it("does not fabricate 'pro' over a richer entitlement plan", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_pro_ultra",
+        app_entitled: true,
+        cloud_subscribed: true,
+        entitlement: {
+          active: true,
+          plan: "pro_ultra",
+          source: "subscription",
+          checked_at: NOW.toISOString(),
+          features: { app: true, cloud: true },
+        },
+      },
+      "token",
+    );
+
+    expect(normalized.subscription_plan).toBe("pro_ultra");
+    expect(getLocalPlanPolicy(normalized)).toBe("verified-paid");
+  });
+
+  it("still prefers an explicit server subscription_plan over the entitlement", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_explicit",
+        app_entitled: true,
+        subscription_plan: "team",
+        entitlement: {
+          active: true,
+          plan: "team",
+          source: "subscription",
+          checked_at: NOW.toISOString(),
+          features: { app: true },
+        },
+      },
+      "token",
+    );
+
+    expect(normalized.subscription_plan).toBe("team");
+    expect(getLocalPlanPolicy(normalized)).toBe("verified-paid");
+  });
+
+  it("keeps explicit server denial at 'none' even when the entitlement names a plan", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_revoked",
+        app_entitled: false,
+        cloud_subscribed: false,
+        entitlement: {
+          active: true,
+          plan: "lifetime",
+          source: "lifetime",
+          checked_at: NOW.toISOString(),
+          features: { app: true },
+        },
+      },
+      "token",
+    );
+
+    expect(normalized.subscription_plan).toBe("none");
+    expect(hasAppEntitlement(normalized)).toBe(false);
+  });
+
   it("does not let cloud_subscribed override explicit server app denial", () => {
     const normalized = normalizeAppUser(
       {

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -561,9 +561,23 @@ export function normalizeAppUser(rawUser: any, token: string): AppUser {
   // Explicit server denial is stronger than a stale users.plan label left by a
   // canceled or refunded account.
   const explicitlyFree = rawUser?.app_entitled === false && !cloudSubscribed;
+  // The server computes `subscription_plan` per request and can omit it while
+  // still returning a full entitlement. The cloud_subscribed/app_entitled
+  // fallbacks below invent a *label* ("pro"/"standard"), and the entitlement is
+  // passed through verbatim — so inventing one when the entitlement already
+  // names a plan guarantees the two disagree. hasVerifiedPaidPlanAt requires
+  // them to be exactly equal, so that mismatch collapses the account to
+  // "unknown" policy, which in turn clears hasConsumerAppSubscription and trips
+  // the enterprise-app gate for a fully paid consumer account. Prefer the
+  // entitlement's own plan so the two sides cannot diverge.
+  const rawEntitlementPlan =
+    typeof rawEntitlement?.plan === "string" && rawEntitlement.plan.trim()
+      ? rawEntitlement.plan
+      : null;
   const subscriptionPlan = explicitlyFree
     ? "none"
     : (rawUser?.subscription_plan ??
+      rawEntitlementPlan ??
       (cloudSubscribed ? "pro" : appEntitled ? "standard" : null));
   const entitlement = explicitlyFree
     ? {


### PR DESCRIPTION
## What users saw

A fully paid consumer account, signed in successfully, got dropped onto this screen — and recording stopped:

```
┌──────────────────────────────────────────────────────┐
│  SCREENPIPE                                          │
│                                                      │
│  enterprise app required                             │
│                                                      │
│  louis@screenpi.pe belongs to screenpipe. download   │
│  the screenpipe enterprise app so this device        │
│  follows workspace policy and uploads to your org    │
│  storage.                                            │
│                                                      │
│  ┌────────────────────────────────────────────────┐  │
│  │  ⤓  DOWNLOAD ENTERPRISE APP                    │  │
│  └────────────────────────────────────────────────┘  │
│  ┌────────────────────────────────────────────────┐  │
│  │  🏢  OPEN ENTERPRISE BUILDS                    │  │
│  └────────────────────────────────────────────────┘  │
│               USE DIFFERENT ACCOUNT                  │
└──────────────────────────────────────────────────────┘
```

Note there is **no "refresh access" button** on this screen — so the only escape
was relaunching the app, which papers over it until the next bad response.

## Root cause

`normalizeAppUser` invents a `subscription_plan` label whenever the server omits
the field, while passing the server's `entitlement` through verbatim. Nothing
reconciles the two — and `hasVerifiedPaidPlanAt` requires them to be **exactly
equal**.

```mermaid
flowchart TD
    A["/api/user returns entitlement.plan = 'lifetime'<br/>but omits subscription_plan"] --> B["normalizeAppUser fabricates<br/>subscription_plan = 'standard'"]
    A --> C["entitlement.plan passed<br/>through verbatim = 'lifetime'"]
    B --> D{"hasVerifiedPaidPlanAt<br/>accountPlan === entitlementPlan ?"}
    C --> D
    D -->|"'standard' !== 'lifetime'"| E["getLocalPlanPolicy() = 'unknown'"]
    E --> F["hasConsumerAppSubscription() = false"]
    F --> G["shouldGateForEnterpriseApp = TRUE"]
    G --> H["'enterprise app required' screen<br/>+ recorder stopped"]

    style E fill:#ffe6e6
    style F fill:#ffe6e6
    style G fill:#ffcccc
    style H fill:#ff9999
```

The `enterprise app required` copy is a **misdiagnosis**. The account's org
membership was never the problem — an unknown plan policy is what clears
`hasConsumerAppSubscription`, and that is the last condition guarding the
enterprise-app gate.

## Evidence from production telemetry

Same account, `app_entitlement_gate_shown` over 2 days. Note the plan flapping,
and that `reason` and `gate_path` **disagree on every row**:

| timestamp | os | plan | reason | gate_path |
|---|---|---|---|---|
| 2026-08-02 23:33 | Windows | `lifetime` | plan_verification_required | **enterprise_app** |
| 2026-08-02 23:27 | Windows | `pro` | plan_verification_required | **enterprise_app** |
| 2026-08-01 16:53 | Mac OS X | `pro_ultra` | plan_verification_required | **enterprise_app** |
| 2026-08-01 16:13 | Mac OS X | `pro_ultra` | plan_verification_required | **enterprise_app** |
| 2026-08-01 16:13 | Windows | `pro_ultra` | plan_verification_required | **enterprise_app** |

Three different plan values in two days for one account — including `pro`, which
is exactly what the `cloud_subscribed` fallback fabricates. Both platforms are
affected; this is not OS-specific.

## Proof

A scratch repro against the real `normalizeAppUser`, before the fix:

```
fabricated subscription_plan : standard
server  entitlement.plan     : lifetime
resulting policy             : unknown
hasConsumerAppSubscription   : false      ← trips the enterprise gate

fabricated subscription_plan : pro
server  entitlement.plan     : pro_ultra
resulting policy             : unknown
```

The two bug-catching cases in this PR fail on `main` and pass with the fix:

```
$ git stash push -- lib/app-entitlement.ts   # remove only the fix
  Tests  2 failed | 43 passed (45)

$ git stash pop                              # restore the fix
  Tests  84 passed (84)
```

## The fix

Prefer the entitlement's own plan before falling back to an invented label, so
the two sides cannot diverge:

```diff
+ const rawEntitlementPlan =
+   typeof rawEntitlement?.plan === "string" && rawEntitlement.plan.trim()
+     ? rawEntitlement.plan
+     : null;
  const subscriptionPlan = explicitlyFree
    ? "none"
    : (rawUser?.subscription_plan ??
+     rawEntitlementPlan ??
       (cloudSubscribed ? "pro" : appEntitled ? "standard" : null));
```

Explicit server denial (`app_entitled: false`) still wins and still forces
`"none"` — covered by a regression test.

### Telemetry precedence

`reason` checked unknown-policy before enterprise-app, while `gate_path` and the
render branches check enterprise-app first. Both flags are true simultaneously in
this failure, so affected users were logged as `plan_verification_required` while
actually looking at the enterprise screen. `reason` now follows the same
precedence as the render branches — which is why this bug read as an org-routing
issue for as long as it did.

## Testing

- `bunx vitest run lib/app-entitlement.test.ts components/app-entitlement-gate.tsx` → **84 passed**
- `bunx tsc --noEmit` → clean
- 4 new tests: 2 reproduce the bug (verified failing without the fix), 2 guard
  existing behaviour (explicit `subscription_plan` still wins; explicit denial
  still forces `"none"`)

## Not addressed here

The backend still computes `subscription_plan` per request and returns
inconsistent values for one account (`lifetime` / `pro` / `pro_ultra` above).
That lives in the private screenpipe.com repo. This change makes the client
resilient to it, but the server-side instability is worth fixing separately —
`packages/ai-gateway/src/utils/auth.ts` (`resolveAccountPlan`) duplicates the
same strict-equality rule and will hit the same failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
