### PR TITLE
test(account): pin checkout activation clock

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -303,6 +303,7 @@ describe("AccountSection subscription/login gating", () => {
 
   it("clears the trial date and refreshes entitlement when checkout activates", async () => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-21T12:00:00.000Z"));
     mocks.state.user = {
       id: "u1",
       email: "trial@screenpipe.test",


### PR DESCRIPTION
## Root cause

The checkout-activation test used an absolute `plan_expires_at` of `2026-08-04T12:00:00Z` while leaving fake timers at the real wall clock. Once CI ran after that instant, the profile grant was no longer considered active, so the correctly rendered active Business view had no `upgrade to business` button.

This is a time-dependent test fixture, not a product regression from the Live Views change.

## Fix

Pin the test clock to `2026-07-21T12:00:00Z`, matching the neighboring profile-grant tests and keeping the fixture inside its intended active window.

```text
before expiry  -> expiring profile grant -> upgrade card -> checkout polling
wall clock now -> expired profile grant  -> active card only -> stale assertion
```

## Verification

- Targeted file: 12/12 passed, three consecutive runs
- Full Vitest: 2,139/2,139 passed
- Bun-native tests: 230/230 passed
- TypeScript typecheck passed
- Biome check passed
