### PR TITLE
[codex] suppress Wayland output compatibility noise

### DIFF
--- a/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
+++ b/crates/screenpipe-engine/src/bin/screenpipe-engine.rs
@@ -556,6 +556,11 @@ async fn main() -> anyhow::Result<()> {
                             r"Library not loaded.*libx265\.",
                             // Linux system library missing — distro-local, not our bug
                             r"Failed to load ayatana-appindicator3 or appindicator3 dynamic library",
+                            // libwayshot reports an older Wayland compositor's wl_output
+                            // protocol as an error even though it deliberately ignores that
+                            // output and continues (CLI-ZY: 130 duplicate events, one user).
+                            // Keep the local log for diagnosis, but do not send it to Sentry.
+                            r"^Ignoring a wl_output with version < 4\.$",
                             // Deepgram DNS / connectivity blips — already logged locally
                             r"deepgram transcription failed: Cannot resolve audio transcription server",
                         ]


### PR DESCRIPTION
## Summary

- suppress the exact `libwayshot` compatibility log behind Sentry issue `SCREENPIPE-CLI-ZY`
- keep the local error log unchanged for diagnostics
- leave Wayland capture behavior unchanged

## Why

A fresh dry-run Sentry audit on current `main` found 130 duplicate events from one user on engine v0.4.35:

> Ignoring a wl_output with version < 4.

`libwayshot-xcap` emits this at error level when a compositor exposes an older `wl_output` protocol. Its control flow deliberately ignores that output and continues. Because screenpipe's Sentry tracing layer ingests error-level logs, this expected compatibility branch becomes an actionable-looking issue.

The filter is anchored to the full exact message, so nearby Wayland failures still reach Sentry.

Audit: https://github.com/screenpipe/screenpipe/actions/runs/31022633955
Sentry issue: https://mediar.sentry.io/issues/7648775077/
Upstream source: https://github.com/nashaofu/wayshot/blob/3813118b8b59483f0387f1da58e3dbe6760b24ea/libwayshot/src/dispatch.rs#L75-L89

## Verification

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check -p screenpipe-engine --bin screenpipe --locked`

The locked engine check passed from a clean worktree. Existing deprecation and dead-code warnings remain unrelated.

## Release boundary

This is source and local-build proof only. The Sentry group will stop receiving this event after the change is merged, a new engine/app artifact is released, and affected installations update.
