### PR TITLE
test: align platform E2E expectations with intentional UI changes

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -838,6 +838,7 @@ Refresh the assigned Live View output targets from source-backed activity.
           documentWidth: document.documentElement.scrollWidth,
           viewportHeight: document.documentElement.clientHeight,
           documentHeight: document.documentElement.scrollHeight,
+          sectionTop: sectionRect.top,
           sectionLeft: sectionRect.left,
           sectionRight: sectionRect.right,
           sectionBottom: sectionRect.bottom,
@@ -849,7 +850,7 @@ Refresh the assigned Live View output targets from source-backed activity.
             .filter((element) => {
               const rect = element.getBoundingClientRect();
               return (
-                rect.top < 32 ||
+                rect.top < sectionRect.top - 1 ||
                 rect.left < -1 ||
                 rect.right > document.documentElement.clientWidth + 1
               );
@@ -873,6 +874,7 @@ Refresh the assigned Live View output targets from source-backed activity.
         documentWidth: number;
         viewportHeight: number;
         documentHeight: number;
+        sectionTop: number;
         sectionLeft: number;
         sectionRight: number;
         sectionBottom: number;
@@ -889,7 +891,11 @@ Refresh the assigned Live View output targets from source-backed activity.
       } | null;
 
       expect(layout).not.toBeNull();
-      expect(layout!.firstContentTop).toBeGreaterThanOrEqual(32);
+      // Windows and Linux intentionally render the custom titlebar flush with
+      // the section top; macOS keeps extra space for the traffic lights.
+      expect(layout!.firstContentTop).toBeGreaterThanOrEqual(
+        layout!.sectionTop - 1,
+      );
       expect(layout!.sectionLeft).toBeGreaterThanOrEqual(-1);
       expect(layout!.sectionRight).toBeLessThanOrEqual(
         layout!.viewportWidth + 1,

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-sidebar-pipe-inventory.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-sidebar-pipe-inventory.spec.ts
@@ -282,7 +282,7 @@ describe("chat sidebar pipe inventory", function () {
     });
     expect(fetchesWhileCollapsed).toEqual([0, 0, 0]);
 
-    await clickSection("pipes");
+    await clickSection("scheduled");
     const groupSelector = `[data-testid="pipe-group-pipe:${PIPE_NAME}"]`;
     await browser.waitUntil(
       async () => await browser.execute((selector: string) =>

--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-guide.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-guide.spec.ts
@@ -39,7 +39,7 @@ import {
 } from "../helpers/test-utils.js";
 import { saveScreenshot } from "../helpers/screenshot-utils.js";
 
-const PROMPT = "create a pipe that tracks what i do every hour";
+const PROMPT = "create a scheduled task that tracks what i do every hour";
 const COMPOSER_TA = '[data-firstrun-target="composer"] textarea';
 
 /** Request the guide through its internal handoff and wait for the invite. */


### PR DESCRIPTION
## Summary
- make the Live View clipping check relative to the app section instead of a macOS-specific 32px inset
- update the first-run prompt expectation for the scheduled-task rename
- update the chat sidebar section expectation from Pipes to Scheduled

Product code is unchanged.

## Verification
- `bun run typecheck`
- `bun run e2e:coverage:check`
- `git diff --check`

Windows/Linux packaged E2E remains the authoritative platform verification.