### PR TITLE
chore(ci): refresh v2.5.175 lock and coverage

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 310
-- Active test blocks: 2900
+- Active test blocks: 2901
 - Ignored/manual test blocks: 133
-- Weighted coverage points: 2384.4
+- Weighted coverage points: 2385.4
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2772 | 128 | 2325.6 | 21 | 11 | 100% |
-| macos | 29 | 2823 | 108 | 2335.5 | 22 | 11 | 100% |
-| linux | 25 | 2466 | 102 | 2048.0 | 20 | 11 | 100% |
+| windows | 29 | 2773 | 128 | 2326.6 | 21 | 11 | 100% |
+| macos | 29 | 2824 | 108 | 2336.5 | 22 | 11 | 100% |
+| linux | 25 | 2467 | 102 | 2049.0 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11148,7 +11148,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.5.174"
+version = "2.5.175"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 310
-- Active test blocks: 2900
+- Active test blocks: 2901
 - Ignored/manual test blocks: 133
-- Declared test blocks: 3033
-- Weighted coverage points: 2384.4
+- Declared test blocks: 3034
+- Weighted coverage points: 2385.4
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,16 +23,16 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2772 | 128 | 2325.6 | 21 | 11 | 100% |
-| macos | 29 | 2823 | 108 | 2335.5 | 22 | 11 | 100% |
-| linux | 25 | 2466 | 102 | 2048.0 | 20 | 11 | 100% |
+| windows | 29 | 2773 | 128 | 2326.6 | 21 | 11 | 100% |
+| macos | 29 | 2824 | 108 | 2336.5 | 22 | 11 | 100% |
+| linux | 25 | 2467 | 102 | 2049.0 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | screenpipe-engine | 10 | 18 | 100 | 1390 | 42 | 1068.3 | 10 |
-| screenpipe-db | 5 | 49 | 14 | 412 | 16 | 391.7 | 9 |
+| screenpipe-db | 5 | 49 | 14 | 413 | 16 | 392.7 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 11 | 0 | 11.0 | 2 |
 | screenpipe-audio | 6 | 23 | 47 | 524 | 39 | 454.6 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 233 | 9 | 212.5 | 4 |
@@ -65,21 +65,21 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio | 7 suites / 619 active / 40 ignored / 549.6 pts | 7 suites / 619 active / 40 ignored / 549.6 pts | 6 suites / 551 active / 40 ignored / 502.0 pts |
 | audio-device | 2 suites / 193 active / 6 ignored / 172.6 pts | 2 suites / 193 active / 6 ignored / 172.6 pts | 1 suites / 125 active / 6 ignored / 125.0 pts |
 | configuration | 2 suites / 135 active / 3 ignored / 122.8 pts | 2 suites / 135 active / 3 ignored / 122.8 pts | 2 suites / 135 active / 3 ignored / 122.8 pts |
-| database | 6 suites / 330 active / 12 ignored / 309.7 pts | 6 suites / 330 active / 12 ignored / 309.7 pts | 6 suites / 330 active / 12 ignored / 309.7 pts |
+| database | 6 suites / 331 active / 12 ignored / 310.7 pts | 6 suites / 331 active / 12 ignored / 310.7 pts | 6 suites / 331 active / 12 ignored / 310.7 pts |
 | db-search | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts |
 | engine-lifecycle | 6 suites / 204 active / 1 ignored / 179.3 pts | 6 suites / 204 active / 1 ignored / 179.3 pts | 5 suites / 198 active / 1 ignored / 177.6 pts |
 | local-api | 2 suites / 295 active / 9 ignored / 207.7 pts | 2 suites / 295 active / 9 ignored / 207.7 pts | 2 suites / 295 active / 9 ignored / 207.7 pts |
 | meeting | 6 suites / 1309 active / 15 ignored / 1064.8 pts | 6 suites / 1309 active / 15 ignored / 1064.8 pts | 4 suites / 1038 active / 12 ignored / 814.2 pts |
 | ocr | 4 suites / 120 active / 7 ignored / 114.3 pts | 4 suites / 124 active / 7 ignored / 119.8 pts | 3 suites / 115 active / 6 ignored / 110.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1318 active / 67 ignored / 1165.2 pts | 14 suites / 1413 active / 70 ignored / 1203.2 pts | 13 suites / 1318 active / 67 ignored / 1165.2 pts |
+| performance | 13 suites / 1319 active / 67 ignored / 1166.2 pts | 14 suites / 1414 active / 70 ignored / 1204.2 pts | 13 suites / 1319 active / 67 ignored / 1166.2 pts |
 | pipes | 1 suites / 455 active / 3 ignored / 318.5 pts | 1 suites / 455 active / 3 ignored / 318.5 pts | 1 suites / 455 active / 3 ignored / 318.5 pts |
 | privacy | 5 suites / 862 active / 36 ignored / 700.9 pts | 5 suites / 909 active / 16 ignored / 705.3 pts | 5 suites / 838 active / 14 ignored / 679.1 pts |
 | real-app | - | 1 suites / 95 active / 3 ignored / 38.0 pts | - |
 | speaker | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts |
-| storage | 3 suites / 448 active / 29 ignored / 363.1 pts | 3 suites / 448 active / 29 ignored / 363.1 pts | 3 suites / 448 active / 29 ignored / 363.1 pts |
+| storage | 3 suites / 449 active / 29 ignored / 364.1 pts | 3 suites / 449 active / 29 ignored / 364.1 pts | 3 suites / 449 active / 29 ignored / 364.1 pts |
 | sync | 1 suites / 455 active / 3 ignored / 318.5 pts | 1 suites / 455 active / 3 ignored / 318.5 pts | 1 suites / 455 active / 3 ignored / 318.5 pts |
-| timeline | 4 suites / 876 active / 33 ignored / 715.5 pts | 4 suites / 876 active / 33 ignored / 715.5 pts | 4 suites / 876 active / 33 ignored / 715.5 pts |
+| timeline | 4 suites / 877 active / 33 ignored / 716.5 pts | 4 suites / 877 active / 33 ignored / 716.5 pts | 4 suites / 877 active / 33 ignored / 716.5 pts |
 | transcription | 5 suites / 622 active / 37 ignored / 485.7 pts | 5 suites / 622 active / 37 ignored / 485.7 pts | 5 suites / 622 active / 37 ignored / 485.7 pts |
 | ui-events | 4 suites / 690 active / 28 ignored / 526.9 pts | 3 suites / 642 active / 5 ignored / 493.3 pts | 3 suites / 642 active / 5 ignored / 493.3 pts |
 | vision-capture | 5 suites / 468 active / 32 ignored / 374.3 pts | 5 suites / 472 active / 32 ignored / 379.8 pts | 4 suites / 463 active / 31 ignored / 370.8 pts |
@@ -132,7 +132,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-audio-meetings-speakers | screenpipe-db | windows, macos, linux | database, audio, meeting, speaker | audio-record-transcribe, audio-device-health, meeting-live-notes | high | strong | integration | 14 | 95 | 1 | Audio transcript dedupe, live meeting mirroring, open meeting invariants, liveness, and speaker reassignment coverage. |
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 12 | 27 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 101 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
-| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 165 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
+| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 166 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 29 | 291 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 244 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
@@ -257,7 +257,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio-meetings-speakers-dedup | screenpipe-audio | tests/speaker_identification.rs | integration | 2 | 1 | 3 |
 | db-runtime-reliability | screenpipe-db | src/cancellable_query.rs | source | 1 | 0 | 1 |
 | db-accessibility-ui-events | screenpipe-db | src/db/elements.rs | source | 2 | 0 | 2 |
-| db-timeline-frames | screenpipe-db | src/db/feedback.rs | source | 1 | 0 | 1 |
+| db-timeline-frames | screenpipe-db | src/db/feedback.rs | source | 2 | 0 | 2 |
 | db-timeline-frames | screenpipe-db | src/db/maintenance.rs | source | 4 | 1 | 5 |
 | db-timeline-frames | screenpipe-db | src/db/setup.rs | source | 5 | 0 | 5 |
 | db-timeline-frames | screenpipe-db | src/db/tests.rs | source | 31 | 1 | 32 |


### PR DESCRIPTION
## What

- refresh the Tauri app lock entry to v2.5.175
- regenerate core and unified coverage dashboards after the new database regression test

## Root cause

The v2.5.175 bump and recently merged database/capture work left generated artifacts stale on `main`. Exact-main Code Quality run 30955131772 failed only Cargo.lock freshness and coverage freshness.

## Verification

- `./scripts/regenerate-locks.sh --check`
- E2E coverage report check
- core coverage report check
- unified coverage report check
- `git diff --check`

Generated-artifact-only change; no product visual is applicable.