### PR TITLE
fix(app): keep canvas hint above AI composer

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-canvas.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-canvas.test.tsx
@@ -159,16 +159,19 @@ describe("LiveViewCanvas", () => {
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(toggle.getAttribute("aria-label")).toContain("select tool active");
     expect(screen.queryByTestId("canvas-tools-panel")).toBeNull();
+    expect(screen.getByTestId("canvas-interaction-hint")).toBeTruthy();
 
     const panel = openCanvasTools();
     expect(panel).toBeTruthy();
     expect(screen.getByTestId("canvas-tool-pan")).toBeTruthy();
+    expect(screen.queryByTestId("canvas-interaction-hint")).toBeNull();
 
     fireEvent.click(screen.getByTestId("canvas-tool-pan"));
     expect(screen.queryByTestId("canvas-tools-panel")).toBeNull();
     expect(
       screen.getByTestId("canvas-tools-toggle").getAttribute("aria-label"),
     ).toContain("pan tool active");
+    expect(screen.getByTestId("canvas-interaction-hint")).toBeTruthy();
 
     openCanvasTools();
     fireEvent.keyDown(screen.getByTestId("canvas-tools-panel"), {

--- a/apps/screenpipe-app-tauri/components/settings/live-view-canvas.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-canvas.tsx
@@ -1386,9 +1386,14 @@ export function LiveViewCanvas({
           choose another Block or note to connect
         </div>
       )}
-      <div className="pointer-events-none absolute bottom-3 right-3 z-20 border border-border bg-background/95 px-2 py-1 font-mono text-[9px] text-muted-foreground">
-        drag nodes · pan tool or middle-drag · ctrl/⌘ + wheel to zoom
-      </div>
+      {!toolsOpen && (
+        <div
+          data-testid="canvas-interaction-hint"
+          className="pointer-events-none absolute right-3 top-3 z-20 max-w-[calc(100%-11rem)] border border-border bg-background/95 px-2 py-1 text-right font-mono text-[9px] leading-tight text-muted-foreground"
+        >
+          drag nodes · pan tool or middle-drag · ctrl/⌘ + wheel to zoom
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -1167,9 +1167,54 @@ Refresh the assigned Live View output targets from source-backed activity.
     for (const size of [SUPPORTED_WINDOW_SIZES[0], SUPPORTED_WINDOW_SIZES[5]]) {
       await setCssWindowSize(size.width, size.height);
       await browser.pause(150);
+      const compactCanvasLayout = (await browser.execute(() => {
+        const canvasElement = document.querySelector<HTMLElement>(
+          "[data-testid='live-view-canvas']",
+        );
+        const toolbar = document.querySelector<HTMLElement>(
+          "[data-canvas-toolbar]",
+        );
+        const hint = document.querySelector<HTMLElement>(
+          "[data-testid='canvas-interaction-hint']",
+        );
+        const composer = document.querySelector<HTMLElement>(
+          "[data-testid='overview-floating-composer']",
+        );
+        if (!canvasElement || !toolbar || !hint || !composer) return null;
+        const canvasRect = canvasElement.getBoundingClientRect();
+        const toolbarRect = toolbar.getBoundingClientRect();
+        const hintRect = hint.getBoundingClientRect();
+        const composerRect = composer.getBoundingClientRect();
+        const overlaps = (a: DOMRect, b: DOMRect) =>
+          a.left < b.right &&
+          a.right > b.left &&
+          a.top < b.bottom &&
+          a.bottom > b.top;
+        return {
+          hintInsideCanvas:
+            hintRect.left >= canvasRect.left &&
+            hintRect.right <= canvasRect.right &&
+            hintRect.top >= canvasRect.top &&
+            hintRect.bottom <= canvasRect.bottom,
+          hintOverlapsToolbar: overlaps(hintRect, toolbarRect),
+          hintOverlapsComposer: overlaps(hintRect, composerRect),
+        };
+      })) as {
+        hintInsideCanvas: boolean;
+        hintOverlapsToolbar: boolean;
+        hintOverlapsComposer: boolean;
+      } | null;
+      expect(compactCanvasLayout).not.toBeNull();
+      expect(compactCanvasLayout!.hintInsideCanvas).toBe(true);
+      expect(compactCanvasLayout!.hintOverlapsToolbar).toBe(false);
+      expect(compactCanvasLayout!.hintOverlapsComposer).toBe(false);
+
       await pointerPressTestId("canvas-tools-toggle");
       const toolsPanel = await waitForTestId("canvas-tools-panel", 10_000);
       await toolsPanel.waitForDisplayed({ timeout: t(10_000) });
+      expect(
+        await $("[data-testid='canvas-interaction-hint']").isExisting(),
+      ).toBe(false);
       const canvasLayout = (await browser.execute(() => {
         const canvasElement = document.querySelector<HTMLElement>(
           "[data-testid='live-view-canvas']",


### PR DESCRIPTION
## Summary
- move the persistent canvas interaction hint from bottom-right to top-right
- hide the hint while the Tools dock is expanded so top controls never collide
- assert at narrow and wide native window sizes that the hint stays inside the canvas and overlaps neither Tools nor the AI composer

## Verification
- focused LiveViewCanvas suite: 10/10
- app TypeScript
- changed-file ESLint
- unified coverage freshness
- git diff --check