### PR TITLE
fix(enterprise): complete rejected sync credential recovery

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -2183,12 +2183,13 @@ async saveEnterpriseLicenseKey(licenseKey: string) : Promise<Result<null, string
 },
 /**
  * Persist the user's enterprise admin status, team API token, and the org's
- * team API base URL so the pi-agent's `screenpipe-team` skill knows whether
- * to install itself and where to point.
+ * team API base URL. The Enterprise app uses the role/license/token fields to
+ * decide whether to inject `screenpipe-team`; the native CLI resolves the API
+ * base and token from the same file when that skill invokes it.
  *
  * Called by the frontend right after a policy fetch confirms admin
  * role. Storing this alongside the license key in `enterprise.json`
- * keeps everything pi-agent needs in one file the skill can read
+ * keeps the Enterprise app and native CLI on one local configuration contract
  * without a Tauri round-trip.
  *
  * All fields are optional so callers can update one at a time —
@@ -3792,7 +3793,7 @@ chatAlwaysOnTop?: boolean;
 showRestartNotifications?: boolean;
 /**
  * Stop capture before the data volume is completely full. Search, pipes,
- * and the local API remain available. Explicitly opt-in for now.
+ * and the local API remain available. Safety-on unless explicitly disabled.
  */
 stopRecordingOnLowDisk?: boolean;
 /**

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -11,6 +11,7 @@ use crate::{
     updates::is_enterprise_build,
     window::{RewindWindowId, ShowRewindWindow},
 };
+use sha2::{Digest, Sha256};
 use tauri::{Emitter, Manager};
 use tracing::{debug, error, info, warn};
 
@@ -42,8 +43,11 @@ fn log_webview_build_failure(label: &str, url_hint: &str, err: &(impl std::fmt::
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::{
-        fallback_local_api_config, is_login_callback_scheme, read_enterprise_config_from_path,
-        save_enterprise_team_config, scan_chat_entries_by_mtime,
+        enterprise_license_key_sha256, fallback_local_api_config, is_login_callback_scheme,
+        merge_enterprise_file_configs, persist_enterprise_device_config,
+        persist_recovered_enterprise_device_config, read_enterprise_config_from_path,
+        recovery_anchor_license_key, save_enterprise_team_config, scan_chat_entries_by_mtime,
+        EnterpriseFileConfig, RecoveredEnterpriseDeviceConfig,
     };
 
     /// The whole point of SCR-300: `gateway_url` is the ONE name the server,
@@ -92,7 +96,75 @@ mod tests {
         save_enterprise_team_config(None, None, None, Some(String::new())).unwrap();
         assert!(read()["gateway_url"].is_null());
 
+        persist_recovered_enterprise_device_config(
+            "rejected-key",
+            "replacement-key",
+            Some("https://new.example/api/enterprise/ingest"),
+        )
+        .unwrap();
+        let persisted = read();
+        assert_eq!(
+            persisted["credential_recovery"]["replaces_license_key_sha256"],
+            enterprise_license_key_sha256("rejected-key")
+        );
+        assert_eq!(
+            persisted["credential_recovery"]["license_key"],
+            "replacement-key"
+        );
+        assert_ne!(
+            persisted["credential_recovery"]["replaces_license_key_sha256"],
+            "rejected-key"
+        );
+
+        persist_enterprise_device_config(Some("manual-key"), None).unwrap();
+        assert!(read().get("credential_recovery").is_none());
+
         std::env::remove_var("SCREENPIPE_DATA_DIR");
+    }
+
+    #[test]
+    fn bundled_config_accepts_only_its_matching_recovery_record() {
+        let bundled = EnterpriseFileConfig {
+            license_key: Some("bundled-rejected-key".to_string()),
+            ingest_url: Some("https://old.example/api/enterprise/ingest".to_string()),
+            recovered_device_config: None,
+        };
+        let user = EnterpriseFileConfig {
+            license_key: Some("replacement-key".to_string()),
+            ingest_url: Some("https://new.example/api/enterprise/ingest".to_string()),
+            recovered_device_config: Some(RecoveredEnterpriseDeviceConfig {
+                replaces_license_key_sha256: enterprise_license_key_sha256("bundled-rejected-key"),
+                license_key: "replacement-key".to_string(),
+                ingest_url: Some("https://new.example/api/enterprise/ingest".to_string()),
+            }),
+        };
+
+        let recovered = merge_enterprise_file_configs(Some(bundled.clone()), Some(user.clone()));
+        assert_eq!(recovered.license_key.as_deref(), Some("replacement-key"));
+        assert_eq!(
+            recovered.ingest_url.as_deref(),
+            Some("https://new.example/api/enterprise/ingest")
+        );
+
+        let updated_mdm = EnterpriseFileConfig {
+            license_key: Some("new-mdm-key".to_string()),
+            ..bundled
+        };
+        let authoritative = merge_enterprise_file_configs(Some(updated_mdm), Some(user));
+        assert_eq!(authoritative.license_key.as_deref(), Some("new-mdm-key"));
+        assert_eq!(
+            authoritative.ingest_url.as_deref(),
+            Some("https://old.example/api/enterprise/ingest")
+        );
+
+        assert_eq!(
+            recovery_anchor_license_key(Some("bundled-rejected-key"), "recovered-key-now-rejected"),
+            "bundled-rejected-key"
+        );
+        assert_eq!(
+            recovery_anchor_license_key(None, "unbundled-rejected-key"),
+            "unbundled-rejected-key"
+        );
     }
 
     #[test]
@@ -457,6 +529,14 @@ pub fn set_cloud_media_analysis_skill(enabled: bool) -> Result<(), String> {
 pub struct EnterpriseFileConfig {
     pub license_key: Option<String>,
     pub ingest_url: Option<String>,
+    recovered_device_config: Option<RecoveredEnterpriseDeviceConfig>,
+}
+
+#[derive(Debug, Clone)]
+struct RecoveredEnterpriseDeviceConfig {
+    replaces_license_key_sha256: String,
+    license_key: String,
+    ingest_url: Option<String>,
 }
 
 impl EnterpriseFileConfig {
@@ -465,26 +545,63 @@ impl EnterpriseFileConfig {
     }
 }
 
-/// Read the full enterprise device config from `enterprise.json`.
-/// Checks in order (first file found wins entirely):
-/// 1. Next to executable (pushed via Intune/MDM to Program Files / .app bundle)
-/// 2. `~/.screenpipe/enterprise.json` (in-app prompt or sign-in auto-config)
-pub fn get_enterprise_file_config() -> EnterpriseFileConfig {
-    if let Some(cfg) = read_enterprise_config_from_exe_dir() {
-        return cfg;
+fn enterprise_license_key_sha256(license_key: &str) -> String {
+    format!("{:x}", Sha256::digest(license_key.trim().as_bytes()))
+}
+
+fn recovery_anchor_license_key<'a>(
+    bundled_license_key: Option<&'a str>,
+    rejected_license_key: &'a str,
+) -> &'a str {
+    bundled_license_key.unwrap_or(rejected_license_key)
+}
+
+/// Preserve bundled/MDM precedence except for a recovery record tied to the
+/// exact bundled key it replaces. A later MDM key automatically wins because
+/// its fingerprint no longer matches.
+fn merge_enterprise_file_configs(
+    bundled: Option<EnterpriseFileConfig>,
+    user: Option<EnterpriseFileConfig>,
+) -> EnterpriseFileConfig {
+    let Some(mut bundled) = bundled else {
+        return user.unwrap_or_default();
+    };
+    let Some(bundled_key) = bundled.license_key.as_deref() else {
+        return bundled;
+    };
+    let Some(recovered) = user.and_then(|user| user.recovered_device_config) else {
+        return bundled;
+    };
+    if recovered.replaces_license_key_sha256 != enterprise_license_key_sha256(bundled_key) {
+        return bundled;
     }
+
+    bundled.license_key = Some(recovered.license_key);
+    if recovered.ingest_url.is_some() {
+        bundled.ingest_url = recovered.ingest_url;
+    }
+    info!("enterprise: applied persisted credential recovery over bundled config");
+    bundled
+}
+
+/// Read enterprise device config. Bundled/MDM config is authoritative unless
+/// the user file carries a validated recovery for that exact bundled key.
+pub fn get_enterprise_file_config() -> EnterpriseFileConfig {
+    let bundled = read_enterprise_config_from_exe_dir();
     let user_path = screenpipe_core::paths::default_screenpipe_data_dir().join("enterprise.json");
-    if user_path.exists() {
+    let user = if user_path.exists() {
         info!(
             "enterprise: checking user config at {}",
             user_path.display()
         );
-        if let Some(cfg) = read_enterprise_config_from_path(&user_path) {
-            return cfg;
-        }
+        read_enterprise_config_from_path(&user_path)
+    } else {
+        None
+    };
+    if bundled.is_none() && user.is_none() {
+        info!("enterprise: no enterprise.json found in any location");
     }
-    info!("enterprise: no enterprise.json found in any location");
-    EnterpriseFileConfig::default()
+    merge_enterprise_file_configs(bundled, user)
 }
 
 /// Read the enterprise license key from `enterprise.json`.
@@ -552,6 +669,24 @@ fn read_enterprise_config_from_path(path: &std::path::Path) -> Option<Enterprise
     let cfg = EnterpriseFileConfig {
         license_key: string_field("license_key"),
         ingest_url: string_field("ingest_url"),
+        recovered_device_config: parsed
+            .get("credential_recovery")
+            .and_then(|value| value.as_object())
+            .and_then(|recovery| {
+                let string = |name: &str| {
+                    recovery
+                        .get(name)
+                        .and_then(|value| value.as_str())
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(str::to_string)
+                };
+                Some(RecoveredEnterpriseDeviceConfig {
+                    replaces_license_key_sha256: string("replaces_license_key_sha256")?,
+                    license_key: string("license_key")?,
+                    ingest_url: string("ingest_url"),
+                })
+            }),
     };
 
     match &cfg.license_key {
@@ -572,9 +707,10 @@ fn read_enterprise_config_from_path(path: &std::path::Path) -> Option<Enterprise
 /// preserving any other keys already in the file. Used by the in-app
 /// license prompt and by the sign-in-driven auto-config
 /// (enterprise/device_config.rs).
-pub fn persist_enterprise_device_config(
+fn persist_enterprise_device_config_inner(
     license_key: Option<&str>,
     ingest_url: Option<&str>,
+    replaces_license_key: Option<&str>,
 ) -> Result<(), String> {
     let dir = screenpipe_core::paths::default_screenpipe_data_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("failed to create dir: {}", e))?;
@@ -590,6 +726,20 @@ pub fn persist_enterprise_device_config(
     if let Some(url) = ingest_url {
         json["ingest_url"] = serde_json::Value::String(url.to_string());
     }
+    if let Some(replaced) = replaces_license_key {
+        let mut recovery = serde_json::json!({
+            "replaces_license_key_sha256": enterprise_license_key_sha256(replaced),
+            "license_key": license_key.expect("recovery includes a replacement key"),
+        });
+        if let Some(url) = ingest_url {
+            recovery["ingest_url"] = serde_json::Value::String(url.to_string());
+        }
+        json["credential_recovery"] = recovery;
+    } else if license_key.is_some() {
+        json.as_object_mut()
+            .expect("enterprise device config is a JSON object")
+            .remove("credential_recovery");
+    }
     std::fs::write(&path, serde_json::to_string_pretty(&json).unwrap())
         .map_err(|e| format!("failed to write {}: {}", path.display(), e))?;
 
@@ -597,12 +747,40 @@ pub fn persist_enterprise_device_config(
     Ok(())
 }
 
+pub fn persist_enterprise_device_config(
+    license_key: Option<&str>,
+    ingest_url: Option<&str>,
+) -> Result<(), String> {
+    persist_enterprise_device_config_inner(license_key, ingest_url, None)
+}
+
+pub fn persist_recovered_enterprise_device_config(
+    replaced_license_key: &str,
+    license_key: &str,
+    ingest_url: Option<&str>,
+) -> Result<(), String> {
+    // A user recovery overlays the executable-adjacent file. Keep every
+    // subsequent rotation tied to that immutable source key so recovery B can
+    // replace recovery A without making the overlay disappear on restart.
+    let bundled_license_key = read_enterprise_config_from_exe_dir().and_then(|cfg| cfg.license_key);
+    let recovery_anchor =
+        recovery_anchor_license_key(bundled_license_key.as_deref(), replaced_license_key);
+    persist_enterprise_device_config_inner(Some(license_key), ingest_url, Some(recovery_anchor))
+}
+
 /// Save the enterprise license key to `~/.screenpipe/enterprise.json`.
 /// Used by the in-app prompt when enterprise.json is not deployed via MDM.
 #[tauri::command]
 #[specta::specta]
 pub fn save_enterprise_license_key(license_key: String) -> Result<(), String> {
-    persist_enterprise_device_config(Some(&license_key), None)
+    let bundled_key = read_enterprise_config_from_exe_dir().and_then(|cfg| cfg.license_key);
+    match bundled_key
+        .as_deref()
+        .filter(|key| *key != license_key.as_str())
+    {
+        Some(replaced) => persist_recovered_enterprise_device_config(replaced, &license_key, None),
+        None => persist_enterprise_device_config(Some(&license_key), None),
+    }
 }
 
 /// Persist the resolved "hide app UI" decision into `~/.screenpipe/enterprise.json`

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise/sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise/sync.rs
@@ -1547,50 +1547,107 @@ fn apply_rotated_device_config(
     true
 }
 
-/// Exchange a signed-in enterprise member's Clerk session for the current
-/// device credential. This is deliberately attempted only after the server
-/// rejects the saved key; ordinary sync remains key-authenticated and no Clerk
-/// token is attached to telemetry requests.
-async fn recover_rotated_license_key(cfg: &mut EnterpriseSyncConfig) -> bool {
-    let Some(token) = crate::commands::get_cloud_token() else {
-        return false;
-    };
-    let url = super::device_config::device_config_url(Some(&cfg.ingest_url));
-    let remote = match super::device_config::fetch_remote_device_config(&url, &token).await {
-        Ok(remote) => remote,
-        Err(error) => {
-            debug!(
-                error = %error,
-                "enterprise sync: account device-config recovery not available"
-            );
+#[async_trait::async_trait]
+trait LicenseKeyRecovery: Send + Sync {
+    async fn recover(&self, cfg: &mut EnterpriseSyncConfig) -> bool;
+}
+
+struct SavedOrAccountLicenseKeyRecovery;
+
+#[async_trait::async_trait]
+impl LicenseKeyRecovery for SavedOrAccountLicenseKeyRecovery {
+    async fn recover(&self, cfg: &mut EnterpriseSyncConfig) -> bool {
+        // The enterprise gate validates replacement keys before saving them.
+        // Re-read it so key entry repairs the running worker without a restart.
+        if let Some(saved_key) = crate::commands::get_enterprise_license_key()
+            .filter(|saved_key| !saved_key.trim().is_empty() && saved_key != &cfg.license_key)
+        {
+            cfg.license_key = saved_key;
+            info!("enterprise sync: applied replacement credential from device config");
+            return true;
+        }
+
+        let Some(token) = crate::commands::get_cloud_token() else {
+            return false;
+        };
+        let url = super::device_config::device_config_url(Some(&cfg.ingest_url));
+        let remote = match super::device_config::fetch_remote_device_config(&url, &token).await {
+            Ok(remote) => remote,
+            Err(error) => {
+                debug!(
+                    error = %error,
+                    "enterprise sync: account device-config recovery not available"
+                );
+                return false;
+            }
+        };
+        let replaced_license_key = cfg.license_key.clone();
+        if !apply_rotated_device_config(cfg, &remote) {
             return false;
         }
-    };
-    if !apply_rotated_device_config(cfg, &remote) {
-        return false;
+
+        if let Err(error) = crate::commands::persist_recovered_enterprise_device_config(
+            &replaced_license_key,
+            &remote.license_key,
+            remote.ingest_url.as_deref(),
+        ) {
+            warn!(
+                error = %error,
+                "enterprise sync: rotated key works for this session but could not be persisted"
+            );
+        }
+        info!(
+            org = remote.org_name.as_deref().unwrap_or("?"),
+            "enterprise sync: recovered rotated device credential through account auth"
+        );
+        true
+    }
+}
+
+/// Replace a rejected credential from a newly saved key or a signed-in
+/// enterprise member's current device config. Ordinary sync remains
+/// key-authenticated; no account token is attached to telemetry requests.
+async fn recover_rotated_license_key<R: LicenseKeyRecovery + ?Sized>(
+    cfg: &mut EnterpriseSyncConfig,
+    recovery: &R,
+) -> bool {
+    recovery.recover(cfg).await
+}
+
+/// Resolve policy, recover a rejected credential at most once, then upload.
+/// A mode-endpoint auth rejection is handled before `run_sync_burst`, so no local
+/// telemetry is read with a rejected credential. Upload-plane rejections use
+/// the same path for explicit MDM modes and previously resolved modes.
+async fn run_sync_burst_with_recovery<R: LicenseKeyRecovery + ?Sized>(
+    cfg: &mut EnterpriseSyncConfig,
+    cursor: &mut Cursor,
+    local: &dyn LocalApiClient,
+    http: &reqwest::Client,
+    recovery: &R,
+) -> Result<SyncBurstReport, EnterpriseSyncError> {
+    let mut recovered = false;
+    match cfg.resolve_upload_mode().await {
+        Ok(()) => {}
+        Err(EnterpriseSyncError::IngestAuthRejected) => {
+            if !recover_rotated_license_key(cfg, recovery).await {
+                return Err(EnterpriseSyncError::IngestAuthRejected);
+            }
+            recovered = true;
+            cfg.resolve_upload_mode().await?;
+        }
+        Err(error) => return Err(error),
     }
 
-    if let Err(error) = crate::commands::persist_enterprise_device_config(
-        Some(&remote.license_key),
-        remote.ingest_url.as_deref(),
-    ) {
-        warn!(
-            error = %error,
-            "enterprise sync: rotated key works for this session but could not be persisted"
-        );
+    match run_sync_burst(cfg, cursor, local, http).await {
+        Err(EnterpriseSyncError::IngestAuthRejected) if !recovered => {
+            if !recover_rotated_license_key(cfg, recovery).await {
+                return Err(EnterpriseSyncError::IngestAuthRejected);
+            }
+            cfg.resolve_upload_mode().await?;
+            run_sync_burst(cfg, cursor, local, http).await
+        }
+        result => result,
     }
-    if let Err(error) = cfg.resolve_upload_mode().await {
-        warn!(
-            error = %error,
-            "enterprise sync: replacement device credential was rejected"
-        );
-        return false;
-    }
-    info!(
-        org = remote.org_name.as_deref().unwrap_or("?"),
-        "enterprise sync: recovered rotated device credential through account auth"
-    );
-    true
 }
 
 /// The single place that knows the redirect policy for license-authenticated
@@ -1612,6 +1669,7 @@ pub async fn run(
     mut cfg: EnterpriseSyncConfig,
     local: Arc<dyn LocalApiClient>,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
+    on_auth_rejected: Option<Arc<dyn Fn() + Send + Sync>>,
 ) {
     info!(
         "enterprise sync: starting for device={} ingest_url={}",
@@ -1622,6 +1680,7 @@ pub async fn run(
 
     let mut cursor = Cursor::load(&cfg.cursor_path);
     let mut backoff = BACKOFF_INITIAL;
+    let recovery = SavedOrAccountLicenseKeyRecovery;
     let mut log_request_loop = tokio::spawn(run_log_request_loop(
         cfg.clone(),
         http.clone(),
@@ -1629,19 +1688,33 @@ pub async fn run(
     ));
 
     loop {
-        // Re-resolve before touching local telemetry. This picks up a live
-        // hosted-to-customer-storage policy change without requiring an app
-        // restart, and preserves the last safe mode on lookup failure.
-        let result = match cfg.resolve_upload_mode().await {
-            Ok(()) => run_sync_burst(&cfg, &mut cursor, local.as_ref(), &http).await,
-            Err(error) => Err(error),
-        };
+        // Re-resolve before touching local telemetry. Auth rejection recovers
+        // and reruns resolution before any local read; other failures preserve
+        // the last safe mode.
+        let license_key_before_tick = cfg.license_key.clone();
+        let result =
+            run_sync_burst_with_recovery(&mut cfg, &mut cursor, local.as_ref(), &http, &recovery)
+                .await;
+
+        if cfg.license_key != license_key_before_tick {
+            // The log poller owns a cloned config, so restart it with the
+            // recovered key. Fulfillment state lives server-side.
+            log_request_loop.abort();
+            log_request_loop = tokio::spawn(run_log_request_loop(
+                cfg.clone(),
+                http.clone(),
+                shutdown.clone(),
+            ));
+        }
 
         match &result {
             Err(EnterpriseSyncError::IngestAuthRejected) => {
                 error!(
-                    "enterprise sync: device credential rejected by the enterprise control plane, attempting account recovery"
+                    "enterprise sync: device credential rejected and recovery is unavailable; enterprise access is required"
                 );
+                if let Some(notify) = &on_auth_rejected {
+                    notify();
+                }
             }
             Err(EnterpriseSyncError::CentralizedDataDisabled) => {
                 error!(
@@ -1696,19 +1769,6 @@ pub async fn run(
                 }
             }
             Err(EnterpriseSyncError::IngestAuthRejected) => {
-                if recover_rotated_license_key(&mut cfg).await {
-                    // The log poller owns a cloned config, so restart it with
-                    // the recovered key too. No diagnostic request is lost;
-                    // fulfillment state lives server-side.
-                    log_request_loop.abort();
-                    log_request_loop = tokio::spawn(run_log_request_loop(
-                        cfg.clone(),
-                        http.clone(),
-                        shutdown.clone(),
-                    ));
-                    backoff = BACKOFF_INITIAL;
-                    continue;
-                }
                 if sleep_or_shutdown(RETRY_WHILE_WAITING_FOR_ACCOUNT, &mut shutdown).await {
                     break;
                 }
@@ -1764,8 +1824,13 @@ mod tests {
     use super::*;
     use base64::Engine;
     use enterprise_upload::DirectUploadConfig;
-    use std::sync::Mutex;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    };
     use tempfile::TempDir;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn enterprise_log_identifier_is_regex_safe() {
@@ -2401,6 +2466,7 @@ mod tests {
     /// eliminating the race entirely without pulling in a serial-test crate.
     #[test]
     fn from_env_handles_all_cases() {
+        let _env_guard = ENV_LOCK.lock().unwrap();
         // Snapshot prior env so we don't leak state into other tests.
         let prior_license = std::env::var("SCREENPIPE_ENTERPRISE_LICENSE_KEY").ok();
         let prior_url = std::env::var("SCREENPIPE_ENTERPRISE_INGEST_URL").ok();
@@ -2786,6 +2852,351 @@ mod tests {
         assert_eq!(cfg.license_key, "sek_rotated");
         assert_eq!(cfg.ingest_url, "https://new.example/api/enterprise/ingest");
         assert!(!apply_rotated_device_config(&mut cfg, &remote));
+    }
+
+    struct UploadModeEnvGuard(Option<String>);
+
+    impl UploadModeEnvGuard {
+        fn clear() -> Self {
+            let prior = std::env::var("SCREENPIPE_ENTERPRISE_UPLOAD_MODE").ok();
+            std::env::remove_var("SCREENPIPE_ENTERPRISE_UPLOAD_MODE");
+            Self(prior)
+        }
+    }
+
+    impl Drop for UploadModeEnvGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => std::env::set_var("SCREENPIPE_ENTERPRISE_UPLOAD_MODE", value),
+                None => std::env::remove_var("SCREENPIPE_ENTERPRISE_UPLOAD_MODE"),
+            }
+        }
+    }
+
+    struct TestLicenseKeyRecovery {
+        replacement_key: Option<String>,
+        calls: AtomicUsize,
+        local_reads: Arc<AtomicUsize>,
+        reads_seen_during_recovery: Mutex<Vec<usize>>,
+    }
+
+    impl TestLicenseKeyRecovery {
+        fn replacing(key: &str, local_reads: Arc<AtomicUsize>) -> Self {
+            Self {
+                replacement_key: Some(key.to_string()),
+                calls: AtomicUsize::new(0),
+                local_reads,
+                reads_seen_during_recovery: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn unavailable(local_reads: Arc<AtomicUsize>) -> Self {
+            Self {
+                replacement_key: None,
+                calls: AtomicUsize::new(0),
+                local_reads,
+                reads_seen_during_recovery: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LicenseKeyRecovery for TestLicenseKeyRecovery {
+        async fn recover(&self, cfg: &mut EnterpriseSyncConfig) -> bool {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.reads_seen_during_recovery
+                .lock()
+                .unwrap()
+                .push(self.local_reads.load(Ordering::SeqCst));
+            let Some(replacement_key) = &self.replacement_key else {
+                return false;
+            };
+            cfg.license_key = replacement_key.clone();
+            true
+        }
+    }
+
+    struct CountingLocal {
+        reads: Arc<AtomicUsize>,
+        frames_to_yield: Mutex<Vec<Vec<FrameRow>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LocalApiClient for CountingLocal {
+        async fn fetch_frames_since(
+            &self,
+            _since_ts: Option<&str>,
+            _limit: u32,
+        ) -> Result<Vec<FrameRow>, EnterpriseSyncError> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .frames_to_yield
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or_default())
+        }
+
+        async fn fetch_audio_since(
+            &self,
+            _since_ts: Option<&str>,
+            _limit: u32,
+        ) -> Result<Vec<AudioRow>, EnterpriseSyncError> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
+    fn initialized_cursor() -> Cursor {
+        Cursor {
+            last_frame_ts: Some("2026-08-04T00:00:00Z".to_string()),
+            last_audio_ts: Some("2026-08-04T00:00:00Z".to_string()),
+            last_ui_ts: Some("2026-08-04T00:00:00Z".to_string()),
+            last_memory_ts: Some("2026-08-04T00:00:00Z".to_string()),
+            last_feedback_ts: Some("2026-08-04T00:00:00Z".to_string()),
+            last_parsed_ts: Some("2026-08-04T00:00:00Z".to_string()),
+        }
+    }
+
+    fn counting_local(reads: Arc<AtomicUsize>, pages: Vec<Vec<FrameRow>>) -> CountingLocal {
+        CountingLocal {
+            reads,
+            frames_to_yield: Mutex::new(pages),
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mode_auth_rejection_recovers_before_local_reads_and_uploads() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _mode_env = UploadModeEnvGuard::clear();
+        let server = wiremock::MockServer::start().await;
+        let mode_path = "/api/enterprise/storage-binding/mode";
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(mode_path))
+            .and(wiremock::matchers::header("x-license-key", "stale-key"))
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(mode_path))
+            .and(wiremock::matchers::header("x-license-key", "current-key"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "desired_mode": "hosted_ingest" })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/enterprise/ingest"))
+            .and(wiremock::matchers::header("x-license-key", "current-key"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_cfg(&dir, format!("{}/api/enterprise/ingest", server.uri()));
+        cfg.license_key = "stale-key".to_string();
+        cfg.upload_mode = EnterpriseUploadMode::Blocked("fresh start".to_string());
+        let reads = Arc::new(AtomicUsize::new(0));
+        let local = counting_local(
+            reads.clone(),
+            vec![vec![frame(1, "2026-08-04T00:01:00Z", "Arc", "recovered")]],
+        );
+        let recovery = TestLicenseKeyRecovery::replacing("current-key", reads.clone());
+
+        let report = run_sync_burst_with_recovery(
+            &mut cfg,
+            &mut initialized_cursor(),
+            &local,
+            &enterprise_http_client(),
+            &recovery,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.total.frames, 1);
+        assert_eq!(cfg.license_key, "current-key");
+        assert!(matches!(
+            cfg.upload_mode,
+            EnterpriseUploadMode::HostedIngest
+        ));
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *recovery.reads_seen_during_recovery.lock().unwrap(),
+            vec![0]
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resolved_mode_upload_rejection_rotates_and_retries_same_tick() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _mode_env = UploadModeEnvGuard::clear();
+        let server = wiremock::MockServer::start().await;
+        let mode_path = "/api/enterprise/storage-binding/mode";
+        for key in ["stale-key", "current-key"] {
+            wiremock::Mock::given(wiremock::matchers::method("GET"))
+                .and(wiremock::matchers::path(mode_path))
+                .and(wiremock::matchers::header("x-license-key", key))
+                .respond_with(
+                    wiremock::ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({ "desired_mode": "hosted_ingest" })),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/enterprise/ingest"))
+            .and(wiremock::matchers::header("x-license-key", "stale-key"))
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&server)
+            .await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/api/enterprise/ingest"))
+            .and(wiremock::matchers::header("x-license-key", "current-key"))
+            .respond_with(wiremock::ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_cfg(&dir, format!("{}/api/enterprise/ingest", server.uri()));
+        cfg.license_key = "stale-key".to_string();
+        let reads = Arc::new(AtomicUsize::new(0));
+        let page = vec![frame(1, "2026-08-04T00:01:00Z", "Arc", "rotation")];
+        let local = counting_local(reads.clone(), vec![page.clone(), page]);
+        let recovery = TestLicenseKeyRecovery::replacing("current-key", reads.clone());
+
+        let report = run_sync_burst_with_recovery(
+            &mut cfg,
+            &mut initialized_cursor(),
+            &local,
+            &enterprise_http_client(),
+            &recovery,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.total.frames, 1);
+        assert_eq!(cfg.license_key, "current-key");
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+        assert!(recovery.reads_seen_during_recovery.lock().unwrap()[0] > 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn signed_out_stale_key_stays_blocked_and_reports_auth_rejection() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _mode_env = UploadModeEnvGuard::clear();
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path(
+                "/api/enterprise/storage-binding/mode",
+            ))
+            .respond_with(wiremock::ResponseTemplate::new(401))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_cfg(&dir, format!("{}/api/enterprise/ingest", server.uri()));
+        cfg.license_key = "stale-key".to_string();
+        cfg.upload_mode = EnterpriseUploadMode::Blocked("fresh start".to_string());
+        let reads = Arc::new(AtomicUsize::new(0));
+        let local = counting_local(reads.clone(), Vec::new());
+        let recovery = TestLicenseKeyRecovery::unavailable(reads.clone());
+
+        let error = run_sync_burst_with_recovery(
+            &mut cfg,
+            &mut initialized_cursor(),
+            &local,
+            &enterprise_http_client(),
+            &recovery,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, EnterpriseSyncError::IngestAuthRejected));
+        assert!(matches!(cfg.upload_mode, EnterpriseUploadMode::Blocked(_)));
+        assert_eq!(reads.load(Ordering::SeqCst), 0);
+        assert_eq!(recovery.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn server_mode_resolution_covers_hosted_and_both_direct_modes() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _mode_env = UploadModeEnvGuard::clear();
+        for (desired_mode, expected_label) in [
+            ("hosted_ingest", "hosted_ingest"),
+            ("direct_upload_readable", "direct_readable"),
+            ("direct_upload_write_only", "direct_write_only"),
+        ] {
+            let server = wiremock::MockServer::start().await;
+            wiremock::Mock::given(wiremock::matchers::method("GET"))
+                .respond_with(
+                    wiremock::ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({ "desired_mode": desired_mode })),
+                )
+                .expect(1)
+                .mount(&server)
+                .await;
+            let dir = TempDir::new().unwrap();
+            let mut cfg = test_cfg(&dir, format!("{}/api/enterprise/ingest", server.uri()));
+            cfg.upload_mode = EnterpriseUploadMode::Blocked("fresh start".to_string());
+
+            cfg.resolve_upload_mode().await.unwrap();
+
+            assert_eq!(cfg.upload_mode.label(), expected_label);
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn explicit_mdm_mode_resolves_without_calling_the_control_plane() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _mode_env = UploadModeEnvGuard(std::env::var("SCREENPIPE_ENTERPRISE_UPLOAD_MODE").ok());
+        std::env::set_var(
+            "SCREENPIPE_ENTERPRISE_UPLOAD_MODE",
+            "direct_upload_write_only",
+        );
+
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_cfg(&dir, "http://control-plane-must-not-run/ingest".to_string());
+        cfg.upload_mode = EnterpriseUploadMode::Blocked("fresh start".to_string());
+
+        cfg.resolve_upload_mode().await.unwrap();
+
+        assert!(matches!(
+            cfg.upload_mode,
+            EnterpriseUploadMode::DirectWriteOnly(_)
+        ));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn mode_failures_preserve_fresh_start_block() {
+        let _env_lock = ENV_LOCK.lock().unwrap();
+        let _mode_env = UploadModeEnvGuard::clear();
+        for response in [
+            wiremock::ResponseTemplate::new(503),
+            wiremock::ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({ "desired_mode": "unknown" })),
+        ] {
+            let server = wiremock::MockServer::start().await;
+            wiremock::Mock::given(wiremock::matchers::method("GET"))
+                .respond_with(response)
+                .expect(1)
+                .mount(&server)
+                .await;
+            let dir = TempDir::new().unwrap();
+            let mut cfg = test_cfg(&dir, format!("{}/api/enterprise/ingest", server.uri()));
+            cfg.upload_mode = EnterpriseUploadMode::Blocked("fresh start".to_string());
+
+            cfg.resolve_upload_mode().await.unwrap();
+
+            assert!(matches!(cfg.upload_mode, EnterpriseUploadMode::Blocked(_)));
+        }
     }
 
     #[tokio::test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise/upload.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise/upload.rs
@@ -247,8 +247,9 @@ struct ModeResponse {
 const MODE_RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// HTTP GET `<ingest sibling>/storage-binding/mode` with the license-key
-/// header. Returns the parsed hint; any non-2xx, parse failure, or network
-/// error bubbles up so the caller can preserve its last known mode.
+/// header. A 401 is the credential-rotation signal. Other failures remain
+/// transient policy-resolution errors so the caller preserves its last safe
+/// mode (`Blocked` on a fresh process).
 async fn fetch_desired_mode_from_server(
     license_key: &str,
     ingest_url: &str,

--- a/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/enterprise_sync.rs
@@ -900,6 +900,7 @@ mod imp {
 
         let (tx, rx) = tokio::sync::watch::channel(false);
         let mut shutdown_rx = rx.clone();
+        let auth_gate_app = app.clone();
         tauri::async_runtime::spawn(async move {
             // Wait until a device config exists. Config sources, checked
             // every tick until one lands (previously this was a boot-time
@@ -985,29 +986,23 @@ mod imp {
                 cfg.device_id, cfg.device_label, cfg.ingest_url
             );
 
-            // Ask the control plane what upload mode this license should run
-            // in. Replaces the old "set SCREENPIPE_ENTERPRISE_UPLOAD_MODE on
-            // every customer machine" UX — the dashboard binding is now the
-            // single source of truth, so a fresh enterprise install just
-            // needs the license key and uploads start automatically.
-            if let Err(error) = cfg.resolve_upload_mode().await {
-                warn!(
-                    error = %error,
-                    "enterprise sync: saved device credential rejected during startup; account recovery will run after the local recorder starts"
-                );
-            }
-            info!(
-                "enterprise sync: resolved upload mode = {}",
-                cfg.upload_mode.label()
-            );
-
             // Small startup delay so the local screenpipe server is up before
-            // we hammer it. Mode resolution runs first so customer root keys
-            // are removed from the process environment before child agents
-            // can inherit them.
+            // we hammer it. The sync state machine resolves upload policy and
+            // recovers rejected credentials before its first local data read.
             tokio::time::sleep(std::time::Duration::from_secs(15)).await;
 
-            ee_sync::run(cfg, local, rx).await;
+            let on_auth_rejected: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+                if let Err(error) =
+                    crate::window::ShowRewindWindow::PermissionRecovery.show(&auth_gate_app)
+                {
+                    warn!(
+                        error = %error,
+                        "enterprise sync: failed to show enterprise access gate"
+                    );
+                }
+            });
+
+            ee_sync::run(cfg, local, rx, Some(on_auth_rejected)).await;
         });
 
         Some(tx)

--- a/apps/screenpipe-app-tauri/src-tauri/tests/enterprise_sync_test.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/tests/enterprise_sync_test.rs
@@ -34,12 +34,24 @@ mod web_base;
 // test target has no Tauri command tree, so keep that boundary inert here;
 // device-config parsing and the key-swap state transition remain real.
 mod commands {
+    pub(crate) fn get_enterprise_license_key() -> Option<String> {
+        None
+    }
+
     pub(crate) fn get_cloud_token() -> Option<String> {
         None
     }
 
     pub(crate) fn persist_enterprise_device_config(
         _license_key: Option<&str>,
+        _ingest_url: Option<&str>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+
+    pub(crate) fn persist_recovered_enterprise_device_config(
+        _replaced_license_key: &str,
+        _license_key: &str,
         _ingest_url: Option<&str>,
     ) -> Result<(), String> {
         Ok(())


### PR DESCRIPTION
## Summary

Completes enterprise credential recovery when a revoked or stale device key is rejected during upload-mode resolution.

The smaller startup classification fix is already on `main`. This follow-up closes the remaining class-level gaps: same-tick recovery before local reads, already-running rotation, headless credential gating, and restart persistence when a bundled `enterprise.json` still contains the rejected key.

## Root cause

Mode lookup authentication failures were previously treated like transient network failures. Resolution swallowed the error, preserved the fresh-process `Blocked` mode, and `run_one_sync` returned `Configuration`. The main loop only recovered `IngestAuthRejected`, so the recovery path was unreachable after restart.

A second restart defect existed because executable-adjacent `enterprise.json` won over the user file where recovery persisted the replacement key.

## Exact behavior

```text
mode endpoint rejects credential (401/403)
  -> recover once from a newly validated saved key or signed-in account
  -> apply replacement credential
  -> resolve upload mode again
  -> upload in the same tick

recovery unavailable
  -> keep uploads blocked
  -> show the existing enterprise entitlement gate
  -> gate remains available in hidden/headless mode
  -> user signs in or enters a server-validated key
```

Unknown modes and network failures preserve the last safe mode. A fresh process therefore remains blocked.

## Call-site audit

| Mechanism | Production usage | Verdict |
| --- | --- | --- |
| `fetch_desired_mode_from_server` | `EnterpriseUploadMode::resolve` only | 401/403 remain explicit auth rejection |
| `EnterpriseUploadMode::resolve` | `EnterpriseSyncConfig::resolve_upload_mode` only | auth rejection propagates; other failures preserve mode |
| `resolve_upload_mode` | recovery wrapper before upload and after replacement | no ignored production result remains |
| `recover_rotated_license_key` | mode-rejection and upload-rejection branches | both recover once, re-resolve, and retry |

Direct test callers are intentional and safe.

## Persistence precedence

Recovery writes a credential overlay tied to the SHA-256 fingerprint of the executable-adjacent key it replaces. The overlay survives restart while that bundled key remains installed. A newly deployed MDM key has a different fingerprint and immediately becomes authoritative. Repeated rotations stay anchored to the bundled key.

## Regression coverage

- [x] Fresh restart: stale key -> mode rejection -> account recovery -> mode resolution -> upload
- [x] Rotation while running with a resolved mode
- [x] Signed-out stale key remains upload-blocked and reports auth rejection
- [x] Headless/hidden deployments display the existing account/key gate
- [x] Hosted, direct-readable, direct-write-only, and explicit MDM mode paths
- [x] Transient and unknown mode failures remain fail-closed
- [x] Bundled old key recovery survives restart and later MDM replacement wins
- [x] Repeated credential rotations remain restart-safe

## Tests

- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --features enterprise-build --test enterprise_sync_test -- --nocapture` — 81 passed
- Focused entitlement, auth-recovery, and permission-recovery Vitest suite — 45 passed
- Headless/hidden permission-recovery Rust tests — 2 passed
- Bundled persistence Rust tests — passed
- `bun run bindings:check` — passed
- `git diff --check` — passed

## Deployment and backfill

Ship the updated enterprise app. Signed-in devices recover automatically; signed-out devices receive the credential gate. Devices with their persisted sync cursor drain forward from the last successful upload. Devices with a missing or corrupt cursor need a separate historical backfill beyond the built-in 15-minute safety window.

No customer keys or identifying data are included in this change.