### PR TITLE
feat(app): collapse Brain canvas tools

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,15 +18,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 91
-- Declared test blocks: 255
-- Weighted coverage points: 197.7
+- Mapped specs: 92
+- Declared test blocks: 256
+- Weighted coverage points: 198.7
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 73 | 227 | 184.2 | 15 | 77 | 91% |
-| macos | 87 | 218 | 168.5 | 17 | 79 | 89% |
-| linux | 63 | 187 | 154.0 | 14 | 72 | 88% |
+| windows | 74 | 228 | 185.2 | 15 | 77 | 91% |
+| macos | 88 | 219 | 169.5 | 17 | 79 | 89% |
+| linux | 64 | 188 | 155.0 | 14 | 72 | 88% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-canvas.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-canvas.test.tsx
@@ -108,6 +108,11 @@ function CanvasHarness({
   );
 }
 
+function openCanvasTools() {
+  fireEvent.click(screen.getByTestId("canvas-tools-toggle"));
+  return screen.getByTestId("canvas-tools-panel");
+}
+
 beforeEach(() => {
   vi.stubGlobal("PointerEvent", PointerEventMock);
   HTMLElement.prototype.setPointerCapture = vi.fn();
@@ -145,6 +150,31 @@ describe("LiveViewCanvas", () => {
         "Whiteboard canvas. Use the toolbar to select, pan, add notes, connect Blocks, or draw.",
       ),
     ).toBeTruthy();
+  });
+
+  it("keeps canvas tools compact until opened and preserves the active tool", () => {
+    render(<CanvasHarness />);
+
+    const toggle = screen.getByTestId("canvas-tools-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.getAttribute("aria-label")).toContain("select tool active");
+    expect(screen.queryByTestId("canvas-tools-panel")).toBeNull();
+
+    const panel = openCanvasTools();
+    expect(panel).toBeTruthy();
+    expect(screen.getByTestId("canvas-tool-pan")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("canvas-tool-pan"));
+    expect(screen.queryByTestId("canvas-tools-panel")).toBeNull();
+    expect(
+      screen.getByTestId("canvas-tools-toggle").getAttribute("aria-label"),
+    ).toContain("pan tool active");
+
+    openCanvasTools();
+    fireEvent.keyDown(screen.getByTestId("canvas-tools-panel"), {
+      key: "Escape",
+    });
+    expect(screen.queryByTestId("canvas-tools-panel")).toBeNull();
   });
 
   it("does not persist React Flow's programmatic mount viewport", async () => {
@@ -259,6 +289,7 @@ describe("LiveViewCanvas", () => {
     const onPersist = vi.fn();
     render(<CanvasHarness onPersist={onPersist} />);
 
+    openCanvasTools();
     fireEvent.click(screen.getByTestId("canvas-tool-note"));
     fireEvent.pointerDown(screen.getByTestId("live-view-canvas-surface"), {
       clientX: 320,
@@ -277,6 +308,7 @@ describe("LiveViewCanvas", () => {
       );
     });
 
+    openCanvasTools();
     fireEvent.click(screen.getByTestId("canvas-delete-selection"));
     expect(screen.queryByLabelText("Canvas note")).toBeNull();
     expect(onPersist).toHaveBeenLastCalledWith(
@@ -288,6 +320,7 @@ describe("LiveViewCanvas", () => {
     const onPersist = vi.fn();
     render(<CanvasHarness onPersist={onPersist} />);
 
+    openCanvasTools();
     fireEvent.click(screen.getByTestId("canvas-tool-arrow"));
     fireEvent.pointerDown(screen.getByTestId("canvas-move-focus-time"), {
       pointerId: 3,
@@ -310,6 +343,7 @@ describe("LiveViewCanvas", () => {
     });
     const arrow = screen.getByTestId(/^canvas-arrow-/);
     fireEvent.pointerDown(arrow, { pointerId: 5 });
+    openCanvasTools();
     fireEvent.click(screen.getByTestId("canvas-delete-selection"));
     expect(screen.queryByTestId(/^canvas-arrow-/)).toBeNull();
   });
@@ -347,6 +381,7 @@ describe("LiveViewCanvas", () => {
       }),
     );
 
+    openCanvasTools();
     fireEvent.click(screen.getByTestId("canvas-tool-draw"));
     fireEvent.pointerDown(surface, {
       pointerId: 10,
@@ -365,6 +400,7 @@ describe("LiveViewCanvas", () => {
     });
     expect(screen.getByTestId(/^canvas-stroke-/)).toBeTruthy();
 
+    openCanvasTools();
     for (let index = 0; index < 20; index += 1) {
       fireEvent.click(screen.getByLabelText("zoom out"));
     }
@@ -376,6 +412,7 @@ describe("LiveViewCanvas", () => {
     const surface = screen.getByTestId("live-view-canvas-surface");
     const pane = surface.querySelector<HTMLElement>(".react-flow__pane");
     expect(pane).toBeTruthy();
+    openCanvasTools();
 
     fireEvent.wheel(pane!, { deltaY: -100, clientX: 500, clientY: 350 });
     expect(screen.getByText("100%")).toBeTruthy();

--- a/apps/screenpipe-app-tauri/components/settings/live-view-canvas.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-canvas.tsx
@@ -31,6 +31,8 @@ import {
 } from "@xyflow/react";
 import {
   ArrowRight,
+  ChevronLeft,
+  ChevronRight,
   Hand,
   LayoutGrid,
   Maximize2,
@@ -375,6 +377,7 @@ export function LiveViewCanvas({
   onItemHandoff: (slot: BrainViewSlot, item: LiveViewListItem) => void;
 }) {
   const [tool, setTool] = useState<CanvasTool>("select");
+  const [toolsOpen, setToolsOpen] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
   const [arrowSource, setArrowSource] = useState<string | null>(null);
   const [draftStroke, setDraftStroke] = useState<BrainViewCanvasStroke | null>(
@@ -997,6 +1000,11 @@ export function LiveViewCanvas({
     (event: React.KeyboardEvent<HTMLDivElement>) => {
       const target = event.target as HTMLElement;
       if (event.key === "Escape") {
+        if (toolsOpen) {
+          event.preventDefault();
+          setToolsOpen(false);
+          return;
+        }
         setArrowSource(null);
         setCanvasSelection([]);
         setTool("select");
@@ -1061,6 +1069,7 @@ export function LiveViewCanvas({
       removeSelection,
       selection,
       setCanvasSelection,
+      toolsOpen,
       updateNodePosition,
       zoomCanvas,
     ],
@@ -1091,6 +1100,9 @@ export function LiveViewCanvas({
   );
 
   const selectedCanDelete = selection.some((id) => !id.startsWith("block:"));
+  const activeTool =
+    TOOL_OPTIONS.find((option) => option.value === tool) ?? TOOL_OPTIONS[0];
+  const ActiveToolIcon = activeTool.icon;
 
   return (
     <section
@@ -1205,99 +1217,168 @@ export function LiveViewCanvas({
 
       <div
         data-canvas-toolbar
-        className="absolute left-3 top-1/2 z-30 flex -translate-y-1/2 flex-col items-center border border-foreground bg-background shadow-lg shadow-black/5"
+        data-state={toolsOpen ? "open" : "closed"}
+        className={`absolute left-3 top-3 z-30 max-w-[calc(100%-1.5rem)] overflow-hidden border border-foreground bg-background p-1 shadow-lg shadow-black/5 transition-[max-width,opacity,transform] duration-150 ease-out motion-reduce:transition-none ${
+          toolsOpen
+            ? "opacity-100"
+            : "max-w-36 opacity-75 hover:-translate-y-0.5 hover:opacity-100 focus-within:opacity-100"
+        }`}
+        onKeyDown={(event) => {
+          if (event.key !== "Escape" || !toolsOpen) return;
+          event.preventDefault();
+          event.stopPropagation();
+          setToolsOpen(false);
+          surfaceRef.current?.focus({ preventScroll: true });
+        }}
       >
-        {TOOL_OPTIONS.map((option) => {
-          const Icon = option.icon;
-          return (
+        {toolsOpen ? (
+          <div
+            data-testid="canvas-tools-panel"
+            className="flex max-w-full animate-in items-center overflow-x-auto fade-in slide-in-from-left-1 duration-150 motion-reduce:animate-none"
+          >
             <Button
-              key={option.value}
               type="button"
-              data-testid={`canvas-tool-${option.value}`}
               variant="ghost"
               size="icon"
-              aria-label={option.label}
-              aria-pressed={tool === option.value}
-              title={option.label}
-              className={`h-9 w-9 rounded-none border-b border-border ${
-                tool === option.value ? "bg-foreground text-background" : ""
-              }`}
+              data-testid="canvas-tools-close"
+              aria-label="close canvas tools"
+              title="close canvas tools"
+              className="h-8 w-8 shrink-0 rounded-none"
               onClick={() => {
-                setTool(option.value);
-                setArrowSource(null);
+                setToolsOpen(false);
+                surfaceRef.current?.focus({ preventScroll: true });
               }}
             >
-              <Icon className="h-3.5 w-3.5" />
-              <span className="sr-only">{option.label}</span>
+              <ChevronLeft className="h-3.5 w-3.5" aria-hidden="true" />
             </Button>
-          );
-        })}
-        <Button
-          type="button"
-          data-testid="canvas-arrange"
-          variant="ghost"
-          size="icon"
-          aria-label="arrange canvas"
-          title="arrange canvas"
-          className="h-9 w-9 rounded-none border-b border-border"
-          onClick={arrangeCanvas}
-        >
-          <LayoutGrid className="h-3.5 w-3.5" />
-          <span className="sr-only">arrange canvas</span>
-        </Button>
-        <Button
-          type="button"
-          data-testid="canvas-delete-selection"
-          variant="ghost"
-          size="icon"
-          aria-label="delete selected canvas item"
-          title="delete selected canvas item"
-          className="h-9 w-9 rounded-none"
-          disabled={!selectedCanDelete}
-          onClick={removeSelection}
-        >
-          <Trash2 className="h-3 w-3" />
-        </Button>
-      </div>
-
-      <div
-        data-canvas-toolbar
-        className="absolute bottom-3 left-3 z-30 flex items-center border border-foreground bg-background shadow-lg shadow-black/5"
-      >
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="zoom out"
-          className="h-8 w-8 rounded-none border-r border-border"
-          onClick={() => zoomCanvas(1 / 1.2)}
-        >
-          <ZoomOut className="h-3 w-3" />
-        </Button>
-        <span className="w-11 text-center font-mono text-[10px] tabular-nums">
-          {Math.round(document.viewport.zoom * 100)}%
-        </span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="zoom in"
-          className="h-8 w-8 rounded-none border-l border-border"
-          onClick={() => zoomCanvas(1.2)}
-        >
-          <ZoomIn className="h-3 w-3" />
-        </Button>
-        <Button
-          type="button"
-          data-testid="canvas-fit"
-          variant="ghost"
-          size="icon"
-          aria-label="fit canvas"
-          className="h-8 w-8 rounded-none border-l border-border"
-          onClick={fitCanvas}
-        >
-          <Maximize2 className="h-3 w-3" />
-        </Button>
+            <span
+              className="mx-0.5 h-5 w-px shrink-0 bg-border"
+              aria-hidden="true"
+            />
+            {TOOL_OPTIONS.map((option) => {
+              const Icon = option.icon;
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  data-testid={`canvas-tool-${option.value}`}
+                  variant="ghost"
+                  size="icon"
+                  aria-label={option.label}
+                  aria-pressed={tool === option.value}
+                  title={option.label}
+                  className={`h-8 w-8 shrink-0 rounded-none ${
+                    tool === option.value
+                      ? "bg-foreground text-background hover:bg-foreground hover:text-background"
+                      : ""
+                  }`}
+                  onClick={() => {
+                    setTool(option.value);
+                    setArrowSource(null);
+                    setToolsOpen(false);
+                    surfaceRef.current?.focus({ preventScroll: true });
+                  }}
+                >
+                  <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                  <span className="sr-only">{option.label}</span>
+                </Button>
+              );
+            })}
+            <span
+              className="mx-0.5 h-5 w-px shrink-0 bg-border"
+              aria-hidden="true"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="zoom out"
+              title="zoom out (-)"
+              className="h-8 w-8 shrink-0 rounded-none"
+              onClick={() => zoomCanvas(1 / 1.2)}
+            >
+              <ZoomOut className="h-3 w-3" aria-hidden="true" />
+            </Button>
+            <button
+              type="button"
+              aria-label="reset zoom to 100%"
+              title="reset zoom to 100%"
+              className="h-8 w-11 shrink-0 text-center font-mono text-[10px] tabular-nums text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
+              onClick={() =>
+                zoomCanvas(1 / latestDocumentRef.current.viewport.zoom)
+              }
+            >
+              {Math.round(document.viewport.zoom * 100)}%
+            </button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="zoom in"
+              title="zoom in (+)"
+              className="h-8 w-8 shrink-0 rounded-none"
+              onClick={() => zoomCanvas(1.2)}
+            >
+              <ZoomIn className="h-3 w-3" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              data-testid="canvas-fit"
+              variant="ghost"
+              size="icon"
+              aria-label="fit canvas"
+              title="fit canvas"
+              className="h-8 w-8 shrink-0 rounded-none"
+              onClick={fitCanvas}
+            >
+              <Maximize2 className="h-3 w-3" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              data-testid="canvas-arrange"
+              variant="ghost"
+              size="icon"
+              aria-label="arrange canvas"
+              title="arrange canvas"
+              className="h-8 w-8 shrink-0 rounded-none"
+              onClick={arrangeCanvas}
+            >
+              <LayoutGrid className="h-3.5 w-3.5" aria-hidden="true" />
+              <span className="sr-only">arrange canvas</span>
+            </Button>
+            <Button
+              type="button"
+              data-testid="canvas-delete-selection"
+              variant="ghost"
+              size="icon"
+              aria-label="delete selected canvas item"
+              title="delete selected canvas item"
+              className="h-8 w-8 shrink-0 rounded-none"
+              disabled={!selectedCanDelete}
+              onClick={removeSelection}
+            >
+              <Trash2 className="h-3 w-3" aria-hidden="true" />
+            </Button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            data-testid="canvas-tools-toggle"
+            aria-label={`open canvas tools. ${activeTool.label} tool active`}
+            aria-expanded="false"
+            className="flex h-8 max-w-32 items-center gap-2 px-2 font-mono text-[10px] uppercase tracking-wide text-muted-foreground transition-colors hover:bg-foreground hover:text-background focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-1 focus-visible:outline-foreground"
+            onClick={() => setToolsOpen(true)}
+          >
+            <ActiveToolIcon
+              className="h-3.5 w-3.5 shrink-0"
+              aria-hidden="true"
+            />
+            <span className="truncate">
+              {tool === "select" ? "tools" : activeTool.label}
+            </span>
+            <ChevronRight className="h-3 w-3 shrink-0" aria-hidden="true" />
+          </button>
+        )}
       </div>
 
       {tool === "arrow" && arrowSource && (

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -1107,14 +1107,19 @@ Refresh the assigned Live View output targets from source-backed activity.
       },
     );
 
+    await pointerPressTestId("canvas-tools-toggle");
     const noteTool = await $("[data-testid='canvas-tool-note']");
     await noteTool.click();
-    expect(await noteTool.getAttribute("aria-pressed")).toBe("true");
+    const compactTools = await waitForTestId("canvas-tools-toggle", 10_000);
+    expect(await compactTools.getAttribute("aria-label")).toContain(
+      "note tool active",
+    );
     await clickEmptyCanvasSpace();
     const surface = await waitForTestId("live-view-canvas-surface", 10_000);
     const noteInput = await $("textarea[aria-label='Canvas note']");
     await noteInput.waitForDisplayed({ timeout: t(10_000) });
     await noteInput.setValue("Review the source evidence before automating.");
+    await pointerPressTestId("canvas-tools-toggle");
     await $("[data-testid='canvas-fit']").click();
 
     const arrowTool = await $("[data-testid='canvas-tool-arrow']");
@@ -1162,6 +1167,9 @@ Refresh the assigned Live View output targets from source-backed activity.
     for (const size of [SUPPORTED_WINDOW_SIZES[0], SUPPORTED_WINDOW_SIZES[5]]) {
       await setCssWindowSize(size.width, size.height);
       await browser.pause(150);
+      await pointerPressTestId("canvas-tools-toggle");
+      const toolsPanel = await waitForTestId("canvas-tools-panel", 10_000);
+      await toolsPanel.waitForDisplayed({ timeout: t(10_000) });
       const canvasLayout = (await browser.execute(() => {
         const canvasElement = document.querySelector<HTMLElement>(
           "[data-testid='live-view-canvas']",
@@ -1216,6 +1224,7 @@ Refresh the assigned Live View output targets from source-backed activity.
       expect(canvasLayout!.toolbarBottom).toBeLessThanOrEqual(
         canvasLayout!.canvasBottom,
       );
+      await pointerPressTestId("canvas-tools-close");
       await canvas.moveTo({ xOffset: 0, yOffset: 160 });
       await browser.keys(["Escape"]);
       await browser.pause(250);


### PR DESCRIPTION
## Summary
- replace the two always-visible Brain canvas toolbars with one compact tools launcher
- expand into one horizontal dock for tools, zoom, fit, arrange, and delete
- collapse after tool selection while preserving the active tool in the launcher
- support close-button and Escape dismissal plus horizontal overflow on narrow canvases

## Visual
Collapsed:

    [ pointer  TOOLS  > ]

Expanded:

    [ < | pointer hand note connect draw | - 100% + fit arrange delete ]

The app keeps its existing sharp 1px-border visual language; this ports the Enterprise interaction rather than its rounded website styling.

## Verification
- bunx vitest run --config vitest.config.ts components/settings/__tests__/live-view-canvas.test.tsx
- bun run typecheck
- bunx eslint components/settings/live-view-canvas.tsx components/settings/__tests__/live-view-canvas.test.tsx e2e/specs/brain-overview.spec.ts
- bun run coverage:all
- bun run coverage:all:check
- git diff --check

The Brain E2E now opens the expanded dock at the supported narrow and wide window sizes and verifies its bounds stay inside the canvas.