### PR TITLE
build(windows): update pinned FFmpeg archive

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/pre_build.js
+++ b/apps/screenpipe-app-tauri/scripts/pre_build.js
@@ -34,8 +34,8 @@ console.log('cwd', cwd)
 const config = {
 	ffmpegRealname: 'ffmpeg',
 	windows: {
-		ffmpegName: 'ffmpeg-8.0.1-full_build-shared',
-		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-8.0.1-full_build-shared.7z',
+		ffmpegName: 'ffmpeg-9.0-full_build-shared',
+		ffmpegUrl: 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-9.0-full_build-shared.7z',
 		// Windows ARM64 (aarch64-pc-windows-msvc) — tordona/ffmpeg-win-arm64
 		// Resolved dynamically at build time via GitHub API (daily autobuilds change filenames)
 		ffmpegArm64GithubRepo: 'tordona/ffmpeg-win-arm64',
@@ -824,7 +824,7 @@ async function validateWindowsFfmpeg(directory) {
 	}
 	if (winArch === 'arm64') return true
 	const readme = await fs.readFile(path.join(directory, 'README.txt'), 'utf8').catch(() => '')
-	return readme.includes('Version: 8.0.1-')
+	return readme.includes('Version: 9.0-')
 }
 
 async function setupWindowsFfmpeg(sevenZ) {


### PR DESCRIPTION
## Root cause

The Windows E2E build on current `main` failed before Rust compilation because Gyan removed the pinned `ffmpeg-8.0.1-full_build-shared.7z` package when FFmpeg 9.0 was published on August 4. The prebuild retried the permanent 404 ten times and then stopped Tauri's `beforeBuildCommand`.

```text
Windows build
  -> pre_build.js
  -> pinned FFmpeg 8.0.1 package
  -> HTTP 404 x10
  -> no compilation / no E2E
```

## Fix

Update the pinned x64 Windows shared build, extraction directory, cache key input, and README validation from FFmpeg 8.0.1 to the exact FFmpeg 9.0 package.

Windows ARM64 remains unchanged and continues resolving its separate ARM64 build.

## Verification

- Exact package URL returns HTTP 200
- Downloaded archive SHA-256: `c07e3313aba524186c4684052e1c860dd2bb6983a7299668255939660126907a`
- Archive contains `ffmpeg-9.0-full_build-shared/bin/ffmpeg.exe` and `ffprobe.exe`
- README contains `Version: 9.0-full_build-www.gyan.dev`
- `bun build scripts/pre_build.js --target bun` passed
- Biome and `git diff --check` passed
- Windows CI build/E2E is the authoritative end-to-end verification

Failed main run: https://github.com/screenpipe/screenpipe/actions/runs/30916513086/job/92015908685
