### PR TITLE
Bump app to v2.5.167

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11148,7 +11148,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.166"
+version = "2.5.167"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ members = ["wer-dump-helper"]
 
 [package]
 name = "screenpipe-app"
-version = "2.5.166"
+version = "2.5.167"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
## Summary
- bump the desktop app from 2.5.166 to 2.5.167
- release the post-2.5.166 changes already merged to main

## Validation
- `git diff --check`
- exactly two version files changed
- `cargo metadata --locked --no-deps --format-version 1` parsed successfully

## Release
Merging to `main` triggers the signed multi-platform Release App workflow.