### PR TITLE
[codex] fix Claude large write output limits

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -21,6 +21,7 @@ pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.83.0";
 pub const PI_NAMESPACE_DIR: &str = "@earendil-works";
 pub const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
 const CUSTOM_PROVIDER_USER_AGENT: &str = "screenpipe";
+const DEFAULT_CLOUD_MAX_OUTPUT_TOKENS: u64 = 32_000;
 
 /// Apply compatibility settings required by OpenAI-compatible custom endpoints.
 ///
@@ -263,7 +264,14 @@ fn gateway_models_to_pi_models(data: &[serde_json::Value]) -> Vec<serde_json::Va
             let ctx = m
                 .get("context_window")
                 .and_then(|v| v.as_u64())
+                .filter(|value| *value > 0)
                 .unwrap_or(128000);
+            let max_tokens = m
+                .get("max_output_tokens")
+                .and_then(|v| v.as_u64())
+                .filter(|value| *value > 0)
+                .unwrap_or(DEFAULT_CLOUD_MAX_OUTPUT_TOKENS)
+                .min(ctx);
             let intelligence = m
                 .get("intelligence")
                 .and_then(|v| v.as_str())
@@ -277,7 +285,7 @@ fn gateway_models_to_pi_models(data: &[serde_json::Value]) -> Vec<serde_json::Va
                 "input": ["text", "image"],
                 "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
                 "contextWindow": ctx,
-                "maxTokens": 32000,
+                "maxTokens": max_tokens,
                 // Pi sends its stable agent session ID as x-session-affinity.
                 // The hosted gateway uses that plus the user-message ordinal to
                 // count one visible turn once across a multi-call tool loop.
@@ -299,7 +307,7 @@ fn selectable_gateway_models(data: &[serde_json::Value]) -> Option<Vec<serde_jso
 /// Only auto — if the gateway is down, nothing works anyway.
 fn fallback_cloud_models() -> serde_json::Value {
     json!([
-        {"id": "auto", "name": "Auto (recommended)", "reasoning": true, "input": ["text", "image"], "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}, "contextWindow": 128000, "maxTokens": 32000, "compat": {"sendSessionAffinityHeaders": true}},
+        {"id": "auto", "name": "Auto (recommended)", "reasoning": true, "input": ["text", "image"], "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}, "contextWindow": 128000, "maxTokens": DEFAULT_CLOUD_MAX_OUTPUT_TOKENS, "compat": {"sendSessionAffinityHeaders": true}},
     ])
 }
 
@@ -4560,6 +4568,30 @@ mod tests {
             "locked": true,
         })])
         .is_none());
+    }
+
+    #[test]
+    fn gateway_catalog_uses_advertised_output_budget_with_safe_fallback() {
+        let models = gateway_models_to_pi_models(&[
+            json!({
+                "id": "claude-sonnet-5",
+                "context_window": 1_000_000,
+                "max_output_tokens": 128_000,
+            }),
+            json!({
+                "id": "legacy-model-without-output-metadata",
+                "context_window": 128_000,
+            }),
+            json!({
+                "id": "invalid-model-budget",
+                "context_window": 64_000,
+                "max_output_tokens": 0,
+            }),
+        ]);
+
+        assert_eq!(models[0].get("maxTokens"), Some(&json!(128_000)));
+        assert_eq!(models[1].get("maxTokens"), Some(&json!(32_000)));
+        assert_eq!(models[2].get("maxTokens"), Some(&json!(32_000)));
     }
 
     #[tokio::test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -4587,11 +4587,51 @@ mod tests {
                 "context_window": 64_000,
                 "max_output_tokens": 0,
             }),
+            json!({
+                "id": "oversized-model-budget",
+                "context_window": 64_000,
+                "max_output_tokens": 128_000,
+            }),
         ]);
 
         assert_eq!(models[0].get("maxTokens"), Some(&json!(128_000)));
         assert_eq!(models[1].get("maxTokens"), Some(&json!(32_000)));
         assert_eq!(models[2].get("maxTokens"), Some(&json!(32_000)));
+        assert_eq!(models[3].get("maxTokens"), Some(&json!(64_000)));
+    }
+
+    #[tokio::test]
+    async fn gateway_output_budget_flows_from_http_to_pi_catalog() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [
+                    {
+                        "id": "claude-sonnet-5",
+                        "name": "Claude Sonnet 5",
+                        "context_window": 1_000_000,
+                        "max_output_tokens": 128_000,
+                        "intelligence": "highest",
+                    },
+                    {
+                        "id": "legacy-model",
+                        "name": "Legacy model",
+                        "context_window": 128_000,
+                    },
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let models = screenpipe_cloud_models(&server.uri(), None).await;
+        assert_eq!(models.pointer("/0/maxTokens"), Some(&json!(128_000)));
+        assert_eq!(models.pointer("/1/maxTokens"), Some(&json!(32_000)));
     }
 
     #[tokio::test]

--- a/packages/ai-gateway/src/handlers/models.ts
+++ b/packages/ai-gateway/src/handlers/models.ts
@@ -20,6 +20,8 @@ interface ModelEntry {
   tags: string[];
   free: boolean;
   context_window: number;
+  /** Maximum completion budget clients should request from this model. */
+  max_output_tokens?: number;
   best_for: string[];
   speed: 'fast' | 'medium' | 'slow';
   intelligence: 'standard' | 'high' | 'highest';
@@ -244,6 +246,7 @@ const CURATED_MODELS: ModelEntry[] = [
     tags: ['premium', 'balanced', 'agentic', 'new'],
     free: false,
     context_window: 1000000,
+    max_output_tokens: 128000,
     best_for: ['agentic work', 'coding', 'computer use', 'complex analysis'],
     speed: 'medium',
     intelligence: 'highest',
@@ -260,6 +263,7 @@ const CURATED_MODELS: ModelEntry[] = [
     tags: ['business', 'frontier', 'agentic', 'new'],
     free: false,
     context_window: 1000000,
+    max_output_tokens: 128000,
     best_for: ['hard reasoning', 'agentic coding', 'complex analysis'],
     speed: 'slow',
     intelligence: 'highest',
@@ -276,6 +280,7 @@ const CURATED_MODELS: ModelEntry[] = [
     tags: ['business', 'frontier', 'agentic', 'new'],
     free: false,
     context_window: 1000000,
+    max_output_tokens: 128000,
     best_for: ['hard reasoning', 'agentic coding', 'complex analysis'],
     speed: 'slow',
     intelligence: 'highest',

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -113,6 +113,13 @@ describe('OpenAI API model catalog', () => {
 		expect(ids).toContain('claude-fable-5');
 	});
 
+	it('publishes the full Claude 5 output budget for agent tool calls', async () => {
+		const models = await listedModels();
+		for (const id of ['claude-sonnet-5', 'claude-opus-5', 'claude-fable-5']) {
+			expect(models.find(model => model.id === id)?.max_output_tokens).toBe(128_000);
+		}
+	});
+
 	it('does not expose provider-secret gates in /v1/models responses', async () => {
 		const models = await listedModels();
 		const openAiModel = models.find(model => model.id === 'gpt-5.5');


### PR DESCRIPTION
## What changed

- publish `max_output_tokens: 128000` for Claude Sonnet 5, Opus 5, and Fable 5 in the hosted model catalog
- make Pi use the gateway-provided output limit when generating its `models.json`
- retain the existing 32k fallback when older gateways or models do not provide metadata
- reject zero limits and clamp advertised output to the model context window

## Root cause

The desktop converted every hosted model to Pi metadata with a hardcoded `maxTokens: 32000`. Claude's adaptive thinking and JSON-encoded tool arguments share that completion budget, so a large `write` call could hit Anthropic's `max_tokens` stop reason before its arguments were complete. The gateway correctly translated that to `finish_reason: length`, and Pi correctly refused to execute the truncated tool call.

```text
before: /v1/models -> hardcoded 32k -> Claude stops at max_tokens -> Pi rejects partial write
after:  /v1/models -> Claude 128k -> Pi requests the model limit -> large write can complete
```

## Impact

Claude 5 agent calls can use the models' full 128k output window. Existing models without explicit metadata remain capped at 32k, and authenticated-free chat remains independently capped by the gateway's existing free-preview policy.

This PR changes source only. It does not deploy the Worker, publish a desktop release, or prove an installed-client recovery.

## Validation

- `bun test --timeout=10000` in `packages/ai-gateway`: 857 passed
- `bunx tsc --noEmit` in `packages/ai-gateway`: passed
- isolated `cargo test -p screenpipe-core`: 417 passed, 1 ignored; doc/integration tests passed
- HTTP-to-Pi catalog regression and context-window clamp cases: passed
- desktop `test_build_models_json_default_has_screenpipe_provider`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
